### PR TITLE
Use any_click() instead of any_pressed() in check

### DIFF
--- a/egui/src/widgets/color_picker.rs
+++ b/egui/src/widgets/color_picker.rs
@@ -335,7 +335,7 @@ pub fn color_edit_button_hsva(ui: &mut Ui, hsva: &mut Hsva, alpha: Alpha) -> Res
             });
 
         if !button_response.clicked() {
-            let clicked_outside = ui.input().pointer.any_pressed() && !area_response.hovered();
+            let clicked_outside = ui.input().pointer.any_click() && !area_response.hovered();
             if clicked_outside || ui.input().key_pressed(Key::Escape) {
                 ui.memory().close_popup();
             }


### PR DESCRIPTION
Hello emilk ,

This is a fix for #143 . Calling `any_click()` instead of `any_pressed()` seems to have fixed the issue. I'm sorry, I'm not sure how to run the web version so I haven't tested on that. Although, as mentioned on the issue, the bug doesn't occur there.

Thanks,
Asparuh