### PR TITLE
Fix scroll bar position

### DIFF
--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -133,9 +133,9 @@ impl ScrollArea {
             ),
             *ui.layout(),
         );
-        let mut content_clip_rect = inner_rect.expand(ui.visuals().clip_rect_margin);
-        content_clip_rect = content_clip_rect.intersect(ui.clip_rect());
-        content_clip_rect.max.x = ui.clip_rect().max.x - current_scroll_bar_width; // Nice handling of forced resizing beyond the possible
+        let content_clip_rect = inner_rect
+            .expand(ui.visuals().clip_rect_margin)
+            .intersect(ui.clip_rect());
         content_ui.set_clip_rect(content_clip_rect);
 
         Prepared {

--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -187,7 +187,7 @@ impl Prepared {
         }
 
         let width = if inner_rect.width().is_finite() {
-            inner_rect.width().max(content_size.x) // Expand width to fit content
+            inner_rect.width().min(content_size.x) // Position scroll bar correctly
         } else {
             // ScrollArea is in an infinitely wide parent
             content_size.x

--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -187,7 +187,7 @@ impl Prepared {
         }
 
         let width = if inner_rect.width().is_finite() {
-            inner_rect.width().min(content_size.x) // Position scroll bar correctly
+            inner_rect.width() // Position scroll bar correctly
         } else {
             // ScrollArea is in an infinitely wide parent
             content_size.x


### PR DESCRIPTION
While experimenting with #391, I noticed a bug in the way the vertical scroll bar is positioned. The screens below show the demo app resized to various widths.

A wide window looks nice, the scroll bar is firmly attached to the right side of the window:

![vertical-scroll-bar-1](https://user-images.githubusercontent.com/456942/118352354-e1132100-b515-11eb-883a-801c6137fddc.png)

At some point, when the window is made thinner, the scroll bar begins to disappear behind the window border:

![vertical-scroll-bar-2](https://user-images.githubusercontent.com/456942/118352381-ff791c80-b515-11eb-8e29-d50fc7ec531e.png)

When the window is very thin, you can see contents getting clipped as if the scroll bar should appear in the blank space:

![vertical-scroll-bar-3](https://user-images.githubusercontent.com/456942/118352400-1881cd80-b516-11eb-9dba-1af2c6722e5f.png)

----

With this very simple patch, the scroll bar correctly sits in that blank space:

![vertical-scroll-bar-4](https://user-images.githubusercontent.com/456942/118352415-2e8f8e00-b516-11eb-8378-395cc599a6de.png)

And bonus, wide windows still allow the scroll bar to stick to the right edge (see first screen).