### PR TITLE
refactor RunMode: move it from backend to the demo App

### DIFF
--- a/demo_glium/src/main.rs
+++ b/demo_glium/src/main.rs
@@ -1,11 +1,11 @@
 #![deny(warnings)]
 #![warn(clippy::all)]
 
-use egui_glium::{storage::FileStorage, RunMode};
+use egui_glium::storage::FileStorage;
 
 fn main() {
     let title = "Egui glium demo";
     let storage = FileStorage::from_path(".egui_demo_glium.json".into());
     let app: egui::DemoApp = egui::app::get_value(&storage, egui::app::APP_KEY).unwrap_or_default();
-    egui_glium::run(title, RunMode::Reactive, storage, app);
+    egui_glium::run(title, storage, app);
 }

--- a/demo_web/src/lib.rs
+++ b/demo_web/src/lib.rs
@@ -6,7 +6,7 @@ use wasm_bindgen::prelude::*;
 /// This is the entry-point for all the web-assembly.
 #[wasm_bindgen]
 pub fn start(canvas_id: &str) -> Result<(), wasm_bindgen::JsValue> {
-    let backend = egui_web::WebBackend::new(canvas_id, egui_web::RunMode::Reactive)?;
+    let backend = egui_web::WebBackend::new(canvas_id)?;
     let app = Box::new(egui::DemoApp::default());
     let runner = egui_web::AppRunner::new(backend, app)?;
     egui_web::run(runner)?;

--- a/egui/src/app.rs
+++ b/egui/src/app.rs
@@ -19,29 +19,12 @@ pub trait App {
     fn on_exit(&mut self, _storage: &mut dyn Storage) {}
 }
 
-// TODO: replace with manually calling `egui::Context::request_repaint()` each frame.
-/// How the backend runs the app
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum RunMode {
-    /// Repaint the UI all the time (at the display refresh rate of e.g. 60 Hz).
-    /// This is good for games where things are constantly moving.
-    /// This can also be achieved with `RunMode::Reactive` combined with calling `egui::Context::request_repaint()` each frame.
-    Continuous,
-
-    /// Only repaint when there are animations or input (mouse movement, keyboard input etc).
-    /// This saves CPU.
-    Reactive,
-}
-
 pub struct WebInfo {
     /// e.g. "#fragment" part of "www.example.com/index.html#fragment"
     pub web_location_hash: String,
 }
 
 pub trait Backend {
-    fn run_mode(&self) -> RunMode;
-    fn set_run_mode(&mut self, run_mode: RunMode);
-
     /// If the app is running in a Web context, this returns information about the environment.
     fn web_info(&self) -> Option<WebInfo> {
         None

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -1,7 +1,7 @@
 use crate::*;
 
 pub use egui::{
-    app::{App, Backend, RunMode, WebInfo},
+    app::{App, Backend, WebInfo},
     Srgba,
 };
 
@@ -12,12 +12,11 @@ pub struct WebBackend {
     painter: webgl::Painter,
     frame_times: egui::MovementTracker<f32>,
     frame_start: Option<f64>,
-    run_mode: RunMode,
     last_save_time: Option<f64>,
 }
 
 impl WebBackend {
-    pub fn new(canvas_id: &str, run_mode: RunMode) -> Result<Self, JsValue> {
+    pub fn new(canvas_id: &str) -> Result<Self, JsValue> {
         let ctx = egui::Context::new();
         load_memory(&ctx);
         Ok(Self {
@@ -25,7 +24,6 @@ impl WebBackend {
             painter: webgl::Painter::new(canvas_id)?,
             frame_times: egui::MovementTracker::new(1000, 1.0),
             frame_start: None,
-            run_mode,
             last_save_time: None,
         })
     }
@@ -83,14 +81,6 @@ impl WebBackend {
 }
 
 impl Backend for WebBackend {
-    fn run_mode(&self) -> RunMode {
-        self.run_mode
-    }
-
-    fn set_run_mode(&mut self, run_mode: RunMode) {
-        self.run_mode = run_mode;
-    }
-
     fn web_info(&self) -> Option<WebInfo> {
         Some(WebInfo {
             web_location_hash: location_hash().unwrap_or_default(),

--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -229,7 +229,7 @@ pub struct AppRunnerRef(Arc<Mutex<AppRunner>>);
 fn paint_and_schedule(runner_ref: AppRunnerRef) -> Result<(), JsValue> {
     fn paint_if_needed(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
         let mut runner_lock = runner_ref.0.lock();
-        if runner_lock.web_backend.run_mode() == RunMode::Continuous || runner_lock.needs_repaint {
+        if runner_lock.needs_repaint {
             runner_lock.needs_repaint = false;
             let (output, paint_jobs) = runner_lock.logic()?;
             runner_lock.paint(paint_jobs)?;

--- a/example_glium/src/main.rs
+++ b/example_glium/src/main.rs
@@ -4,7 +4,7 @@
 #![warn(clippy::all)]
 
 use egui::{Slider, Window};
-use egui_glium::{storage::FileStorage, RunMode};
+use egui_glium::storage::FileStorage;
 
 /// We derive Deserialize/Serialize so we can persist app state on shutdown.
 #[derive(Default, serde::Deserialize, serde::Serialize)]
@@ -39,7 +39,7 @@ fn main() {
     let title = "My Egui Window";
     let storage = FileStorage::from_path(".egui_example_glium.json".into()); // Where to persist app state
     let app: MyApp = egui::app::get_value(&storage, egui::app::APP_KEY).unwrap_or_default(); // Restore `MyApp` from file, or create new `MyApp`.
-    egui_glium::run(title, RunMode::Reactive, storage, app);
+    egui_glium::run(title, storage, app);
 }
 
 fn my_save_function() {


### PR DESCRIPTION
This simplifies the `egui_glium` and `egui_web` backends substantially, reduces the scope of `RunMode` to a single file, and removes duplicated code.

Basically: this is how I should have written it from the beginning.

@parasyte You may want to take a look at the [the changes to `egui_glium/src/backend.rs`](https://github.com/emilk/egui/pull/23/files#diff-ff6ba832648e237ec4a61e76bb1e9498L121-L131). I don't think I could have broken what you fixed, but maybe your fix can be further simplified now that there is less complexity involved w.r.t. https://github.com/emilk/egui/pull/21.