### PR TITLE
fix for lint warnings

### DIFF
--- a/egui/src/lib.rs
+++ b/egui/src/lib.rs
@@ -227,6 +227,7 @@
 //! ui.style_mut().wrap = Some(false);
 //! ```
 
+#![cfg_attr(not(debug_assertions), deny(rustdoc::missing_doc_code_examples))] 
 #![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
 #![forbid(unsafe_code)]
 #![warn(
@@ -274,7 +275,6 @@
     clippy::unused_self,
     clippy::verbose_file_reads,
     future_incompatible,
-    rustdoc::missing_crate_level_docs,
     nonstandard_style,
     rust_2018_idioms
 )]

--- a/egui/src/lib.rs
+++ b/egui/src/lib.rs
@@ -274,7 +274,7 @@
     clippy::unused_self,
     clippy::verbose_file_reads,
     future_incompatible,
-    missing_crate_level_docs,
+    rustdoc::missing_crate_level_docs,
     nonstandard_style,
     rust_2018_idioms
 )]

--- a/egui_demo_lib/src/lib.rs
+++ b/egui_demo_lib/src/lib.rs
@@ -49,7 +49,7 @@
     clippy::unused_self,
     clippy::verbose_file_reads,
     future_incompatible,
-    missing_crate_level_docs,
+    rustdoc::missing_crate_level_docs,
     nonstandard_style,
     rust_2018_idioms
 )]

--- a/egui_demo_lib/src/lib.rs
+++ b/egui_demo_lib/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! The demo-code is also used in benchmarks and tests.
 
+#![cfg_attr(not(debug_assertions), deny(rustdoc::missing_doc_code_examples))] 
 #![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
 #![forbid(unsafe_code)]
 #![warn(
@@ -49,7 +50,6 @@
     clippy::unused_self,
     clippy::verbose_file_reads,
     future_incompatible,
-    rustdoc::missing_crate_level_docs,
     nonstandard_style,
     rust_2018_idioms
 )]

--- a/emath/src/lib.rs
+++ b/emath/src/lib.rs
@@ -56,7 +56,7 @@
     clippy::unused_self,
     clippy::verbose_file_reads,
     future_incompatible,
-    missing_crate_level_docs,
+    rustdoc::missing_crate_level_docs,
     nonstandard_style,
     rust_2018_idioms
 )]

--- a/emath/src/lib.rs
+++ b/emath/src/lib.rs
@@ -9,6 +9,7 @@
 //! * (0,0) is left top.
 //! * Dimension order is always `x y`
 
+#![cfg_attr(not(debug_assertions), deny(rustdoc::missing_doc_code_examples))] 
 #![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
 #![forbid(unsafe_code)]
 #![warn(
@@ -56,7 +57,6 @@
     clippy::unused_self,
     clippy::verbose_file_reads,
     future_incompatible,
-    rustdoc::missing_crate_level_docs,
     nonstandard_style,
     rust_2018_idioms
 )]

--- a/epaint/src/lib.rs
+++ b/epaint/src/lib.rs
@@ -47,7 +47,7 @@
     clippy::unused_self,
     clippy::verbose_file_reads,
     future_incompatible,
-    missing_crate_level_docs,
+    rustdoc::missing_crate_level_docs,
     nonstandard_style,
     rust_2018_idioms
 )]

--- a/epaint/src/lib.rs
+++ b/epaint/src/lib.rs
@@ -1,5 +1,6 @@
 //! 2D graphics/rendering. Fonts, textures, color, geometry, tessellation etc.
 
+#![cfg_attr(not(debug_assertions), deny(rustdoc::missing_doc_code_examples))] 
 #![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
 #![forbid(unsafe_code)]
 #![warn(
@@ -47,7 +48,6 @@
     clippy::unused_self,
     clippy::verbose_file_reads,
     future_incompatible,
-    rustdoc::missing_crate_level_docs,
     nonstandard_style,
     rust_2018_idioms
 )]

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -53,7 +53,7 @@
     clippy::unused_self,
     clippy::verbose_file_reads,
     future_incompatible,
-    missing_crate_level_docs,
+    rustdoc::missing_crate_level_docs,
     nonstandard_style,
     rust_2018_idioms
 )]

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -6,6 +6,7 @@
 //!
 //! Start by looking at the [`App`] trait, and implement [`App::update`].
 
+#![cfg_attr(not(debug_assertions), deny(rustdoc::missing_doc_code_examples))] 
 #![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
 #![forbid(unsafe_code)]
 #![warn(
@@ -53,7 +54,6 @@
     clippy::unused_self,
     clippy::verbose_file_reads,
     future_incompatible,
-    rustdoc::missing_crate_level_docs,
     nonstandard_style,
     rust_2018_idioms
 )]


### PR DESCRIPTION
Quick fix for failing release build documented in [warning: lint missing_crate_level_docs has been removed #250](https://github.com/emilk/egui/issues/250#issue-841180785) issue.
