### PR TITLE
Restrict window move to title bar

### DIFF
--- a/egui/src/containers/window.rs
+++ b/egui/src/containers/window.rs
@@ -298,7 +298,13 @@ impl<'open> Window<'open> {
         } else {
             None
         };
-        let hover_interaction = move_resize_hover(ctx, possible, area_layer_id, last_frame_outer_rect, title_bar_height);
+        let hover_interaction = move_resize_hover(
+            ctx,
+            possible,
+            area_layer_id,
+            last_frame_outer_rect,
+            title_bar_height,
+        );
 
         let mut area_content_ui = area.content_ui(ctx);
 
@@ -523,7 +529,9 @@ fn window_interaction(
     let mut window_interaction = { ctx.memory().window_interaction };
 
     if window_interaction.is_none() {
-        if let Some(hover_window_interaction) = move_resize_hover(ctx, possible, area_layer_id, rect, title_bar_height) {
+        if let Some(hover_window_interaction) =
+            move_resize_hover(ctx, possible, area_layer_id, rect, title_bar_height)
+        {
             hover_window_interaction.set_cursor(ctx);
             if ctx.input().pointer.any_pressed() && ctx.input().pointer.any_down() {
                 ctx.memory().interaction.drag_id = Some(id);
@@ -605,7 +613,9 @@ fn move_resize_hover(
     }
     let resize_hover = left || right || top || bottom;
 
-    let move_hover = !resize_hover && possible.movable && (0.0 ..= title_bar_height).contains(&(pointer_pos.y - rect.top()));
+    let move_hover = !resize_hover
+        && possible.movable
+        && (0.0..=title_bar_height).contains(&(pointer_pos.y - rect.top()));
 
     if resize_hover || move_hover {
         Some(WindowInteraction {

--- a/egui/src/containers/window.rs
+++ b/egui/src/containers/window.rs
@@ -298,7 +298,7 @@ impl<'open> Window<'open> {
         } else {
             None
         };
-        let hover_interaction = resize_hover(ctx, possible, area_layer_id, last_frame_outer_rect, title_bar_height);
+        let hover_interaction = move_resize_hover(ctx, possible, area_layer_id, last_frame_outer_rect, title_bar_height);
 
         let mut area_content_ui = area.content_ui(ctx);
 
@@ -523,7 +523,7 @@ fn window_interaction(
     let mut window_interaction = { ctx.memory().window_interaction };
 
     if window_interaction.is_none() {
-        if let Some(hover_window_interaction) = resize_hover(ctx, possible, area_layer_id, rect, title_bar_height) {
+        if let Some(hover_window_interaction) = move_resize_hover(ctx, possible, area_layer_id, rect, title_bar_height) {
             hover_window_interaction.set_cursor(ctx);
             if ctx.input().pointer.any_pressed() && ctx.input().pointer.any_down() {
                 ctx.memory().interaction.drag_id = Some(id);
@@ -545,7 +545,7 @@ fn window_interaction(
     None
 }
 
-fn resize_hover(
+fn move_resize_hover(
     ctx: &Context,
     possible: PossibleInteractions,
     area_layer_id: LayerId,

--- a/egui/src/containers/window.rs
+++ b/egui/src/containers/window.rs
@@ -603,13 +603,11 @@ fn move_resize_hover(
             }
         }
     }
-    let any_resize = left || right || top || bottom;
+    let resize_hover = left || right || top || bottom;
 
-    if !any_resize && !possible.movable {
-        return None;
-    }
+    let move_hover = !resize_hover && possible.movable && (0.0 ..= title_bar_height).contains(&(pointer_pos.y - rect.top()));
 
-    if any_resize || possible.movable {
+    if resize_hover || move_hover {
         Some(WindowInteraction {
             area_layer_id,
             start_rect: rect,


### PR DESCRIPTION
I found it strange that windows can be moved by grabbing dragging anywhere within the window are except those parts covered by widgets that react to dragging. This patch changes the behavior to allow moving only when dragging the title bar, like most other window systems I know of.

Caveat 1: windows without title bar are not movable at all.
Caveat 2: areas that are not part of a window (e.g. popups like the color picker) still have the old behavior.

This was mostly an exercise for me to learn more about the internals of egui. Feel free to bring ideas how the caveats could best be addressed or how the behavior change needs to be otherwise modified/completed.