### PR TITLE
Revert "Fix scroll bar position"

### DIFF
--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -137,9 +137,9 @@ impl ScrollArea {
             ),
             *ui.layout(),
         );
-        let content_clip_rect = inner_rect
-            .expand(ui.visuals().clip_rect_margin)
-            .intersect(ui.clip_rect());
+        let mut content_clip_rect = inner_rect.expand(ui.visuals().clip_rect_margin);
+        content_clip_rect = content_clip_rect.intersect(ui.clip_rect());
+        content_clip_rect.max.x = ui.clip_rect().max.x - current_scroll_bar_width; // Nice handling of forced resizing beyond the possible
         content_ui.set_clip_rect(content_clip_rect);
 
         let viewport = Rect::from_min_size(Pos2::ZERO + state.offset, inner_size);
@@ -251,7 +251,7 @@ impl Prepared {
         }
 
         let width = if inner_rect.width().is_finite() {
-            inner_rect.width() // Position scroll bar correctly
+            inner_rect.width().max(content_size.x) // Expand width to fit content
         } else {
             // ScrollArea is in an infinitely wide parent
             content_size.x


### PR DESCRIPTION
Reverts emilk/egui#392

It turns out the code that was removed was there for a reason:

<img width="223" alt="Screen Shot 2021-06-04 at 00 02 02" src="https://user-images.githubusercontent.com/1148717/120717721-53997000-c4c8-11eb-8e7d-cb35038cc5af.png">
