### PR TITLE
Make `from_get_set` public

### DIFF
--- a/egui/src/widgets/slider.rs
+++ b/egui/src/widgets/slider.rs
@@ -49,7 +49,7 @@ pub struct Slider<'a> {
 }
 
 impl<'a> Slider<'a> {
-    fn from_get_set(
+    pub fn from_get_set(
         range: RangeInclusive<f64>,
         get_set_value: impl 'a + FnMut(Option<f64>) -> f64,
     ) -> Self {


### PR DESCRIPTION
Hi @emilk,

thank you very much for creating a pure rust immediate mode GUI!
I am currently playing around with it, and it works perfectly :)
I did come along a small limitation that would be fixable by making the `Slider::from_get_set` public.
I am storing my state in an Arc<Mutex<T>> or Atomic value that is accessed by a background thread and would like to avoid the additional lifetime for `&'a mut`, but I can easily clone the Arc and give it to the closure that the `from_get_set` method receives.

In case this is intended and what I am trying to do is bad I am happy to be taught better :)

Kind Regards,
Hizoul