### PR TITLE
Grid fixes

### DIFF
--- a/egui/src/grid.rs
+++ b/egui/src/grid.rs
@@ -184,7 +184,12 @@ impl GridLayout {
 
     pub(crate) fn end_row(&mut self, cursor: &mut Rect, painter: &Painter) {
         cursor.min.x = self.initial_x;
-        cursor.min.y += self.curr_state.row_height(self.row).unwrap_or(self.min_cell_size.y) + self.spacing.y;
+        cursor.min.y += self.spacing.y;
+        cursor.min.y += self
+            .curr_state
+            .row_height(self.row)
+            .unwrap_or(self.min_cell_size.y);
+
         self.col = 0;
         self.row += 1;
 
@@ -332,21 +337,24 @@ impl Grid {
         // If somebody wants to wrap more things inside a cell,
         // then we should pick a default layout that matches that alignment,
         // which we do here:
-        ui.allocate_ui_at_rect(ui.cursor(), |ui|{
-            let id = ui.make_persistent_id(id_source);
-            let grid = GridLayout {
-                striped,
-                spacing,
-                min_cell_size: vec2(min_col_width, min_row_height),
-                max_cell_size,
-                row: start_row,
-                ..GridLayout::new(ui, id)
-            };
+        ui.allocate_ui_at_rect(ui.cursor(), |ui| {
+            ui.horizontal(|ui| {
+                let id = ui.make_persistent_id(id_source);
+                let grid = GridLayout {
+                    striped,
+                    spacing,
+                    min_cell_size: vec2(min_col_width, min_row_height),
+                    max_cell_size,
+                    row: start_row,
+                    ..GridLayout::new(ui, id)
+                };
 
-            ui.set_grid(grid);
-            let r = add_contents(ui);
-            ui.save_grid();
-            r
+                ui.set_grid(grid);
+                let r = add_contents(ui);
+                ui.save_grid();
+                r
+            })
+            .inner
         })
     }
 }

--- a/egui/src/grid.rs
+++ b/egui/src/grid.rs
@@ -148,7 +148,7 @@ impl GridLayout {
         self.align_size_within_rect(size, frame)
     }
 
-    pub(crate) fn advance(&mut self, cursor: &mut Rect, frame_rect: Rect, widget_rect: Rect) {
+    pub(crate) fn advance(&mut self, cursor: &mut Rect, _frame_rect: Rect, widget_rect: Rect) {
         let debug_expand_width = self.style.debug.show_expand_width;
         let debug_expand_height = self.style.debug.show_expand_height;
         if debug_expand_width || debug_expand_height {
@@ -178,8 +178,8 @@ impl GridLayout {
             widget_rect.height().at_least(self.min_cell_size.y),
         );
 
+        cursor.min.x += self.prev_col_width(self.col) + self.spacing.x;
         self.col += 1;
-        cursor.min.x += frame_rect.width() + self.spacing.x;
     }
 
     pub(crate) fn end_row(&mut self, cursor: &mut Rect, painter: &Painter) {

--- a/egui/src/grid.rs
+++ b/egui/src/grid.rs
@@ -183,10 +183,8 @@ impl GridLayout {
     }
 
     pub(crate) fn end_row(&mut self, cursor: &mut Rect, painter: &Painter) {
-        let row_height = self.prev_row_height(self.row);
-
         cursor.min.x = self.initial_x;
-        cursor.min.y += row_height + self.spacing.y;
+        cursor.min.y += self.curr_state.row_height(self.row).unwrap_or(self.min_cell_size.y) + self.spacing.y;
         self.col = 0;
         self.row += 1;
 

--- a/egui/src/grid.rs
+++ b/egui/src/grid.rs
@@ -334,7 +334,7 @@ impl Grid {
         // If somebody wants to wrap more things inside a cell,
         // then we should pick a default layout that matches that alignment,
         // which we do here:
-        ui.horizontal(|ui| {
+        ui.allocate_ui_at_rect(ui.cursor(), |ui|{
             let id = ui.make_persistent_id(id_source);
             let grid = GridLayout {
                 striped,

--- a/egui_demo_lib/src/apps/demo/tests.rs
+++ b/egui_demo_lib/src/apps/demo/tests.rs
@@ -179,6 +179,7 @@ pub struct TableTest {
     num_rows: usize,
     min_col_width: f32,
     max_col_width: f32,
+    text_length: usize,
 }
 
 impl Default for TableTest {
@@ -188,6 +189,7 @@ impl Default for TableTest {
             num_rows: 4,
             min_col_width: 10.0,
             max_col_width: 200.0,
+            text_length: 10,
         }
     }
 }
@@ -248,7 +250,7 @@ impl super::View for TableTest {
             });
 
         ui.separator();
-
+        ui.add(egui::Slider::new(&mut self.text_length, 1..=40).text("Text length"));
         egui::Grid::new("parent grid").striped(true).show(ui, |ui| {
             ui.vertical(|ui| {
                 ui.label("Vertical nest1");
@@ -282,7 +284,9 @@ impl super::View for TableTest {
             ui.label("Fourth row, second column");
             ui.end_row();
 
-            ui.label("Fifth row, first column");
+            let mut dyn_text = String::from("O");
+            dyn_text.extend(std::iter::repeat('h').take(self.text_length));
+            ui.label(dyn_text);
             ui.label("Fifth row, second column");
             ui.end_row();
         });

--- a/egui_demo_lib/src/apps/demo/tests.rs
+++ b/egui_demo_lib/src/apps/demo/tests.rs
@@ -246,33 +246,32 @@ impl super::View for TableTest {
                     ui.end_row();
                 }
             });
-            
+
         ui.separator();
-        
-        egui::Grid::new("parent grid")
-        .show(ui, |ui| {
+
+        egui::Grid::new("parent grid").striped(true).show(ui, |ui| {
             ui.vertical(|ui| {
                 ui.label("Vertical nest1");
                 ui.label("Vertical nest2");
             });
             ui.label("First row, second column");
             ui.end_row();
-            
+
             ui.horizontal(|ui| {
                 ui.label("Horizontal nest1");
                 ui.label("Horizontal nest2");
             });
             ui.label("Second row, second column");
             ui.end_row();
-            
+
             ui.scope(|ui| {
                 ui.label("Scope nest 1");
                 ui.label("Scope nest 2");
-                });
+            });
             ui.label("Third row, second column");
             ui.end_row();
 
-            egui::Grid::new("nested grid").show(ui, |ui|{
+            egui::Grid::new("nested grid").show(ui, |ui| {
                 ui.label("Grid nest11");
                 ui.label("Grid nest12");
                 ui.end_row();
@@ -282,7 +281,7 @@ impl super::View for TableTest {
             });
             ui.label("Fourth row, second column");
             ui.end_row();
-            
+
             ui.label("Fifth row, first column");
             ui.label("Fifth row, second column");
             ui.end_row();

--- a/egui_demo_lib/src/apps/demo/tests.rs
+++ b/egui_demo_lib/src/apps/demo/tests.rs
@@ -246,6 +246,47 @@ impl super::View for TableTest {
                     ui.end_row();
                 }
             });
+            
+        ui.separator();
+        
+        egui::Grid::new("parent grid")
+        .show(ui, |ui| {
+            ui.vertical(|ui| {
+                ui.label("Vertical nest1");
+                ui.label("Vertical nest2");
+            });
+            ui.label("First row, second column");
+            ui.end_row();
+            
+            ui.horizontal(|ui| {
+                ui.label("Horizontal nest1");
+                ui.label("Horizontal nest2");
+            });
+            ui.label("Second row, second column");
+            ui.end_row();
+            
+            ui.scope(|ui| {
+                ui.label("Scope nest 1");
+                ui.label("Scope nest 2");
+                });
+            ui.label("Third row, second column");
+            ui.end_row();
+
+            egui::Grid::new("nested grid").show(ui, |ui|{
+                ui.label("Grid nest11");
+                ui.label("Grid nest12");
+                ui.end_row();
+                ui.label("Grid nest21");
+                ui.label("Grid nest22");
+                ui.end_row();
+            });
+            ui.label("Fourth row, second column");
+            ui.end_row();
+            
+            ui.label("Fifth row, first column");
+            ui.label("Fifth row, second column");
+            ui.end_row();
+        });
 
         ui.vertical_centered(|ui| {
             egui::reset_button(ui, self);


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Open the PR as a draft until you have self-reviewed it and it is green.
* If it is a noteworthy change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Three things here:
- fix vertical spacing when nesting a grid within a grid.
- use current state instead of previous for getting row height, used for advancing cursor
- fix horizontal alignment for items following a cell containing a nested layout.

```rust
egui::Grid::new("unique_id")
        .show(ui, |ui| {
            ui.vertical(|ui| {
                ui.label("nest1");
                ui.label("nest2");
            });
            ui.label("First row, second column");
            ui.end_row();
            
            ui.label("Second row, second column");
            ui.label("Second row, first column");
            ui.end_row();
            
            ui.label("Third row, first column");
            ui.label("Third row, second column");
            ui.end_row();

            egui::Grid::new("unique_id_2").show(ui, |ui|{
                ui.label("nest11");
                ui.label("nest12");
                ui.end_row();
                ui.label("nest21");
                ui.label("nest22");
                ui.end_row();
            });
            ui.label("Fourth row, second column");
            ui.end_row();
            
            ui.label("row 5, 1");
            ui.label("row 5, 2");
            ui.end_row();
        });
```
## Before:
![Screenshot_before_fix](https://user-images.githubusercontent.com/1425156/121302907-f91b6c00-c92c-11eb-96ba-f164ea16dfc2.png)

## After
![Screenshot_after_fix](https://user-images.githubusercontent.com/1425156/121303014-1f410c00-c92d-11eb-91db-3dba947fc4f8.png)
