### PR TITLE
Make `egui_glium::painter::Painter::paint_job` pub

### DIFF
--- a/egui_glium/src/painter.rs
+++ b/egui_glium/src/painter.rs
@@ -154,7 +154,7 @@ impl Painter {
     }
 
     #[inline(never)] // Easier profiling
-    fn paint_job(
+    pub fn paint_job(
         &mut self,
         target: &mut Frame,
         display: &glium::Display,

--- a/egui_glium/src/painter.rs
+++ b/egui_glium/src/painter.rs
@@ -95,7 +95,7 @@ impl Painter {
         }
     }
 
-    fn upload_egui_texture(
+    pub fn upload_egui_texture(
         &mut self,
         facade: &dyn glium::backend::Facade,
         texture: &egui::Texture,
@@ -324,7 +324,7 @@ impl Painter {
         }
     }
 
-    fn upload_pending_user_textures(&mut self, facade: &dyn glium::backend::Facade) {
+    pub fn upload_pending_user_textures(&mut self, facade: &dyn glium::backend::Facade) {
         for user_texture in &mut self.user_textures {
             if let Some(user_texture) = user_texture {
                 if user_texture.gl_texture.is_none() {


### PR DESCRIPTION
The background is: I'm working on an engine where I would like to draw the gui and the game to the same `glium::Frame`. Haven't found any other obvious, trivial solution. I could of course write my own integration, but I just think this makes sense to be public.