### PR TITLE
Multiple mouse button support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed 🔧
 
 * `mouse` has be renamed `pointer` everywhere (to make it clear it includes touches too).
+* `Response::clicked` and `double_clicked` are now methods, so `if ui.button("…").clicked {` is now `if ui.button("…").clicked() {`
 
 ### Added ⭐
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added ⭐
+
+* Add support for secondary and middle mouse buttons.
+* `egui::popup::popup_below_widget`: show a popup area below another widget.
+
 ### Changed 🔧
 
 * `mouse` has be renamed `pointer` everywhere (to make it clear it includes touches too).
-* `Response::clicked` and `double_clicked` are now methods, so `if ui.button("…").clicked {` is now `if ui.button("…").clicked() {`
+* `Response::clicked` and `double_clicked` are now methods, so `if ui.button("…").clicked {` is now `if ui.button("…").clicked() {`.
+* Backend: pointer (mouse/touch) position and buttons are now passed to egui in the event stream.
 
-### Added ⭐
+### Fixed 🐛
 
-* `egui::popup::popup_below_widget`: show a popup area below another widget
+* It is now possible to click widgets even when FPS is very low.
 
 
 ## 0.8.0 - 2021-01-17 - Grid layout & new visual style

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed 🔧
 
 * `mouse` has be renamed `pointer` everywhere (to make it clear it includes touches too).
-* `Response::clicked` and `double_clicked` are now methods, so `if ui.button("…").clicked {` is now `if ui.button("…").clicked() {`.
+* Most parts of `Response` are now methods, so `if ui.button("…").clicked {` is now `if ui.button("…").clicked() {`.
 * Backend: pointer (mouse/touch) position and buttons are now passed to egui in the event stream.
 
 ### Fixed 🐛

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed 🔧
+
+* `mouse` has be renamed `pointer` everywhere (to make it clear it includes touches too).
+
 ### Added ⭐
 
 * `egui::popup::popup_below_widget`: show a popup area below another widget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * `mouse` has be renamed `pointer` everywhere (to make it clear it includes touches too).
 * Most parts of `Response` are now methods, so `if ui.button("…").clicked {` is now `if ui.button("…").clicked() {`.
+* `Response::active` is now gone. You can use `response.dragged()` or `response.clicked()` instead.
 * Backend: pointer (mouse/touch) position and buttons are now passed to egui in the event stream.
 
 ### Fixed 🐛

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ ui.horizontal(|ui| {
     ui.text_edit_singleline(&mut name);
 });
 ui.add(egui::Slider::u32(&mut age, 0..=120).text("age"));
-if ui.button("Click each year").clicked {
+if ui.button("Click each year").clicked() {
     age += 1;
 }
 ui.label(format!("Hello '{}', age {}", name, age));

--- a/eframe/examples/hello_world.rs
+++ b/eframe/examples/hello_world.rs
@@ -29,7 +29,7 @@ impl epi::App for MyApp {
                 ui.text_edit_singleline(name);
             });
             ui.add(egui::Slider::u32(age, 0..=120).text("age"));
-            if ui.button("Click each year").clicked {
+            if ui.button("Click each year").clicked() {
                 *age += 1;
             }
             ui.label(format!("Hello '{}', age {}", name, age));

--- a/egui/src/containers/area.rs
+++ b/egui/src/containers/area.rs
@@ -250,13 +250,13 @@ impl Prepared {
         );
 
         if move_response.active && movable {
-            state.pos += ctx.input().mouse.delta;
+            state.pos += ctx.input().pointer.delta;
         }
 
         state.pos = ctx.constrain_window_rect(state.rect()).min;
 
         if (move_response.active || move_response.clicked)
-            || mouse_pressed_on_area(ctx, layer_id)
+            || pointer_pressed_on_area(ctx, layer_id)
             || !ctx.memory().areas.visible_last_frame(&layer_id)
         {
             ctx.memory().areas.move_to_top(layer_id);
@@ -268,9 +268,9 @@ impl Prepared {
     }
 }
 
-fn mouse_pressed_on_area(ctx: &Context, layer_id: LayerId) -> bool {
-    if let Some(mouse_pos) = ctx.input().mouse.pos {
-        ctx.input().mouse.pressed && ctx.layer_id_at(mouse_pos) == Some(layer_id)
+fn pointer_pressed_on_area(ctx: &Context, layer_id: LayerId) -> bool {
+    if let Some(pointer_pos) = ctx.input().pointer.pos {
+        ctx.input().pointer.pressed && ctx.layer_id_at(pointer_pos) == Some(layer_id)
     } else {
         false
     }

--- a/egui/src/containers/area.rs
+++ b/egui/src/containers/area.rs
@@ -249,13 +249,13 @@ impl Prepared {
             sense,
         );
 
-        if move_response.active && movable {
+        if move_response.dragged() && movable {
             state.pos += ctx.input().pointer.delta;
         }
 
         state.pos = ctx.constrain_window_rect(state.rect()).min;
 
-        if (move_response.active || move_response.clicked())
+        if (move_response.dragged() || move_response.clicked())
             || pointer_pressed_on_area(ctx, layer_id)
             || !ctx.memory().areas.visible_last_frame(&layer_id)
         {

--- a/egui/src/containers/area.rs
+++ b/egui/src/containers/area.rs
@@ -250,7 +250,7 @@ impl Prepared {
         );
 
         if move_response.dragged() && movable {
-            state.pos += ctx.input().pointer.delta;
+            state.pos += ctx.input().pointer.delta();
         }
 
         state.pos = ctx.constrain_window_rect(state.rect()).min;

--- a/egui/src/containers/area.rs
+++ b/egui/src/containers/area.rs
@@ -255,7 +255,7 @@ impl Prepared {
 
         state.pos = ctx.constrain_window_rect(state.rect()).min;
 
-        if (move_response.active || move_response.clicked)
+        if (move_response.active || move_response.clicked())
             || pointer_pressed_on_area(ctx, layer_id)
             || !ctx.memory().areas.visible_last_frame(&layer_id)
         {

--- a/egui/src/containers/area.rs
+++ b/egui/src/containers/area.rs
@@ -269,8 +269,8 @@ impl Prepared {
 }
 
 fn pointer_pressed_on_area(ctx: &Context, layer_id: LayerId) -> bool {
-    if let Some(pointer_pos) = ctx.input().pointer.pos {
-        ctx.input().pointer.pressed && ctx.layer_id_at(pointer_pos) == Some(layer_id)
+    if let Some(pointer_pos) = ctx.input().pointer.interact_pos() {
+        ctx.input().pointer.any_pressed() && ctx.layer_id_at(pointer_pos) == Some(layer_id)
     } else {
         false
     }

--- a/egui/src/containers/collapsing_header.rs
+++ b/egui/src/containers/collapsing_header.rs
@@ -199,7 +199,7 @@ impl CollapsingHeader {
         );
 
         let mut state = State::from_memory_with_default_open(ui.ctx(), id, default_open);
-        if header_response.clicked {
+        if header_response.clicked() {
             state.toggle(ui);
         }
 

--- a/egui/src/containers/combo_box.rs
+++ b/egui/src/containers/combo_box.rs
@@ -84,7 +84,7 @@ pub fn combo_box(
             .galley(text_rect.min, galley, text_style, visuals.text_color());
     });
 
-    if button_response.clicked {
+    if button_response.clicked() {
         ui.memory().toggle_popup(popup_id);
     }
     const MAX_COMBO_HEIGHT: f32 = 128.0;

--- a/egui/src/containers/combo_box.rs
+++ b/egui/src/containers/combo_box.rs
@@ -118,7 +118,7 @@ fn button_frame(
     outer_rect.set_height(outer_rect.height().at_least(interact_size.y));
 
     let mut response = ui.interact(outer_rect, id, sense);
-    response.active |= button_active;
+    response.is_pointer_button_down_on |= button_active;
     let visuals = ui.style().interact(&response);
 
     ui.painter().set(

--- a/egui/src/containers/popup.rs
+++ b/egui/src/containers/popup.rs
@@ -2,7 +2,7 @@
 
 use crate::*;
 
-/// Show a tooltip at the current mouse position (if any).
+/// Show a tooltip at the current pointer position (if any).
 ///
 /// Most of the time it is easier to use [`Response::on_hover_ui`].
 ///
@@ -10,7 +10,7 @@ use crate::*;
 ///
 /// ```
 /// # let mut ui = egui::Ui::__test();
-/// if ui.ui_contains_mouse() {
+/// if ui.ui_contains_pointer() {
 ///     egui::show_tooltip(ui.ctx(), |ui| {
 ///         ui.label("Helpful text");
 ///     });
@@ -21,9 +21,9 @@ pub fn show_tooltip(ctx: &CtxRef, add_contents: impl FnOnce(&mut Ui)) {
 
     let window_pos = if let Some(tooltip_rect) = tooltip_rect {
         tooltip_rect.left_bottom()
-    } else if let Some(mouse_pos) = ctx.input().mouse.pos {
+    } else if let Some(pointer_pos) = ctx.input().pointer.pos {
         let expected_size = vec2(ctx.style().spacing.tooltip_width, 32.0);
-        let position = mouse_pos + vec2(16.0, 16.0);
+        let position = pointer_pos + vec2(16.0, 16.0);
         let position = position.min(ctx.input().screen_rect().right_bottom() - expected_size);
         let position = position.max(ctx.input().screen_rect().left_top());
         position
@@ -41,7 +41,7 @@ pub fn show_tooltip(ctx: &CtxRef, add_contents: impl FnOnce(&mut Ui)) {
     ctx.frame_state().tooltip_rect = Some(tooltip_rect.union(response.rect));
 }
 
-/// Show some text at the current mouse position (if any).
+/// Show some text at the current pointer position (if any).
 ///
 /// Most of the time it is easier to use [`Response::on_hover_text`].
 ///
@@ -49,7 +49,7 @@ pub fn show_tooltip(ctx: &CtxRef, add_contents: impl FnOnce(&mut Ui)) {
 ///
 /// ```
 /// # let mut ui = egui::Ui::__test();
-/// if ui.ui_contains_mouse() {
+/// if ui.ui_contains_pointer() {
 ///     egui::show_tooltip_text(ui.ctx(), "Helpful text");
 /// }
 /// ```
@@ -121,7 +121,8 @@ pub fn popup_below_widget(
                 });
             });
 
-        if ui.input().key_pressed(Key::Escape) || ui.input().mouse.click && !widget_response.clicked
+        if ui.input().key_pressed(Key::Escape)
+            || ui.input().pointer.click && !widget_response.clicked
         {
             ui.memory().close_popup();
         }

--- a/egui/src/containers/popup.rs
+++ b/egui/src/containers/popup.rs
@@ -89,7 +89,7 @@ fn show_tooltip_area(
 /// # let ui = &mut egui::Ui::__test();
 /// let response = ui.button("Open popup");
 /// let popup_id = ui.make_persistent_id("my_unique_id");
-/// if response.clicked {
+/// if response.clicked() {
 ///     ui.memory().toggle_popup(popup_id);
 /// }
 /// egui::popup::popup_below_widget(ui, popup_id, &response, |ui| {
@@ -122,7 +122,7 @@ pub fn popup_below_widget(
             });
 
         if ui.input().key_pressed(Key::Escape)
-            || ui.input().pointer.click && !widget_response.clicked
+            || ui.input().pointer.click && !widget_response.clicked()
         {
             ui.memory().close_popup();
         }

--- a/egui/src/containers/popup.rs
+++ b/egui/src/containers/popup.rs
@@ -21,7 +21,7 @@ pub fn show_tooltip(ctx: &CtxRef, add_contents: impl FnOnce(&mut Ui)) {
 
     let window_pos = if let Some(tooltip_rect) = tooltip_rect {
         tooltip_rect.left_bottom()
-    } else if let Some(pointer_pos) = ctx.input().pointer.pos {
+    } else if let Some(pointer_pos) = ctx.input().pointer.tooltip_pos() {
         let expected_size = vec2(ctx.style().spacing.tooltip_width, 32.0);
         let position = pointer_pos + vec2(16.0, 16.0);
         let position = position.min(ctx.input().screen_rect().right_bottom() - expected_size);
@@ -122,7 +122,7 @@ pub fn popup_below_widget(
             });
 
         if ui.input().key_pressed(Key::Escape)
-            || ui.input().pointer.click && !widget_response.clicked()
+            || ui.input().pointer.any_click() && !widget_response.clicked()
         {
             ui.memory().close_popup();
         }

--- a/egui/src/containers/resize.rs
+++ b/egui/src/containers/resize.rs
@@ -294,7 +294,7 @@ impl Resize {
         if let Some(corner_response) = corner_response {
             paint_resize_corner(ui, &corner_response);
 
-            if corner_response.hovered || corner_response.dragged() {
+            if corner_response.hovered() || corner_response.dragged() {
                 ui.ctx().output().cursor_icon = CursorIcon::ResizeNwSe;
             }
         }

--- a/egui/src/containers/resize.rs
+++ b/egui/src/containers/resize.rs
@@ -192,9 +192,9 @@ impl Resize {
             let corner_response = ui.interact(corner_rect, id.with("corner"), Sense::drag());
 
             if corner_response.active {
-                if let Some(mouse_pos) = ui.input().mouse.pos {
+                if let Some(pointer_pos) = ui.input().pointer.pos {
                     user_requested_size =
-                        Some(mouse_pos - position + 0.5 * corner_response.rect.size());
+                        Some(pointer_pos - position + 0.5 * corner_response.rect.size());
                 }
             }
             Some(corner_response)

--- a/egui/src/containers/resize.rs
+++ b/egui/src/containers/resize.rs
@@ -191,12 +191,11 @@ impl Resize {
                 Rect::from_min_size(position + state.desired_size - corner_size, corner_size);
             let corner_response = ui.interact(corner_rect, id.with("corner"), Sense::drag());
 
-            if corner_response.active {
-                if let Some(pointer_pos) = ui.input().pointer.pos {
-                    user_requested_size =
-                        Some(pointer_pos - position + 0.5 * corner_response.rect.size());
-                }
+            if let Some(pointer_pos) = corner_response.interact_pointer_pos() {
+                user_requested_size =
+                    Some(pointer_pos - position + 0.5 * corner_response.rect.size());
             }
+
             Some(corner_response)
         } else {
             None
@@ -295,7 +294,7 @@ impl Resize {
         if let Some(corner_response) = corner_response {
             paint_resize_corner(ui, &corner_response);
 
-            if corner_response.hovered || corner_response.active {
+            if corner_response.hovered || corner_response.dragged() {
                 ui.ctx().output().cursor_icon = CursorIcon::ResizeNwSe;
             }
         }

--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -212,7 +212,7 @@ impl Prepared {
             let content_response = ui.interact(inner_rect, id.with("area"), Sense::drag());
 
             let input = ui.input();
-            if content_response.active {
+            if content_response.dragged() {
                 state.offset.y -= input.pointer.delta.y;
                 state.vel = input.pointer.velocity;
             } else {
@@ -283,26 +283,24 @@ impl Prepared {
             let interact_id = id.with("vertical");
             let response = ui.interact(outer_scroll_rect, interact_id, Sense::click_and_drag());
 
-            if response.active {
-                if let Some(pointer_pos) = ui.input().pointer.pos {
-                    let scroll_start_offset_from_top =
-                        state.scroll_start_offset_from_top.get_or_insert_with(|| {
-                            if handle_rect.contains(pointer_pos) {
-                                pointer_pos.y - handle_rect.top()
-                            } else {
-                                let handle_top_pos_at_bottom = bottom - handle_rect.height();
-                                // Calculate the new handle top position, centering the handle on the mouse.
-                                let new_handle_top_pos = clamp(
-                                    pointer_pos.y - handle_rect.height() / 2.0,
-                                    top..=handle_top_pos_at_bottom,
-                                );
-                                pointer_pos.y - new_handle_top_pos
-                            }
-                        });
+            if let Some(pointer_pos) = response.interact_pointer_pos() {
+                let scroll_start_offset_from_top =
+                    state.scroll_start_offset_from_top.get_or_insert_with(|| {
+                        if handle_rect.contains(pointer_pos) {
+                            pointer_pos.y - handle_rect.top()
+                        } else {
+                            let handle_top_pos_at_bottom = bottom - handle_rect.height();
+                            // Calculate the new handle top position, centering the handle on the mouse.
+                            let new_handle_top_pos = clamp(
+                                pointer_pos.y - handle_rect.height() / 2.0,
+                                top..=handle_top_pos_at_bottom,
+                            );
+                            pointer_pos.y - new_handle_top_pos
+                        }
+                    });
 
-                    let new_handle_top = pointer_pos.y - *scroll_start_offset_from_top;
-                    state.offset.y = remap(new_handle_top, top..=bottom, 0.0..=content_size.y);
-                }
+                let new_handle_top = pointer_pos.y - *scroll_start_offset_from_top;
+                state.offset.y = remap(new_handle_top, top..=bottom, 0.0..=content_size.y);
             } else {
                 state.scroll_start_offset_from_top = None;
             }

--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -213,8 +213,8 @@ impl Prepared {
 
             let input = ui.input();
             if content_response.active {
-                state.offset.y -= input.mouse.delta.y;
-                state.vel = input.mouse.velocity;
+                state.offset.y -= input.pointer.delta.y;
+                state.vel = input.pointer.velocity;
             } else {
                 let stop_speed = 20.0; // Pixels per second.
                 let friction_coeff = 1000.0; // Pixels per second squared.
@@ -234,7 +234,7 @@ impl Prepared {
         }
 
         let max_offset = content_size.y - inner_rect.height();
-        if ui.rect_contains_mouse(outer_rect) {
+        if ui.rect_contains_pointer(outer_rect) {
             let mut frame_state = ui.ctx().frame_state();
             let scroll_delta = frame_state.scroll_delta;
 
@@ -284,23 +284,23 @@ impl Prepared {
             let response = ui.interact(outer_scroll_rect, interact_id, Sense::click_and_drag());
 
             if response.active {
-                if let Some(mouse_pos) = ui.input().mouse.pos {
+                if let Some(pointer_pos) = ui.input().pointer.pos {
                     let scroll_start_offset_from_top =
                         state.scroll_start_offset_from_top.get_or_insert_with(|| {
-                            if handle_rect.contains(mouse_pos) {
-                                mouse_pos.y - handle_rect.top()
+                            if handle_rect.contains(pointer_pos) {
+                                pointer_pos.y - handle_rect.top()
                             } else {
                                 let handle_top_pos_at_bottom = bottom - handle_rect.height();
                                 // Calculate the new handle top position, centering the handle on the mouse.
                                 let new_handle_top_pos = clamp(
-                                    mouse_pos.y - handle_rect.height() / 2.0,
+                                    pointer_pos.y - handle_rect.height() / 2.0,
                                     top..=handle_top_pos_at_bottom,
                                 );
-                                mouse_pos.y - new_handle_top_pos
+                                pointer_pos.y - new_handle_top_pos
                             }
                         });
 
-                    let new_handle_top = mouse_pos.y - *scroll_start_offset_from_top;
+                    let new_handle_top = pointer_pos.y - *scroll_start_offset_from_top;
                     state.offset.y = remap(new_handle_top, top..=bottom, 0.0..=content_size.y);
                 }
             } else {

--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -213,8 +213,8 @@ impl Prepared {
 
             let input = ui.input();
             if content_response.dragged() {
-                state.offset.y -= input.pointer.delta.y;
-                state.vel = input.pointer.velocity;
+                state.offset.y -= input.pointer.delta().y;
+                state.vel = input.pointer.velocity();
             } else {
                 let stop_speed = 20.0; // Pixels per second.
                 let friction_coeff = 1000.0; // Pixels per second squared.

--- a/egui/src/containers/window.rs
+++ b/egui/src/containers/window.rs
@@ -467,7 +467,7 @@ fn move_and_resize_window(ctx: &Context, window_interaction: &WindowInteraction)
         }
     } else {
         // movement
-        rect = rect.translate(pointer_pos - ctx.input().pointer.press_origin?);
+        rect = rect.translate(pointer_pos - ctx.input().pointer.press_origin()?);
     }
 
     Some(rect)

--- a/egui/src/containers/window.rs
+++ b/egui/src/containers/window.rs
@@ -671,7 +671,7 @@ fn show_title_bar(
 
             let (_id, rect) = ui.allocate_space(button_size);
             let collapse_button_response = ui.interact(rect, collapsing_id, Sense::click());
-            if collapse_button_response.clicked {
+            if collapse_button_response.clicked() {
                 collapsing.toggle(ui);
             }
             let openness = collapsing.openness(ui.ctx(), collapsing_id);
@@ -721,7 +721,7 @@ impl TitleBar {
 
         if let Some(open) = open {
             // Add close button now that we know our full width:
-            if self.close_button_ui(ui).clicked {
+            if self.close_button_ui(ui).clicked() {
                 *open = false;
             }
         }
@@ -752,7 +752,7 @@ impl TitleBar {
 
         if ui
             .interact(self.rect, self.id, Sense::click())
-            .double_clicked
+            .double_clicked()
             && collapsible
         {
             collapsing.toggle(ui);

--- a/egui/src/containers/window.rs
+++ b/egui/src/containers/window.rs
@@ -363,12 +363,14 @@ impl<'open> Window<'open> {
                     ctx.style().visuals.widgets.active,
                 );
             } else if let Some(hover_interaction) = hover_interaction {
-                paint_frame_interaction(
-                    &mut area_content_ui,
-                    outer_rect,
-                    hover_interaction,
-                    ctx.style().visuals.widgets.hovered,
-                );
+                if ctx.input().pointer.has_pointer() {
+                    paint_frame_interaction(
+                        &mut area_content_ui,
+                        outer_rect,
+                        hover_interaction,
+                        ctx.style().visuals.widgets.hovered,
+                    );
+                }
             }
         }
         let full_response = area.end(ctx, area_content_ui);
@@ -448,7 +450,7 @@ fn interact(
 
 fn move_and_resize_window(ctx: &Context, window_interaction: &WindowInteraction) -> Option<Rect> {
     window_interaction.set_cursor(ctx);
-    let pointer_pos = ctx.input().pointer.pos?;
+    let pointer_pos = ctx.input().pointer.interact_pos()?;
     let mut rect = window_interaction.start_rect; // prevent drift
 
     if window_interaction.is_resize() {
@@ -491,7 +493,7 @@ fn window_interaction(
     if window_interaction.is_none() {
         if let Some(hover_window_interaction) = resize_hover(ctx, possible, area_layer_id, rect) {
             hover_window_interaction.set_cursor(ctx);
-            if ctx.input().pointer.pressed {
+            if ctx.input().pointer.any_pressed() && ctx.input().pointer.any_down() {
                 ctx.memory().interaction.drag_id = Some(id);
                 ctx.memory().interaction.drag_is_window = true;
                 window_interaction = Some(hover_window_interaction);
@@ -517,9 +519,9 @@ fn resize_hover(
     area_layer_id: LayerId,
     rect: Rect,
 ) -> Option<WindowInteraction> {
-    let pointer_pos = ctx.input().pointer.pos?;
+    let pointer_pos = ctx.input().pointer.interact_pos()?;
 
-    if ctx.input().pointer.down && !ctx.input().pointer.pressed {
+    if ctx.input().pointer.any_down() && !ctx.input().pointer.any_pressed() {
         return None; // already dragging (something)
     }
 

--- a/egui/src/containers/window.rs
+++ b/egui/src/containers/window.rs
@@ -448,24 +448,24 @@ fn interact(
 
 fn move_and_resize_window(ctx: &Context, window_interaction: &WindowInteraction) -> Option<Rect> {
     window_interaction.set_cursor(ctx);
-    let mouse_pos = ctx.input().mouse.pos?;
+    let pointer_pos = ctx.input().pointer.pos?;
     let mut rect = window_interaction.start_rect; // prevent drift
 
     if window_interaction.is_resize() {
         if window_interaction.left {
-            rect.min.x = ctx.round_to_pixel(mouse_pos.x);
+            rect.min.x = ctx.round_to_pixel(pointer_pos.x);
         } else if window_interaction.right {
-            rect.max.x = ctx.round_to_pixel(mouse_pos.x);
+            rect.max.x = ctx.round_to_pixel(pointer_pos.x);
         }
 
         if window_interaction.top {
-            rect.min.y = ctx.round_to_pixel(mouse_pos.y);
+            rect.min.y = ctx.round_to_pixel(pointer_pos.y);
         } else if window_interaction.bottom {
-            rect.max.y = ctx.round_to_pixel(mouse_pos.y);
+            rect.max.y = ctx.round_to_pixel(pointer_pos.y);
         }
     } else {
         // movement
-        rect = rect.translate(mouse_pos - ctx.input().mouse.press_origin?);
+        rect = rect.translate(pointer_pos - ctx.input().pointer.press_origin?);
     }
 
     Some(rect)
@@ -491,7 +491,7 @@ fn window_interaction(
     if window_interaction.is_none() {
         if let Some(hover_window_interaction) = resize_hover(ctx, possible, area_layer_id, rect) {
             hover_window_interaction.set_cursor(ctx);
-            if ctx.input().mouse.pressed {
+            if ctx.input().pointer.pressed {
                 ctx.memory().interaction.drag_id = Some(id);
                 ctx.memory().interaction.drag_is_window = true;
                 window_interaction = Some(hover_window_interaction);
@@ -517,13 +517,13 @@ fn resize_hover(
     area_layer_id: LayerId,
     rect: Rect,
 ) -> Option<WindowInteraction> {
-    let mouse_pos = ctx.input().mouse.pos?;
+    let pointer_pos = ctx.input().pointer.pos?;
 
-    if ctx.input().mouse.down && !ctx.input().mouse.pressed {
+    if ctx.input().pointer.down && !ctx.input().pointer.pressed {
         return None; // already dragging (something)
     }
 
-    if let Some(top_layer_id) = ctx.layer_id_at(mouse_pos) {
+    if let Some(top_layer_id) = ctx.layer_id_at(pointer_pos) {
         if top_layer_id != area_layer_id && top_layer_id.order != Order::Background {
             return None; // Another window is on top here
         }
@@ -536,33 +536,33 @@ fn resize_hover(
 
     let side_grab_radius = ctx.style().interaction.resize_grab_radius_side;
     let corner_grab_radius = ctx.style().interaction.resize_grab_radius_corner;
-    if !rect.expand(side_grab_radius).contains(mouse_pos) {
+    if !rect.expand(side_grab_radius).contains(pointer_pos) {
         return None;
     }
 
     let (mut left, mut right, mut top, mut bottom) = Default::default();
     if possible.resizable {
-        right = (rect.right() - mouse_pos.x).abs() <= side_grab_radius;
-        bottom = (rect.bottom() - mouse_pos.y).abs() <= side_grab_radius;
+        right = (rect.right() - pointer_pos.x).abs() <= side_grab_radius;
+        bottom = (rect.bottom() - pointer_pos.y).abs() <= side_grab_radius;
 
-        if rect.right_bottom().distance(mouse_pos) < corner_grab_radius {
+        if rect.right_bottom().distance(pointer_pos) < corner_grab_radius {
             right = true;
             bottom = true;
         }
 
         if possible.movable {
-            left = (rect.left() - mouse_pos.x).abs() <= side_grab_radius;
-            top = (rect.top() - mouse_pos.y).abs() <= side_grab_radius;
+            left = (rect.left() - pointer_pos.x).abs() <= side_grab_radius;
+            top = (rect.top() - pointer_pos.y).abs() <= side_grab_radius;
 
-            if rect.right_top().distance(mouse_pos) < corner_grab_radius {
+            if rect.right_top().distance(pointer_pos) < corner_grab_radius {
                 right = true;
                 top = true;
             }
-            if rect.left_top().distance(mouse_pos) < corner_grab_radius {
+            if rect.left_top().distance(pointer_pos) < corner_grab_radius {
                 left = true;
                 top = true;
             }
-            if rect.left_bottom().distance(mouse_pos) < corner_grab_radius {
+            if rect.left_bottom().distance(pointer_pos) < corner_grab_radius {
                 left = true;
                 bottom = true;
             }

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -643,6 +643,16 @@ impl Context {
         self.memory().interaction.is_using_pointer()
     }
 
+    #[deprecated = "Renamed wants_pointer_input"]
+    pub fn wants_mouse_input(&self) -> bool {
+        self.wants_pointer_input()
+    }
+
+    #[deprecated = "Renamed is_using_pointer"]
+    pub fn is_using_mouse(&self) -> bool {
+        self.is_using_pointer()
+    }
+
     /// If `true`, egui is currently listening on text input (e.g. typing text in a [`TextEdit`]).
     pub fn wants_keyboard_input(&self) -> bool {
         self.memory().interaction.kb_focus_id.is_some()

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -794,7 +794,7 @@ impl Context {
         if ui
             .button("Reset all")
             .on_hover_text("Reset all egui state")
-            .clicked
+            .clicked()
         {
             *self.memory() = Default::default();
         }
@@ -804,7 +804,7 @@ impl Context {
                 "{} areas (window positions)",
                 self.memory().areas.count()
             ));
-            if ui.button("Reset").clicked {
+            if ui.button("Reset").clicked() {
                 self.memory().areas = Default::default();
             }
         });
@@ -837,28 +837,28 @@ impl Context {
                 "{} collapsing headers",
                 self.memory().collapsing_headers.len()
             ));
-            if ui.button("Reset").clicked {
+            if ui.button("Reset").clicked() {
                 self.memory().collapsing_headers = Default::default();
             }
         });
 
         ui.horizontal(|ui| {
             ui.label(format!("{} menu bars", self.memory().menu_bar.len()));
-            if ui.button("Reset").clicked {
+            if ui.button("Reset").clicked() {
                 self.memory().menu_bar = Default::default();
             }
         });
 
         ui.horizontal(|ui| {
             ui.label(format!("{} scroll areas", self.memory().scroll_areas.len()));
-            if ui.button("Reset").clicked {
+            if ui.button("Reset").clicked() {
                 self.memory().scroll_areas = Default::default();
             }
         });
 
         ui.horizontal(|ui| {
             ui.label(format!("{} resize areas", self.memory().resize.len()));
-            if ui.button("Reset").clicked {
+            if ui.button("Reset").clicked() {
                 self.memory().resize = Default::default();
             }
         });

--- a/egui/src/data/input.rs
+++ b/egui/src/data/input.rs
@@ -9,12 +9,12 @@ use crate::math::*;
 /// All coordinates are in points (logical pixels) with origin (0, 0) in the top left corner.
 #[derive(Clone, Debug)]
 pub struct RawInput {
-    /// Is the button currently down?
+    /// Is the mouse button currently down (or a finger, on touch screens??
     /// NOTE: egui currently only supports the primary mouse button.
-    pub mouse_down: bool,
+    pub pointer_button_down: bool,
 
-    /// Current position of the mouse in points.
-    pub mouse_pos: Option<Pos2>,
+    /// Current position of the mouse/touch in points.
+    pub pointer_pos: Option<Pos2>,
 
     /// How many points (logical pixels) the user scrolled
     pub scroll_delta: Vec2,
@@ -56,8 +56,8 @@ impl Default for RawInput {
     fn default() -> Self {
         #![allow(deprecated)] // for screen_size
         Self {
-            mouse_down: false,
-            mouse_pos: None,
+            pointer_button_down: false,
+            pointer_pos: None,
             scroll_delta: Vec2::zero(),
             screen_size: Default::default(),
             screen_rect: None,
@@ -75,8 +75,8 @@ impl RawInput {
     pub fn take(&mut self) -> RawInput {
         #![allow(deprecated)] // for screen_size
         RawInput {
-            mouse_down: self.mouse_down,
-            mouse_pos: self.mouse_pos,
+            pointer_button_down: self.pointer_button_down,
+            pointer_pos: self.pointer_pos,
             scroll_delta: std::mem::take(&mut self.scroll_delta),
             screen_size: self.screen_size,
             screen_rect: self.screen_rect,
@@ -208,8 +208,8 @@ impl RawInput {
     pub fn ui(&self, ui: &mut crate::Ui) {
         #![allow(deprecated)] // for screen_size
         let Self {
-            mouse_down,
-            mouse_pos,
+            pointer_button_down,
+            pointer_pos,
             scroll_delta,
             screen_size: _,
             screen_rect,
@@ -220,10 +220,8 @@ impl RawInput {
             events,
         } = self;
 
-        // TODO: simpler way to show values, e.g. `ui.value("Mouse Pos:", self.mouse_pos);
-        // TODO: `ui.style_mut().text_style = TextStyle::Monospace`;
-        ui.label(format!("mouse_down: {}", mouse_down));
-        ui.label(format!("mouse_pos: {:.1?}", mouse_pos));
+        ui.label(format!("pointer_button_down: {}", pointer_button_down));
+        ui.label(format!("pointer_pos: {:.1?}", pointer_pos));
         ui.label(format!("scroll_delta: {:?} points", scroll_delta));
         ui.label(format!("screen_rect: {:?} points", screen_rect));
         ui.label(format!("pixels_per_point: {:?}", pixels_per_point))

--- a/egui/src/input_state.rs
+++ b/egui/src/input_state.rs
@@ -225,10 +225,10 @@ pub struct PointerState {
     interact_pos: Option<Pos2>,
 
     /// How much the pointer moved compared to last frame, in points.
-    pub delta: Vec2,
+    delta: Vec2,
 
     /// Current velocity of pointer.
-    pub velocity: Vec2,
+    velocity: Vec2,
 
     /// Recent movement of the pointer.
     /// Used for calculating velocity of pointer.
@@ -238,7 +238,7 @@ pub struct PointerState {
 
     /// Where did the current click/drag originate?
     /// `None` if no mouse button is down.
-    pub press_origin: Option<Pos2>,
+    press_origin: Option<Pos2>,
 
     /// If the pointer button is down, will it register as a click when released?
     /// Set to true on pointer button down, set to false when pointer button moves too much.
@@ -273,7 +273,7 @@ impl Default for PointerState {
 
 impl PointerState {
     #[must_use]
-    pub fn begin_frame(mut self, time: f64, new: &RawInput) -> PointerState {
+    pub(crate) fn begin_frame(mut self, time: f64, new: &RawInput) -> PointerState {
         // self.clicks.clear();
         self.pointer_events.clear();
 
@@ -384,6 +384,22 @@ impl PointerState {
         !self.pointer_events.is_empty() || self.delta != Vec2::zero()
     }
 
+    /// How much the pointer moved compared to last frame, in points.
+    pub fn delta(&self) -> Vec2 {
+        self.delta
+    }
+
+    /// Current velocity of pointer.
+    pub fn velocity(&self) -> Vec2 {
+        self.velocity
+    }
+
+    /// Where did the current click/drag originate?
+    /// `None` if no mouse button is down.
+    pub fn press_origin(&self) -> Option<Pos2> {
+        self.press_origin
+    }
+
     /// Latest reported pointer position.
     /// When tapping a touch screen, this will be `None`.
     pub(crate) fn latest_pos(&self) -> Option<Pos2> {
@@ -395,6 +411,8 @@ impl PointerState {
         self.latest_pos
     }
 
+    /// If you detect a click or drag and wants to know where it happened, use this.
+    ///
     /// Latest position of the mouse, but ignoring any [`Event::PointerGone`]
     /// if there were interactions this frame.
     /// When tapping a touch screen, this will be the location of the touch.
@@ -402,6 +420,9 @@ impl PointerState {
         self.interact_pos
     }
 
+    /// Do we have a pointer?
+    ///
+    /// `false` if the mouse is not over the egui area, or if no touches are down on touch screens.
     pub fn has_pointer(&self) -> bool {
         self.latest_pos.is_some()
     }

--- a/egui/src/input_state.rs
+++ b/egui/src/input_state.rs
@@ -274,7 +274,6 @@ impl Default for PointerState {
 impl PointerState {
     #[must_use]
     pub(crate) fn begin_frame(mut self, time: f64, new: &RawInput) -> PointerState {
-        // self.clicks.clear();
         self.pointer_events.clear();
 
         let old_pos = self.latest_pos;
@@ -366,7 +365,7 @@ impl PointerState {
         } else {
             // we do not clear the `pos_history` here, because it is exactly when a finger has
             // released from the touch screen that we may want to assign a velocity to whatever
-            // the user tried to throw
+            // the user tried to throw.
         }
 
         self.pos_history.flush(time);

--- a/egui/src/introspection.rs
+++ b/egui/src/introspection.rs
@@ -29,12 +29,10 @@ impl Widget for &epaint::Texture {
 
             let (tex_w, tex_h) = (self.width as f32, self.height as f32);
 
+            let pointer_pos = response.interact_pointer_pos();
+
             response.on_hover_ui(|ui| {
-                let pos = ui
-                    .input()
-                    .pointer
-                    .pos
-                    .unwrap_or_else(|| ui.min_rect().left_top());
+                let pos = pointer_pos.unwrap_or_else(|| ui.min_rect().left_top());
                 let (_id, zoom_rect) = ui.allocate_space(vec2(128.0, 128.0));
                 let u = remap_clamp(pos.x, rect.x_range(), 0.0..=tex_w);
                 let v = remap_clamp(pos.y, rect.y_range(), 0.0..=tex_h);

--- a/egui/src/introspection.rs
+++ b/egui/src/introspection.rs
@@ -32,7 +32,7 @@ impl Widget for &epaint::Texture {
             response.on_hover_ui(|ui| {
                 let pos = ui
                     .input()
-                    .mouse
+                    .pointer
                     .pos
                     .unwrap_or_else(|| ui.min_rect().left_top());
                 let (_id, zoom_rect) = ui.allocate_space(vec2(128.0, 128.0));

--- a/egui/src/memory.rs
+++ b/egui/src/memory.rs
@@ -125,7 +125,8 @@ pub(crate) struct Interaction {
 }
 
 impl Interaction {
-    pub fn is_using_mouse(&self) -> bool {
+    /// Are we currently clicking or dragging an egui widget?
+    pub fn is_using_pointer(&self) -> bool {
         self.click_id.is_some() || self.drag_id.is_some()
     }
 
@@ -138,12 +139,12 @@ impl Interaction {
         self.click_interest = false;
         self.drag_interest = false;
 
-        if !prev_input.mouse.could_be_click {
+        if !prev_input.pointer.could_be_click {
             self.click_id = None;
         }
 
-        if !prev_input.mouse.down || prev_input.mouse.pos.is_none() {
-            // mouse was not down last frame
+        if !prev_input.pointer.down || prev_input.pointer.pos.is_none() {
+            // pointer button was not down last frame
             self.click_id = None;
             self.drag_id = None;
         }
@@ -175,7 +176,7 @@ impl Memory {
     ) {
         self.interaction.begin_frame(prev_input, new_input);
 
-        if !prev_input.mouse.down {
+        if !prev_input.pointer.down {
             self.window_interaction = None;
         }
     }

--- a/egui/src/memory.rs
+++ b/egui/src/memory.rs
@@ -139,11 +139,7 @@ impl Interaction {
         self.click_interest = false;
         self.drag_interest = false;
 
-        if !prev_input.pointer.could_be_click {
-            self.click_id = None;
-        }
-
-        if !prev_input.pointer.down || prev_input.pointer.pos.is_none() {
+        if !prev_input.pointer.any_down() || prev_input.pointer.latest_pos().is_none() {
             // pointer button was not down last frame
             self.click_id = None;
             self.drag_id = None;
@@ -176,7 +172,7 @@ impl Memory {
     ) {
         self.interaction.begin_frame(prev_input, new_input);
 
-        if !prev_input.pointer.down {
+        if !prev_input.pointer.any_down() {
             self.window_interaction = None;
         }
     }

--- a/egui/src/menu.rs
+++ b/egui/src/menu.rs
@@ -117,7 +117,7 @@ fn menu_impl<'c>(
 
         // TODO: this prevents sub-menus in menus. We should fix that.
         if ui.input().key_pressed(Key::Escape)
-            || ui.input().pointer.click && !button_response.clicked()
+            || ui.input().pointer.any_click() && !button_response.clicked()
         {
             bar_state.open_menu = None;
         }

--- a/egui/src/menu.rs
+++ b/egui/src/menu.rs
@@ -7,7 +7,7 @@
 //!
 //!     menu::bar(ui, |ui| {
 //!         menu::menu(ui, "File", |ui| {
-//!             if ui.button("Open").clicked {
+//!             if ui.button("Open").clicked() {
 //!                 // ...
 //!             }
 //!         });
@@ -83,7 +83,7 @@ fn menu_impl<'c>(
     }
 
     let button_response = ui.add(button);
-    if button_response.clicked {
+    if button_response.clicked() {
         // Toggle
         if bar_state.open_menu == Some(menu_id) {
             bar_state.open_menu = None;
@@ -117,7 +117,7 @@ fn menu_impl<'c>(
 
         // TODO: this prevents sub-menus in menus. We should fix that.
         if ui.input().key_pressed(Key::Escape)
-            || ui.input().pointer.click && !button_response.clicked
+            || ui.input().pointer.click && !button_response.clicked()
         {
             bar_state.open_menu = None;
         }

--- a/egui/src/menu.rs
+++ b/egui/src/menu.rs
@@ -116,7 +116,8 @@ fn menu_impl<'c>(
         });
 
         // TODO: this prevents sub-menus in menus. We should fix that.
-        if ui.input().key_pressed(Key::Escape) || ui.input().mouse.click && !button_response.clicked
+        if ui.input().key_pressed(Key::Escape)
+            || ui.input().pointer.click && !button_response.clicked
         {
             bar_state.open_menu = None;
         }

--- a/egui/src/menu.rs
+++ b/egui/src/menu.rs
@@ -90,7 +90,7 @@ fn menu_impl<'c>(
         } else {
             bar_state.open_menu = Some(menu_id);
         }
-    } else if button_response.hovered && bar_state.open_menu.is_some() {
+    } else if button_response.hovered() && bar_state.open_menu.is_some() {
         bar_state.open_menu = Some(menu_id);
     }
 

--- a/egui/src/response.rs
+++ b/egui/src/response.rs
@@ -102,6 +102,16 @@ impl Response {
         self.clicked[PointerButton::Primary as usize]
     }
 
+    /// Returns true if this widget was clicked this frame by the secondary mouse button (e.g. the right mouse button).
+    pub fn secondary_clicked(&self) -> bool {
+        self.clicked[PointerButton::Secondary as usize]
+    }
+
+    /// Returns true if this widget was clicked this frame by the middle mouse button.
+    pub fn middle_clicked(&self) -> bool {
+        self.clicked[PointerButton::Middle as usize]
+    }
+
     /// Returns true if this widget was double-clicked this frame by the primary button.
     pub fn double_clicked(&self) -> bool {
         self.double_clicked[PointerButton::Primary as usize]
@@ -143,12 +153,12 @@ impl Response {
     }
 
     /// Returns true if this widget was clicked this frame by the given button.
-    pub fn clicked_with(&self, button: PointerButton) -> bool {
+    pub fn clicked_by(&self, button: PointerButton) -> bool {
         self.clicked[button as usize]
     }
 
     /// Returns true if this widget was double-clicked this frame by the given button.
-    pub fn double_clicked_with(&self, button: PointerButton) -> bool {
+    pub fn double_clicked_by(&self, button: PointerButton) -> bool {
         self.double_clicked[button as usize]
     }
 

--- a/egui/src/response.rs
+++ b/egui/src/response.rs
@@ -31,10 +31,10 @@ pub struct Response {
     pub hovered: bool,
 
     /// The pointer clicked this thing this frame.
-    pub clicked: bool,
+    pub(crate) clicked: bool,
 
     /// The thing was double-clicked.
-    pub double_clicked: bool,
+    pub(crate) double_clicked: bool,
 
     /// The pointer is interacting with this thing (e.g. dragging it).
     pub active: bool,
@@ -89,6 +89,16 @@ impl std::fmt::Debug for Response {
 }
 
 impl Response {
+    /// Returns true if this widget was clicked this frame by the primary button.
+    pub fn clicked(&self) -> bool {
+        self.clicked
+    }
+
+    /// Returns true if this widget was double-clicked this frame by the primary button.
+    pub fn double_clicked(&self) -> bool {
+        self.double_clicked
+    }
+
     /// Show this UI if the item was hovered (i.e. a tooltip).
     /// If you call this multiple times the tooltips will stack underneath the previous ones.
     pub fn on_hover_ui(self, add_contents: impl FnOnce(&mut Ui)) -> Self {
@@ -116,9 +126,9 @@ impl Response {
     /// ```
     /// # let mut ui = egui::Ui::__test();
     /// let response = ui.label("hello");
-    /// assert!(!response.clicked); // labels don't sense clicks
+    /// assert!(!response.clicked()); // labels don't sense clicks
     /// let response = response.interact(egui::Sense::click());
-    /// if response.clicked { /* … */ }
+    /// if response.clicked() { /* … */ }
     /// ```
     pub fn interact(&self, sense: Sense) -> Self {
         self.ctx
@@ -133,7 +143,7 @@ impl Response {
     /// egui::ScrollArea::auto_sized().show(ui, |ui| {
     ///     for i in 0..1000 {
     ///         let response = ui.button(format!("Button {}", i));
-    ///         if response.clicked {
+    ///         if response.clicked() {
     ///             response.scroll_to_me(Align::Center);
     ///         }
     ///     }

--- a/egui/src/response.rs
+++ b/egui/src/response.rs
@@ -27,16 +27,16 @@ pub struct Response {
     pub sense: Sense,
 
     // OUT:
-    /// The mouse is hovering above this.
+    /// The pointer is hovering above this.
     pub hovered: bool,
 
-    /// The mouse clicked this thing this frame.
+    /// The pointer clicked this thing this frame.
     pub clicked: bool,
 
     /// The thing was double-clicked.
     pub double_clicked: bool,
 
-    /// The mouse is interacting with this thing (e.g. dragging it).
+    /// The pointer is interacting with this thing (e.g. dragging it).
     pub active: bool,
 
     /// This widget has the keyboard focus (i.e. is receiving key pressed).

--- a/egui/src/response.rs
+++ b/egui/src/response.rs
@@ -31,7 +31,7 @@ pub struct Response {
 
     // OUT:
     /// The pointer is hovering above this widget or the widget was clicked/tapped this frame.
-    pub hovered: bool,
+    pub(crate) hovered: bool,
 
     /// The pointer clicked this thing this frame.
     pub(crate) clicked: [bool; NUM_POINTER_BUTTONS],
@@ -56,20 +56,8 @@ pub struct Response {
     /// This widget has the keyboard focus (i.e. is receiving key pressed).
     pub(crate) has_kb_focus: bool,
 
-    /// The widget had keyboard focus and lost it,
-    /// perhaps because the user pressed enter.
-    /// If you want to do an action when a user presses enter in a text field,
-    /// use this.
-    ///
-    /// ```
-    /// # let mut ui = egui::Ui::__test();
-    /// # let mut my_text = String::new();
-    /// # fn do_request(_: &str) {}
-    /// if ui.text_edit_singleline(&mut my_text).lost_kb_focus {
-    ///     do_request(&my_text);
-    /// }
-    /// ```
-    pub lost_kb_focus: bool,
+    /// The widget had keyboard focus and lost it.
+    pub(crate) lost_kb_focus: bool,
 }
 
 impl std::fmt::Debug for Response {
@@ -119,6 +107,28 @@ impl Response {
         self.double_clicked[PointerButton::Primary as usize]
     }
 
+    /// The pointer is hovering above this widget or the widget was clicked/tapped this frame.
+    pub fn hovered(&self) -> bool {
+        self.hovered
+    }
+
+    /// The widget had keyboard focus and lost it,
+    /// perhaps because the user pressed enter.
+    /// If you want to do an action when a user presses enter in a text field,
+    /// use this.
+    ///
+    /// ```
+    /// # let mut ui = egui::Ui::__test();
+    /// # let mut my_text = String::new();
+    /// # fn do_request(_: &str) {}
+    /// if ui.text_edit_singleline(&mut my_text).lost_kb_focus() {
+    ///     do_request(&my_text);
+    /// }
+    /// ```
+    pub fn lost_kb_focus(&self) -> bool {
+        self.lost_kb_focus
+    }
+
     /// The widgets is being dragged.
     ///
     /// To find out which button(s), query [`PointerState::button_down`]
@@ -157,7 +167,7 @@ impl Response {
     /// Show this UI if the item was hovered (i.e. a tooltip).
     /// If you call this multiple times the tooltips will stack underneath the previous ones.
     pub fn on_hover_ui(self, add_contents: impl FnOnce(&mut Ui)) -> Self {
-        if (self.hovered && self.ctx.input().pointer.tooltip_pos().is_some())
+        if (self.hovered() && self.ctx.input().pointer.tooltip_pos().is_some())
             || self.ctx.memory().everything_is_visible()
         {
             crate::containers::show_tooltip(&self.ctx, add_contents);
@@ -274,7 +284,7 @@ impl std::ops::BitOr for Response {
 /// let mut response = ui.add(widget_a);
 /// response |= ui.add(widget_b);
 /// response |= ui.add(widget_c);
-/// if response.hovered { ui.label("You hovered at least one of the widgets"); }
+/// if response.hovered() { ui.label("You hovered at least one of the widgets"); }
 /// ```
 impl std::ops::BitOrAssign for Response {
     fn bitor_assign(&mut self, rhs: Self) {

--- a/egui/src/style.rs
+++ b/egui/src/style.rs
@@ -199,7 +199,7 @@ impl Widgets {
             &self.active
         } else if response.sense == crate::Sense::hover() {
             &self.disabled
-        } else if response.hovered {
+        } else if response.hovered() {
             &self.hovered
         } else {
             &self.inactive

--- a/egui/src/style.rs
+++ b/egui/src/style.rs
@@ -195,7 +195,7 @@ pub struct Widgets {
 
 impl Widgets {
     pub fn style(&self, response: &Response) -> &WidgetVisuals {
-        if response.active || response.has_kb_focus {
+        if response.is_pointer_button_down_on() || response.has_kb_focus {
             &self.active
         } else if response.sense == crate::Sense::hover() {
             &self.disabled

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -363,6 +363,10 @@ impl Ui {
         )
     }
 
+    /// Is the pointer (mouse/touch) above this rectangle in this `Ui`?
+    ///
+    /// The `clip_rect` and layer of this `Ui` will be respected, so, for instance,
+    /// if this `Ui` is behind some other window, this will always return `false`.
     pub fn rect_contains_pointer(&self, rect: Rect) -> bool {
         self.ctx()
             .rect_contains_pointer(self.layer_id(), self.clip_rect().intersect(rect))
@@ -372,6 +376,16 @@ impl Ui {
     /// Equivalent to `ui.rect_contains_pointer(ui.min_rect())`
     pub fn ui_contains_pointer(&self) -> bool {
         self.rect_contains_pointer(self.min_rect())
+    }
+
+    #[deprecated = "renamed rect_contains_pointer"]
+    pub fn rect_contains_mouse(&self, rect: Rect) -> bool {
+        self.rect_contains_pointer(rect)
+    }
+
+    #[deprecated = "renamed ui_contains_pointer"]
+    pub fn ui_contains_mouse(&self) -> bool {
+        self.ui_contains_pointer()
     }
 
     #[deprecated = "Use: interact(rect, id, Sense::hover())"]

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -410,7 +410,7 @@ impl Ui {
     /// ```
     /// # let mut ui = egui::Ui::__test();
     /// let response = ui.allocate_response(egui::vec2(100.0, 200.0), egui::Sense::click());
-    /// if response.clicked { /* … */ }
+    /// if response.clicked() { /* … */ }
     /// ui.painter().rect_stroke(response.rect, 0.0, (1.0, egui::Color32::WHITE));
     /// ```
     pub fn allocate_response(&mut self, desired_size: Vec2, sense: Sense) -> Response {
@@ -572,7 +572,7 @@ impl Ui {
     /// # use egui::Align;
     /// # let mut ui = &mut egui::Ui::__test();
     /// egui::ScrollArea::auto_sized().show(ui, |ui| {
-    ///     let scroll_bottom = ui.button("Scroll to bottom.").clicked;
+    ///     let scroll_bottom = ui.button("Scroll to bottom.").clicked();
     ///     for i in 0..1000 {
     ///         ui.label(format!("Item {}", i));
     ///     }
@@ -654,20 +654,20 @@ impl Ui {
         self.add(TextEdit::multiline(text))
     }
 
-    /// Usage: `if ui.button("Click me").clicked { ... }`
+    /// Usage: `if ui.button("Click me").clicked() { ... }`
     ///
     /// Shortcut for `add(Button::new(text))`
-    #[must_use = "You should check if the user clicked this with `if ui.button(...).clicked { ... } "]
+    #[must_use = "You should check if the user clicked this with `if ui.button(...).clicked() { ... } "]
     pub fn button(&mut self, text: impl Into<String>) -> Response {
         self.add(Button::new(text))
     }
 
     /// A button as small as normal body text.
     ///
-    /// Usage: `if ui.small_button("Click me").clicked { ... }`
+    /// Usage: `if ui.small_button("Click me").clicked() { ... }`
     ///
     /// Shortcut for `add(Button::new(text).small())`
-    #[must_use = "You should check if the user clicked this with `if ui.small_button(...).clicked { ... } "]
+    #[must_use = "You should check if the user clicked this with `if ui.small_button(...).clicked() { ... } "]
     pub fn small_button(&mut self, text: impl Into<String>) -> Response {
         self.add(Button::new(text).small())
     }
@@ -694,7 +694,7 @@ impl Ui {
         text: impl Into<String>,
     ) -> Response {
         let response = self.radio(*current_value == selected_value, text);
-        if response.clicked {
+        if response.clicked() {
             *current_value = selected_value;
         }
         response
@@ -716,7 +716,7 @@ impl Ui {
         text: impl Into<String>,
     ) -> Response {
         let response = self.selectable_label(*current_value == selected_value, text);
-        if response.clicked {
+        if response.clicked() {
             *current_value = selected_value;
         }
         response

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -363,15 +363,15 @@ impl Ui {
         )
     }
 
-    pub fn rect_contains_mouse(&self, rect: Rect) -> bool {
+    pub fn rect_contains_pointer(&self, rect: Rect) -> bool {
         self.ctx()
-            .rect_contains_mouse(self.layer_id(), self.clip_rect().intersect(rect))
+            .rect_contains_pointer(self.layer_id(), self.clip_rect().intersect(rect))
     }
 
-    /// Is the mouse above this `Ui`?
-    /// Equivalent to `ui.rect_contains_mouse(ui.min_rect())`
-    pub fn ui_contains_mouse(&self) -> bool {
-        self.rect_contains_mouse(self.min_rect())
+    /// Is the pointer (mouse/touch) above this `Ui`?
+    /// Equivalent to `ui.rect_contains_pointer(ui.min_rect())`
+    pub fn ui_contains_pointer(&self) -> bool {
+        self.rect_contains_pointer(self.min_rect())
     }
 
     #[deprecated = "Use: interact(rect, id, Sense::hover())"]
@@ -379,7 +379,7 @@ impl Ui {
         self.interact(rect, self.auto_id_with("hover_rect"), Sense::hover())
     }
 
-    #[deprecated = "Use: rect_contains_mouse()"]
+    #[deprecated = "Use: rect_contains_pointer()"]
     pub fn hovered(&self, rect: Rect) -> bool {
         self.interact(rect, self.id, Sense::hover()).hovered
     }

--- a/egui/src/widgets/button.rs
+++ b/egui/src/widgets/button.rs
@@ -191,7 +191,7 @@ impl<'a> Widget for Checkbox<'a> {
         desired_size = desired_size.at_least(spacing.interact_size);
         desired_size.y = desired_size.y.max(icon_width);
         let (rect, response) = ui.allocate_exact_size(desired_size, Sense::click());
-        if response.clicked {
+        if response.clicked() {
             *checked = !*checked;
         }
 

--- a/egui/src/widgets/color_picker.rs
+++ b/egui/src/widgets/color_picker.rs
@@ -335,7 +335,7 @@ pub fn color_edit_button_hsva(ui: &mut Ui, hsva: &mut Hsva, alpha: Alpha) -> Res
             });
 
         if !button_response.clicked() {
-            let clicked_outside = ui.input().pointer.any_pressed() && !area_response.hovered;
+            let clicked_outside = ui.input().pointer.any_pressed() && !area_response.hovered();
             if clicked_outside || ui.input().key_pressed(Key::Escape) {
                 ui.memory().close_popup();
             }

--- a/egui/src/widgets/color_picker.rs
+++ b/egui/src/widgets/color_picker.rs
@@ -335,7 +335,7 @@ pub fn color_edit_button_hsva(ui: &mut Ui, hsva: &mut Hsva, alpha: Alpha) -> Res
             });
 
         if !button_response.clicked() {
-            let clicked_outside = ui.input().pointer.click && !area_response.hovered;
+            let clicked_outside = ui.input().pointer.any_pressed() && !area_response.hovered;
             if clicked_outside || ui.input().key_pressed(Key::Escape) {
                 ui.memory().close_popup();
             }

--- a/egui/src/widgets/color_picker.rs
+++ b/egui/src/widgets/color_picker.rs
@@ -95,7 +95,7 @@ fn color_slider_1d(ui: &mut Ui, value: &mut f32, color_at: impl Fn(f32) -> Color
     let (rect, response) = ui.allocate_at_least(desired_size, Sense::click_and_drag());
 
     if response.active {
-        if let Some(mpos) = ui.input().mouse.pos {
+        if let Some(mpos) = ui.input().pointer.pos {
             *value = remap_clamp(mpos.x, rect.left()..=rect.right(), 0.0..=1.0);
         }
     }
@@ -152,7 +152,7 @@ fn color_slider_2d(
     let (rect, response) = ui.allocate_at_least(desired_size, Sense::click_and_drag());
 
     if response.active {
-        if let Some(mpos) = ui.input().mouse.pos {
+        if let Some(mpos) = ui.input().pointer.pos {
             *x_value = remap_clamp(mpos.x, rect.left()..=rect.right(), 0.0..=1.0);
             *y_value = remap_clamp(mpos.y, rect.bottom()..=rect.top(), 0.0..=1.0);
         }
@@ -339,7 +339,7 @@ pub fn color_edit_button_hsva(ui: &mut Ui, hsva: &mut Hsva, alpha: Alpha) -> Res
             });
 
         if !button_response.clicked {
-            let clicked_outside = ui.input().mouse.click && !area_response.hovered;
+            let clicked_outside = ui.input().pointer.click && !area_response.hovered;
             if clicked_outside || ui.input().key_pressed(Key::Escape) {
                 ui.memory().close_popup();
             }

--- a/egui/src/widgets/color_picker.rs
+++ b/egui/src/widgets/color_picker.rs
@@ -217,7 +217,7 @@ fn color_text_ui(ui: &mut Ui, color: impl Into<Color32>) {
             r, g, b, a
         ));
 
-        if ui.button("📋").on_hover_text("Click to copy").clicked {
+        if ui.button("📋").on_hover_text("Click to copy").clicked() {
             ui.output().copied_text = format!("rgba({}, {}, {}, {})", r, g, b, a);
         }
     });
@@ -323,7 +323,7 @@ pub fn color_edit_button_hsva(ui: &mut Ui, hsva: &mut Hsva, alpha: Alpha) -> Res
     let pupup_id = ui.auto_id_with("popup");
     let button_response = color_button(ui, (*hsva).into()).on_hover_text("Click to edit color");
 
-    if button_response.clicked {
+    if button_response.clicked() {
         ui.memory().toggle_popup(pupup_id);
     }
     // TODO: make it easier to show a temporary popup that closes when you click outside it
@@ -338,7 +338,7 @@ pub fn color_edit_button_hsva(ui: &mut Ui, hsva: &mut Hsva, alpha: Alpha) -> Res
                 })
             });
 
-        if !button_response.clicked {
+        if !button_response.clicked() {
             let clicked_outside = ui.input().pointer.click && !area_response.hovered;
             if clicked_outside || ui.input().key_pressed(Key::Escape) {
                 ui.memory().close_popup();

--- a/egui/src/widgets/color_picker.rs
+++ b/egui/src/widgets/color_picker.rs
@@ -94,10 +94,8 @@ fn color_slider_1d(ui: &mut Ui, value: &mut f32, color_at: impl Fn(f32) -> Color
     );
     let (rect, response) = ui.allocate_at_least(desired_size, Sense::click_and_drag());
 
-    if response.active {
-        if let Some(mpos) = ui.input().pointer.pos {
-            *value = remap_clamp(mpos.x, rect.left()..=rect.right(), 0.0..=1.0);
-        }
+    if let Some(mpos) = response.interact_pointer_pos() {
+        *value = remap_clamp(mpos.x, rect.left()..=rect.right(), 0.0..=1.0);
     }
 
     let visuals = ui.style().interact(&response);
@@ -151,11 +149,9 @@ fn color_slider_2d(
     let desired_size = Vec2::splat(ui.style().spacing.slider_width);
     let (rect, response) = ui.allocate_at_least(desired_size, Sense::click_and_drag());
 
-    if response.active {
-        if let Some(mpos) = ui.input().pointer.pos {
-            *x_value = remap_clamp(mpos.x, rect.left()..=rect.right(), 0.0..=1.0);
-            *y_value = remap_clamp(mpos.y, rect.bottom()..=rect.top(), 0.0..=1.0);
-        }
+    if let Some(mpos) = response.interact_pointer_pos() {
+        *x_value = remap_clamp(mpos.x, rect.left()..=rect.right(), 0.0..=1.0);
+        *y_value = remap_clamp(mpos.y, rect.bottom()..=rect.top(), 0.0..=1.0);
     }
 
     let visuals = ui.style().interact(&response);

--- a/egui/src/widgets/drag_value.rs
+++ b/egui/src/widgets/drag_value.rs
@@ -185,7 +185,7 @@ impl<'a> Widget for DragValue<'a> {
                 value as f32, // Show full precision value on-hover. TODO: figure out f64 vs f32
                 suffix
             ));
-            if response.clicked {
+            if response.clicked() {
                 ui.memory().request_kb_focus(kb_edit_id);
                 ui.memory().temp_edit_string = None; // Filled in next frame
             } else if response.active {

--- a/egui/src/widgets/drag_value.rs
+++ b/egui/src/widgets/drag_value.rs
@@ -188,7 +188,7 @@ impl<'a> Widget for DragValue<'a> {
             if response.clicked() {
                 ui.memory().request_kb_focus(kb_edit_id);
                 ui.memory().temp_edit_string = None; // Filled in next frame
-            } else if response.active {
+            } else if response.dragged() {
                 let mdelta = ui.input().pointer.delta;
                 let delta_points = mdelta.x - mdelta.y; // Increase to the right and up
                 let delta_value = speed * delta_points;

--- a/egui/src/widgets/drag_value.rs
+++ b/egui/src/widgets/drag_value.rs
@@ -189,7 +189,7 @@ impl<'a> Widget for DragValue<'a> {
                 ui.memory().request_kb_focus(kb_edit_id);
                 ui.memory().temp_edit_string = None; // Filled in next frame
             } else if response.active {
-                let mdelta = ui.input().mouse.delta;
+                let mdelta = ui.input().pointer.delta;
                 let delta_points = mdelta.x - mdelta.y; // Increase to the right and up
                 let delta_value = speed * delta_points;
                 if delta_value != 0.0 {

--- a/egui/src/widgets/drag_value.rs
+++ b/egui/src/widgets/drag_value.rs
@@ -189,7 +189,7 @@ impl<'a> Widget for DragValue<'a> {
                 ui.memory().request_kb_focus(kb_edit_id);
                 ui.memory().temp_edit_string = None; // Filled in next frame
             } else if response.dragged() {
-                let mdelta = ui.input().pointer.delta;
+                let mdelta = ui.input().pointer.delta();
                 let delta_points = mdelta.x - mdelta.y; // Increase to the right and up
                 let delta_value = speed * delta_points;
                 if delta_value != 0.0 {

--- a/egui/src/widgets/hyperlink.rs
+++ b/egui/src/widgets/hyperlink.rs
@@ -48,7 +48,7 @@ impl Widget for Hyperlink {
         let galley = font.layout_multiline(text, ui.available_width());
         let (rect, response) = ui.allocate_exact_size(galley.size, Sense::click());
 
-        if response.hovered {
+        if response.hovered() {
             ui.ctx().output().cursor_icon = CursorIcon::PointingHand;
         }
         if response.clicked() {
@@ -58,7 +58,7 @@ impl Widget for Hyperlink {
         let color = ui.style().visuals.hyperlink_color;
         let visuals = ui.style().interact(&response);
 
-        if response.hovered {
+        if response.hovered() {
             // Underline:
             for line in &galley.rows {
                 let pos = rect.min;

--- a/egui/src/widgets/hyperlink.rs
+++ b/egui/src/widgets/hyperlink.rs
@@ -51,7 +51,7 @@ impl Widget for Hyperlink {
         if response.hovered {
             ui.ctx().output().cursor_icon = CursorIcon::PointingHand;
         }
-        if response.clicked {
+        if response.clicked() {
             ui.ctx().output().open_url = Some(url.clone());
         }
 

--- a/egui/src/widgets/mod.rs
+++ b/egui/src/widgets/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Example widget uses:
 //! * `ui.add(Label::new("Text").text_color(color::red));`
-//! * `if ui.add(Button::new("Click me")).clicked { ... }`
+//! * `if ui.add(Button::new("Click me")).clicked() { ... }`
 
 #![allow(clippy::new_without_default)]
 
@@ -40,7 +40,10 @@ pub trait Widget {
 /// The button is only enabled if the value does not already have its original value.
 pub fn reset_button<T: Default + PartialEq>(ui: &mut Ui, value: &mut T) {
     let def = T::default();
-    if ui.add(Button::new("Reset").enabled(*value != def)).clicked {
+    if ui
+        .add(Button::new("Reset").enabled(*value != def))
+        .clicked()
+    {
         *value = def;
     }
 }

--- a/egui/src/widgets/selected_label.rs
+++ b/egui/src/widgets/selected_label.rs
@@ -42,7 +42,7 @@ impl Widget for SelectableLabel {
 
         let visuals = ui.style().interact(&response);
 
-        if selected || response.hovered {
+        if selected || response.hovered() {
             let rect = rect.expand(visuals.expansion);
             let fill = if selected {
                 ui.style().visuals.selection.bg_fill

--- a/egui/src/widgets/slider.rs
+++ b/egui/src/widgets/slider.rs
@@ -252,19 +252,17 @@ impl<'a> Slider<'a> {
         let rect = &response.rect;
         let x_range = x_range(rect);
 
-        if let Some(pointer_pos) = ui.input().pointer.pos {
-            if response.active {
-                let new_value = if self.smart_aim {
-                    let aim_radius = ui.input().aim_radius();
-                    crate::math::smart_aim::best_in_range_f64(
-                        self.value_from_x(pointer_pos.x - aim_radius, x_range.clone()),
-                        self.value_from_x(pointer_pos.x + aim_radius, x_range.clone()),
-                    )
-                } else {
-                    self.value_from_x(pointer_pos.x, x_range.clone())
-                };
-                self.set_value(new_value);
-            }
+        if let Some(pointer_pos) = response.interact_pointer_pos() {
+            let new_value = if self.smart_aim {
+                let aim_radius = ui.input().aim_radius();
+                crate::math::smart_aim::best_in_range_f64(
+                    self.value_from_x(pointer_pos.x - aim_radius, x_range.clone()),
+                    self.value_from_x(pointer_pos.x + aim_radius, x_range.clone()),
+                )
+            } else {
+                self.value_from_x(pointer_pos.x, x_range.clone())
+            };
+            self.set_value(new_value);
         }
 
         // Paint it:

--- a/egui/src/widgets/slider.rs
+++ b/egui/src/widgets/slider.rs
@@ -350,7 +350,7 @@ impl<'a> Slider<'a> {
                 self.get_value() as f32 // Show full precision value on-hover. TODO: figure out f64 vs f32
             ));
             // let response = ui.interact(response.rect, kb_edit_id, Sense::click());
-            if response.clicked {
+            if response.clicked() {
                 ui.memory().request_kb_focus(kb_edit_id);
                 ui.memory().temp_edit_string = None; // Filled in next frame
             }

--- a/egui/src/widgets/slider.rs
+++ b/egui/src/widgets/slider.rs
@@ -252,16 +252,16 @@ impl<'a> Slider<'a> {
         let rect = &response.rect;
         let x_range = x_range(rect);
 
-        if let Some(mouse_pos) = ui.input().mouse.pos {
+        if let Some(pointer_pos) = ui.input().pointer.pos {
             if response.active {
                 let new_value = if self.smart_aim {
                     let aim_radius = ui.input().aim_radius();
                     crate::math::smart_aim::best_in_range_f64(
-                        self.value_from_x(mouse_pos.x - aim_radius, x_range.clone()),
-                        self.value_from_x(mouse_pos.x + aim_radius, x_range.clone()),
+                        self.value_from_x(pointer_pos.x - aim_radius, x_range.clone()),
+                        self.value_from_x(pointer_pos.x + aim_radius, x_range.clone()),
                     )
                 } else {
-                    self.value_from_x(mouse_pos.x, x_range.clone())
+                    self.value_from_x(pointer_pos.x, x_range.clone())
                 };
                 self.set_value(new_value);
             }

--- a/egui/src/widgets/text_edit.rs
+++ b/egui/src/widgets/text_edit.rs
@@ -318,45 +318,45 @@ impl<'t> TextEdit<'t> {
         }
 
         if enabled {
-            if let Some(mouse_pos) = ui.input().mouse.pos {
+            if let Some(pointer_pos) = ui.input().pointer.pos {
                 // TODO: triple-click to select whole paragraph
                 // TODO: drag selected text to either move or clone (ctrl on windows, alt on mac)
 
-                let cursor_at_mouse = galley.cursor_from_pos(mouse_pos - response.rect.min);
+                let cursor_at_pointer = galley.cursor_from_pos(pointer_pos - response.rect.min);
 
-                if response.hovered && ui.input().mouse.is_moving() {
+                if response.hovered && ui.input().pointer.is_moving() {
                     // preview:
-                    paint_cursor_end(ui, response.rect.min, &galley, &cursor_at_mouse);
+                    paint_cursor_end(ui, response.rect.min, &galley, &cursor_at_pointer);
                 }
 
                 if response.hovered && response.double_clicked {
                     // Select word:
-                    let center = cursor_at_mouse;
+                    let center = cursor_at_pointer;
                     let ccursorp = select_word_at(text, center.ccursor);
                     state.cursorp = Some(CursorPair {
                         primary: galley.from_ccursor(ccursorp.primary),
                         secondary: galley.from_ccursor(ccursorp.secondary),
                     });
-                } else if response.hovered && ui.input().mouse.pressed {
+                } else if response.hovered && ui.input().pointer.pressed {
                     ui.memory().request_kb_focus(id);
                     if ui.input().modifiers.shift {
                         if let Some(cursorp) = &mut state.cursorp {
-                            cursorp.primary = cursor_at_mouse;
+                            cursorp.primary = cursor_at_pointer;
                         } else {
-                            state.cursorp = Some(CursorPair::one(cursor_at_mouse));
+                            state.cursorp = Some(CursorPair::one(cursor_at_pointer));
                         }
                     } else {
-                        state.cursorp = Some(CursorPair::one(cursor_at_mouse));
+                        state.cursorp = Some(CursorPair::one(cursor_at_pointer));
                     }
-                } else if ui.input().mouse.down && response.active {
+                } else if ui.input().pointer.down && response.active {
                     if let Some(cursorp) = &mut state.cursorp {
-                        cursorp.primary = cursor_at_mouse;
+                        cursorp.primary = cursor_at_pointer;
                     }
                 }
             }
         }
 
-        if ui.input().mouse.pressed && !response.hovered {
+        if ui.input().pointer.pressed && !response.hovered {
             // User clicked somewhere else
             ui.memory().surrender_kb_focus(id);
         }

--- a/egui/src/widgets/text_edit.rs
+++ b/egui/src/widgets/text_edit.rs
@@ -318,7 +318,7 @@ impl<'t> TextEdit<'t> {
         }
 
         if enabled {
-            if let Some(pointer_pos) = ui.input().pointer.pos {
+            if let Some(pointer_pos) = ui.input().pointer.interact_pos() {
                 // TODO: triple-click to select whole paragraph
                 // TODO: drag selected text to either move or clone (ctrl on windows, alt on mac)
 
@@ -337,7 +337,7 @@ impl<'t> TextEdit<'t> {
                         primary: galley.from_ccursor(ccursorp.primary),
                         secondary: galley.from_ccursor(ccursorp.secondary),
                     });
-                } else if response.hovered && ui.input().pointer.pressed {
+                } else if response.hovered && ui.input().pointer.any_pressed() {
                     ui.memory().request_kb_focus(id);
                     if ui.input().modifiers.shift {
                         if let Some(cursorp) = &mut state.cursorp {
@@ -348,7 +348,7 @@ impl<'t> TextEdit<'t> {
                     } else {
                         state.cursorp = Some(CursorPair::one(cursor_at_pointer));
                     }
-                } else if ui.input().pointer.down && response.is_pointer_button_down_on() {
+                } else if ui.input().pointer.any_down() && response.is_pointer_button_down_on() {
                     if let Some(cursorp) = &mut state.cursorp {
                         cursorp.primary = cursor_at_pointer;
                     }
@@ -356,7 +356,7 @@ impl<'t> TextEdit<'t> {
             }
         }
 
-        if ui.input().pointer.pressed && !response.hovered {
+        if ui.input().pointer.any_pressed() && !response.hovered {
             // User clicked somewhere else
             ui.memory().surrender_kb_focus(id);
         }
@@ -471,7 +471,7 @@ impl<'t> TextEdit<'t> {
                         modifiers,
                     } => on_key_press(&mut cursorp, text, &galley, *key, modifiers),
 
-                    Event::Key { .. } => None,
+                    _ => None,
                 };
 
                 if let Some(new_ccursorp) = did_mutate_text {

--- a/egui/src/widgets/text_edit.rs
+++ b/egui/src/widgets/text_edit.rs
@@ -348,7 +348,7 @@ impl<'t> TextEdit<'t> {
                     } else {
                         state.cursorp = Some(CursorPair::one(cursor_at_pointer));
                     }
-                } else if ui.input().pointer.down && response.active {
+                } else if ui.input().pointer.down && response.is_pointer_button_down_on() {
                     if let Some(cursorp) = &mut state.cursorp {
                         cursorp.primary = cursor_at_pointer;
                     }

--- a/egui/src/widgets/text_edit.rs
+++ b/egui/src/widgets/text_edit.rs
@@ -115,7 +115,7 @@ impl CCursorPair {
 /// # let mut ui = egui::Ui::__test();
 /// # let mut my_string = String::new();
 /// let response = ui.add(egui::TextEdit::singleline(&mut my_string));
-/// if response.lost_kb_focus {
+/// if response.lost_kb_focus() {
 ///     // use my_string
 /// }
 /// ```
@@ -324,12 +324,12 @@ impl<'t> TextEdit<'t> {
 
                 let cursor_at_pointer = galley.cursor_from_pos(pointer_pos - response.rect.min);
 
-                if response.hovered && ui.input().pointer.is_moving() {
+                if response.hovered() && ui.input().pointer.is_moving() {
                     // preview:
                     paint_cursor_end(ui, response.rect.min, &galley, &cursor_at_pointer);
                 }
 
-                if response.hovered && response.double_clicked() {
+                if response.hovered() && response.double_clicked() {
                     // Select word:
                     let center = cursor_at_pointer;
                     let ccursorp = select_word_at(text, center.ccursor);
@@ -337,7 +337,7 @@ impl<'t> TextEdit<'t> {
                         primary: galley.from_ccursor(ccursorp.primary),
                         secondary: galley.from_ccursor(ccursorp.secondary),
                     });
-                } else if response.hovered && ui.input().pointer.any_pressed() {
+                } else if response.hovered() && ui.input().pointer.any_pressed() {
                     ui.memory().request_kb_focus(id);
                     if ui.input().modifiers.shift {
                         if let Some(cursorp) = &mut state.cursorp {
@@ -356,7 +356,7 @@ impl<'t> TextEdit<'t> {
             }
         }
 
-        if ui.input().pointer.any_pressed() && !response.hovered {
+        if ui.input().pointer.any_pressed() && !response.hovered() {
             // User clicked somewhere else
             ui.memory().surrender_kb_focus(id);
         }
@@ -365,7 +365,7 @@ impl<'t> TextEdit<'t> {
             ui.memory().surrender_kb_focus(id);
         }
 
-        if response.hovered && enabled {
+        if response.hovered() && enabled {
             ui.output().cursor_icon = CursorIcon::Text;
         }
 

--- a/egui/src/widgets/text_edit.rs
+++ b/egui/src/widgets/text_edit.rs
@@ -329,7 +329,7 @@ impl<'t> TextEdit<'t> {
                     paint_cursor_end(ui, response.rect.min, &galley, &cursor_at_pointer);
                 }
 
-                if response.hovered && response.double_clicked {
+                if response.hovered && response.double_clicked() {
                     // Select word:
                     let center = cursor_at_pointer;
                     let ccursorp = select_word_at(text, center.ccursor);

--- a/egui_demo_lib/src/apps/demo/demo_window.rs
+++ b/egui_demo_lib/src/apps/demo/demo_window.rs
@@ -57,7 +57,7 @@ impl DemoWindow {
             ui.columns(self.num_columns, |cols| {
                 for (i, col) in cols.iter_mut().enumerate() {
                     col.label(format!("Column {} out of {}", i + 1, self.num_columns));
-                    if i + 1 == self.num_columns && col.button("Delete this").clicked {
+                    if i + 1 == self.num_columns && col.button("Delete this").clicked() {
                         self.num_columns -= 1;
                     }
                 }
@@ -287,15 +287,15 @@ impl LayoutDemo {
 
     pub fn content_ui(&mut self, ui: &mut Ui) {
         ui.horizontal(|ui| {
-            if ui.button("Top-down").clicked {
+            if ui.button("Top-down").clicked() {
                 *self = Default::default();
             }
-            if ui.button("Top-down, centered and justified").clicked {
+            if ui.button("Top-down, centered and justified").clicked() {
                 *self = Default::default();
                 self.cross_align = Align::Center;
                 self.cross_justify = true;
             }
-            if ui.button("Horizontal wrapped").clicked {
+            if ui.button("Horizontal wrapped").clicked() {
                 *self = Default::default();
                 self.main_dir = Direction::LeftToRight;
                 self.cross_align = Align::Center;
@@ -391,7 +391,7 @@ impl Tree {
         if depth > 0
             && ui
                 .add(Button::new("delete").text_color(Color32::RED))
-                .clicked
+                .clicked()
         {
             return Action::Delete;
         }
@@ -409,7 +409,7 @@ impl Tree {
             })
             .collect();
 
-        if ui.button("+").clicked {
+        if ui.button("+").clicked() {
             self.0.push(Tree::default());
         }
 

--- a/egui_demo_lib/src/apps/demo/demo_windows.rs
+++ b/egui_demo_lib/src/apps/demo/demo_windows.rs
@@ -86,7 +86,7 @@ impl DemoWindows {
 
                 ui.separator();
 
-                if ui.button("Organize windows").clicked {
+                if ui.button("Organize windows").clicked() {
                     ui.ctx().memory().reset_areas();
                 }
             });
@@ -255,13 +255,13 @@ fn show_menu_bar(ui: &mut Ui) {
 
     menu::bar(ui, |ui| {
         menu::menu(ui, "File", |ui| {
-            if ui.button("Organize windows").clicked {
+            if ui.button("Organize windows").clicked() {
                 ui.ctx().memory().reset_areas();
             }
             if ui
                 .button("Clear egui memory")
                 .on_hover_text("Forget scroll, collapsing headers etc")
-                .clicked
+                .clicked()
             {
                 *ui.ctx().memory() = Default::default();
             }

--- a/egui_demo_lib/src/apps/demo/demo_windows.rs
+++ b/egui_demo_lib/src/apps/demo/demo_windows.rs
@@ -14,6 +14,7 @@ impl Default for Demos {
     fn default() -> Self {
         let demos: Vec<Box<dyn super::Demo>> = vec![
             Box::new(super::WidgetGallery::default()),
+            Box::new(super::input_test::InputTest::default()),
             Box::new(super::FontBook::default()),
             Box::new(super::Painting::default()),
             Box::new(super::DancingStrings::default()),

--- a/egui_demo_lib/src/apps/demo/drag_and_drop.rs
+++ b/egui_demo_lib/src/apps/demo/drag_and_drop.rs
@@ -25,8 +25,8 @@ pub fn drag_source(ui: &mut Ui, id: Id, body: impl FnOnce(&mut Ui)) {
         // (anything with `Order::Tooltip` always gets an empty `Response`)
         // So this is fine!
 
-        if let Some(mouse_pos) = ui.input().mouse.pos {
-            let delta = mouse_pos - response.rect.center();
+        if let Some(pointer_pos) = ui.input().pointer.pos {
+            let delta = pointer_pos - response.rect.center();
             ui.ctx().translate_layer(layer_id, delta);
         }
     }
@@ -143,7 +143,7 @@ impl super::View for DragAndDropDemo {
 
         if let Some((source_col, source_row)) = source_col_row {
             if let Some(drop_col) = drop_col {
-                if ui.input().mouse.released {
+                if ui.input().pointer.released {
                     // do the drop:
                     let item = self.columns[source_col].remove(source_row);
                     self.columns[drop_col].push(item);

--- a/egui_demo_lib/src/apps/demo/drag_and_drop.rs
+++ b/egui_demo_lib/src/apps/demo/drag_and_drop.rs
@@ -8,7 +8,7 @@ pub fn drag_source(ui: &mut Ui, id: Id, body: impl FnOnce(&mut Ui)) {
 
         // Check for drags:
         let response = ui.interact(response.rect, id, Sense::drag());
-        if response.hovered {
+        if response.hovered() {
             ui.output().cursor_icon = CursorIcon::Grab;
         }
     } else {
@@ -49,7 +49,7 @@ pub fn drop_target<R>(
     let outer_rect = Rect::from_min_max(outer_rect_bounds.min, content_ui.min_rect().max + margin);
     let (rect, response) = ui.allocate_at_least(outer_rect.size(), Sense::hover());
 
-    let style = if is_being_dragged && can_accept_what_is_being_dragged && response.hovered {
+    let style = if is_being_dragged && can_accept_what_is_being_dragged && response.hovered() {
         ui.style().visuals.widgets.active
     } else if is_being_dragged && can_accept_what_is_being_dragged {
         ui.style().visuals.widgets.inactive
@@ -134,7 +134,7 @@ impl super::View for DragAndDropDemo {
                 .1;
 
                 let is_being_dragged = ui.memory().is_anything_being_dragged();
-                if is_being_dragged && can_accept_what_is_being_dragged && response.hovered {
+                if is_being_dragged && can_accept_what_is_being_dragged && response.hovered() {
                     drop_col = Some(col_idx);
                 }
             }

--- a/egui_demo_lib/src/apps/demo/drag_and_drop.rs
+++ b/egui_demo_lib/src/apps/demo/drag_and_drop.rs
@@ -25,7 +25,7 @@ pub fn drag_source(ui: &mut Ui, id: Id, body: impl FnOnce(&mut Ui)) {
         // (anything with `Order::Tooltip` always gets an empty `Response`)
         // So this is fine!
 
-        if let Some(pointer_pos) = ui.input().pointer.pos {
+        if let Some(pointer_pos) = ui.input().pointer.interact_pos() {
             let delta = pointer_pos - response.rect.center();
             ui.ctx().translate_layer(layer_id, delta);
         }
@@ -126,8 +126,7 @@ impl super::View for DragAndDropDemo {
                             ui.label(item);
                         });
 
-                        let this_item_being_dragged = ui.memory().is_being_dragged(item_id);
-                        if this_item_being_dragged {
+                        if ui.memory().is_being_dragged(item_id) {
                             source_col_row = Some((col_idx, row_idx));
                         }
                     }
@@ -143,7 +142,7 @@ impl super::View for DragAndDropDemo {
 
         if let Some((source_col, source_row)) = source_col_row {
             if let Some(drop_col) = drop_col {
-                if ui.input().pointer.released {
+                if ui.input().pointer.any_released() {
                     // do the drop:
                     let item = self.columns[source_col].remove(source_row);
                     self.columns[drop_col].push(item);

--- a/egui_demo_lib/src/apps/demo/font_book.rs
+++ b/egui_demo_lib/src/apps/demo/font_book.rs
@@ -31,7 +31,7 @@ impl FontBook {
                     ui.label(format!("{}\nU+{:X}\n\nClick to copy", name, chr as u32));
                 };
 
-                if ui.add(button).on_hover_ui(tooltip_ui).clicked {
+                if ui.add(button).on_hover_ui(tooltip_ui).clicked() {
                     ui.output().copied_text = chr.to_string();
                 }
             }
@@ -81,7 +81,7 @@ impl super::View for FontBook {
             ui.label("Filter:");
             ui.text_edit_singleline(&mut self.filter);
             self.filter = self.filter.to_lowercase();
-            if ui.button("ｘ").clicked {
+            if ui.button("ｘ").clicked() {
                 self.filter.clear();
             }
         });

--- a/egui_demo_lib/src/apps/demo/input_test.rs
+++ b/egui_demo_lib/src/apps/demo/input_test.rs
@@ -1,0 +1,52 @@
+#[cfg_attr(feature = "persistence", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Default)]
+pub struct InputTest {
+    info: String,
+}
+
+impl super::Demo for InputTest {
+    fn name(&self) -> &str {
+        "🖱 Input Test"
+    }
+
+    fn show(&mut self, ctx: &egui::CtxRef, open: &mut bool) {
+        egui::Window::new(self.name())
+            .open(open)
+            .resizable(false)
+            .show(ctx, |ui| {
+                use super::View;
+                self.ui(ui);
+            });
+    }
+}
+
+impl super::View for InputTest {
+    fn ui(&mut self, ui: &mut egui::Ui) {
+        let response = ui.add(
+            egui::Button::new("Click, double-click or drag me with any mouse button")
+                .sense(egui::Sense::click_and_drag()),
+        );
+
+        let mut new_info = String::new();
+        for &button in &[
+            egui::PointerButton::Primary,
+            egui::PointerButton::Secondary,
+            egui::PointerButton::Middle,
+        ] {
+            if response.clicked_with(button) {
+                new_info += &format!("Clicked by {:?}\n", button);
+            }
+            if response.double_clicked_with(button) {
+                new_info += &format!("Double-clicked by {:?}\n", button);
+            }
+            if response.dragged() && ui.input().pointer.button_down(button) {
+                new_info += &format!("Dragged by {:?}\n", button);
+            }
+        }
+        if !new_info.is_empty() {
+            self.info = new_info;
+        }
+
+        ui.label(&self.info);
+    }
+}

--- a/egui_demo_lib/src/apps/demo/input_test.rs
+++ b/egui_demo_lib/src/apps/demo/input_test.rs
@@ -33,10 +33,10 @@ impl super::View for InputTest {
             egui::PointerButton::Secondary,
             egui::PointerButton::Middle,
         ] {
-            if response.clicked_with(button) {
+            if response.clicked_by(button) {
                 new_info += &format!("Clicked by {:?}\n", button);
             }
-            if response.double_clicked_with(button) {
+            if response.double_clicked_by(button) {
                 new_info += &format!("Double-clicked by {:?}\n", button);
             }
             if response.dragged() && ui.input().pointer.button_down(button) {

--- a/egui_demo_lib/src/apps/demo/mod.rs
+++ b/egui_demo_lib/src/apps/demo/mod.rs
@@ -12,6 +12,7 @@ mod drag_and_drop;
 mod font_book;
 pub mod font_contents_emoji;
 pub mod font_contents_ubuntu;
+pub mod input_test;
 mod painting;
 mod scrolls;
 mod sliders;

--- a/egui_demo_lib/src/apps/demo/painting.rs
+++ b/egui_demo_lib/src/apps/demo/painting.rs
@@ -39,8 +39,8 @@ impl Painting {
         let current_line = self.lines.last_mut().unwrap();
 
         if response.active {
-            if let Some(mouse_pos) = ui.input().mouse.pos {
-                let canvas_pos = mouse_pos - rect.min;
+            if let Some(pointer_pos) = ui.input().pointer.pos {
+                let canvas_pos = pointer_pos - rect.min;
                 if current_line.last() != Some(&canvas_pos) {
                     current_line.push(canvas_pos);
                 }

--- a/egui_demo_lib/src/apps/demo/painting.rs
+++ b/egui_demo_lib/src/apps/demo/painting.rs
@@ -38,12 +38,10 @@ impl Painting {
 
         let current_line = self.lines.last_mut().unwrap();
 
-        if response.active {
-            if let Some(pointer_pos) = ui.input().pointer.pos {
-                let canvas_pos = pointer_pos - rect.min;
-                if current_line.last() != Some(&canvas_pos) {
-                    current_line.push(canvas_pos);
-                }
+        if let Some(pointer_pos) = response.interact_pointer_pos() {
+            let canvas_pos = pointer_pos - rect.min;
+            if current_line.last() != Some(&canvas_pos) {
+                current_line.push(canvas_pos);
             }
         } else if !current_line.is_empty() {
             self.lines.push(vec![]);

--- a/egui_demo_lib/src/apps/demo/painting.rs
+++ b/egui_demo_lib/src/apps/demo/painting.rs
@@ -21,7 +21,7 @@ impl Painting {
         ui.horizontal(|ui| {
             egui::stroke_ui(ui, &mut self.stroke, "Stroke");
             ui.separator();
-            if ui.button("Clear Painting").clicked {
+            if ui.button("Clear Painting").clicked() {
                 self.lines.clear();
             }
         });

--- a/egui_demo_lib/src/apps/demo/scrolls.rs
+++ b/egui_demo_lib/src/apps/demo/scrolls.rs
@@ -33,13 +33,13 @@ impl Scrolls {
             ui.add(Slider::usize(&mut self.track_item, 1..=50).text("Track Item"));
         });
         let (scroll_offset, _) = ui.horizontal(|ui| {
-            let scroll_offset = ui.small_button("Scroll Offset").clicked;
+            let scroll_offset = ui.small_button("Scroll Offset").clicked();
             ui.add(DragValue::f32(&mut self.offset).speed(1.0).suffix("px"));
             scroll_offset
         });
 
-        let scroll_top = ui.button("Scroll to top").clicked;
-        let scroll_bottom = ui.button("Scroll to bottom").clicked;
+        let scroll_top = ui.button("Scroll to top").clicked();
+        let scroll_bottom = ui.button("Scroll to bottom").clicked();
         if scroll_bottom || scroll_top {
             self.tracking = false;
         }

--- a/egui_demo_lib/src/apps/demo/sliders.rs
+++ b/egui_demo_lib/src/apps/demo/sliders.rs
@@ -73,7 +73,7 @@ impl Sliders {
                 You can always see the full precision value by hovering the value.",
             );
 
-            if ui.button("Assign PI").clicked {
+            if ui.button("Assign PI").clicked() {
                 self.value = std::f64::consts::PI;
             }
         }

--- a/egui_demo_lib/src/apps/demo/toggle_switch.rs
+++ b/egui_demo_lib/src/apps/demo/toggle_switch.rs
@@ -27,7 +27,7 @@ pub fn toggle(ui: &mut egui::Ui, on: &mut bool) -> egui::Response {
     let (rect, response) = ui.allocate_exact_size(desired_size, egui::Sense::click());
 
     // 3. Interact: Time to check for clicks!.
-    if response.clicked {
+    if response.clicked() {
         *on = !*on;
     }
 
@@ -63,7 +63,7 @@ pub fn toggle(ui: &mut egui::Ui, on: &mut bool) -> egui::Response {
 fn toggle_compact(ui: &mut egui::Ui, on: &mut bool) -> egui::Response {
     let desired_size = ui.style().spacing.interact_size;
     let (rect, response) = ui.allocate_exact_size(desired_size, egui::Sense::click());
-    *on ^= response.clicked; // toggle if clicked
+    *on ^= response.clicked(); // toggle if clicked
 
     let how_on = ui.ctx().animate_bool(response.id, *on);
     let visuals = ui.style().interact(&response);

--- a/egui_demo_lib/src/apps/demo/widget_gallery.rs
+++ b/egui_demo_lib/src/apps/demo/widget_gallery.rs
@@ -115,7 +115,7 @@ impl super::View for WidgetGallery {
             ui.end_row();
 
             ui.label("Button:");
-            if ui.button("Toggle boolean").clicked {
+            if ui.button("Toggle boolean").clicked() {
                 *boolean = !*boolean;
             }
             ui.end_row();
@@ -123,7 +123,7 @@ impl super::View for WidgetGallery {
             ui.label("ImageButton:");
             if ui
                 .add(egui::ImageButton::new(egui::TextureId::Egui, [24.0, 16.0]))
-                .clicked
+                .clicked()
             {
                 *boolean = !*boolean;
             }

--- a/egui_demo_lib/src/apps/demo/widgets.rs
+++ b/egui_demo_lib/src/apps/demo/widgets.rs
@@ -146,7 +146,7 @@ impl Widgets {
         ui.horizontal(|ui| {
             ui.label("Single line text input:");
             let response = ui.text_edit_singleline(&mut self.single_line_text_input);
-            if response.lost_kb_focus {
+            if response.lost_kb_focus() {
                 // The user pressed enter.
             }
         });

--- a/egui_demo_lib/src/apps/demo/widgets.rs
+++ b/egui_demo_lib/src/apps/demo/widgets.rs
@@ -97,7 +97,7 @@ impl Widgets {
             if ui
                 .add(Button::new("Click me").enabled(self.button_enabled))
                 .on_hover_text("This will just increase a counter.")
-                .clicked
+                .clicked()
             {
                 self.count += 1;
             }

--- a/egui_demo_lib/src/apps/http_app.rs
+++ b/egui_demo_lib/src/apps/http_app.rs
@@ -114,7 +114,7 @@ fn ui_url(ui: &mut egui::Ui, frame: &mut epi::Frame<'_>, url: &mut String) -> Op
     ui.horizontal(|ui| {
         ui.label("URL:");
         trigger_fetch |= ui.text_edit_singleline(url).lost_kb_focus;
-        trigger_fetch |= ui.button("GET").clicked;
+        trigger_fetch |= ui.button("GET").clicked();
     });
 
     if frame.is_web() {
@@ -122,14 +122,14 @@ fn ui_url(ui: &mut egui::Ui, frame: &mut epi::Frame<'_>, url: &mut String) -> Op
     }
 
     ui.horizontal(|ui| {
-        if ui.button("Source code for this example").clicked {
+        if ui.button("Source code for this example").clicked() {
             *url = format!(
                 "https://raw.githubusercontent.com/emilk/egui/master/{}",
                 file!()
             );
             trigger_fetch = true;
         }
-        if ui.button("Random image").clicked {
+        if ui.button("Random image").clicked() {
             let seed = ui.input().time;
             let width = 640;
             let height = 480;
@@ -170,7 +170,7 @@ fn ui_resouce(
 
     if let Some(text) = &response.text {
         let tooltip = "Click to copy the response body";
-        if ui.button("📋").on_hover_text(tooltip).clicked {
+        if ui.button("📋").on_hover_text(tooltip).clicked() {
             ui.output().copied_text = text.clone();
         }
     }

--- a/egui_demo_lib/src/apps/http_app.rs
+++ b/egui_demo_lib/src/apps/http_app.rs
@@ -113,7 +113,7 @@ fn ui_url(ui: &mut egui::Ui, frame: &mut epi::Frame<'_>, url: &mut String) -> Op
 
     ui.horizontal(|ui| {
         ui.label("URL:");
-        trigger_fetch |= ui.text_edit_singleline(url).lost_kb_focus;
+        trigger_fetch |= ui.text_edit_singleline(url).lost_kb_focus();
         trigger_fetch |= ui.button("GET").clicked();
     });
 

--- a/egui_demo_lib/src/frame_history.rs
+++ b/egui_demo_lib/src/frame_history.rs
@@ -79,9 +79,9 @@ impl FrameHistory {
         let rect = rect.shrink(4.0);
         let line_stroke = Stroke::new(1.0, Color32::from_additive_luminance(128));
 
-        if let Some(mouse_pos) = ui.input().mouse.pos {
-            if rect.contains(mouse_pos) {
-                let y = mouse_pos.y;
+        if let Some(pointer_pos) = ui.input().pointer.pos {
+            if rect.contains(pointer_pos) {
+                let y = pointer_pos.y;
                 shapes.push(Shape::line_segment(
                     [pos2(rect.left(), y), pos2(rect.right(), y)],
                     line_stroke,

--- a/egui_demo_lib/src/frame_history.rs
+++ b/egui_demo_lib/src/frame_history.rs
@@ -79,7 +79,7 @@ impl FrameHistory {
         let rect = rect.shrink(4.0);
         let line_stroke = Stroke::new(1.0, Color32::from_additive_luminance(128));
 
-        if let Some(pointer_pos) = ui.input().pointer.pos {
+        if let Some(pointer_pos) = ui.input().pointer.tooltip_pos() {
             if rect.contains(pointer_pos) {
                 let y = pointer_pos.y;
                 shapes.push(Shape::line_segment(

--- a/egui_demo_lib/src/wrap_app.rs
+++ b/egui_demo_lib/src/wrap_app.rs
@@ -73,7 +73,7 @@ impl epi::App for WrapApp {
                 for (anchor, app) in self.apps.iter_mut() {
                     if ui
                         .selectable_label(self.selected_anchor == anchor, app.name())
-                        .clicked
+                        .clicked()
                     {
                         self.selected_anchor = anchor.to_owned();
                         if frame.is_web() {
@@ -86,7 +86,7 @@ impl epi::App for WrapApp {
                     if false {
                         // TODO: fix the overlap on small screens
                         if let Some(seconds_since_midnight) = frame.info().seconds_since_midnight {
-                            if clock_button(ui, seconds_since_midnight).clicked {
+                            if clock_button(ui, seconds_since_midnight).clicked() {
                                 self.selected_anchor = "clock".to_owned();
                                 if frame.is_web() {
                                     ui.output().open_url = Some("#clock".to_owned());
@@ -234,11 +234,11 @@ impl BackendPanel {
             if ui
                 .button("📱 Phone Size")
                 .on_hover_text("Resize the window to be small like a phone.")
-                .clicked
+                .clicked()
             {
                 frame.set_window_size(egui::Vec2::new(375.0, 812.0)); // iPhone 12 mini
             }
-            if ui.button("Quit").clicked {
+            if ui.button("Quit").clicked() {
                 frame.quit();
             }
         }
@@ -275,7 +275,7 @@ impl BackendPanel {
                         "Reset scale to native value ({:.1})",
                         native_pixels_per_point
                     ))
-                    .clicked
+                    .clicked()
                 {
                     *pixels_per_point = native_pixels_per_point;
                 }

--- a/egui_demo_lib/src/wrap_app.rs
+++ b/egui_demo_lib/src/wrap_app.rs
@@ -283,7 +283,7 @@ impl BackendPanel {
         });
 
         // We wait until mouse release to activate:
-        if ui.ctx().is_using_mouse() {
+        if ui.ctx().is_using_pointer() {
             None
         } else {
             Some(*pixels_per_point)

--- a/egui_glium/src/lib.rs
+++ b/egui_glium/src/lib.rs
@@ -53,19 +53,19 @@ pub fn input_to_egui(
     match event {
         WindowEvent::CloseRequested | WindowEvent::Destroyed => *control_flow = ControlFlow::Exit,
         WindowEvent::MouseInput { state, .. } => {
-            input_state.raw.mouse_down = state == glutin::event::ElementState::Pressed;
+            input_state.raw.pointer_button_down = state == glutin::event::ElementState::Pressed;
         }
         WindowEvent::CursorMoved {
             position: pos_in_pixels,
             ..
         } => {
-            input_state.raw.mouse_pos = Some(pos2(
+            input_state.raw.pointer_pos = Some(pos2(
                 pos_in_pixels.x as f32 / input_state.raw.pixels_per_point.unwrap(),
                 pos_in_pixels.y as f32 / input_state.raw.pixels_per_point.unwrap(),
             ));
         }
         WindowEvent::CursorLeft { .. } => {
-            input_state.raw.mouse_pos = None;
+            input_state.raw.pointer_pos = None;
         }
         WindowEvent::ReceivedCharacter(ch) => {
             if printable_char(ch)

--- a/egui_glium/src/lib.rs
+++ b/egui_glium/src/lib.rs
@@ -18,7 +18,6 @@ pub mod persistence;
 pub mod window_settings;
 
 pub use backend::*;
-use glutin::event::MouseButton;
 pub use painter::Painter;
 
 use {
@@ -184,11 +183,11 @@ fn is_printable_char(chr: char) -> bool {
     !is_in_private_use_area && !chr.is_ascii_control()
 }
 
-pub fn translate_mouse_button(button: MouseButton) -> Option<egui::PointerButton> {
+pub fn translate_mouse_button(button: glutin::event::MouseButton) -> Option<egui::PointerButton> {
     match button {
-        MouseButton::Left => Some(egui::PointerButton::Primary),
-        MouseButton::Right => Some(egui::PointerButton::Secondary),
-        MouseButton::Middle => Some(egui::PointerButton::Middle),
+        glutin::event::MouseButton::Left => Some(egui::PointerButton::Primary),
+        glutin::event::MouseButton::Right => Some(egui::PointerButton::Secondary),
+        glutin::event::MouseButton::Middle => Some(egui::PointerButton::Middle),
         _ => None,
     }
 }

--- a/egui_web/CHANGELOG.md
+++ b/egui_web/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added ⭐
+
+* Right-clicks will no longer open browser context menu.
+
+### Fixed ⭐
+
+* Fix a bug where one couldn't select items in a combo box on a touch screen.
+
 
 ## 0.8.0 - 2021-01-17
 

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -81,6 +81,9 @@ pub struct WebInput {
     /// Is this a touch screen? If so, we ignore mouse events.
     pub is_touch: bool,
 
+    /// Required because we don't get a position on touched
+    pub latest_touch_pos: Option<egui::Pos2>,
+
     pub raw: egui::RawInput,
 }
 

--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -97,6 +97,15 @@ pub fn pos_from_mouse_event(canvas_id: &str, event: &web_sys::MouseEvent) -> egu
     }
 }
 
+pub fn button_from_mouse_event(event: &web_sys::MouseEvent) -> Option<egui::PointerButton> {
+    match event.button() {
+        0 => Some(egui::PointerButton::Primary),
+        1 => Some(egui::PointerButton::Middle),
+        2 => Some(egui::PointerButton::Secondary),
+        _ => None,
+    }
+}
+
 pub fn pos_from_touch_event(event: &web_sys::TouchEvent) -> egui::Pos2 {
     let t = event.touches().get(0).unwrap();
     egui::Pos2 {
@@ -600,18 +609,39 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
     let canvas = canvas_element(runner_ref.0.lock().canvas_id()).unwrap();
 
     {
+        // By default, right-clicks open a context menu.
+        // We don't want to do that (right clicks is handled by Egui):
+        let event_name = "contextmenu";
+        let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
+            event.prevent_default();
+        }) as Box<dyn FnMut(_)>);
+        canvas.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
+        closure.forget();
+    }
+
+    {
         let event_name = "mousedown";
         let runner_ref = runner_ref.clone();
         let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
             let mut runner_lock = runner_ref.0.lock();
             if !runner_lock.input.is_touch {
-                runner_lock.input.raw.pointer_pos =
-                    Some(pos_from_mouse_event(runner_lock.canvas_id(), &event));
-                runner_lock.input.raw.pointer_button_down = true;
-                runner_lock.logic().unwrap(); // in case we get "mouseup" the same frame. TODO: handle via events instead
-                runner_lock.needs_repaint.set_true();
-                event.stop_propagation();
-                event.prevent_default();
+                if let Some(button) = button_from_mouse_event(&event) {
+                    let pos = pos_from_mouse_event(runner_lock.canvas_id(), &event);
+                    let modifiers = runner_lock.input.raw.modifiers;
+                    runner_lock
+                        .input
+                        .raw
+                        .events
+                        .push(egui::Event::PointerButton {
+                            pos,
+                            button,
+                            pressed: true,
+                            modifiers,
+                        });
+                    runner_lock.needs_repaint.set_true();
+                    event.stop_propagation();
+                    event.prevent_default();
+                }
             }
         }) as Box<dyn FnMut(_)>);
         canvas.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
@@ -624,8 +654,12 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
         let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
             let mut runner_lock = runner_ref.0.lock();
             if !runner_lock.input.is_touch {
-                runner_lock.input.raw.pointer_pos =
-                    Some(pos_from_mouse_event(runner_lock.canvas_id(), &event));
+                let pos = pos_from_mouse_event(runner_lock.canvas_id(), &event);
+                runner_lock
+                    .input
+                    .raw
+                    .events
+                    .push(egui::Event::PointerMoved(pos));
                 runner_lock.needs_repaint.set_true();
                 event.stop_propagation();
                 event.prevent_default();
@@ -641,12 +675,23 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
         let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
             let mut runner_lock = runner_ref.0.lock();
             if !runner_lock.input.is_touch {
-                runner_lock.input.raw.pointer_pos =
-                    Some(pos_from_mouse_event(runner_lock.canvas_id(), &event));
-                runner_lock.input.raw.pointer_button_down = false;
-                runner_lock.needs_repaint.set_true();
-                event.stop_propagation();
-                event.prevent_default();
+                if let Some(button) = button_from_mouse_event(&event) {
+                    let pos = pos_from_mouse_event(runner_lock.canvas_id(), &event);
+                    let modifiers = runner_lock.input.raw.modifiers;
+                    runner_lock
+                        .input
+                        .raw
+                        .events
+                        .push(egui::Event::PointerButton {
+                            pos,
+                            button,
+                            pressed: false,
+                            modifiers,
+                        });
+                    runner_lock.needs_repaint.set_true();
+                    event.stop_propagation();
+                    event.prevent_default();
+                }
             }
         }) as Box<dyn FnMut(_)>);
         canvas.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
@@ -659,7 +704,7 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
         let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
             let mut runner_lock = runner_ref.0.lock();
             if !runner_lock.input.is_touch {
-                runner_lock.input.raw.pointer_pos = None;
+                runner_lock.input.raw.events.push(egui::Event::PointerGone);
                 runner_lock.needs_repaint.set_true();
                 event.stop_propagation();
                 event.prevent_default();
@@ -673,10 +718,21 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
         let event_name = "touchstart";
         let runner_ref = runner_ref.clone();
         let closure = Closure::wrap(Box::new(move |event: web_sys::TouchEvent| {
+            let pos = pos_from_touch_event(&event);
             let mut runner_lock = runner_ref.0.lock();
+            runner_lock.input.latest_touch_pos = Some(pos);
             runner_lock.input.is_touch = true;
-            runner_lock.input.raw.pointer_pos = Some(pos_from_touch_event(&event));
-            runner_lock.input.raw.pointer_button_down = true;
+            let modifiers = runner_lock.input.raw.modifiers;
+            runner_lock
+                .input
+                .raw
+                .events
+                .push(egui::Event::PointerButton {
+                    pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers,
+                });
             runner_lock.needs_repaint.set_true();
             event.stop_propagation();
             event.prevent_default();
@@ -689,9 +745,15 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
         let event_name = "touchmove";
         let runner_ref = runner_ref.clone();
         let closure = Closure::wrap(Box::new(move |event: web_sys::TouchEvent| {
+            let pos = pos_from_touch_event(&event);
             let mut runner_lock = runner_ref.0.lock();
+            runner_lock.input.latest_touch_pos = Some(pos);
             runner_lock.input.is_touch = true;
-            runner_lock.input.raw.pointer_pos = Some(pos_from_touch_event(&event));
+            runner_lock
+                .input
+                .raw
+                .events
+                .push(egui::Event::PointerMoved(pos));
             runner_lock.needs_repaint.set_true();
             event.stop_propagation();
             event.prevent_default();
@@ -706,12 +768,25 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
         let closure = Closure::wrap(Box::new(move |event: web_sys::TouchEvent| {
             let mut runner_lock = runner_ref.0.lock();
             runner_lock.input.is_touch = true;
-            runner_lock.input.raw.pointer_button_down = false; // First release mouse to click...
-            runner_lock.logic().unwrap(); // ...do the clicking... (TODO: handle via events instead)
-            runner_lock.input.raw.pointer_pos = None; // ...remove hover effect
-            runner_lock.needs_repaint.set_true();
-            event.stop_propagation();
-            event.prevent_default();
+            if let Some(pos) = runner_lock.input.latest_touch_pos {
+                let modifiers = runner_lock.input.raw.modifiers;
+                // First release mouse to click:
+                runner_lock
+                    .input
+                    .raw
+                    .events
+                    .push(egui::Event::PointerButton {
+                        pos,
+                        button: egui::PointerButton::Primary,
+                        pressed: false,
+                        modifiers,
+                    });
+                // Then remove hover effect:
+                runner_lock.input.raw.events.push(egui::Event::PointerGone);
+                runner_lock.needs_repaint.set_true();
+                event.stop_propagation();
+                event.prevent_default();
+            }
         }) as Box<dyn FnMut(_)>);
         canvas.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
         closure.forget();

--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -610,7 +610,7 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
 
     {
         // By default, right-clicks open a context menu.
-        // We don't want to do that (right clicks is handled by Egui):
+        // We don't want to do that (right clicks is handled by egui):
         let event_name = "contextmenu";
         let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
             event.prevent_default();

--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -605,9 +605,9 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
         let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
             let mut runner_lock = runner_ref.0.lock();
             if !runner_lock.input.is_touch {
-                runner_lock.input.raw.mouse_pos =
+                runner_lock.input.raw.pointer_pos =
                     Some(pos_from_mouse_event(runner_lock.canvas_id(), &event));
-                runner_lock.input.raw.mouse_down = true;
+                runner_lock.input.raw.pointer_button_down = true;
                 runner_lock.logic().unwrap(); // in case we get "mouseup" the same frame. TODO: handle via events instead
                 runner_lock.needs_repaint.set_true();
                 event.stop_propagation();
@@ -624,7 +624,7 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
         let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
             let mut runner_lock = runner_ref.0.lock();
             if !runner_lock.input.is_touch {
-                runner_lock.input.raw.mouse_pos =
+                runner_lock.input.raw.pointer_pos =
                     Some(pos_from_mouse_event(runner_lock.canvas_id(), &event));
                 runner_lock.needs_repaint.set_true();
                 event.stop_propagation();
@@ -641,9 +641,9 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
         let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
             let mut runner_lock = runner_ref.0.lock();
             if !runner_lock.input.is_touch {
-                runner_lock.input.raw.mouse_pos =
+                runner_lock.input.raw.pointer_pos =
                     Some(pos_from_mouse_event(runner_lock.canvas_id(), &event));
-                runner_lock.input.raw.mouse_down = false;
+                runner_lock.input.raw.pointer_button_down = false;
                 runner_lock.needs_repaint.set_true();
                 event.stop_propagation();
                 event.prevent_default();
@@ -659,7 +659,7 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
         let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
             let mut runner_lock = runner_ref.0.lock();
             if !runner_lock.input.is_touch {
-                runner_lock.input.raw.mouse_pos = None;
+                runner_lock.input.raw.pointer_pos = None;
                 runner_lock.needs_repaint.set_true();
                 event.stop_propagation();
                 event.prevent_default();
@@ -675,8 +675,8 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
         let closure = Closure::wrap(Box::new(move |event: web_sys::TouchEvent| {
             let mut runner_lock = runner_ref.0.lock();
             runner_lock.input.is_touch = true;
-            runner_lock.input.raw.mouse_pos = Some(pos_from_touch_event(&event));
-            runner_lock.input.raw.mouse_down = true;
+            runner_lock.input.raw.pointer_pos = Some(pos_from_touch_event(&event));
+            runner_lock.input.raw.pointer_button_down = true;
             runner_lock.needs_repaint.set_true();
             event.stop_propagation();
             event.prevent_default();
@@ -691,7 +691,7 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
         let closure = Closure::wrap(Box::new(move |event: web_sys::TouchEvent| {
             let mut runner_lock = runner_ref.0.lock();
             runner_lock.input.is_touch = true;
-            runner_lock.input.raw.mouse_pos = Some(pos_from_touch_event(&event));
+            runner_lock.input.raw.pointer_pos = Some(pos_from_touch_event(&event));
             runner_lock.needs_repaint.set_true();
             event.stop_propagation();
             event.prevent_default();
@@ -706,9 +706,9 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
         let closure = Closure::wrap(Box::new(move |event: web_sys::TouchEvent| {
             let mut runner_lock = runner_ref.0.lock();
             runner_lock.input.is_touch = true;
-            runner_lock.input.raw.mouse_down = false; // First release mouse to click...
+            runner_lock.input.raw.pointer_button_down = false; // First release mouse to click...
             runner_lock.logic().unwrap(); // ...do the clicking... (TODO: handle via events instead)
-            runner_lock.input.raw.mouse_pos = None; // ...remove hover effect
+            runner_lock.input.raw.pointer_pos = None; // ...remove hover effect
             runner_lock.needs_repaint.set_true();
             event.stop_propagation();
             event.prevent_default();

--- a/emath/src/vec2.rs
+++ b/emath/src/vec2.rs
@@ -21,6 +21,9 @@ pub const fn vec2(x: f32, y: f32) -> Vec2 {
     Vec2 { x, y }
 }
 
+// ----------------------------------------------------------------------------
+// Compatibility and convenience conversions to and from [f32; 2]:
+
 impl From<[f32; 2]> for Vec2 {
     fn from(v: [f32; 2]) -> Self {
         Self { x: v[0], y: v[1] }
@@ -32,6 +35,47 @@ impl From<&[f32; 2]> for Vec2 {
         Self { x: v[0], y: v[1] }
     }
 }
+
+impl From<Vec2> for [f32; 2] {
+    fn from(v: Vec2) -> Self {
+        [v.x, v.y]
+    }
+}
+
+impl From<&Vec2> for [f32; 2] {
+    fn from(v: &Vec2) -> Self {
+        [v.x, v.y]
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Compatibility and convenience conversions to and from (f32, f32):
+
+impl From<(f32, f32)> for Vec2 {
+    fn from(v: (f32, f32)) -> Self {
+        Self { x: v.0, y: v.1 }
+    }
+}
+
+impl From<&(f32, f32)> for Vec2 {
+    fn from(v: &(f32, f32)) -> Self {
+        Self { x: v.0, y: v.1 }
+    }
+}
+
+impl From<Vec2> for (f32, f32) {
+    fn from(v: Vec2) -> Self {
+        (v.x, v.y)
+    }
+}
+
+impl From<&Vec2> for (f32, f32) {
+    fn from(v: &Vec2) -> Self {
+        (v.x, v.y)
+    }
+}
+
+// ----------------------------------------------------------------------------
 
 impl Vec2 {
     pub const X: Vec2 = Vec2 { x: 1.0, y: 0.0 };


### PR DESCRIPTION
Closes https://github.com/emilk/egui/issues/96

Add support for primary, secondary and middle mouse buttons. Also improve ability to click things in low FPS situations.

This introduces a lot of breaking changes:

* Backends/integrations now pass mouse events via the even stream.
* Response has an interface of mostly methods instead of public members.
* `input.mouse` is now `input.pointer` and has new interface.