### PR TITLE
Kinetic scrolling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@ TODO-list for the Egui project. If you looking for something to do, look here.
         * [x] Scroll-wheel input
         * [x] Drag background to scroll
         * [ ] Horizontal scrolling
-        * [ ] Kinetic scrolling
+        * [X] Kinetic scrolling
 * [ ] Text
     * [ ] Unicode
         * [ ] Shared mutable expanding texture map?

--- a/egui/src/containers/area.rs
+++ b/egui/src/containers/area.rs
@@ -32,7 +32,7 @@ impl State {
     }
 }
 
-/// An area on the screen that can be move by dragging.
+/// An area on the screen that can be moved by dragging.
 ///
 /// This forms the base of the `Window` container.
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
I implemented kinetic scrolling to the extent that it makes sense to me right now:

- Kinetic scrolling is only active when you drag the background, not when you use the scroll wheel or drag the scroll handle. I feel like people would prefer precise scrolling when using those methods.
- Kinetic velocity (like offset) is stored and updated as a Vec2, event though right now we only use the y component
- I basically copy-pasted the kinetic part from area.rs; Maybe you would prefer to factor it out, but I'm not sure where to