### PR TITLE
Make `style` module public

### DIFF
--- a/egui/src/lib.rs
+++ b/egui/src/lib.rs
@@ -92,7 +92,7 @@ mod memory;
 pub mod menu;
 pub mod paint;
 mod painter;
-mod style;
+pub mod style;
 mod types;
 mod ui;
 pub mod util;


### PR DESCRIPTION
Allow access to types such as `Visual` to configure the Ui style:

```rust
        // ...
        egui::CentralPanel::default().show(ctx, |ui| {
            let mut_style = ui.style_mut();
            mut_style.visuals = egui::style::Visuals {
                 widgets: egui::style::Widgets {
                 // ...
            };
```

Have not found a better solution ¯\_(ツ)_/¯