### PR TITLE
Add support for buffers other than a `String` in `TextEdit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ NOTE: [`eframe`](eframe/CHANGELOG.md), [`egui_web`](egui_web/CHANGELOG.md) and [
 
 ### Added ⭐
 * Add features `extra_asserts` and `extra_debug_asserts` to enable additional checks.
+* `TextEdit` now supports edits on a generic buffer using `TextBuffer`.
 
 ## 0.12.0 - 2021-05-10 - Multitouch, user memory, window pivots, and improved plots
 
@@ -26,7 +27,6 @@ NOTE: [`eframe`](eframe/CHANGELOG.md), [`egui_web`](egui_web/CHANGELOG.md) and [
   enabling zoom, rotate, and more. Works with `egui_web` on mobile devices,
   and should work with `egui_glium` for certain touch devices/screens.
 * Add (optional) compatibility with [mint](https://docs.rs/mint).
-* `TextEdit` now supports edits on a generic buffer using `TextBuffer`.
 
 ### Changed 🔧
 * Make `Memory::has_focus` public (again).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ NOTE: [`eframe`](eframe/CHANGELOG.md), [`egui_web`](egui_web/CHANGELOG.md) and [
   enabling zoom, rotate, and more. Works with `egui_web` on mobile devices,
   and should work with `egui_glium` for certain touch devices/screens.
 * Add (optional) compatibility with [mint](https://docs.rs/mint).
+* `TextEdit` now supports edits on a generic buffer using `TextBuffer`.
 
 ### Changed 🔧
 * Make `Memory::has_focus` public (again).

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -953,14 +953,20 @@ impl Ui {
     /// No newlines (`\n`) allowed. Pressing enter key will result in the `TextEdit` losing focus (`response.lost_focus`).
     ///
     /// See also [`TextEdit`].
-    pub fn text_edit_singleline(&mut self, text: &mut String) -> Response {
+    pub fn text_edit_singleline<S: widgets::text_edit::TextBuffer>(
+        &mut self,
+        text: &mut S,
+    ) -> Response {
         TextEdit::singleline(text).ui(self)
     }
 
     /// A `TextEdit` for multiple lines. Pressing enter key will create a new line.
     ///
     /// See also [`TextEdit`].
-    pub fn text_edit_multiline(&mut self, text: &mut String) -> Response {
+    pub fn text_edit_multiline<S: widgets::text_edit::TextBuffer>(
+        &mut self,
+        text: &mut S,
+    ) -> Response {
         TextEdit::multiline(text).ui(self)
     }
 
@@ -969,7 +975,7 @@ impl Ui {
     /// This will be multiline, monospace, and will insert tabs instead of moving focus.
     ///
     /// See also [`TextEdit::code_editor`].
-    pub fn code_editor(&mut self, text: &mut String) -> Response {
+    pub fn code_editor<S: widgets::text_edit::TextBuffer>(&mut self, text: &mut S) -> Response {
         self.add(TextEdit::multiline(text).code_editor())
     }
 

--- a/egui/src/widgets/text_edit.rs
+++ b/egui/src/widgets/text_edit.rs
@@ -109,8 +109,10 @@ impl CCursorPair {
     }
 }
 
-/// Trait contraining what types [`TextEdit`] may use as
-/// an underlying buffer
+/// Trait constraining what types [`TextEdit`] may use as
+/// an underlying buffer.
+///
+/// Most likely you will use a `String` which implements `TextBuffer`.
 pub trait TextBuffer:
     AsRef<str> + Into<String> + PartialEq + Clone + Default + Send + Sync + 'static + std::fmt::Display
 {

--- a/egui/src/widgets/text_edit.rs
+++ b/egui/src/widgets/text_edit.rs
@@ -129,7 +129,7 @@ pub trait TextBuffer:
     ///
     /// # Notes
     /// `ch_range` is a *character range*, not a byte range.
-    fn delete_text_range(&mut self, ch_range: Range<usize>);
+    fn delete_char_range(&mut self, ch_range: Range<usize>);
 }
 
 impl TextBuffer for String {
@@ -143,7 +143,7 @@ impl TextBuffer for String {
         text.chars().count()
     }
 
-    fn delete_text_range(&mut self, ch_range: Range<usize>) {
+    fn delete_char_range(&mut self, ch_range: Range<usize>) {
         assert!(ch_range.start <= ch_range.end);
 
         // Get both byte indices
@@ -806,7 +806,7 @@ fn delete_selected<S: TextBuffer>(text: &mut S, cursorp: &CursorPair) -> CCursor
 }
 
 fn delete_selected_ccursor_range<S: TextBuffer>(text: &mut S, [min, max]: [CCursor; 2]) -> CCursor {
-    text.delete_text_range(min.index..max.index);
+    text.delete_char_range(min.index..max.index);
     CCursor {
         index: min.index,
         prefer_next_row: true,
@@ -1128,7 +1128,7 @@ fn decrease_identation<S: TextBuffer>(ccursor: &mut CCursor, text: &mut S) {
     };
 
     if let Some(len) = remove_len {
-        text.delete_text_range(line_start.index..(line_start.index + len));
+        text.delete_char_range(line_start.index..(line_start.index + len));
         if *ccursor != line_start {
             *ccursor -= len;
         }

--- a/egui/src/widgets/text_edit.rs
+++ b/egui/src/widgets/text_edit.rs
@@ -127,7 +127,10 @@ pub trait TextBuffer:
     ///
     /// # Notes
     /// `ch_idx` is a *character index*, not a byte index.
-    fn insert_text(&mut self, text: &str, ch_idx: usize);
+    ///
+    /// # Return
+    /// Returns how many *characters* were successfully inserted
+    fn insert_text(&mut self, text: &str, ch_idx: usize) -> usize;
 
     /// Deletes a range of text `ch_range` from this buffer.
     ///
@@ -137,7 +140,7 @@ pub trait TextBuffer:
 }
 
 impl TextBuffer for String {
-    fn insert_text(&mut self, text: &str, ch_idx: usize) {
+    fn insert_text(&mut self, text: &str, ch_idx: usize) -> usize {
         let mut indices = self::str_indices_with_last(self);
 
         // Get the byte index from the character index
@@ -148,6 +151,8 @@ impl TextBuffer for String {
         // Then insert the string
         std::mem::drop(indices);
         self.insert_str(byte_idx, text);
+
+        text.chars().count()
     }
 
     fn delete_text_range(&mut self, ch_range: Range<usize>) {
@@ -806,8 +811,7 @@ fn byte_index_from_char_index(s: &str, char_index: usize) -> usize {
 }
 
 fn insert_text<S: TextBuffer>(ccursor: &mut CCursor, text: &mut S, text_to_insert: &str) {
-    text.insert_text(text_to_insert, ccursor.index);
-    ccursor.index += text_to_insert.chars().count();
+    ccursor.index += text.insert_text(text_to_insert, ccursor.index);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Adds support for custom buffers to be used with the `TextEdit` widget.

I haven't made an issue because this was relatively simple to implement and it's something I need for one of my projects, so I'd likely re-use it even if you'd prefer to not make this change.

The motivation behind this for me is to use an `AsciiString` from the `ascii` crate as the underlying buffer, and also limit it's size to a certain number of max characters.
In order to achieve this the `TextBuffer` trait hands responsibility of any actual insertions / removals to the type itself, with a default impl for `String`.
Due to the default type of `String` I believe this doesn't break any existing code and a default of `String` is likely the best option either way.
This also modifies most operations to be in-place instead of creating a new string and assigning it to it. This should (?) also increase performance slightly, but I doubt it's too noticeable.