### PR TITLE
Make it possible to change checkbox's TextStyle

### DIFF
--- a/egui/src/containers/combo_box.rs
+++ b/egui/src/containers/combo_box.rs
@@ -24,6 +24,7 @@ pub struct ComboBox {
     label: Option<Label>,
     selected_text: String,
     width: Option<f32>,
+    text_style: TextStyle,
 }
 
 impl ComboBox {
@@ -35,6 +36,7 @@ impl ComboBox {
             label: Some(label),
             selected_text: Default::default(),
             width: None,
+            text_style: TextStyle::Button,
         }
     }
 
@@ -45,6 +47,7 @@ impl ComboBox {
             label: Default::default(),
             selected_text: Default::default(),
             width: None,
+            text_style: TextStyle::Button,
         }
     }
 
@@ -61,6 +64,11 @@ impl ComboBox {
         self
     }
 
+    pub fn text_style(mut self, text_style: TextStyle) -> Self {
+        self.text_style = text_style;
+        self
+    }
+
     /// Show the combo box, with the given ui code for the menu contents.
     pub fn show_ui(self, ui: &mut Ui, menu_contents: impl FnOnce(&mut Ui)) -> Response {
         let Self {
@@ -68,6 +76,7 @@ impl ComboBox {
             label,
             selected_text,
             width,
+            text_style,
         } = self;
 
         let button_id = ui.make_persistent_id(id_source);
@@ -76,7 +85,7 @@ impl ComboBox {
             if let Some(width) = width {
                 ui.spacing_mut().slider_width = width; // yes, this is ugly. Will remove later.
             }
-            let mut response = combo_box(ui, button_id, selected_text, menu_contents);
+            let mut response = combo_box(ui, button_id, selected_text, text_style, menu_contents);
             if let Some(label) = label {
                 response.widget_info(|| WidgetInfo::labeled(WidgetType::ComboBox, label.text()));
                 response |= ui.add(label);
@@ -158,7 +167,7 @@ pub fn combo_box_with_label(
     let button_id = ui.make_persistent_id(label.text());
 
     ui.horizontal(|ui| {
-        let mut response = combo_box(ui, button_id, selected, menu_contents);
+        let mut response = combo_box(ui, button_id, selected, TextStyle::Button, menu_contents);
         response.widget_info(|| WidgetInfo::labeled(WidgetType::ComboBox, label.text()));
         response |= ui.add(label);
         response
@@ -171,6 +180,7 @@ fn combo_box(
     ui: &mut Ui,
     button_id: Id,
     selected: impl ToString,
+    text_style: TextStyle,
     menu_contents: impl FnOnce(&mut Ui),
 ) -> Response {
     let popup_id = button_id.with("popup");
@@ -183,7 +193,7 @@ fn combo_box(
 
         let galley = ui
             .fonts()
-            .layout_no_wrap(TextStyle::Button, selected.to_string());
+            .layout_no_wrap(text_style, selected.to_string());
 
         let width = galley.size.x + ui.spacing().item_spacing.x + icon_size.x;
         let width = width.at_least(full_minimum_width);

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -1039,10 +1039,16 @@ impl Ui {
 
     /// Show a label which can be selected or not.
     ///
-    /// See also [`SelectableLabel`].
+    /// See also [`SelectableLabel`] and [`selectable_label_with_text_style`](Self::selectable_label_with_text_style).
     #[must_use = "You should check if the user clicked this with `if ui.selectable_label(…).clicked() { … } "]
     pub fn selectable_label(&mut self, checked: bool, text: impl ToString) -> Response {
-        SelectableLabel::new(checked, text).ui(self)
+        self.selectable_label_with_text_style(checked, text, TextStyle::Button)
+    }
+
+    /// Same as [`selectable_label`](Self::selectable_label) but you can set the [`TextStyle`].
+    #[must_use = "You should check if the user clicked this with `if ui.selectable_label(…).clicked() { … } "]
+    pub fn selectable_label_with_text_style(&mut self, checked: bool, text: impl ToString, text_style: TextStyle) -> Response {
+        SelectableLabel::new(checked, text).text_style(text_style).ui(self)
     }
 
     /// Show selectable text. It is selected if `*current_value == selected_value`.
@@ -1050,14 +1056,25 @@ impl Ui {
     ///
     /// Example: `ui.selectable_value(&mut my_enum, Enum::Alternative, "Alternative")`.
     ///
-    /// See also [`SelectableLabel`].
+    /// See also [`SelectableLabel`] and [`selectable_value_with_text_style`](Self::selectable_value_with_text_style).
     pub fn selectable_value<Value: PartialEq>(
         &mut self,
         current_value: &mut Value,
         selected_value: Value,
         text: impl ToString,
     ) -> Response {
-        let mut response = self.selectable_label(*current_value == selected_value, text);
+        self.selectable_value_with_text_style(current_value, selected_value, text, TextStyle::Button)
+    }
+
+    /// Same as [`selectable_value`](Self::selectable_value) but you can set the [`TextStyle`].
+    pub fn selectable_value_with_text_style<Value: PartialEq>(
+        &mut self,
+        current_value: &mut Value,
+        selected_value: Value,
+        text: impl ToString,
+        text_style: TextStyle,
+    ) -> Response {
+        let mut response = self.selectable_label_with_text_style(*current_value == selected_value, text, text_style);
         if response.clicked() {
             *current_value = selected_value;
             response.mark_changed();

--- a/egui/src/widgets/button.rs
+++ b/egui/src/widgets/button.rs
@@ -209,6 +209,7 @@ pub struct Checkbox<'a> {
     checked: &'a mut bool,
     text: String,
     text_color: Option<Color32>,
+    text_style: TextStyle,
 }
 
 impl<'a> Checkbox<'a> {
@@ -218,11 +219,17 @@ impl<'a> Checkbox<'a> {
             checked,
             text: text.to_string(),
             text_color: None,
+            text_style: TextStyle::Button,
         }
     }
 
     pub fn text_color(mut self, text_color: Color32) -> Self {
         self.text_color = Some(text_color);
+        self
+    }
+
+    pub fn text_style(mut self, text_style: TextStyle) -> Self {
+        self.text_style = text_style;
         self
     }
 }
@@ -233,6 +240,7 @@ impl<'a> Widget for Checkbox<'a> {
             checked,
             text,
             text_color,
+            text_style,
         } = self;
 
         let spacing = &ui.spacing();
@@ -241,7 +249,6 @@ impl<'a> Widget for Checkbox<'a> {
         let button_padding = spacing.button_padding;
         let total_extra = button_padding + vec2(icon_width + icon_spacing, 0.0) + button_padding;
 
-        let text_style = TextStyle::Button;
         let galley = if ui.wrap_text() {
             ui.fonts()
                 .layout_multiline(text_style, text, ui.available_width() - total_extra.x)
@@ -320,6 +327,7 @@ pub struct RadioButton {
     checked: bool,
     text: String,
     text_color: Option<Color32>,
+    text_style: TextStyle,
 }
 
 impl RadioButton {
@@ -329,11 +337,17 @@ impl RadioButton {
             checked,
             text: text.to_string(),
             text_color: None,
+            text_style: TextStyle::Button,
         }
     }
 
     pub fn text_color(mut self, text_color: Color32) -> Self {
         self.text_color = Some(text_color);
+        self
+    }
+
+    pub fn text_style(mut self, text_style: TextStyle) -> Self {
+        self.text_style = text_style;
         self
     }
 }
@@ -344,6 +358,7 @@ impl Widget for RadioButton {
             checked,
             text,
             text_color,
+            text_style,
         } = self;
 
         let icon_width = ui.spacing().icon_width;
@@ -351,7 +366,6 @@ impl Widget for RadioButton {
         let button_padding = ui.spacing().button_padding;
         let total_extra = button_padding + vec2(icon_width + icon_spacing, 0.0) + button_padding;
 
-        let text_style = TextStyle::Button;
         let galley = if ui.wrap_text() {
             ui.fonts()
                 .layout_multiline(text_style, text, ui.available_width() - total_extra.x)

--- a/egui/src/widgets/selected_label.rs
+++ b/egui/src/widgets/selected_label.rs
@@ -25,6 +25,7 @@ use crate::*;
 pub struct SelectableLabel {
     selected: bool,
     text: String,
+    text_style: TextStyle,
 }
 
 impl SelectableLabel {
@@ -33,18 +34,23 @@ impl SelectableLabel {
         Self {
             selected,
             text: text.to_string(),
+            text_style: TextStyle::Button,
         }
+    }
+
+    pub fn text_style(mut self, text_style: TextStyle) -> Self {
+        self.text_style = text_style;
+        self
     }
 }
 
 impl Widget for SelectableLabel {
     fn ui(self, ui: &mut Ui) -> Response {
-        let Self { selected, text } = self;
+        let Self { selected, text, text_style } = self;
 
         let button_padding = ui.spacing().button_padding;
         let total_extra = button_padding + button_padding;
 
-        let text_style = TextStyle::Button;
         let galley = if ui.wrap_text() {
             ui.fonts()
                 .layout_multiline(text_style, text, ui.available_width() - total_extra.x)


### PR DESCRIPTION
Add `text_style` method on `Checkbox`, `RadioButton`, `ComboBox` and `SelectableLabel`.

```rust
Checkbox::new(&mut enabled, "Enable").text_style(TextStyle::Body);
```

Non-breaking
Closes #406 

