### PR TITLE
Additional accessibility support

### DIFF
--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -193,7 +193,8 @@ impl CtxRef {
             drag_released: false,
             is_pointer_button_down_on: false,
             interact_pointer_pos: None,
-            changed: false, // must be set by the widget itself
+            changed: false,         // must be set by the widget itself
+            has_widget_info: false, // must be set by the widget itself
         };
 
         if !enabled || !sense.focusable || !layer_id.allow_interaction() {

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -193,8 +193,7 @@ impl CtxRef {
             drag_released: false,
             is_pointer_button_down_on: false,
             interact_pointer_pos: None,
-            changed: false,         // must be set by the widget itself
-            has_widget_info: false, // must be set by the widget itself
+            changed: false, // must be set by the widget itself
         };
 
         if !enabled || !sense.focusable || !layer_id.allow_interaction() {

--- a/egui/src/data/output.rs
+++ b/egui/src/data/output.rs
@@ -242,7 +242,7 @@ pub struct WidgetInfo {
     /// The text on labels, buttons, checkboxes etc.
     pub label: Option<String>,
     /// The contents of some editable text (for `TextEdit` fields).
-    pub text_value: Option<String>,
+    pub current_text_value: Option<String>,
     // The previous text value.
     pub prev_text_value: Option<String>,
     /// The current value of checkboxes and radio buttons.
@@ -261,7 +261,7 @@ impl std::fmt::Debug for WidgetInfo {
             typ,
             enabled,
             label,
-            text_value,
+            current_text_value: text_value,
             prev_text_value,
             selected,
             value,
@@ -306,7 +306,7 @@ impl WidgetInfo {
             typ,
             enabled: true,
             label: None,
-            text_value: None,
+            current_text_value: None,
             prev_text_value: None,
             selected: None,
             value: None,
@@ -353,7 +353,7 @@ impl WidgetInfo {
     #[allow(clippy::needless_pass_by_value)]
     pub fn text_edit(text_value: impl ToString, prev_text_value: impl ToString) -> Self {
         Self {
-            text_value: Some(text_value.to_string()),
+            current_text_value: Some(text_value.to_string()),
             prev_text_value: Some(prev_text_value.to_string()),
             ..Self::new(WidgetType::TextEdit)
         }
@@ -368,7 +368,7 @@ impl WidgetInfo {
         Self {
             primary_cursor: Some(primary_cursor),
             secondary_cursor: Some(secondary_cursor),
-            text_value: Some(text_value.to_string()),
+            current_text_value: Some(text_value.to_string()),
             ..Self::new(WidgetType::TextEdit)
         }
     }
@@ -379,7 +379,7 @@ impl WidgetInfo {
             typ,
             enabled,
             label,
-            text_value,
+            current_text_value: text_value,
             prev_text_value: _,
             selected,
             value,

--- a/egui/src/data/output.rs
+++ b/egui/src/data/output.rs
@@ -40,6 +40,12 @@ impl Output {
         // only describe last event:
         if let Some(event) = self.events.iter().rev().next() {
             match event {
+                OutputEvent::Clicked(widget_info) => {
+                    return widget_info.description();
+                }
+                OutputEvent::DoubleClicked(widget_info) => {
+                    return widget_info.description();
+                }
                 OutputEvent::FocusGained(widget_info) => {
                     return widget_info.description();
                 }
@@ -204,6 +210,10 @@ impl Default for CursorIcon {
 /// In particular, these events may be useful for accessability, i.e. for screen readers.
 #[derive(Clone, PartialEq)]
 pub enum OutputEvent {
+    // A widget was clicked.
+    Clicked(WidgetInfo),
+    // A widget was double-clicked.
+    DoubleClicked(WidgetInfo),
     /// A widget gained keyboard focus (by tab key).
     FocusGained(WidgetInfo),
 }
@@ -211,6 +221,8 @@ pub enum OutputEvent {
 impl std::fmt::Debug for OutputEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Clicked(wi) => write!(f, "Clicked({:?})", wi),
+            Self::DoubleClicked(wi) => write!(f, "DoubleClicked({:?})", wi),
             Self::FocusGained(wi) => write!(f, "FocusGained({:?})", wi),
         }
     }

--- a/egui/src/data/output.rs
+++ b/egui/src/data/output.rs
@@ -249,10 +249,8 @@ pub struct WidgetInfo {
     pub selected: Option<bool>,
     /// The current value of sliders etc.
     pub value: Option<f64>,
-    // Location of primary cursor.
-    pub primary_cursor: Option<usize>,
-    // Location of secondary cursor.
-    pub secondary_cursor: Option<usize>,
+    // Selected range of characters in [`Self::current_text_value`].
+    pub text_selection: Option<std::ops::RangeInclusive<usize>>,
 }
 
 impl std::fmt::Debug for WidgetInfo {
@@ -265,8 +263,7 @@ impl std::fmt::Debug for WidgetInfo {
             prev_text_value,
             selected,
             value,
-            primary_cursor,
-            secondary_cursor,
+            text_selection,
         } = self;
 
         let mut s = f.debug_struct("WidgetInfo");
@@ -289,11 +286,8 @@ impl std::fmt::Debug for WidgetInfo {
         if let Some(value) = value {
             s.field("value", value);
         }
-        if let Some(primary_cursor) = primary_cursor {
-            s.field("primary_cursor", primary_cursor);
-        }
-        if let Some(secondary_cursor) = secondary_cursor {
-            s.field("secondary_cursor", secondary_cursor);
+        if let Some(text_selection) = text_selection {
+            s.field("text_selection", text_selection);
         }
 
         s.finish()
@@ -310,8 +304,7 @@ impl WidgetInfo {
             prev_text_value: None,
             selected: None,
             value: None,
-            primary_cursor: None,
-            secondary_cursor: None,
+            text_selection: None,
         }
     }
 
@@ -361,14 +354,12 @@ impl WidgetInfo {
 
     #[allow(clippy::needless_pass_by_value)]
     pub fn text_selection_changed(
-        primary_cursor: usize,
-        secondary_cursor: usize,
-        text_value: impl ToString,
+        text_selection: std::ops::RangeInclusive<usize>,
+        current_text_value: impl ToString,
     ) -> Self {
         Self {
-            primary_cursor: Some(primary_cursor),
-            secondary_cursor: Some(secondary_cursor),
-            current_text_value: Some(text_value.to_string()),
+            text_selection: Some(text_selection),
+            current_text_value: Some(current_text_value.to_string()),
             ..Self::new(WidgetType::TextEdit)
         }
     }
@@ -383,8 +374,7 @@ impl WidgetInfo {
             prev_text_value: _,
             selected,
             value,
-            primary_cursor: _,
-            secondary_cursor: _,
+            text_selection: _,
         } = self;
 
         // TODO: localization

--- a/egui/src/data/output.rs
+++ b/egui/src/data/output.rs
@@ -327,7 +327,7 @@ impl WidgetInfo {
         } = self;
 
         // TODO: localization
-        let widget_name = match typ {
+        let widget_type = match typ {
             WidgetType::Hyperlink => "link",
             WidgetType::TextEdit => "text edit",
             WidgetType::Button => "button",
@@ -343,20 +343,19 @@ impl WidgetInfo {
             WidgetType::Label | WidgetType::Other => "",
         };
 
-        let mut description = widget_name.to_owned();
+        let mut description = widget_type.to_owned();
 
         if let Some(selected) = selected {
             if *typ == WidgetType::Checkbox {
-                description += " ";
-                description += if *selected { "checked" } else { "unchecked" };
+                let state = if *selected { "checked" } else { "unchecked" };
+                description = format!("{} {}", state, description);
             } else {
                 description += if *selected { "selected" } else { "" };
             };
         }
 
         if let Some(label) = label {
-            description += " ";
-            description += label;
+            description = format!("{}: {}", label, description);
         }
 
         if let Some(edit_text) = edit_text {

--- a/egui/src/data/output.rs
+++ b/egui/src/data/output.rs
@@ -40,7 +40,7 @@ impl Output {
         // only describe last event:
         if let Some(event) = self.events.iter().rev().next() {
             match event {
-                OutputEvent::WidgetEvent(WidgetEvent::Focus, widget_info) => {
+                OutputEvent::FocusGained(widget_info) => {
                     return widget_info.description();
                 }
             }
@@ -205,23 +205,15 @@ impl Default for CursorIcon {
 #[derive(Clone, PartialEq)]
 pub enum OutputEvent {
     /// A widget gained keyboard focus (by tab key).
-    WidgetEvent(WidgetEvent, WidgetInfo),
+    FocusGained(WidgetInfo),
 }
 
 impl std::fmt::Debug for OutputEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::WidgetEvent(we, wi) => write!(f, "{:?}: {:?}", we, wi),
+            Self::FocusGained(wi) => write!(f, "FocusGained({:?})", wi),
         }
     }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum WidgetEvent {
-    /// Keyboard focused moved onto the widget.
-    Focus,
-    // /// Started hovering a new widget.
-    // Hover, // TODO: cursor hovered events
 }
 
 /// Describes a widget such as a [`crate::Button`] or a [`crate::TextEdit`].

--- a/egui/src/data/output.rs
+++ b/egui/src/data/output.rs
@@ -237,6 +237,8 @@ impl std::fmt::Debug for OutputEvent {
 pub struct WidgetInfo {
     /// The type of widget this is.
     pub typ: WidgetType,
+    // Whether the widget is enabled.
+    pub enabled: bool,
     /// The text on labels, buttons, checkboxes etc.
     pub label: Option<String>,
     /// The contents of some editable text (for `TextEdit` fields).
@@ -257,6 +259,7 @@ impl std::fmt::Debug for WidgetInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {
             typ,
+            enabled,
             label,
             text_value,
             prev_text_value,
@@ -269,6 +272,7 @@ impl std::fmt::Debug for WidgetInfo {
         let mut s = f.debug_struct("WidgetInfo");
 
         s.field("typ", typ);
+        s.field("enabled", enabled);
 
         if let Some(label) = label {
             s.field("label", label);
@@ -300,6 +304,7 @@ impl WidgetInfo {
     pub fn new(typ: WidgetType) -> Self {
         Self {
             typ,
+            enabled: true,
             label: None,
             text_value: None,
             prev_text_value: None,
@@ -372,6 +377,7 @@ impl WidgetInfo {
     pub fn description(&self) -> String {
         let Self {
             typ,
+            enabled,
             label,
             text_value,
             prev_text_value: _,
@@ -432,6 +438,9 @@ impl WidgetInfo {
             description += &value.to_string();
         }
 
+        if !enabled {
+            description += ": disabled";
+        }
         description.trim().to_owned()
     }
 }

--- a/egui/src/data/output.rs
+++ b/egui/src/data/output.rs
@@ -344,7 +344,7 @@ impl WidgetInfo {
     }
 
     #[allow(clippy::needless_pass_by_value)]
-    pub fn text_edit(text_value: impl ToString, prev_text_value: impl ToString) -> Self {
+    pub fn text_edit(prev_text_value: impl ToString, text_value: impl ToString) -> Self {
         Self {
             current_text_value: Some(text_value.to_string()),
             prev_text_value: Some(prev_text_value.to_string()),

--- a/egui/src/data/output.rs
+++ b/egui/src/data/output.rs
@@ -24,7 +24,7 @@ pub struct Output {
     /// Events that may be useful to e.g. a screen reader.
     pub events: Vec<OutputEvent>,
 
-    /// Position of text widgts' cursor
+    /// Position of text widget's cursor
     pub text_cursor: Option<crate::Pos2>,
 }
 

--- a/egui/src/data/output.rs
+++ b/egui/src/data/output.rs
@@ -353,7 +353,7 @@ impl WidgetInfo {
             Some(prev_text_value)
         };
         Self {
-            current_text_value: Some(text_value.to_string()),
+            current_text_value: Some(text_value),
             prev_text_value,
             ..Self::new(WidgetType::TextEdit)
         }

--- a/egui/src/data/output.rs
+++ b/egui/src/data/output.rs
@@ -345,9 +345,16 @@ impl WidgetInfo {
 
     #[allow(clippy::needless_pass_by_value)]
     pub fn text_edit(prev_text_value: impl ToString, text_value: impl ToString) -> Self {
+        let text_value = text_value.to_string();
+        let prev_text_value = prev_text_value.to_string();
+        let prev_text_value = if text_value == prev_text_value {
+            None
+        } else {
+            Some(prev_text_value)
+        };
         Self {
             current_text_value: Some(text_value.to_string()),
-            prev_text_value: Some(prev_text_value.to_string()),
+            prev_text_value,
             ..Self::new(WidgetType::TextEdit)
         }
     }

--- a/egui/src/memory.rs
+++ b/egui/src/memory.rs
@@ -314,6 +314,11 @@ impl Memory {
         self.interaction.focus.id == Some(id)
     }
 
+    /// Which widget has keyboard focus?
+    pub fn focus(&self) -> Option<Id> {
+        self.interaction.focus.id
+    }
+
     pub(crate) fn lock_focus(&mut self, id: Id, lock_focus: bool) {
         if self.had_focus_last_frame(id) && self.has_focus(id) {
             self.interaction.focus.is_focus_locked = lock_focus;

--- a/egui/src/response.rs
+++ b/egui/src/response.rs
@@ -65,8 +65,6 @@ pub struct Response {
     /// e.g. the slider was dragged, text was entered in a `TextEdit` etc.
     /// Always `false` for something like a `Button`.
     pub(crate) changed: bool,
-    /// Has a `WidgetInfo` but isn't covered by some other case (E.g. `changed`, `clicked`.)
-    pub(crate) has_widget_info: bool,
 }
 
 impl std::fmt::Debug for Response {
@@ -86,7 +84,6 @@ impl std::fmt::Debug for Response {
             is_pointer_button_down_on,
             interact_pointer_pos,
             changed,
-            has_widget_info,
         } = self;
         f.debug_struct("Response")
             .field("layer_id", layer_id)
@@ -102,7 +99,6 @@ impl std::fmt::Debug for Response {
             .field("is_pointer_button_down_on", is_pointer_button_down_on)
             .field("interact_pointer_pos", interact_pointer_pos)
             .field("changed", changed)
-            .field("has_widget_info", has_widget_info)
             .finish()
     }
 }
@@ -441,13 +437,6 @@ impl Response {
             Some(OutputEvent::FocusGained(make_info()))
         } else if self.changed {
             Some(OutputEvent::ValueChanged(make_info()))
-        } else if self.has_widget_info {
-            let info = make_info();
-            if info.primary_cursor.is_some() && info.secondary_cursor.is_some() {
-                Some(OutputEvent::TextSelectionChanged(info))
-            } else {
-                None
-            }
         } else {
             None
         };
@@ -490,7 +479,6 @@ impl Response {
                 || other.is_pointer_button_down_on,
             interact_pointer_pos: self.interact_pointer_pos.or(other.interact_pointer_pos),
             changed: self.changed || other.changed,
-            has_widget_info: self.has_widget_info || other.has_widget_info,
         }
     }
 }

--- a/egui/src/response.rs
+++ b/egui/src/response.rs
@@ -65,6 +65,8 @@ pub struct Response {
     /// e.g. the slider was dragged, text was entered in a `TextEdit` etc.
     /// Always `false` for something like a `Button`.
     pub(crate) changed: bool,
+    /// Has a `WidgetInfo` but isn't covered by some other case (E.g. `changed`, `clicked`.)
+    pub(crate) has_widget_info: bool,
 }
 
 impl std::fmt::Debug for Response {
@@ -84,6 +86,7 @@ impl std::fmt::Debug for Response {
             is_pointer_button_down_on,
             interact_pointer_pos,
             changed,
+            has_widget_info,
         } = self;
         f.debug_struct("Response")
             .field("layer_id", layer_id)
@@ -99,6 +102,7 @@ impl std::fmt::Debug for Response {
             .field("is_pointer_button_down_on", is_pointer_button_down_on)
             .field("interact_pointer_pos", interact_pointer_pos)
             .field("changed", changed)
+            .field("has_widget_info", has_widget_info)
             .finish()
     }
 }
@@ -437,6 +441,13 @@ impl Response {
             Some(OutputEvent::FocusGained(make_info()))
         } else if self.changed {
             Some(OutputEvent::ValueChanged(make_info()))
+        } else if self.has_widget_info {
+            let info = make_info();
+            if info.primary_cursor.is_some() && info.secondary_cursor.is_some() {
+                Some(OutputEvent::TextSelectionChanged(info))
+            } else {
+                None
+            }
         } else {
             None
         };
@@ -479,6 +490,7 @@ impl Response {
                 || other.is_pointer_button_down_on,
             interact_pointer_pos: self.interact_pointer_pos.or(other.interact_pointer_pos),
             changed: self.changed || other.changed,
+            has_widget_info: self.has_widget_info || other.has_widget_info,
         }
     }
 }

--- a/egui/src/response.rs
+++ b/egui/src/response.rs
@@ -428,10 +428,17 @@ impl Response {
     ///
     /// Call after interacting and potential calls to [`Self::mark_changed`].
     pub fn widget_info(&self, make_info: impl Fn() -> crate::WidgetInfo) {
-        if self.gained_focus() {
-            use crate::output::OutputEvent;
-            let widget_info = make_info();
-            let event = OutputEvent::FocusGained(widget_info);
+        use crate::output::OutputEvent;
+        let event = if self.clicked() {
+            Some(OutputEvent::Clicked(make_info()))
+        } else if self.double_clicked() {
+            Some(OutputEvent::DoubleClicked(make_info()))
+        } else if self.gained_focus() {
+            Some(OutputEvent::FocusGained(make_info()))
+        } else {
+            None
+        };
+        if let Some(event) = event {
             self.ctx.output().events.push(event);
         }
     }

--- a/egui/src/response.rs
+++ b/egui/src/response.rs
@@ -435,6 +435,8 @@ impl Response {
             Some(OutputEvent::DoubleClicked(make_info()))
         } else if self.gained_focus() {
             Some(OutputEvent::FocusGained(make_info()))
+        } else if self.changed {
+            Some(OutputEvent::ValueChanged(make_info()))
         } else {
             None
         };

--- a/egui/src/response.rs
+++ b/egui/src/response.rs
@@ -429,9 +429,9 @@ impl Response {
     /// Call after interacting and potential calls to [`Self::mark_changed`].
     pub fn widget_info(&self, make_info: impl Fn() -> crate::WidgetInfo) {
         if self.gained_focus() {
-            use crate::output::{OutputEvent, WidgetEvent};
+            use crate::output::OutputEvent;
             let widget_info = make_info();
-            let event = OutputEvent::WidgetEvent(WidgetEvent::Focus, widget_info);
+            let event = OutputEvent::FocusGained(widget_info);
             self.ctx.output().events.push(event);
         }
     }

--- a/egui/src/widgets/text_edit.rs
+++ b/egui/src/widgets/text_edit.rs
@@ -661,7 +661,7 @@ impl<'t> TextEdit<'t> {
         ui.memory().id_data.insert(id, state);
 
         if response.changed {
-            response.widget_info(|| WidgetInfo::text_edit(&*text, &*prev_text));
+            response.widget_info(|| WidgetInfo::text_edit(&*prev_text, &*text));
         } else if let Some(text_cursor) = text_cursor {
             let char_range =
                 text_cursor.primary.ccursor.index..=text_cursor.secondary.ccursor.index;

--- a/egui/src/widgets/text_edit.rs
+++ b/egui/src/widgets/text_edit.rs
@@ -138,7 +138,6 @@ impl CCursorPair {
 #[derive(Debug)]
 pub struct TextEdit<'t> {
     text: &'t mut String,
-    prev_text: String,
     hint_text: String,
     id: Option<Id>,
     id_source: Option<Id>,
@@ -171,7 +170,6 @@ impl<'t> TextEdit<'t> {
     pub fn singleline(text: &'t mut String) -> Self {
         TextEdit {
             text,
-            prev_text: Default::default(),
             hint_text: Default::default(),
             id: None,
             id_source: None,
@@ -191,7 +189,6 @@ impl<'t> TextEdit<'t> {
     pub fn multiline(text: &'t mut String) -> Self {
         TextEdit {
             text,
-            prev_text: Default::default(),
             hint_text: Default::default(),
             id: None,
             id_source: None,
@@ -334,7 +331,6 @@ impl<'t> Widget for TextEdit<'t> {
 impl<'t> TextEdit<'t> {
     fn content_ui(self, ui: &mut Ui) -> Response {
         let TextEdit {
-            mut prev_text,
             text,
             hint_text,
             id,
@@ -350,6 +346,7 @@ impl<'t> TextEdit<'t> {
             lock_focus,
         } = self;
 
+        let mut prev_text = text.clone();
         let text_style = text_style.unwrap_or_else(|| ui.style().body_text_style);
         let line_spacing = ui.fonts().row_height(text_style);
         let available_width = ui.available_width();
@@ -556,7 +553,6 @@ impl<'t> TextEdit<'t> {
                         if let Some((undo_ccursorp, undo_txt)) =
                             state.undoer.undo(&(cursorp.as_ccursorp(), text.clone()))
                         {
-                            prev_text = text.clone();
                             *text = undo_txt.clone();
                             Some(*undo_ccursorp)
                         } else {

--- a/egui/src/widgets/text_edit.rs
+++ b/egui/src/widgets/text_edit.rs
@@ -663,11 +663,9 @@ impl<'t> TextEdit<'t> {
         if response.changed {
             response.widget_info(|| WidgetInfo::text_edit(&*text, &*prev_text));
         } else if let Some(text_cursor) = text_cursor {
-            let info = WidgetInfo::text_selection_changed(
-                text_cursor.primary.ccursor.index,
-                text_cursor.secondary.ccursor.index,
-                &*text,
-            );
+            let char_range =
+                text_cursor.primary.ccursor.index..=text_cursor.secondary.ccursor.index;
+            let info = WidgetInfo::text_selection_changed(char_range, &*text);
             response
                 .ctx
                 .output()

--- a/egui/src/widgets/text_edit.rs
+++ b/egui/src/widgets/text_edit.rs
@@ -665,7 +665,18 @@ impl<'t> TextEdit<'t> {
 
         ui.memory().id_data.insert(id, state);
 
-        response.widget_info(|| WidgetInfo::text_edit(&*text, &*prev_text));
+        if response.changed {
+            response.widget_info(|| WidgetInfo::text_edit(&*text, &*prev_text));
+        } else if let Some(text_cursor) = text_cursor {
+            response.has_widget_info = true;
+            response.widget_info(|| {
+                WidgetInfo::text_selection_changed(
+                    text_cursor.primary.ccursor.index,
+                    text_cursor.secondary.ccursor.index,
+                    &*text,
+                )
+            });
+        }
         response
     }
 }

--- a/egui/src/widgets/text_edit.rs
+++ b/egui/src/widgets/text_edit.rs
@@ -1,4 +1,4 @@
-use crate::{util::undoer::Undoer, *};
+use crate::{output::OutputEvent, util::undoer::Undoer, *};
 use epaint::{text::cursor::*, *};
 
 #[derive(Clone, Debug, Default)]
@@ -505,7 +505,6 @@ impl<'t> TextEdit<'t> {
                             && text_to_insert != "\r"
                         {
                             let mut ccursor = delete_selected(text, &mut prev_text, &cursorp);
-
                             insert_text(&mut ccursor, text, &mut prev_text, text_to_insert);
                             Some(CCursorPair::one(ccursor))
                         } else {
@@ -664,14 +663,16 @@ impl<'t> TextEdit<'t> {
         if response.changed {
             response.widget_info(|| WidgetInfo::text_edit(&*text, &*prev_text));
         } else if let Some(text_cursor) = text_cursor {
-            response.has_widget_info = true;
-            response.widget_info(|| {
-                WidgetInfo::text_selection_changed(
-                    text_cursor.primary.ccursor.index,
-                    text_cursor.secondary.ccursor.index,
-                    &*text,
-                )
-            });
+            let info = WidgetInfo::text_selection_changed(
+                text_cursor.primary.ccursor.index,
+                text_cursor.secondary.ccursor.index,
+                &*text,
+            );
+            response
+                .ctx
+                .output()
+                .events
+                .push(OutputEvent::TextSelectionChanged(info));
         }
         response
     }


### PR DESCRIPTION
This is an initial stab at broadening egui's accessibility support. It isn't at all complete, but I'm hoping to merge what I can as I go, and to get some feedback. I'd particularly like to merge regularly so branches don't get out of sync, and particularly because I think something is better than nothing where accessibility is concerned. Currently supported:

* Focus changes
* Value updates when clicking on things (I.e. checkboxes)
* Reporting of changed text in `TextEdit`, as well as reporting when the selection changes. Still not perfect, but it's something.

[bevy_egui_a11y](https://github.com/ndarilek/bevy_egui_a11y) has been updated to show off these changes. Note that you can tab through all fields, get meaningful feedback, type into the text field, check the checkbox, arrow around, etc.

I've already started using my fork in my game and it seems to work well, but I really don't want to maintain a fork going forward. Please let me know if you'd rather not go down this road, and I'll stop work and back out the integration in my game.

Thanks.