### PR TITLE
Add links to the changelogs for other crates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the egui crate will be documented in this file.
 
-NOTE: `eframe`, `egui_web` and `egui_glium` has their own changelogs!
+NOTE: [`eframe`](eframe/CHANGELOG.md), [`egui_web`](egui_web/CHANGELOG.md) and [`egui_glium`](egui_glium/CHANGELOG.md) has their own changelogs!
 
 
 ## Unreleased


### PR DESCRIPTION
Makes the other changelogs easier to find/access.

I always forget that the other crates aren't in separate repos & waste time when trying to catch up on the changelogs.

Now they're only a click away. :)

(Tested via the GH web interface.)
