### PR TITLE
Allow user to check for Key::Space

### DIFF
--- a/egui/src/input.rs
+++ b/egui/src/input.rs
@@ -201,6 +201,7 @@ pub enum Key {
     Delete,
     End,
     Enter,
+    Space,
     Escape,
     Home,
     Insert,

--- a/egui_glium/src/lib.rs
+++ b/egui_glium/src/lib.rs
@@ -171,6 +171,7 @@ pub fn translate_virtual_key_code(key: VirtualKeyCode) -> Option<egui::Key> {
         Back => Key::Backspace,
         Return => Key::Enter,
         Tab => Key::Tab,
+        Space => Key::Space,
 
         A => Key::A,
         K => Key::K,

--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -279,6 +279,7 @@ pub fn translate_key(key: &str) -> Option<egui::Key> {
         "Delete" => Some(egui::Key::Delete),
         "End" => Some(egui::Key::End),
         "Enter" => Some(egui::Key::Enter),
+        "Space" => Some(egui::Key::Space),
         "Esc" | "Escape" => Some(egui::Key::Escape),
         "Help" | "Insert" => Some(egui::Key::Insert),
         "Home" => Some(egui::Key::Home),


### PR DESCRIPTION
This is part of #31 to allow a user (or internally) to check for `Key::Space` to press on widgets to toggle on/off/press/etc. I didn't want to do everything in one large PR as this one may be useful otherwise as well.