### PR TITLE
Add custom margin support on all panels

### DIFF
--- a/egui/src/containers/frame.rs
+++ b/egui/src/containers/frame.rs
@@ -19,7 +19,8 @@ impl Frame {
         Self::default()
     }
 
-    /// For when you want to group a few widgets together within a frame.
+    /// For when you want to group a few widgets together within a frame.  
+    /// Default margin is `vec2(8.0, 6.0)`. Use [`group_with_margin`](Self::group_with_margin) to set the margin.
     pub fn group(style: &Style) -> Self {
         Self {
             margin: Vec2::new(8.0, 6.0),
@@ -29,9 +30,19 @@ impl Frame {
         }
     }
 
-    pub(crate) fn side_top_panel(style: &Style) -> Self {
+    /// Same as [`group`](Self::group) but with custom margin.
+    pub fn group_with_margin(style: &Style, margin: Vec2) -> Self {
         Self {
-            margin: Vec2::new(8.0, 2.0),
+            margin,
+            corner_radius: 4.0,
+            stroke: style.visuals.window_stroke(),
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn side_top_panel(style: &Style, margin: Vec2) -> Self {
+        Self {
+            margin,
             corner_radius: 0.0,
             fill: style.visuals.window_fill(),
             stroke: style.visuals.window_stroke(),
@@ -39,9 +50,9 @@ impl Frame {
         }
     }
 
-    pub(crate) fn central_panel(style: &Style) -> Self {
+    pub(crate) fn central_panel(style: &Style, margin: Vec2) -> Self {
         Self {
-            margin: Vec2::new(8.0, 8.0),
+            margin,
             corner_radius: 0.0,
             fill: style.visuals.window_fill(),
             stroke: Default::default(),

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -1202,7 +1202,8 @@ impl Ui {
 
 /// # Adding Containers / Sub-uis:
 impl Ui {
-    /// Put into a [`Frame::group`], visually grouping the contents together
+    /// Put into a [`Frame::group`], visually grouping the contents together.  
+    /// Default margin is `vec2(8.0, 6.0)`. Use [`group_with_margin`](Self::group_with_margin) to set the margin.
     ///
     /// ```
     /// # let ui = &mut egui::Ui::__test();
@@ -1211,7 +1212,12 @@ impl Ui {
     /// });
     /// ```
     pub fn group<R>(&mut self, add_contents: impl FnOnce(&mut Ui) -> R) -> InnerResponse<R> {
-        crate::Frame::group(self.style()).show(self, add_contents)
+        self.group_with_margin(vec2(8.0, 6.0), add_contents)
+    }
+
+    /// Same as [`group`](Self::group) but with custom margin.
+    pub fn group_with_margin<R>(&mut self, margin: Vec2, add_contents: impl FnOnce(&mut Ui) -> R) -> InnerResponse<R> {
+        crate::Frame::group_with_margin(self.style(), margin).show(self, add_contents)
     }
 
     /// Create a scoped child ui.


### PR DESCRIPTION
It was not possible to set margin on side panels. 

## Example

```rust
egui::SidePanel::left("my_side_panel", 0.0).margin(vec2(5.0, 3.0)).show(ctx, |ui| {
    ui.label("Hello World!");
});
```

This PR is non-breaking. It keeps all default margin values and does not change signature of any existing public function.