### PR TITLE
Downgrade ahash for wasm build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,13 +23,9 @@ checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "ahash"
-version = "0.5.6"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2deff5792519f5985c9cdd5a0399df3ca3419114841d282bae646acadbf0a99"
-dependencies = [
- "getrandom",
- "lazy_static",
-]
+checksum = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c"
 
 [[package]]
 name = "andrew"
@@ -619,17 +615,6 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
-name = "getrandom"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
 
 [[package]]
 name = "gimli"
@@ -1504,7 +1489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi",
  "winapi 0.3.9",
 ]
 
@@ -1561,12 +1546,6 @@ dependencies = [
  "winapi 0.3.9",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/egui/Cargo.toml
+++ b/egui/Cargo.toml
@@ -10,12 +10,17 @@ readme = "../README.md"
 repository = "https://github.com/emilk/egui"
 categories = ["gui", "graphics"]
 keywords = ["gui", "imgui", "immediate", "portable", "gamedev"]
-include = [ "**/*.rs", "Cargo.toml", "fonts/ProggyClean.ttf", "fonts/Comfortaa-Regular.ttf"]
+include = [
+  "**/*.rs",
+  "Cargo.toml",
+  "fonts/ProggyClean.ttf",
+  "fonts/Comfortaa-Regular.ttf",
+]
 
 [lib]
 
 [dependencies]
-ahash = { version = "0.5", features = ["std"], default-features = false }
+ahash = { version = "0.4", features = ["std"], default-features = false }
 parking_lot = "0.11"
 rusttype = "0.9"
 serde = { version = "1", features = ["derive"], optional = true }

--- a/egui/Cargo.toml
+++ b/egui/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 [lib]
 
 [dependencies]
+# ahash 0.5 breaks ./build_web.sh, keep at 0.4, more info https://github.com/emilk/egui/pull/35
 ahash = { version = "0.4", features = ["std"], default-features = false }
 parking_lot = "0.11"
 rusttype = "0.9"


### PR DESCRIPTION
When running `./build_web.sh`, I ran into the following errors:

```
error: target is not supported, for more information see: https://docs.rs/getrandom/#unsupported-targets
   --> /Users/sss/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.0/src/lib.rs:224:9
    |
224 | /         compile_error!("target is not supported, for more information see: \
225 | |                         https://docs.rs/getrandom/#unsupported-targets");
    | |_________________________________________________________________________^

error[E0433]: failed to resolve: use of undeclared type or module `imp`
   --> /Users/sss/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.0/src/lib.rs:246:5
    |
246 |     imp::getrandom_inner(dest)
    |     ^^^ use of undeclared type or module `imp`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0433`.
error: could not compile `getrandom`.

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
````

Seems like getrandom doesn't see `wasm32-unknown-unknown` as a valid target.
Dropping ahash, which has the getrandom dependency, to version 0.4.6 fixes this for now.
