### PR TITLE
Add ability to turn off default_fonts feature for all crates

### DIFF
--- a/eframe/Cargo.toml
+++ b/eframe/Cargo.toml
@@ -20,19 +20,23 @@ include = [
 [lib]
 
 [dependencies]
-egui = { version = "0.11.0", path = "../egui" }
+egui = { version = "0.11.0", path = "../egui", default-features = false }
 epi = { version = "0.11.0", path = "../epi" }
 
 # For compiling natively:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-egui_glium = { version = "0.11.0", path = "../egui_glium" }
+egui_glium = { version = "0.11.0", path = "../egui_glium", default-features = false }
 
 # For compiling to web:
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-egui_web = { version = "0.11.0", path = "../egui_web" }
+egui_web = { version = "0.11.0", path = "../egui_web", default-features = false }
 
 [features]
-default = []
+default = ["default_fonts"]
+
+# If set, egui will use `include_bytes!` to bundle some fonts.
+# If you plan on specifying your own fonts you may disable this feature.
+default_fonts = ["egui/default_fonts"]
 http = ["egui_glium/http", "egui_web/http"]
 persistence = ["epi/persistence", "egui_glium/persistence", "egui_web/persistence"]
 screen_reader = ["egui_glium/screen_reader", "egui_web/screen_reader"] # experimental

--- a/egui_demo_lib/Cargo.toml
+++ b/egui_demo_lib/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 [lib]
 
 [dependencies]
-egui = { version = "0.11.0", path = "../egui" }
+egui = { version = "0.11.0", path = "../egui", default-features = false }
 epi = { version = "0.11.0", path = "../epi" }
 
 # feature "http":

--- a/egui_glium/Cargo.toml
+++ b/egui_glium/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 
 [dependencies]
 copypasta = "0.7"
-egui = { version = "0.11.0", path = "../egui" }
+egui = { version = "0.11.0", path = "../egui", default-features = false, features = ["single_threaded"] }
 epi = { version = "0.11.0", path = "../epi" }
 glium = "0.29"
 webbrowser = "0.5"
@@ -40,7 +40,11 @@ tts = { version = "0.15", optional = true }
 chrono = { version = "0.4", optional = true }
 
 [features]
-default = []
+default = ["default_fonts"]
+
+# If set, egui will use `include_bytes!` to bundle some fonts.
+# If you plan on specifying your own fonts you may disable this feature.
+default_fonts = ["egui/default_fonts"]
 http = ["ureq"]
 persistence = [
     "directories-next",

--- a/egui_web/Cargo.toml
+++ b/egui_web/Cargo.toml
@@ -22,7 +22,7 @@ include = [
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-egui = { version = "0.11.0", path = "../egui" }
+egui = { version = "0.11.0", path = "../egui", default-features = false, features = ["single_threaded"] }
 epi = { version = "0.11.0", path = "../epi" }
 js-sys = "0.3"
 ron = { version = "0.6", optional = true }
@@ -32,7 +32,11 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 
 [features]
-default = []
+default = ["default_fonts"]
+
+# If set, egui will use `include_bytes!` to bundle some fonts.
+# If you plan on specifying your own fonts you may disable this feature.
+default_fonts = ["egui/default_fonts"]
 http = [
   "epi/http",
   "web-sys/Headers",

--- a/epi/Cargo.toml
+++ b/epi/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 [lib]
 
 [dependencies]
-egui = { version = "0.11.0", path = "../egui" }
+egui = { version = "0.11.0", path = "../egui", default-features = false }
 ron = { version = "0.6", optional = true }
 serde = { version = "1", optional = true }
 


### PR DESCRIPTION
Closes https://github.com/emilk/egui/issues/227

My hope was that by setting `default-features = false` one would not get the `default_font` feature and thus avoid the bundled font.

But whatever I try, the `default_fonts` is turned on when I compile `egui_demo_app`.

Any ideas? I find cargo dependencies super confusing.