### PR TITLE
[egui] Stop velocity after overscroll

### DIFF
--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -307,8 +307,13 @@ impl Prepared {
                 state.scroll_start_offset_from_top = None;
             }
 
+            let unbounded_offset_y = state.offset.y;
             state.offset.y = state.offset.y.max(0.0);
             state.offset.y = state.offset.y.min(max_offset);
+            #[allow(clippy::float_cmp)]
+            if state.offset.y != unbounded_offset_y {
+                state.vel = Vec2::zero();
+            }
 
             // Avoid frame-delay by calculating a new handle rect:
             let mut handle_rect = Rect::from_min_max(


### PR DESCRIPTION
This stops a `ScrollArea`'s velocity after it has hit an edge. Prior to this change, using the mousewheel after hitting an edge via momentum scrolling led to weird behavior (momentum continued)