### PR TITLE
Prefer overlapping row in galley cursor_from_pos

### DIFF
--- a/epaint/src/text/galley.rs
+++ b/epaint/src/text/galley.rs
@@ -197,8 +197,9 @@ impl Galley {
         let mut pcursor_it = PCursor::default();
 
         for (row_nr, row) in self.rows.iter().enumerate() {
+            let is_pos_within_row = pos.y >= row.y_min && pos.y <= row.y_max;
             let y_dist = (row.y_min - pos.y).abs().min((row.y_max - pos.y).abs());
-            if y_dist < best_y_dist {
+            if is_pos_within_row || y_dist < best_y_dist {
                 best_y_dist = y_dist;
                 let column = row.char_at(pos.x);
                 let prefer_next_row = column < row.char_count_excluding_newline();
@@ -216,6 +217,10 @@ impl Galley {
                         offset: pcursor_it.offset + column,
                         prefer_next_row,
                     },
+                };
+
+                if is_pos_within_row {
+                    return cursor;
                 }
             }
             ccursor_index += row.char_count_including_newline();


### PR DESCRIPTION
This changes `cursor_from_pos` to prefer the row that the cursor is in. Prior to this change, `cursor_from_pos` would bias towards the previous row. The cursor is equidistant from the previous row's `y_max` and next row's `y_min`.

confirmed that this is how the cursor functions in other apps (eg Chrome textarea). video showing the TextEdit component without this change.

https://user-images.githubusercontent.com/2266187/105284424-47d78d80-5b67-11eb-8260-037e46a446a9.mp4

