### PR TITLE
Typo fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the egui crate will be documented in this file.
 
-NOTE: [`eframe`](eframe/CHANGELOG.md), [`egui_web`](egui_web/CHANGELOG.md) and [`egui_glium`](egui_glium/CHANGELOG.md) has their own changelogs!
+NOTE: [`eframe`](eframe/CHANGELOG.md), [`egui_web`](egui_web/CHANGELOG.md) and [`egui_glium`](egui_glium/CHANGELOG.md) have their own changelogs!
 
 
 ## Unreleased
@@ -20,7 +20,7 @@ NOTE: [`eframe`](eframe/CHANGELOG.md), [`egui_web`](egui_web/CHANGELOG.md) and [
 * Support for raw [multi touch](https://github.com/emilk/egui/pull/306) events,
   enabling zoom, rotate, and more. Works with `egui_web` on mobile devices,
   and should work with `egui_glium` for certain touch devices/screens.
-* Add (optional) compatability with [mint](https://docs.rs/mint).
+* Add (optional) compatibility with [mint](https://docs.rs/mint).
 
 ### Changed 🔧
 * Make `Memory::has_focus` public (again).


### PR DESCRIPTION
"compatability"->"compatibility"

"has"->"have" (grammar)

