### PR TITLE
Wrapping layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added ⭐
 
-* `SelectableLabel` (`ui.selectable_label` and `ui.selectable_value`): a text-button that can be selected
+* Wrapping layouts:
+  * `ui.horizontal_wrapped(|ui| ...)`: Add widgets on a row but wrap at `max_size`.
+  * `ui.horizontal_wrapped_for_text`: Like `horizontal_wrapped`, but with spacing made for embedding text.
+* `egui::Layout` now supports justified layouts where contents is _also_ centered, right-aligned, etc.
+* `ui.allocate_ui(size, |ui| ...)`: Easily created a sized child-`Ui`.
+* `SelectableLabel` (`ui.selectable_label` and `ui.selectable_value`): A text-button that can be selected.
+* `ui.small_button`: A smaller button that looks good embedded in text.
 * Add `Resize::id_source` and `ScrollArea::id_source` to let the user avoid Id clashes.
 
 ### Changed 🔧
 
 * Changed default font to [Ubuntu-Light](https://fonts.google.com/specimen/Ubuntu).
+* Refactored `egui::Layout` substantially, changing its interface.
 
 ### Removed 🔥
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@ TODO-list for the Egui project. If you looking for something to do, look here.
 ## Layout refactor
 
 * Test `allocate_ui`
-* Text wrapping
+* Mix wrapping text and other widgets.
 
 ## Misc
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,6 @@
 
 TODO-list for the Egui project. If you looking for something to do, look here.
 
-## Layout refactor
-
-* Test `allocate_ui`
-* Mix wrapping text and other widgets.
-
 ## Misc
 
 * Widgets

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,12 @@
 
 TODO-list for the Egui project. If you looking for something to do, look here.
 
+## Layout refactor
+
+* Deprecate `add_custom_contents`
+* Fix and test `allocate_ui`
+*
+
 ## Misc
 
 * Widgets

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@ TODO-list for the Egui project. If you looking for something to do, look here.
 ## Layout refactor
 
 * Test `allocate_ui`
-* Justified alignment of radio button and checkboxes
+* Text wrapping
 
 ## Misc
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,9 +4,8 @@ TODO-list for the Egui project. If you looking for something to do, look here.
 
 ## Layout refactor
 
-* Deprecate `add_custom_contents`
-* Fix and test `allocate_ui`
-*
+* Test `allocate_ui`
+* Justified alignment of radio button and checkboxes
 
 ## Misc
 

--- a/egui/src/align.rs
+++ b/egui/src/align.rs
@@ -16,6 +16,21 @@ pub enum Align {
     Max,
 }
 
+impl Align {
+    pub fn left() -> Self {
+        Self::Min
+    }
+    pub fn right() -> Self {
+        Self::Max
+    }
+    pub fn top() -> Self {
+        Self::Min
+    }
+    pub fn bottom() -> Self {
+        Self::Max
+    }
+}
+
 impl Default for Align {
     fn default() -> Align {
         Align::Min

--- a/egui/src/containers/collapsing_header.rs
+++ b/egui/src/containers/collapsing_header.rs
@@ -1,7 +1,6 @@
 use std::hash::Hash;
 
 use crate::{
-    layout::Direction,
     paint::{PaintCmd, TextStyle},
     widgets::Label,
     *,
@@ -168,7 +167,7 @@ struct Prepared {
 impl CollapsingHeader {
     fn begin(self, ui: &mut Ui) -> Prepared {
         assert!(
-            ui.layout().dir() == Direction::Vertical,
+            ui.layout().main_dir().is_vertical(),
             "Horizontal collapsing is unimplemented"
         );
         let Self {

--- a/egui/src/containers/collapsing_header.rs
+++ b/egui/src/containers/collapsing_header.rs
@@ -180,7 +180,7 @@ impl CollapsingHeader {
 
         let id = ui.make_persistent_id(id_source);
 
-        let available = ui.available_finite();
+        let available = ui.available_rect_before_wrap_finite();
         let text_pos = available.min + vec2(ui.style().spacing.indent, 0.0);
         let galley = label.layout_width(ui, available.right() - text_pos.x);
         let text_max_x = text_pos.x + galley.size.x;

--- a/egui/src/containers/combo_box.rs
+++ b/egui/src/containers/combo_box.rs
@@ -87,7 +87,7 @@ fn button_frame(
     add_contents: impl FnOnce(&mut Ui),
 ) -> Response {
     let margin = ui.style().spacing.button_padding;
-    let outer_rect_bounds = ui.available();
+    let outer_rect_bounds = ui.available_rect_before_wrap();
     let inner_rect = outer_rect_bounds.shrink2(margin);
     let where_to_put_background = ui.painter().add(PaintCmd::Noop);
     let mut content_ui = ui.child_ui(inner_rect, *ui.layout());

--- a/egui/src/containers/combo_box.rs
+++ b/egui/src/containers/combo_box.rs
@@ -60,10 +60,13 @@ pub fn combo_box(
                 let frame = Frame::popup(ui.style());
                 let frame_margin = frame.margin;
                 frame.show(ui, |ui| {
-                    ui.with_layout(Layout::justified(Direction::Vertical), |ui| {
-                        ui.set_min_width(button_response.rect.width() - 2.0 * frame_margin.x);
-                        menu_contents(ui);
-                    });
+                    ui.with_layout(
+                        Layout::top_down(Align::left()).with_cross_justify(true),
+                        |ui| {
+                            ui.set_min_width(button_response.rect.width() - 2.0 * frame_margin.x);
+                            menu_contents(ui);
+                        },
+                    );
                 })
             });
 

--- a/egui/src/containers/frame.rs
+++ b/egui/src/containers/frame.rs
@@ -99,7 +99,7 @@ pub struct Prepared {
 impl Frame {
     pub fn begin(self, ui: &mut Ui) -> Prepared {
         let where_to_put_background = ui.painter().add(PaintCmd::Noop);
-        let outer_rect_bounds = ui.available();
+        let outer_rect_bounds = ui.available_rect_before_wrap();
         let inner_rect = outer_rect_bounds.shrink2(self.margin);
         let content_ui = ui.child_ui(inner_rect, *ui.layout());
 

--- a/egui/src/containers/resize.rs
+++ b/egui/src/containers/resize.rs
@@ -153,7 +153,7 @@ struct Prepared {
 
 impl Resize {
     fn begin(&mut self, ui: &mut Ui) -> Prepared {
-        let position = ui.available().min;
+        let position = ui.available_rect_before_wrap().min;
         let id = self.id.unwrap_or_else(|| {
             let id_source = self.id_source.unwrap_or_else(|| Id::new("resize"));
             ui.make_persistent_id(id_source)

--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -103,7 +103,7 @@ impl ScrollArea {
         };
 
         let outer_size = vec2(
-            ui.available().width(),
+            ui.available_width(),
             ui.available().height().at_most(max_height),
         );
 

--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -104,11 +104,11 @@ impl ScrollArea {
 
         let outer_size = vec2(
             ui.available_width(),
-            ui.available().height().at_most(max_height),
+            ui.available_size_before_wrap().y.at_most(max_height),
         );
 
         let inner_size = outer_size - vec2(current_scroll_bar_width, 0.0);
-        let inner_rect = Rect::from_min_size(ui.available().min, inner_size);
+        let inner_rect = Rect::from_min_size(ui.available_rect_before_wrap().min, inner_size);
 
         let mut content_ui = ui.child_ui(
             Rect::from_min_size(

--- a/egui/src/demos/app.rs
+++ b/egui/src/demos/app.rs
@@ -106,7 +106,7 @@ impl FrameHistory {
 
         // TODO: we should not use `slider_width` as default graph width.
         let height = ui.style().spacing.slider_width;
-        let rect = ui.allocate_space(vec2(ui.available_finite().width(), height));
+        let rect = ui.allocate_space(vec2(ui.available_size_before_wrap_finite().x, height));
         let style = ui.style().noninteractive();
 
         let mut cmds = vec![PaintCmd::Rect {

--- a/egui/src/demos/dancing_strings.rs
+++ b/egui/src/demos/dancing_strings.rs
@@ -32,7 +32,7 @@ impl View for DancingStrings {
             ui.ctx().request_repaint();
             let time = ui.input().time;
 
-            let desired_size = ui.available().width() * vec2(1.0, 0.35);
+            let desired_size = ui.available_width() * vec2(1.0, 0.35);
             let rect = ui.allocate_space(desired_size);
 
             let mut cmds = vec![];

--- a/egui/src/demos/demo_window.rs
+++ b/egui/src/demos/demo_window.rs
@@ -335,14 +335,13 @@ impl LayoutDemo {
 
     pub fn content_ui(&mut self, ui: &mut Ui) {
         // ui.label(format!("Available space: {:?}", ui.available().size()));
-        if ui.button("Reset").clicked {
+        if ui.button("Default").clicked {
             *self = Default::default();
         }
+
         ui.separator();
-        ui.label("Direction:");
 
-        // TODO: enum iter
-
+        ui.label("Main Direction:");
         for &dir in &[
             Direction::LeftToRight,
             Direction::RightToLeft,
@@ -354,12 +353,14 @@ impl LayoutDemo {
 
         ui.separator();
 
-        ui.label("Align:");
+        ui.label("Cross Align:");
         for &align in &[Align::Min, Align::Center, Align::Max] {
             ui.radio_value(&mut self.cross_align, align, format!("{:?}", align));
         }
 
-        ui.checkbox(&mut self.cross_justify, "Justified")
+        ui.separator();
+
+        ui.checkbox(&mut self.cross_justify, "Cross Justified")
             .on_hover_text("Try to fill full width/height (e.g. buttons)");
     }
 }

--- a/egui/src/demos/demo_window.rs
+++ b/egui/src/demos/demo_window.rs
@@ -389,16 +389,20 @@ impl LayoutDemo {
             }
         });
 
-        ui.checkbox(&mut self.main_wrap, "Main wrap")
-            .on_hover_text("Wrap when next widget doesn't fit the current row/column");
+        ui.horizontal(|ui| {
+            ui.checkbox(&mut self.main_wrap, "Main wrap")
+                .on_hover_text("Wrap when next widget doesn't fit the current row/column");
 
-        if self.main_wrap {
-            if self.main_dir.is_horizontal() {
-                ui.add(Slider::f32(&mut self.wrap_row_height, 0.0..=200.0).text("Row height"));
-            } else {
-                ui.add(Slider::f32(&mut self.wrap_column_width, 0.0..=200.0).text("Column width"));
+            if self.main_wrap {
+                if self.main_dir.is_horizontal() {
+                    ui.add(Slider::f32(&mut self.wrap_row_height, 0.0..=200.0).text("Row height"));
+                } else {
+                    ui.add(
+                        Slider::f32(&mut self.wrap_column_width, 0.0..=200.0).text("Column width"),
+                    );
+                }
             }
-        }
+        });
 
         ui.horizontal(|ui| {
             ui.label("Cross Align:");

--- a/egui/src/demos/demo_window.rs
+++ b/egui/src/demos/demo_window.rs
@@ -44,7 +44,7 @@ impl DemoWindow {
             });
 
         CollapsingHeader::new("Layout")
-            .default_open(true)
+            .default_open(false)
             .show(ui, |ui| self.layout.ui(ui));
 
         CollapsingHeader::new("Tree")
@@ -417,19 +417,15 @@ impl LayoutDemo {
 
     pub fn demo_ui(&mut self, ui: &mut Ui) {
         ui.monospace("Example widgets:");
-        for i in 0..9 {
-            match i % 3 {
-                0 => {
-                    ui.label(format!("{} label", i));
-                }
-                1 => {
-                    let mut dummy = false;
-                    ui.checkbox(&mut dummy, format!("{} checkbox", i));
-                }
-                _ => {
-                    let _ = ui.button(format!("{} button", i));
-                }
-            }
+        for _ in 0..3 {
+            ui.label("label");
+        }
+        for _ in 0..3 {
+            let mut dummy = false;
+            ui.checkbox(&mut dummy, "checkbox");
+        }
+        for _ in 0..3 {
+            let _ = ui.button("button");
         }
     }
 }

--- a/egui/src/demos/demo_window.rs
+++ b/egui/src/demos/demo_window.rs
@@ -342,12 +342,12 @@ impl LayoutDemo {
             .show(ui, |ui| {
                 if self.main_wrap {
                     if self.main_dir.is_horizontal() {
-                        ui.allocate_ui_min(
+                        ui.allocate_ui(
                             vec2(ui.available_finite().width(), self.wrap_row_height),
                             |ui| ui.with_layout(self.layout(), |ui| self.demo_ui(ui)),
                         );
                     } else {
-                        ui.allocate_ui_min(
+                        ui.allocate_ui(
                             vec2(self.wrap_column_width, ui.available_finite().height()),
                             |ui| ui.with_layout(self.layout(), |ui| self.demo_ui(ui)),
                         );

--- a/egui/src/demos/demo_window.rs
+++ b/egui/src/demos/demo_window.rs
@@ -323,7 +323,7 @@ impl Default for LayoutDemo {
             cross_align: Align::Min,
             cross_justify: false,
             wrap_column_width: 150.0,
-            wrap_row_height: 40.0,
+            wrap_row_height: 20.0,
         }
     }
 }
@@ -338,7 +338,7 @@ impl LayoutDemo {
     pub fn ui(&mut self, ui: &mut Ui) {
         self.content_ui(ui);
         Resize::default()
-            .default_size([200.0, 100.0])
+            .default_size([300.0, 200.0])
             .show(ui, |ui| {
                 if self.main_wrap {
                     if self.main_dir.is_horizontal() {
@@ -360,10 +360,22 @@ impl LayoutDemo {
     }
 
     pub fn content_ui(&mut self, ui: &mut Ui) {
-        // ui.label(format!("Available space: {:?}", ui.available().size()));
-        if ui.button("Default").clicked {
-            *self = Default::default();
-        }
+        ui.horizontal(|ui| {
+            if ui.button("Top-down").clicked {
+                *self = Default::default();
+            }
+            if ui.button("Top-down, centered and justified").clicked {
+                *self = Default::default();
+                self.cross_align = Align::Center;
+                self.cross_justify = true;
+            }
+            if ui.button("Horizontal wrapped").clicked {
+                *self = Default::default();
+                self.main_dir = Direction::LeftToRight;
+                self.cross_align = Align::Center;
+                self.main_wrap = true;
+            }
+        });
 
         ui.horizontal(|ui| {
             ui.label("Main Direction:");
@@ -400,9 +412,20 @@ impl LayoutDemo {
     }
 
     pub fn demo_ui(&mut self, ui: &mut Ui) {
-        ui.heading("Effect:");
-        for i in 0..7 {
-            let _ = ui.button(format!("Button {}", i));
+        ui.monospace("Example widgets:");
+        for i in 0..9 {
+            match i % 3 {
+                0 => {
+                    ui.label(format!("{} label", i));
+                }
+                1 => {
+                    let mut dummy = false;
+                    ui.checkbox(&mut dummy, format!("{} checkbox", i));
+                }
+                _ => {
+                    let _ = ui.button(format!("{} button", i));
+                }
+            }
         }
     }
 }

--- a/egui/src/demos/demo_window.rs
+++ b/egui/src/demos/demo_window.rs
@@ -265,7 +265,7 @@ impl Painting {
     }
 
     fn content(&mut self, ui: &mut Ui) {
-        let rect = ui.allocate_space(ui.available_finite().size());
+        let rect = ui.allocate_space(ui.available_size_before_wrap_finite());
         let response = ui.interact(rect, ui.id(), Sense::drag());
         let rect = response.rect;
         let clip_rect = ui.clip_rect().intersect(rect); // Make sure we don't paint out of bounds
@@ -343,12 +343,18 @@ impl LayoutDemo {
                 if self.main_wrap {
                     if self.main_dir.is_horizontal() {
                         ui.allocate_ui(
-                            vec2(ui.available_finite().width(), self.wrap_row_height),
+                            vec2(
+                                ui.available_size_before_wrap_finite().x,
+                                self.wrap_row_height,
+                            ),
                             |ui| ui.with_layout(self.layout(), |ui| self.demo_ui(ui)),
                         );
                     } else {
                         ui.allocate_ui(
-                            vec2(self.wrap_column_width, ui.available_finite().height()),
+                            vec2(
+                                self.wrap_column_width,
+                                ui.available_size_before_wrap_finite().y,
+                            ),
                             |ui| ui.with_layout(self.layout(), |ui| self.demo_ui(ui)),
                         );
                     }

--- a/egui/src/demos/demo_window.rs
+++ b/egui/src/demos/demo_window.rs
@@ -44,7 +44,7 @@ impl DemoWindow {
             });
 
         CollapsingHeader::new("Layout")
-            .default_open(false)
+            .default_open(true)
             .show(ui, |ui| self.layout.ui(ui));
 
         CollapsingHeader::new("Tree")
@@ -304,29 +304,25 @@ use crate::layout::*;
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 struct LayoutDemo {
-    dir: Direction,
-    align: Option<Align>, // None == justified
-    reversed: bool,
+    // Identical to contents of `egui::Layout`
+    main_dir: Direction,
+    cross_align: Align,
+    cross_justify: bool,
 }
 
 impl Default for LayoutDemo {
     fn default() -> Self {
         Self {
-            dir: Direction::Vertical,
-            align: Some(Align::Center),
-            reversed: false,
+            main_dir: Direction::TopDown,
+            cross_align: Align::Min,
+            cross_justify: false,
         }
     }
 }
 
 impl LayoutDemo {
     fn layout(&self) -> Layout {
-        let layout = Layout::from_dir_align(self.dir, self.align);
-        if self.reversed {
-            layout.reverse()
-        } else {
-            layout
-        }
+        Layout::from_parts(self.main_dir, self.cross_align, self.cross_justify)
     }
 
     pub fn ui(&mut self, ui: &mut Ui) {
@@ -347,39 +343,24 @@ impl LayoutDemo {
 
         // TODO: enum iter
 
-        for &dir in &[Direction::Horizontal, Direction::Vertical] {
-            if ui
-                .add(RadioButton::new(self.dir == dir, format!("{:?}", dir)))
-                .clicked
-            {
-                self.dir = dir;
-            }
+        for &dir in &[
+            Direction::LeftToRight,
+            Direction::RightToLeft,
+            Direction::TopDown,
+            Direction::BottomUp,
+        ] {
+            ui.radio_value(&mut self.main_dir, dir, format!("{:?}", dir));
         }
-
-        ui.checkbox(&mut self.reversed, "Reversed");
 
         ui.separator();
 
         ui.label("Align:");
-
         for &align in &[Align::Min, Align::Center, Align::Max] {
-            if ui
-                .add(RadioButton::new(
-                    self.align == Some(align),
-                    format!("{:?}", align),
-                ))
-                .clicked
-            {
-                self.align = Some(align);
-            }
+            ui.radio_value(&mut self.cross_align, align, format!("{:?}", align));
         }
-        if ui
-            .add(RadioButton::new(self.align == None, "Justified"))
-            .on_hover_text("Try to fill full width/height (e.g. buttons)")
-            .clicked
-        {
-            self.align = None;
-        }
+
+        ui.checkbox(&mut self.cross_justify, "Justified")
+            .on_hover_text("Try to fill full width/height (e.g. buttons)");
     }
 }
 

--- a/egui/src/demos/demo_windows.rs
+++ b/egui/src/demos/demo_windows.rs
@@ -345,7 +345,7 @@ fn show_menu_bar(ui: &mut Ui, windows: &mut OpenWindows, seconds_since_midnight:
                 (time % 1.0 * 100.0).floor()
             );
 
-            ui.with_layout(Layout::horizontal(Align::Center).reverse(), |ui| {
+            ui.with_layout(Layout::right_to_left(), |ui| {
                 if ui
                     .add(Button::new(time).text_style(TextStyle::Monospace))
                     .clicked

--- a/egui/src/demos/drag_and_drop.rs
+++ b/egui/src/demos/drag_and_drop.rs
@@ -44,7 +44,7 @@ pub fn drop_target<R>(
 
     let margin = Vec2::splat(4.0);
 
-    let outer_rect_bounds = ui.available();
+    let outer_rect_bounds = ui.available_rect_before_wrap();
     let inner_rect = outer_rect_bounds.shrink2(margin);
     let where_to_put_background = ui.painter().add(PaintCmd::Noop);
     let mut content_ui = ui.child_ui(inner_rect, *ui.layout());

--- a/egui/src/demos/fractal_clock.rs
+++ b/egui/src/demos/fractal_clock.rs
@@ -52,8 +52,12 @@ impl FractalClock {
             ui.ctx().request_repaint();
         }
 
-        let painter = Painter::new(ui.ctx().clone(), ui.layer_id(), ui.available_finite());
-        self.fractal_ui(&painter);
+        let painter = Painter::new(
+            ui.ctx().clone(),
+            ui.layer_id(),
+            ui.available_rect_before_wrap_finite(),
+        );
+        self.paint(&painter);
 
         Frame::popup(ui.style())
             .fill(Rgba::luminance_alpha(0.02, 0.5).into())
@@ -97,7 +101,7 @@ impl FractalClock {
         );
     }
 
-    fn fractal_ui(&mut self, painter: &Painter) {
+    fn paint(&mut self, painter: &Painter) {
         let rect = painter.clip_rect();
 
         struct Hand {

--- a/egui/src/demos/widgets.rs
+++ b/egui/src/demos/widgets.rs
@@ -56,8 +56,9 @@ impl Widgets {
                 "This is a multiline tooltip that demonstrates that you can easily add tooltips to any element.\nThis is the second line.\nThis is the third.",
             );
 
-            ui.label("You can mix in other widgets into text, like this button:");
-            let _ = ui.button("button");
+            ui.label("You can mix in other widgets into text, like this");
+            let _ = ui.small_button("button");
+            ui.label(".");
 
             ui.label("There is also (limited) non-ASCII support: Ευρηκα! τ = 2×π")
                 .on_hover_text("The current font supports only a few non-latin characters and Egui does not currently support right-to-left text.");

--- a/egui/src/demos/widgets.rs
+++ b/egui/src/demos/widgets.rs
@@ -55,18 +55,24 @@ impl Widgets {
             ui.add(Label::new("and tooltips.")).on_hover_text(
                 "This is a multiline tooltip that demonstrates that you can easily add tooltips to any element.\nThis is the second line.\nThis is the third.",
             );
-            let tooltip_ui = |ui: &mut Ui| {
-                ui.heading("The name of the tooltip");
-                ui.horizontal(|ui| {
-                    ui.label("This tooltip was created with");
-                    ui.monospace(".on_hover_ui(...)");
-                });
-                let _ = ui.button("A button you can never press");
-            };
-            ui.label("Tooltips can be more than just simple text.").on_hover_ui(tooltip_ui);
+
+            ui.label("You can mix in other widgets into text, like this button:");
+            let _ = ui.button("button");
+
             ui.label("There is also (limited) non-ASCII support: Ευρηκα! τ = 2×π")
                 .on_hover_text("The current font supports only a few non-latin characters and Egui does not currently support right-to-left text.");
         });
+
+        let tooltip_ui = |ui: &mut Ui| {
+            ui.heading("The name of the tooltip");
+            ui.horizontal(|ui| {
+                ui.label("This tooltip was created with");
+                ui.monospace(".on_hover_ui(...)");
+            });
+            let _ = ui.button("A button you can never press");
+        };
+        ui.label("Tooltips can be more than just simple text.")
+            .on_hover_ui(tooltip_ui);
 
         ui.horizontal(|ui| {
             ui.radio_value(&mut self.radio, Enum::First, "First");

--- a/egui/src/demos/widgets.rs
+++ b/egui/src/demos/widgets.rs
@@ -49,6 +49,7 @@ impl Widgets {
         ui.add(__egui_github_link_file_line!());
 
         ui.horizontal_wrapped_for_text(TextStyle::Body, |ui| {
+            ui.label("Long text will wrap, just as you would expect.");
             ui.add(Label::new("Text can have").text_color(srgba(110, 255, 110, 255)));
             ui.add(Label::new("color").text_color(srgba(128, 140, 255, 255)));
             ui.add(Label::new("and tooltips.")).on_hover_text(
@@ -63,7 +64,7 @@ impl Widgets {
                 let _ = ui.button("A button you can never press");
             };
             ui.label("Tooltips can be more than just simple text.").on_hover_ui(tooltip_ui);
-            ui.label("Ευρηκα! τ = 2×π")
+            ui.label("There is also (limited) non-ASCII support: Ευρηκα! τ = 2×π")
                 .on_hover_text("The current font supports only a few non-latin characters and Egui does not currently support right-to-left text.");
         });
 

--- a/egui/src/demos/widgets.rs
+++ b/egui/src/demos/widgets.rs
@@ -46,28 +46,26 @@ impl Default for Widgets {
 
 impl Widgets {
     pub fn ui(&mut self, ui: &mut Ui) {
-        ui.add(crate::__egui_github_link_file_line!());
+        ui.add(__egui_github_link_file_line!());
 
-        ui.horizontal(|ui| {
-            ui.style_mut().spacing.item_spacing.x = 0.0;
-            ui.add(Label::new("Text can have ").text_color(srgba(110, 255, 110, 255)));
-            ui.add(Label::new("color ").text_color(srgba(128, 140, 255, 255)));
+        ui.horizontal_wrapped_for_text(TextStyle::Body, |ui| {
+            ui.add(Label::new("Text can have").text_color(srgba(110, 255, 110, 255)));
+            ui.add(Label::new("color").text_color(srgba(128, 140, 255, 255)));
             ui.add(Label::new("and tooltips.")).on_hover_text(
                 "This is a multiline tooltip that demonstrates that you can easily add tooltips to any element.\nThis is the second line.\nThis is the third.",
             );
-        });
-        ui.label("Tooltips can be more than just simple text.")
-            .on_hover_ui(|ui| {
+            let tooltip_ui = |ui: &mut Ui| {
                 ui.heading("The name of the tooltip");
                 ui.horizontal(|ui| {
                     ui.label("This tooltip was created with");
                     ui.monospace(".on_hover_ui(...)");
                 });
                 let _ = ui.button("A button you can never press");
-            });
-
-        ui.label("Ευρηκα! τ = 2×π")
-            .on_hover_text("The current font supports only a few non-latin characters and Egui does not currently support right-to-left text.");
+            };
+            ui.label("Tooltips can be more than just simple text.").on_hover_ui(tooltip_ui);
+            ui.label("Ευρηκα! τ = 2×π")
+                .on_hover_text("The current font supports only a few non-latin characters and Egui does not currently support right-to-left text.");
+        });
 
         ui.horizontal(|ui| {
             ui.radio_value(&mut self.radio, Enum::First, "First");

--- a/egui/src/introspection.rs
+++ b/egui/src/introspection.rs
@@ -16,8 +16,8 @@ impl Texture {
             return;
         }
         let mut size = vec2(self.width as f32, self.height as f32);
-        if size.x > ui.available().width() {
-            size *= ui.available().width() / size.x;
+        if size.x > ui.available_width() {
+            size *= ui.available_width() / size.x;
         }
         let rect = ui.allocate_space(size);
         let mut triangles = Triangles::default();

--- a/egui/src/layout.rs
+++ b/egui/src/layout.rs
@@ -303,25 +303,6 @@ impl Layout {
         rect
     }
 
-    /// Advance the cursor by this many points.
-    pub fn advance_cursor(self, region: &mut Region, amount: f32) {
-        match self.main_dir {
-            Direction::LeftToRight => region.cursor.x += amount,
-            Direction::RightToLeft => region.cursor.x -= amount,
-            Direction::TopDown => region.cursor.y += amount,
-            Direction::BottomUp => region.cursor.y -= amount,
-        }
-    }
-
-    /// Advance the cursor by this spacing
-    pub fn advance_cursor2(self, region: &mut Region, amount: Vec2) {
-        if self.main_dir.is_horizontal() {
-            self.advance_cursor(region, amount.x)
-        } else {
-            self.advance_cursor(region, amount.y)
-        }
-    }
-
     /// Reserve this much space and move the cursor.
     /// Returns where to put the widget.
     ///
@@ -374,6 +355,36 @@ impl Layout {
         };
 
         Rect::from_min_size(child_pos, child_size)
+    }
+
+    /// Advance the cursor by this many points.
+    pub fn advance_cursor(self, region: &mut Region, amount: f32) {
+        match self.main_dir {
+            Direction::LeftToRight => region.cursor.x += amount,
+            Direction::RightToLeft => region.cursor.x -= amount,
+            Direction::TopDown => region.cursor.y += amount,
+            Direction::BottomUp => region.cursor.y -= amount,
+        }
+    }
+
+    /// Advance the cursor by this spacing
+    pub fn advance_cursor2(self, region: &mut Region, amount: Vec2) {
+        if self.main_dir.is_horizontal() {
+            self.advance_cursor(region, amount.x)
+        } else {
+            self.advance_cursor(region, amount.y)
+        }
+    }
+
+    /// Advance cursor after a widget was added to a specific rectangle.
+    pub fn advance_after_rect(self, region: &mut Region, rect: Rect, item_spacing: Vec2) {
+        match self.main_dir {
+            Direction::LeftToRight => region.cursor.x = rect.right() + item_spacing.x,
+            Direction::RightToLeft => region.cursor.x = rect.left() - item_spacing.x,
+            Direction::TopDown => region.cursor.y = rect.bottom() + item_spacing.y,
+            Direction::BottomUp => region.cursor.y = rect.top() - item_spacing.y,
+        }
+        region.expand_to_include_rect(rect);
     }
 }
 

--- a/egui/src/layout.rs
+++ b/egui/src/layout.rs
@@ -264,27 +264,6 @@ impl Layout {
         }
     }
 
-    pub fn rect_from_cursor_size(self, region: &Region, size: Vec2) -> Rect {
-        let mut rect = Rect::from_min_size(region.cursor, size);
-
-        match self.dir {
-            Direction::Horizontal => {
-                if self.reversed {
-                    rect.min.x = region.cursor.x - size.x;
-                    rect.max.x = rect.min.x - size.x
-                }
-            }
-            Direction::Vertical => {
-                if self.reversed {
-                    rect.min.y = region.cursor.y - size.y;
-                    rect.max.y = rect.min.y - size.y
-                }
-            }
-        }
-
-        rect
-    }
-
     /// Reserve this much space and move the cursor.
     /// Returns where to put the widget.
     ///
@@ -294,10 +273,10 @@ impl Layout {
     /// If you want to fill the space, ask about `available().size()` and use that.
     ///
     /// You may get MORE space than you asked for, for instance
-    /// for `Justified` aligned layouts, like in menus.
+    /// for justified layouts, like in menus.
     ///
     /// You may get LESS space than you asked for if the current layout won't fit what you asked for.
-    pub fn allocate_space(self, region: &mut Region, minimum_child_size: Vec2) -> Rect {
+    pub fn next_space(self, region: &Region, minimum_child_size: Vec2) -> Rect {
         let available_size = self.available_finite(region).size();
         let available_size = available_size.at_least(minimum_child_size);
 
@@ -341,11 +320,9 @@ impl Layout {
                 Direction::Horizontal => child_pos + vec2(-child_size.x, 0.0),
                 Direction::Vertical => child_pos + vec2(0.0, -child_size.y),
             };
-            region.cursor -= cursor_change; // TODO: separate call
             Rect::from_min_size(child_pos, child_size)
         } else {
             let child_pos = region.cursor + child_move;
-            region.cursor += cursor_change; // TODO: separate call
             Rect::from_min_size(child_pos, child_size)
         }
     }

--- a/egui/src/layout.rs
+++ b/egui/src/layout.rs
@@ -290,9 +290,20 @@ impl Layout {
         }
     }
 
-    // TODO: clarify if it is before or after wrap
-    pub(crate) fn available(&self, region: &Region) -> Rect {
+    pub(crate) fn available_rect_before_wrap(&self, region: &Region) -> Rect {
         self.available_from_cursor_max_rect(region.cursor, region.max_rect)
+    }
+
+    pub(crate) fn available_size_before_wrap(&self, region: &Region) -> Vec2 {
+        self.available_rect_before_wrap(region).size()
+    }
+
+    pub(crate) fn available_rect_before_wrap_finite(&self, region: &Region) -> Rect {
+        self.available_from_cursor_max_rect(region.cursor, region.max_rect_finite())
+    }
+
+    pub(crate) fn available_size_before_wrap_finite(&self, region: &Region) -> Vec2 {
+        self.available_rect_before_wrap_finite(region).size()
     }
 
     /// Amount of space available for a widget.
@@ -308,17 +319,6 @@ impl Layout {
             self.available_from_cursor_max_rect(r.cursor, r.max_rect)
                 .size()
         }
-    }
-
-    /// In case of a wrapping layout, how much space is left on this row/column?
-    pub fn available_size_before_wrap(&self, region: &Region) -> Vec2 {
-        self.available_from_cursor_max_rect(region.cursor, region.max_rect)
-            .size()
-    }
-
-    // TODO
-    pub fn available_finite(&self, region: &Region) -> Rect {
-        self.available_from_cursor_max_rect(region.cursor, region.max_rect_finite())
     }
 
     /// Given the cursor in the region, how much space is available
@@ -398,7 +398,7 @@ impl Layout {
             }
         }
 
-        let available_size = self.available_finite(region).size();
+        let available_size = self.available_size_before_wrap_finite(region);
         if self.main_dir.is_horizontal() {
             // Fill full height
             child_size.y = child_size.y.max(available_size.y);

--- a/egui/src/layout.rs
+++ b/egui/src/layout.rs
@@ -230,18 +230,22 @@ impl Layout {
             || self.main_dir.is_vertical() && self.cross_align == Align::Max
     }
 
-    pub fn horizontal_align(self) -> Align {
+    fn horizontal_align(self) -> Align {
         match self.main_dir {
-            Direction::LeftToRight => Align::left(),
-            Direction::RightToLeft => Align::right(),
+            // Direction::LeftToRight => Align::left(),
+            // Direction::RightToLeft => Align::right(),
+            Direction::LeftToRight | Direction::RightToLeft => Align::Center, // looks better to e.g. center text within a button
+
             Direction::TopDown | Direction::BottomUp => self.cross_align,
         }
     }
 
-    pub fn vertical_align(self) -> Align {
+    fn vertical_align(self) -> Align {
         match self.main_dir {
-            Direction::TopDown => Align::top(),
-            Direction::BottomUp => Align::bottom(),
+            // Direction::TopDown => Align::top(),
+            // Direction::BottomUp => Align::bottom(),
+            Direction::TopDown | Direction::BottomUp => Align::Center, // looks better to e.g. center text within a button
+
             Direction::LeftToRight | Direction::RightToLeft => self.cross_align,
         }
     }

--- a/egui/src/layout.rs
+++ b/egui/src/layout.rs
@@ -209,6 +209,10 @@ impl Layout {
         self.main_dir
     }
 
+    pub fn main_wrap(self) -> bool {
+        self.main_wrap
+    }
+
     pub fn cross_align(self) -> Align {
         self.cross_align
     }
@@ -306,8 +310,10 @@ impl Layout {
         }
     }
 
-    fn available_size_before_wrap(&self, region: &Region) -> Rect {
+    /// In case of a wrapping layout, how much space is left on this row/column?
+    pub fn available_size_before_wrap(&self, region: &Region) -> Vec2 {
         self.available_from_cursor_max_rect(region.cursor, region.max_rect)
+            .size()
     }
 
     // TODO
@@ -351,7 +357,7 @@ impl Layout {
         let mut cursor = region.cursor;
 
         if self.main_wrap {
-            let available_size = self.available_size_before_wrap(region).size();
+            let available_size = self.available_size_before_wrap(region);
             match self.main_dir {
                 Direction::LeftToRight => {
                     if available_size.x < child_size.x && region.max_rect.left() < cursor.x {

--- a/egui/src/layout.rs
+++ b/egui/src/layout.rs
@@ -465,7 +465,6 @@ impl Layout {
             Direction::TopDown => pos2(rect.left(), rect.bottom() + item_spacing.y),
             Direction::BottomUp => pos2(rect.left(), rect.top() - item_spacing.y),
         };
-        region.expand_to_include_rect(rect);
     }
 }
 

--- a/egui/src/layout.rs
+++ b/egui/src/layout.rs
@@ -462,12 +462,20 @@ impl Layout {
     }
 
     /// Advance cursor after a widget was added to a specific rectangle.
-    pub fn advance_after_outer_rect(self, region: &mut Region, rect: Rect, item_spacing: Vec2) {
+    /// `outer_rect` is a hack needed because the Vec2 cursor is not quite sufficient to keep track
+    /// of what is happening when we are doing wrapping layouts.
+    pub fn advance_after_outer_rect(
+        self,
+        region: &mut Region,
+        outer_rect: Rect,
+        inner_rect: Rect,
+        item_spacing: Vec2,
+    ) {
         region.cursor = match self.main_dir {
-            Direction::LeftToRight => pos2(rect.right() + item_spacing.x, rect.top()),
-            Direction::RightToLeft => pos2(rect.left() - item_spacing.x, rect.top()),
-            Direction::TopDown => pos2(rect.left(), rect.bottom() + item_spacing.y),
-            Direction::BottomUp => pos2(rect.left(), rect.top() - item_spacing.y),
+            Direction::LeftToRight => pos2(inner_rect.right() + item_spacing.x, outer_rect.top()),
+            Direction::RightToLeft => pos2(inner_rect.left() - item_spacing.x, outer_rect.top()),
+            Direction::TopDown => pos2(outer_rect.left(), inner_rect.bottom() + item_spacing.y),
+            Direction::BottomUp => pos2(outer_rect.left(), inner_rect.top() - item_spacing.y),
         };
     }
 }

--- a/egui/src/layout.rs
+++ b/egui/src/layout.rs
@@ -216,6 +216,37 @@ impl Layout {
             || self.main_dir.is_vertical() && self.cross_align == Align::Max
     }
 
+    pub fn horizontal_align(self) -> Align {
+        match self.main_dir {
+            Direction::LeftToRight => Align::left(),
+            Direction::RightToLeft => Align::right(),
+            Direction::TopDown | Direction::BottomUp => self.cross_align,
+        }
+    }
+
+    pub fn vertical_align(self) -> Align {
+        match self.main_dir {
+            Direction::TopDown => Align::top(),
+            Direction::BottomUp => Align::bottom(),
+            Direction::LeftToRight | Direction::RightToLeft => self.cross_align,
+        }
+    }
+
+    pub fn align_size_within_rect(&self, size: Vec2, outer: Rect) -> Rect {
+        let x = match self.horizontal_align() {
+            Align::Min => outer.left(),
+            Align::Center => outer.center().x - size.x / 2.0,
+            Align::Max => outer.right() - size.x,
+        };
+        let y = match self.vertical_align() {
+            Align::Min => outer.top(),
+            Align::Center => outer.center().y - size.y / 2.0,
+            Align::Max => outer.bottom() - size.y,
+        };
+
+        Rect::from_min_size(Pos2::new(x, y), size)
+    }
+
     // ------------------------------------------------------------------------
 
     fn initial_cursor(self, max_rect: Rect) -> Pos2 {
@@ -303,6 +334,7 @@ impl Layout {
     /// for justified layouts, like in menus.
     ///
     /// You may get LESS space than you asked for if the current layout won't fit what you asked for.
+    #[allow(clippy::collapsible_if)]
     pub fn next_space(self, region: &Region, minimum_child_size: Vec2) -> Rect {
         let available_size = self.available_finite(region).size();
         let available_size = available_size.at_least(minimum_child_size);

--- a/egui/src/menu.rs
+++ b/egui/src/menu.rs
@@ -111,7 +111,10 @@ fn menu_impl<'c>(
                 style.visuals.widgets.inactive.bg_fill = TRANSPARENT;
                 style.visuals.widgets.inactive.bg_stroke = Stroke::none();
                 ui.set_style(style);
-                ui.with_layout(Layout::justified(Direction::Vertical), add_contents);
+                ui.with_layout(
+                    Layout::top_down(Align::left()).with_cross_justify(true),
+                    add_contents,
+                );
             })
         });
 

--- a/egui/src/menu.rs
+++ b/egui/src/menu.rs
@@ -54,7 +54,7 @@ pub fn bar<R>(ui: &mut Ui, add_contents: impl FnOnce(&mut Ui) -> R) -> (R, Respo
 
         // Take full width and fixed height:
         let height = ui.style().spacing.interact_size.y;
-        ui.set_min_size(vec2(ui.available().width(), height));
+        ui.set_min_size(vec2(ui.available_width(), height));
 
         add_contents(ui)
     })

--- a/egui/src/paint/font.rs
+++ b/egui/src/paint/font.rs
@@ -119,6 +119,10 @@ impl Font {
         self.glyph_infos.read().get(&c).and_then(|gi| gi.uv_rect)
     }
 
+    pub fn glyph_width(&self, c: char) -> f32 {
+        self.glyph_info(c).advance_width
+    }
+
     /// `\n` will (intentionally) show up as '?' (`REPLACEMENT_CHAR`)
     fn glyph_info(&self, c: char) -> GlyphInfo {
         {

--- a/egui/src/paint/galley.rs
+++ b/egui/src/paint/galley.rs
@@ -196,6 +196,13 @@ impl Row {
         self.y_max - self.y_min
     }
 
+    pub fn rect(&self) -> Rect {
+        Rect::from_min_max(
+            pos2(self.min_x(), self.y_min),
+            pos2(self.max_x(), self.y_max),
+        )
+    }
+
     /// Closest char at the desired x coordinate.
     /// Returns something in the range `[0, char_count_excluding_newline()]`.
     pub fn char_at(&self, desired_x: f32) -> usize {

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -323,6 +323,11 @@ impl Ui {
         self.available_size().x
     }
 
+    /// In case of a wrapping layout, how much space is left on this row/column?
+    pub fn available_width_before_wrap(&self) -> f32 {
+        self.layout.available_size_before_wrap(&self.region).x
+    }
+
     // TODO: clarify if this is before or after wrap
     pub fn available(&self) -> Rect {
         self.layout.available(&self.region)
@@ -462,6 +467,17 @@ impl Ui {
 
         self.next_auto_id = self.next_auto_id.wrapping_add(1);
         inner_child_rect
+    }
+
+    pub(crate) fn advance_cursor_after_rect(&mut self, rect: Rect) {
+        let item_spacing = self.style().spacing.item_spacing;
+        self.layout
+            .advance_after_outer_rect(&mut self.region, rect, rect, item_spacing);
+        self.region.expand_to_include_rect(rect);
+    }
+
+    pub(crate) fn cursor(&self) -> Pos2 {
+        self.region.cursor
     }
 
     /// Allocated the given space and then adds content to that space.

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -439,11 +439,10 @@ impl Ui {
     /// Returns where to put the widget.
     fn allocate_space_impl(&mut self, desired_size: Vec2) -> Rect {
         let child_rect = self.layout.next_space(&self.region, desired_size);
-        self.layout
-            .advance_cursor2(&mut self.region, child_rect.size());
+
         let item_spacing = self.style().spacing.item_spacing;
-        self.layout.advance_cursor2(&mut self.region, item_spacing);
-        self.region.expand_to_include_rect(child_rect);
+        self.layout
+            .advance_after_rect(&mut self.region, child_rect, item_spacing);
 
         self.next_auto_id = self.next_auto_id.wrapping_add(1);
         child_rect
@@ -463,11 +462,9 @@ impl Ui {
         let ret = add_contents(&mut child_ui);
         let child_rect = child_ui.region.max_rect;
 
-        self.layout
-            .advance_cursor2(&mut self.region, child_rect.size());
         let item_spacing = self.style().spacing.item_spacing;
-        self.layout.advance_cursor2(&mut self.region, item_spacing);
-        self.region.expand_to_include_rect(child_rect);
+        self.layout
+            .advance_after_rect(&mut self.region, child_rect, item_spacing);
 
         let response = self.interact_hover(child_rect);
         (ret, response)
@@ -477,7 +474,7 @@ impl Ui {
     /// If the contents overflow, more space will be allocated.
     /// When finished, the amount of space actually used (`min_rect`) will be allocated.
     /// So you can request a lot of space and then use less.
-    fn allocate_ui_min<R>(
+    pub fn allocate_ui_min<R>(
         &mut self,
         initial_size: Vec2,
         add_contents: impl FnOnce(&mut Self) -> R,
@@ -487,11 +484,9 @@ impl Ui {
         let ret = add_contents(&mut child_ui);
         let child_rect = child_ui.region.min_rect;
 
-        self.layout
-            .advance_cursor2(&mut self.region, child_rect.size());
         let item_spacing = self.style().spacing.item_spacing;
-        self.layout.advance_cursor2(&mut self.region, item_spacing);
-        self.region.expand_to_include_rect(child_rect);
+        self.layout
+            .advance_after_rect(&mut self.region, child_rect, item_spacing);
 
         let response = self.interact_hover(child_rect);
         (ret, response)

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -454,6 +454,7 @@ impl Ui {
 
         self.layout
             .advance_after_outer_rect(&mut self.region, outer_child_rect, item_spacing);
+        self.region.expand_to_include_rect(inner_child_rect);
 
         self.next_auto_id = self.next_auto_id.wrapping_add(1);
         inner_child_rect
@@ -483,6 +484,7 @@ impl Ui {
             outer_child_rect.union(final_child_rect),
             item_spacing,
         );
+        self.region.expand_to_include_rect(final_child_rect);
 
         let response = self.interact_hover(final_child_rect);
         (ret, response)
@@ -512,6 +514,7 @@ impl Ui {
             outer_child_rect.union(final_child_rect),
             item_spacing,
         );
+        self.region.expand_to_include_rect(final_child_rect);
 
         let response = self.interact_hover(final_child_rect);
         (ret, response)
@@ -852,6 +855,7 @@ impl Ui {
         let item_spacing = self.style().spacing.item_spacing;
         self.layout
             .advance_after_outer_rect(&mut self.region, rect, item_spacing);
+        self.region.expand_to_include_rect(rect);
         (ret, self.interact_hover(rect))
     }
 

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -558,10 +558,22 @@ impl Ui {
         self.add(TextEdit::multiline(text))
     }
 
+    /// Usage: `if ui.button("Click me").clicked { ... }`
+    ///
     /// Shortcut for `add(Button::new(text))`
     #[must_use = "You should check if the user clicked this with `if ui.button(...).clicked { ... } "]
     pub fn button(&mut self, text: impl Into<String>) -> Response {
         self.add(Button::new(text))
+    }
+
+    /// A button as small as normal body text.
+    ///
+    /// Usage: `if ui.small_button("Click me").clicked { ... }`
+    ///
+    /// Shortcut for `add(Button::new(text).small())`
+    #[must_use = "You should check if the user clicked this with `if ui.small_button(...).clicked { ... } "]
+    pub fn small_button(&mut self, text: impl Into<String>) -> Response {
+        self.add(Button::new(text).small())
     }
 
     /// Show a checkbox.

--- a/egui/src/widgets/mod.rs
+++ b/egui/src/widgets/mod.rs
@@ -385,6 +385,7 @@ impl<'a> Widget for Checkbox<'a> {
         desired_size = desired_size.at_least(spacing.interact_size);
         desired_size.y = desired_size.y.max(icon_width);
         let rect = ui.allocate_space(desired_size);
+        let rect = ui.layout().align_size_within_rect(desired_size, rect);
 
         let id = ui.make_position_id();
         let response = ui.interact(rect, id, Sense::click());
@@ -473,6 +474,8 @@ impl Widget for RadioButton {
         desired_size = desired_size.at_least(ui.style().spacing.interact_size);
         desired_size.y = desired_size.y.max(icon_width);
         let rect = ui.allocate_space(desired_size);
+        let rect = ui.layout().align_size_within_rect(desired_size, rect);
+
         let id = ui.make_position_id();
         let response = ui.interact(rect, id, Sense::click());
 

--- a/egui/src/widgets/mod.rs
+++ b/egui/src/widgets/mod.rs
@@ -79,7 +79,7 @@ impl Label {
     }
 
     pub fn layout(&self, ui: &Ui) -> Galley {
-        let max_width = ui.available().width();
+        let max_width = ui.available_width();
         // Prevent word-wrapping after a single letter, and other silly shit:
         // TODO: general "don't force labels and similar to wrap so early"
         // TODO: max_width = max_width.at_least(ui.spacing.first_wrap_width);
@@ -198,7 +198,7 @@ impl Widget for Hyperlink {
         let color = color::LIGHT_BLUE;
         let text_style = text_style.unwrap_or_else(|| ui.style().body_text_style);
         let font = &ui.fonts()[text_style];
-        let galley = font.layout_multiline(text, ui.available().width());
+        let galley = font.layout_multiline(text, ui.available_width());
         let rect = ui.allocate_space(galley.size);
 
         let id = ui.make_position_id();
@@ -307,7 +307,7 @@ impl Widget for Button {
         let button_padding = ui.style().spacing.button_padding;
 
         let font = &ui.fonts()[text_style];
-        let galley = font.layout_multiline(text, ui.available().width());
+        let galley = font.layout_multiline(text, ui.available_width());
         let mut desired_size = galley.size + 2.0 * button_padding;
         desired_size = desired_size.at_least(ui.style().spacing.interact_size);
         let rect = ui.allocate_space(desired_size);
@@ -379,7 +379,7 @@ impl<'a> Widget for Checkbox<'a> {
         let total_extra = button_padding + vec2(icon_width + icon_spacing, 0.0) + button_padding;
 
         let galley = font.layout_single_line(text);
-        // let galley = font.layout_multiline(text, ui.available().width() - total_extra.x);
+        // let galley = font.layout_multiline(text, ui.available_width() - total_extra.x);
 
         let mut desired_size = total_extra + galley.size;
         desired_size = desired_size.at_least(spacing.interact_size);
@@ -467,7 +467,7 @@ impl Widget for RadioButton {
         let button_padding = ui.style().spacing.button_padding;
         let total_extra = button_padding + vec2(icon_width + icon_spacing, 0.0) + button_padding;
 
-        let galley = font.layout_multiline(text, ui.available().width() - total_extra.x);
+        let galley = font.layout_multiline(text, ui.available_width() - total_extra.x);
 
         let mut desired_size = total_extra + galley.size;
         desired_size = desired_size.at_least(ui.style().spacing.interact_size);
@@ -543,7 +543,7 @@ impl Widget for SelectableLabel {
         let button_padding = ui.style().spacing.button_padding;
         let total_extra = button_padding + button_padding;
 
-        let galley = font.layout_multiline(text, ui.available().width() - total_extra.x);
+        let galley = font.layout_multiline(text, ui.available_width() - total_extra.x);
 
         let mut desired_size = total_extra + galley.size;
         desired_size = desired_size.at_least(ui.style().spacing.interact_size);

--- a/egui/src/widgets/mod.rs
+++ b/egui/src/widgets/mod.rs
@@ -130,7 +130,7 @@ impl Widget for Label {
             // then continue on the line below! This will take some extra work:
 
             let max_width = ui.available_width();
-            let first_row_indentation = max_width - ui.available_width_before_wrap();
+            let first_row_indentation = max_width - ui.available_size_before_wrap().x;
 
             let text_style = self.text_style_or_default(ui.style());
             let font = &ui.fonts()[text_style];
@@ -664,7 +664,7 @@ impl Widget for Separator {
     fn ui(self, ui: &mut Ui) -> Response {
         let Separator { spacing } = self;
 
-        let available_space = ui.available_finite().size();
+        let available_space = ui.available_size_before_wrap_finite();
 
         let (points, rect) = if ui.layout().main_dir().is_horizontal() {
             let rect = ui.allocate_space(vec2(spacing, available_space.y));

--- a/egui/src/widgets/mod.rs
+++ b/egui/src/widgets/mod.rs
@@ -287,6 +287,7 @@ pub struct Button {
     /// None means default for interact
     fill: Option<Srgba>,
     sense: Sense,
+    small: bool,
 }
 
 impl Button {
@@ -297,6 +298,7 @@ impl Button {
             text_style: TextStyle::Button,
             fill: Default::default(),
             sense: Sense::click(),
+            small: false,
         }
     }
 
@@ -317,6 +319,13 @@ impl Button {
 
     pub fn fill(mut self, fill: Option<Srgba>) -> Self {
         self.fill = fill;
+        self
+    }
+
+    /// Make this a small button, suitable for embedding into text.
+    pub fn small(mut self) -> Self {
+        self.text_style = TextStyle::Body;
+        self.small = true;
         self
     }
 
@@ -345,14 +354,20 @@ impl Widget for Button {
             text_style,
             fill,
             sense,
+            small,
         } = self;
 
-        let button_padding = ui.style().spacing.button_padding;
+        let mut button_padding = ui.style().spacing.button_padding;
+        if small {
+            button_padding.y = 0.0;
+        }
 
         let font = &ui.fonts()[text_style];
         let galley = font.layout_multiline(text, ui.available_width());
         let mut desired_size = galley.size + 2.0 * button_padding;
-        desired_size = desired_size.at_least(ui.style().spacing.interact_size);
+        if !small {
+            desired_size = desired_size.at_least(ui.style().spacing.interact_size);
+        }
         let rect = ui.allocate_space(desired_size);
 
         let id = ui.make_position_id();

--- a/egui/src/widgets/mod.rs
+++ b/egui/src/widgets/mod.rs
@@ -6,7 +6,7 @@
 
 #![allow(clippy::new_without_default)]
 
-use crate::{layout::Direction, *};
+use crate::*;
 
 pub mod color_picker;
 mod drag_value;
@@ -606,27 +606,24 @@ impl Widget for Separator {
 
         let available_space = ui.available_finite().size();
 
-        let (points, rect) = match ui.layout().dir() {
-            Direction::Horizontal => {
-                let rect = ui.allocate_space(vec2(spacing, available_space.y));
-                (
-                    [
-                        pos2(rect.center().x, rect.top()),
-                        pos2(rect.center().x, rect.bottom()),
-                    ],
-                    rect,
-                )
-            }
-            Direction::Vertical => {
-                let rect = ui.allocate_space(vec2(available_space.x, spacing));
-                (
-                    [
-                        pos2(rect.left(), rect.center().y),
-                        pos2(rect.right(), rect.center().y),
-                    ],
-                    rect,
-                )
-            }
+        let (points, rect) = if ui.layout().main_dir().is_horizontal() {
+            let rect = ui.allocate_space(vec2(spacing, available_space.y));
+            (
+                [
+                    pos2(rect.center().x, rect.top()),
+                    pos2(rect.center().x, rect.bottom()),
+                ],
+                rect,
+            )
+        } else {
+            let rect = ui.allocate_space(vec2(available_space.x, spacing));
+            (
+                [
+                    pos2(rect.left(), rect.center().y),
+                    pos2(rect.right(), rect.center().y),
+                ],
+                rect,
+            )
         };
         let stroke = ui.style().visuals.widgets.noninteractive.bg_stroke;
         ui.painter().line_segment(points, stroke);

--- a/egui/src/widgets/mod.rs
+++ b/egui/src/widgets/mod.rs
@@ -127,6 +127,7 @@ impl Widget for Label {
     fn ui(self, ui: &mut Ui) -> Response {
         let galley = self.layout(ui);
         let rect = ui.allocate_space(galley.size);
+        let rect = ui.layout().align_size_within_rect(galley.size, rect);
         self.paint_galley(ui, rect.min, galley);
         ui.interact_hover(rect)
     }
@@ -314,11 +315,10 @@ impl Widget for Button {
         let id = ui.make_position_id();
         let response = ui.interact(rect, id, sense);
         let visuals = ui.style().interact(&response);
-        // let text_cursor = response.rect.center() - 0.5 * galley.size; // centered-centered (looks bad for justified drop-down menus
-        let text_cursor = pos2(
-            response.rect.left() + button_padding.x,
-            response.rect.center().y - 0.5 * galley.size.y,
-        ); // left-centered
+        let text_cursor = ui
+            .layout()
+            .align_size_within_rect(galley.size, response.rect.shrink2(button_padding))
+            .min;
         let fill = fill.unwrap_or(visuals.bg_fill);
         ui.painter().rect(
             response.rect,
@@ -473,7 +473,6 @@ impl Widget for RadioButton {
         desired_size = desired_size.at_least(ui.style().spacing.interact_size);
         desired_size.y = desired_size.y.max(icon_width);
         let rect = ui.allocate_space(desired_size);
-
         let id = ui.make_position_id();
         let response = ui.interact(rect, id, Sense::click());
 

--- a/egui/src/widgets/text_edit.rs
+++ b/egui/src/widgets/text_edit.rs
@@ -228,7 +228,7 @@ impl<'t> Widget for TextEdit<'t> {
         let text_style = text_style.unwrap_or_else(|| ui.style().body_text_style);
         let font = &ui.fonts()[text_style];
         let line_spacing = font.row_height();
-        let available_width = ui.available().width();
+        let available_width = ui.available_width();
         let mut galley = if multiline {
             font.layout_multiline(text.clone(), available_width)
         } else {


### PR DESCRIPTION
This implements wrapping layouts. In particular, `ui.horizontal_wrapping(|ui| ...)` is a new way to arrange widgets on a horizontal row and then wrap at some max width. Text will also wrap at the same width. This allows you to use mix text of different fonts and colors with buttons and other widgets:

![wrapping](https://user-images.githubusercontent.com/1148717/101688664-9ffd7900-3a6c-11eb-96f6-6890c62c0473.gif)

This was quite tricky to get right, but worth the added complexity.