### PR TITLE
Derive (de)serialize for Key

### DIFF
--- a/egui/src/data/input.rs
+++ b/egui/src/data/input.rs
@@ -160,6 +160,7 @@ pub struct Modifiers {
 /// Many keys are omitted because they are not always physical keys (depending on keyboard language), e.g. `;` and `§`,
 /// and are therefor unsuitable as keyboard shortcuts if you want your app to be portable.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+#[cfg_attr(feature = "persistence", derive(serde::Deserialize, serde::Serialize))]
 pub enum Key {
     ArrowDown,
     ArrowLeft,


### PR DESCRIPTION
Sorry for another one-line PR.

In my application I'd like to add custom user controls to the persistent state. 
I could use serde's [workaround](https://serde.rs/remote-derive.html) for implementing (de)serialize on foreign types. But, considering egui already depends on serde, and this usecase shouldn't be too uncommon, I figured it's not a bad idea to just derive it here.