### PR TITLE
egui_glium: prevent cursor icon flickering at frame boundary on Windows (#217)

### DIFF
--- a/egui_glium/src/backend.rs
+++ b/egui_glium/src/backend.rs
@@ -212,7 +212,10 @@ pub fn run(mut app: Box<dyn epi::App>) -> ! {
         let new_cursor_icon = egui_output.cursor_icon;
         handle_output(egui_output, clipboard.as_mut());
 
-        display.gl_window().window().set_cursor_icon(translate_cursor(new_cursor_icon));
+        display
+            .gl_window()
+            .window()
+            .set_cursor_icon(translate_cursor(new_cursor_icon));
         previous_cursor_icon = Some(new_cursor_icon);
 
         // TODO: handle app_output
@@ -288,10 +291,13 @@ pub fn run(mut app: Box<dyn epi::App>) -> ! {
             if Some(new_cursor_icon) != previous_cursor_icon {
                 // call only when changed to prevent flickering near frame boundary
                 // when Windows OS tries to control cursor icon for window resizing
-                display.gl_window().window().set_cursor_icon(translate_cursor(new_cursor_icon));
+                display
+                    .gl_window()
+                    .window()
+                    .set_cursor_icon(translate_cursor(new_cursor_icon));
                 previous_cursor_icon = Some(new_cursor_icon);
             }
-        
+
             #[cfg(feature = "persistence")]
             if let Some(storage) = &mut storage {
                 let now = Instant::now();

--- a/egui_glium/src/backend.rs
+++ b/egui_glium/src/backend.rs
@@ -210,7 +210,7 @@ pub fn run(mut app: Box<dyn epi::App>) -> ! {
 
         let (egui_output, _shapes) = ctx.end_frame();
         let new_cursor_icon = egui_output.cursor_icon;
-        handle_output(egui_output, &display, clipboard.as_mut());
+        handle_output(egui_output, clipboard.as_mut());
 
         display.gl_window().window().set_cursor_icon(translate_cursor(new_cursor_icon));
         previous_cursor_icon = Some(new_cursor_icon);
@@ -283,7 +283,7 @@ pub fn run(mut app: Box<dyn epi::App>) -> ! {
 
             screen_reader.speak(&egui_output.events_description());
             let new_cursor_icon = egui_output.cursor_icon;
-            handle_output(egui_output, &display, clipboard.as_mut());
+            handle_output(egui_output, clipboard.as_mut());
 
             if Some(new_cursor_icon) != previous_cursor_icon {
                 // call only when changed to prevent flickering near frame boundary

--- a/egui_glium/src/backend.rs
+++ b/egui_glium/src/backend.rs
@@ -173,6 +173,7 @@ pub fn run(mut app: Box<dyn epi::App>) -> ! {
     let mut previous_frame_time = None;
     let mut painter = Painter::new(&display);
     let mut clipboard = init_clipboard();
+    let mut previous_cursor_icon = None;
 
     #[cfg(feature = "persistence")]
     let mut last_auto_save = Instant::now();
@@ -208,7 +209,12 @@ pub fn run(mut app: Box<dyn epi::App>) -> ! {
         ctx.clear_animations();
 
         let (egui_output, _shapes) = ctx.end_frame();
+        let new_cursor_icon = egui_output.cursor_icon;
         handle_output(egui_output, &display, clipboard.as_mut());
+
+        display.gl_window().window().set_cursor_icon(translate_cursor(new_cursor_icon));
+        previous_cursor_icon = Some(new_cursor_icon);
+
         // TODO: handle app_output
         // eprintln!("Warmed up in {} ms", warm_up_start.elapsed().as_millis())
     }
@@ -276,8 +282,16 @@ pub fn run(mut app: Box<dyn epi::App>) -> ! {
             }
 
             screen_reader.speak(&egui_output.events_description());
+            let new_cursor_icon = egui_output.cursor_icon;
             handle_output(egui_output, &display, clipboard.as_mut());
 
+            if Some(new_cursor_icon) != previous_cursor_icon {
+                // call only when changed to prevent flickering near frame boundary
+                // when Windows OS tries to control cursor icon for window resizing
+                display.gl_window().window().set_cursor_icon(translate_cursor(new_cursor_icon));
+                previous_cursor_icon = Some(new_cursor_icon);
+            }
+        
             #[cfg(feature = "persistence")]
             if let Some(storage) = &mut storage {
                 let now = Instant::now();

--- a/egui_glium/src/lib.rs
+++ b/egui_glium/src/lib.rs
@@ -295,11 +295,6 @@ pub fn handle_output(
             }
         }
     }
-
-    display
-        .gl_window()
-        .window()
-        .set_cursor_icon(translate_cursor(output.cursor_icon));
 }
 
 pub fn init_clipboard() -> Option<ClipboardContext> {

--- a/egui_glium/src/lib.rs
+++ b/egui_glium/src/lib.rs
@@ -277,10 +277,7 @@ pub fn translate_cursor(cursor_icon: egui::CursorIcon) -> glutin::window::Cursor
     }
 }
 
-pub fn handle_output(
-    output: egui::Output,
-    clipboard: Option<&mut ClipboardContext>,
-) {
+pub fn handle_output(output: egui::Output, clipboard: Option<&mut ClipboardContext>) {
     if let Some(open) = output.open_url {
         if let Err(err) = webbrowser::open(&open.url) {
             eprintln!("Failed to open url: {}", err);

--- a/egui_glium/src/lib.rs
+++ b/egui_glium/src/lib.rs
@@ -279,7 +279,6 @@ pub fn translate_cursor(cursor_icon: egui::CursorIcon) -> glutin::window::Cursor
 
 pub fn handle_output(
     output: egui::Output,
-    display: &glium::backend::glutin::Display,
     clipboard: Option<&mut ClipboardContext>,
 ) {
     if let Some(open) = output.open_url {


### PR DESCRIPTION
Fixes #217
