### PR TITLE
implement mint conversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 name = "emath"
 version = "0.11.0"
 dependencies = [
+ "mint",
  "serde",
 ]
 
@@ -1361,6 +1362,12 @@ dependencies = [
  "adler",
  "autocfg",
 ]
+
+[[package]]
+name = "mint"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519df8d6856dcd4b40519947737b408f81be051fc032590659cae5d77d664185"
 
 [[package]]
 name = "mio"

--- a/egui/Cargo.toml
+++ b/egui/Cargo.toml
@@ -37,5 +37,7 @@ persistence = ["serde", "epaint/persistence", "ron"]
 single_threaded = ["epaint/single_threaded"]
 multi_threaded = ["epaint/multi_threaded"]
 
+mint = ["epaint/mint"]
+
 [dev-dependencies]
 serde_json = "1"

--- a/emath/Cargo.toml
+++ b/emath/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 [lib]
 
 [dependencies]
+mint = { version = "0.5.6", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [features]

--- a/emath/src/pos2.rs
+++ b/emath/src/pos2.rs
@@ -85,6 +85,23 @@ impl From<&Pos2> for (f32, f32) {
 }
 
 // ----------------------------------------------------------------------------
+// Mint compatibility and convenience conversions
+
+#[cfg(feature = "mint")]
+impl From<mint::Point2<f32>> for Pos2 {
+    fn from(v: mint::Point2<f32>) -> Self {
+        Self::new(v.x, v.y)
+    }
+}
+
+#[cfg(feature = "mint")]
+impl From<Pos2> for mint::Point2<f32> {
+    fn from(v: Pos2) -> Self {
+        Self { x: v.x, y: v.y }
+    }
+}
+
+// ----------------------------------------------------------------------------
 
 impl Pos2 {
     /// The zero position, the origin.

--- a/emath/src/vec2.rs
+++ b/emath/src/vec2.rs
@@ -82,6 +82,23 @@ impl From<&Vec2> for (f32, f32) {
 }
 
 // ----------------------------------------------------------------------------
+// Mint compatibility and convenience conversions
+
+#[cfg(feature = "mint")]
+impl From<mint::Vector2<f32>> for Vec2 {
+    fn from(v: mint::Vector2<f32>) -> Self {
+        Self::new(v.x, v.y)
+    }
+}
+
+#[cfg(feature = "mint")]
+impl From<Vec2> for mint::Vector2<f32> {
+    fn from(v: Vec2) -> Self {
+        Self { x: v.x, y: v.y }
+    }
+}
+
+// ----------------------------------------------------------------------------
 
 impl Vec2 {
     pub const X: Vec2 = Vec2 { x: 1.0, y: 0.0 };

--- a/epaint/Cargo.toml
+++ b/epaint/Cargo.toml
@@ -43,3 +43,5 @@ single_threaded = ["atomic_refcell"]
 
 # Only needed if you plan to use the same fonts from multiple threads.
 multi_threaded = ["parking_lot"]
+
+mint = ["emath/mint"]


### PR DESCRIPTION
Implement conversions for [mint](https://docs.rs/mint) (math interoperability standard types).

- `impl {From, Into}<mint::Point2> for Pos2`
- `impl {From, Into}<mint::Vector2> for Vec2`

Closes #314

