### PR TITLE
Scroll based on the mouse start position.

### DIFF
--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -242,9 +242,14 @@ impl Prepared {
 
             if response.active {
                 if let Some(mouse_pos) = ui.input().mouse.pos {
-                    let scroll_start_offset_from_top = state
-                        .scroll_start_offset_from_top
-                        .get_or_insert_with(|| mouse_pos.y - handle_rect.top());
+                    let scroll_start_offset_from_top =
+                        state.scroll_start_offset_from_top.get_or_insert_with(|| {
+                            if handle_rect.contains(mouse_pos) {
+                                mouse_pos.y - handle_rect.top()
+                            } else {
+                                0.5 * handle_rect.height() // center handle on mouse
+                            }
+                        });
 
                     let new_handle_top = mouse_pos.y - *scroll_start_offset_from_top;
                     state.offset.y = remap(new_handle_top, top..=bottom, 0.0..=content_size.y);

--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -247,7 +247,13 @@ impl Prepared {
                             if handle_rect.contains(mouse_pos) {
                                 mouse_pos.y - handle_rect.top()
                             } else {
-                                0.5 * handle_rect.height() // center handle on mouse
+                                let handle_top_pos_at_bottom = bottom - handle_rect.height();
+                                // Calculate the new handle top position, centering the handle on the mouse.
+                                let new_handle_top_pos = clamp(
+                                    mouse_pos.y - handle_rect.height() / 2.0,
+                                    top..=handle_top_pos_at_bottom,
+                                );
+                                mouse_pos.y - new_handle_top_pos
                             }
                         });
 


### PR DESCRIPTION
Fixes #57

Since i was already changing the `ScrollArea`, decided to try fix some reported bugs in it.

The mouse position relative to the center of the handle is saved, so we can use it to check if we are scrolling top or bottom. Now it behaves similar to how the scroll in the browser works.

