### PR TITLE
fix: Modern browsers encode Space as ' '

### DIFF
--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -358,7 +358,7 @@ pub fn translate_key(key: &str) -> Option<egui::Key> {
         "Tab" => Some(egui::Key::Tab),
         "Backspace" => Some(egui::Key::Backspace),
         "Enter" => Some(egui::Key::Enter),
-        "Space" => Some(egui::Key::Space),
+        "Space" | " " => Some(egui::Key::Space),
 
         "Help" | "Insert" => Some(egui::Key::Insert),
         "Delete" => Some(egui::Key::Delete),


### PR DESCRIPTION
Related to #65 and #31 

egui currently checks for `"Space"` for spaces, while modern browsers prefer to use `" "`. 
This can be checked [here](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values). The documentation also mentions:

> [1] While older browsers used words like "Add", "Decimal", "Multiply", and so forth modern browsers identify these using the actual character ("+", ".", "*", and so forth).

So, for backwards compat, I've left the `"Space"` check in.