### PR TITLE
Discard obviously absurd window positions.

### DIFF
--- a/egui_glium/src/window_settings.rs
+++ b/egui_glium/src/window_settings.rs
@@ -72,7 +72,13 @@ impl WindowSettings {
         //         height: size.y as f64,
         //     });
 
-        if let Some(pos) = self.pos {
+        if let Some(mut pos) = self.pos {
+            if pos.x < 0.0 {
+                pos.x = 0.0;
+            }
+            if pos.y < 0.0 {
+                pos.y = 0.0;
+            }
             display
                 .gl_window()
                 .window()


### PR DESCRIPTION
Looks like winit sometimes writes pos x=-32000.0, y=-32000.0 on multiscreen setups. Clamp this to be at least 0 when we load the window.