### PR TITLE
actually take path for `FileStorage::from_path`

### DIFF
--- a/demo_glium/src/main.rs
+++ b/demo_glium/src/main.rs
@@ -6,7 +6,7 @@ fn main() {
     let title = "Egui glium demo";
 
     // Persist app state to file:
-    let storage = egui_glium::storage::FileStorage::from_path(".egui_demo_glium.json".into());
+    let storage = egui_glium::storage::FileStorage::from_path(".egui_demo_glium.json");
 
     // Alternative: store nowhere
     // let storage = egui::app::DummyStorage::default();

--- a/egui_glium/CHANGELOG.md
+++ b/egui_glium/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+
+* FileStorage::from_path now takes `Into<Path>` instead of `String`
+
 ## 0.4.0 - 2020-11-28
 
 Started changelog. Features:

--- a/egui_glium/src/storage.rs
+++ b/egui_glium/src/storage.rs
@@ -1,17 +1,21 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 // ----------------------------------------------------------------------------
 
 /// A key-value store backed by a JSON file on disk.
 /// Used to restore egui state, glium window position/size and app state.
 pub struct FileStorage {
-    path: String,
+    path: PathBuf,
     kv: HashMap<String, String>,
     dirty: bool,
 }
 
 impl FileStorage {
-    pub fn from_path(path: String) -> Self {
+    pub fn from_path(path: impl Into<PathBuf>) -> Self {
+        let path: PathBuf = path.into();
         Self {
             kv: read_json(&path).unwrap_or_default(),
             path,
@@ -42,7 +46,7 @@ impl egui::app::Storage for FileStorage {
 
 // ----------------------------------------------------------------------------
 
-pub fn read_json<T>(memory_json_path: impl AsRef<std::path::Path>) -> Option<T>
+pub fn read_json<T>(memory_json_path: impl AsRef<Path>) -> Option<T>
 where
     T: serde::de::DeserializeOwned,
 {

--- a/example_glium/.gitignore
+++ b/example_glium/.gitignore
@@ -1,0 +1,1 @@
+.egui_example_glium.json

--- a/example_glium/src/main.rs
+++ b/example_glium/src/main.rs
@@ -10,7 +10,7 @@ fn main() {
     let title = "My Egui Window";
 
     // Persist app state to file:
-    let storage = egui_glium::storage::FileStorage::from_path(".egui_example_glium.json".into());
+    let storage = egui_glium::storage::FileStorage::from_path(".egui_example_glium.json");
 
     // Alternative: store nowhere
     // let storage = egui::app::DummyStorage::default();


### PR DESCRIPTION
Otherwise; if one has a userland pathbuf an unsafe conversion back to String has to be made:

```rust
let mut user_config_directory = dirs::config()?;
user_config_directory.push("foo");
user_config_directory.push("bar.txt");

let egui_filepath = user_config_directory.to_str()?.to_owned(); // fallible but both sides want to use a path.
FileStorage::from_path(egui_filepath);
```

Tests (`cargo test`) unfortunately seem to be broken on main already; but example_glium works as expected with the removal of `.into()` below.
