### PR TITLE
Feature: ComboBox now shows scrollbars with scrollable content.

### DIFF
--- a/egui/src/containers/combo_box.rs
+++ b/egui/src/containers/combo_box.rs
@@ -61,12 +61,16 @@ pub fn combo_box(
                 let frame_margin = frame.margin;
                 frame.show(ui, |ui| {
                     ui.with_layout(Layout::top_down_justified(Align::left()), |ui| {
-                        ui.set_min_width(button_response.rect.width() - 2.0 * frame_margin.x);
-                        menu_contents(ui);
+                        let frame_width = button_response.rect.width() - 2.0 * frame_margin.x;
+                        ui.set_min_width(frame_width);
+                        ScrollArea::from_max_height(100f32)
+                        .show(ui, |ui| {
+                            menu_contents(ui);
+                        })
                     });
-                })
+                });
             });
-
+      
         if ui.input().key_pressed(Key::Escape) || ui.input().mouse.click && !button_response.clicked
         {
             ui.memory().close_popup();

--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -156,7 +156,7 @@ impl Prepared {
         let inner_rect = Rect::from_min_size(
             inner_rect.min,
             vec2(
-                inner_rect.width().max(content_size.x), // Expand width to fit content
+                inner_rect.width().min(content_size.x), // Expand width to fit content
                 inner_rect.height(),
             ),
         );


### PR DESCRIPTION
With regards to https://github.com/emilk/egui/issues/75.

I've tried to make minimum changes to ComboBox to make it work as a scrollable container.  I also had to change one line in scroll_area.rs to make the scroll area fit the content width. Without it, the container exceeds the parent UI width causing the scroll bars to disappear.

I believe the changes are trivial enough that they don't break anything while providing some useful functionality out of the box (so to speak). I've tested the functionality with egui_demo (glium version) and it seems to be in order.