### PR TITLE
Add icon support to eframe

### DIFF
--- a/eframe/CHANGELOG.md
+++ b/eframe/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+*  You can now set your own app icons. See https://github.com/emilk/egui/pull/193
+   for example code.
 
 ## 0.9.0 - 2021-02-07
 

--- a/egui_glium/src/backend.rs
+++ b/egui_glium/src/backend.rs
@@ -136,6 +136,7 @@ fn integration_info(
 fn load_icon(icon_data: Option<epi::IconData>) -> Option<glutin::window::Icon> {
     let icon_data = icon_data?;
     glutin::window::Icon::from_rgba(icon_data.rgba, icon_data.width, icon_data.height).ok()
+}
 
 /// Run an egui app
 pub fn run(mut app: Box<dyn epi::App>) -> ! {

--- a/egui_glium/src/backend.rs
+++ b/egui_glium/src/backend.rs
@@ -60,12 +60,14 @@ fn create_display(
     initial_size_points: Option<Vec2>,
     window_settings: Option<WindowSettings>,
     is_resizable: bool,
+    window_icon: Option<glutin::window::Icon>,
     event_loop: &glutin::event_loop::EventLoop<RequestRepaintEvent>,
 ) -> glium::Display {
     let mut window_builder = glutin::window::WindowBuilder::new()
         .with_decorations(true)
         .with_resizable(is_resizable)
         .with_title(title)
+        .with_window_icon(window_icon)
         .with_transparent(false);
 
     if let Some(window_settings) = &window_settings {
@@ -131,6 +133,17 @@ fn integration_info(
     }
 }
 
+fn load_icon(icon_data: Option<epi::IconData>) -> Option<glutin::window::Icon> {
+    let icon_data = icon_data?;
+    if let Ok(icon) =
+        glutin::window::Icon::from_rgba(icon_data.rgba, icon_data.width, icon_data.height)
+    {
+        Some(icon)
+    } else {
+        None
+    }
+}
+
 /// Run an egui app
 pub fn run(mut app: Box<dyn epi::App>) -> ! {
     let mut storage = create_storage(app.name());
@@ -141,11 +154,13 @@ pub fn run(mut app: Box<dyn epi::App>) -> ! {
 
     let window_settings = deserialize_window_settings(&storage);
     let event_loop = glutin::event_loop::EventLoop::with_user_event();
+    let icon = load_icon(app.icon_data());
     let display = create_display(
         app.name(),
         app.initial_window_size(),
         window_settings,
         app.is_resizable(),
+        icon,
         &event_loop,
     );
 

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -114,6 +114,17 @@ pub trait App {
         // NOTE: a bright gray makes the shadows of the windows look weird.
         egui::Color32::from_rgb(12, 12, 12).into()
     }
+
+    /// The application icon, e.g. in the Windows task bar etc.
+    fn icon_data(&self) -> Option<IconData> {
+        None
+    }
+}
+
+pub struct IconData {
+    pub rgba: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
 }
 
 /// Represents the surroundings of your app.

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -126,10 +126,10 @@ pub struct IconData {
     /// RGBA pixels.
     pub rgba: Vec<u8>,
 
-    // Image width. This should be a multiple of 4.
+    /// Image width. This should be a multiple of 4.
     pub width: u32,
 
-    // Image height. This should be a multiple of 4.
+    /// Image height. This should be a multiple of 4.
     pub height: u32,
 }
 

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -121,9 +121,15 @@ pub trait App {
     }
 }
 
+/// Image data for the icon.
 pub struct IconData {
+    /// RGBA pixels.
     pub rgba: Vec<u8>,
+
+    // Image width. This should be a multiple of 4.
     pub width: u32,
+
+    // Image height. This should be a multiple of 4.
     pub height: u32,
 }
 


### PR DESCRIPTION
Example code using this (uses the image crate to load images):

```
pub fn load_icon(icon_bytes: &Vec<u8>) -> Option<epi::IconData> {
    if let Ok(image) = image::load_from_memory(icon_bytes) {
        let image = image.to_rgba8();
        let (width, height) = image.dimensions();
        Some(epi::IconData {
            width,
            height,
            rgba: image.as_raw().to_vec(),
        })
    } else {
        None
    }
}

impl epi::App for EmbarkSubmitApp {
     ...
    fn icon_data(&self) -> Option<epi::IconData> {
        let icon_bytes = include_bytes!("../icons/my_icon.png");
        crate::icon::load_icon(&icon_bytes.to_vec())
    }
```