### PR TITLE
Use a cubic ease function for animations

### DIFF
--- a/egui/src/animation_manager.rs
+++ b/egui/src/animation_manager.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use crate::{math::remap_clamp, Id, InputState};
+use crate::{
+    math::{clamp, remap_clamp},
+    Id, InputState,
+};
 
 #[derive(Clone, Default)]
 pub(crate) struct AnimationManager {
@@ -50,12 +53,26 @@ impl AnimationManager {
                 // so we extrapolate forwards:
                 let time_since_toggle = time_since_toggle + input.predicted_dt;
 
-                if value {
+                ease_in_out_cubic(if value {
                     remap_clamp(time_since_toggle, 0.0..=animation_time, 0.0..=1.0)
                 } else {
                     remap_clamp(time_since_toggle, 0.0..=animation_time, 1.0..=0.0)
-                }
+                })
             }
         }
     }
+}
+
+/// Maps `x` in the range [0, 1] to the cubic easing function. Clamps outside of this range.
+///
+/// See: https://www.desmos.com/calculator/tdvd2vd4f1
+fn ease_in_out_cubic(x: f32) -> f32 {
+    clamp(
+        if x < 0.5 {
+            0.5 * (2.0 * x).powi(3)
+        } else {
+            0.5 * ((2.0 * x - 2.0).powi(3) + 2.0)
+        },
+        0.0..=1.0,
+    )
 }


### PR DESCRIPTION
This changes the bool animation being linear to using a cubic ease-in-out curve. This curve is widely used in user interface animations (ease-in and ease-out also are frequently found) and lets objects movement and sizing feel more natural at the start and end of the animation (e.g. mimicking acceleration). This is less noticeable at small changes or `animation_time` values, but becomes very noticeable when an animation travels a far distance or takes a longer amount of time.

The curve itself looks something like:

![image](https://user-images.githubusercontent.com/2287247/104794390-2d16aa80-575c-11eb-936e-3fcf8a355bc8.png)
(from https://www.desmos.com/calculator/tdvd2vd4f1)

Note: This is just a proposal for an alternate animation curve with no immediate desire to merge. It's likely `egui` would still want to expose linear (e.g. for opacity animations) and potentially ease-in and ease-out as well (when the end and start of the animation is obscured).