### PR TITLE
Make sure the scroll bar is never outside the screen rectangle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ NOTE: [`eframe`](eframe/CHANGELOG.md), [`egui_web`](egui_web/CHANGELOG.md) and [
 * `TopPanel::top` is now `TopBottomPanel::top`.
 * `SidePanel::left` no longet takes the default width by argument, but by a builder call.
 
+### Fixed 🐛
+* Fix invisible scroll bar when native window is too narrow for egui.
+
 
 ## 0.12.0 - 2021-05-10 - Multitouch, user memory, window pivots, and improved plots
 

--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -250,14 +250,25 @@ impl Prepared {
             state.offset.y = offset_y + spacing;
         }
 
-        let width = if inner_rect.width().is_finite() {
-            inner_rect.width().max(content_size.x) // Expand width to fit content
-        } else {
-            // ScrollArea is in an infinitely wide parent
-            content_size.x
-        };
+        let inner_rect = {
+            let width = if inner_rect.width().is_finite() {
+                inner_rect.width().max(content_size.x) // Expand width to fit content
+            } else {
+                // ScrollArea is in an infinitely wide parent
+                content_size.x
+            };
 
-        let inner_rect = Rect::from_min_size(inner_rect.min, vec2(width, inner_rect.height()));
+            let mut inner_rect =
+                Rect::from_min_size(inner_rect.min, vec2(width, inner_rect.height()));
+
+            // The window that egui sits in can't be expanded by egui, so we need to respect it:
+            let max_x = ui.ctx().available_rect().right() - current_scroll_bar_width;
+            inner_rect.max.x = inner_rect.max.x.at_most(max_x);
+            // TODO: when we support it, we should maybe auto-enable
+            // horizontal scrolling if this limit is reached
+
+            inner_rect
+        };
 
         let outer_rect = Rect::from_min_size(
             inner_rect.min,

--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -262,7 +262,9 @@ impl Prepared {
                 Rect::from_min_size(inner_rect.min, vec2(width, inner_rect.height()));
 
             // The window that egui sits in can't be expanded by egui, so we need to respect it:
-            let max_x = ui.input().screen_rect().right() - current_scroll_bar_width;
+            let max_x = ui.input().screen_rect().right()
+                - current_scroll_bar_width
+                - ui.spacing().item_spacing.x;
             inner_rect.max.x = inner_rect.max.x.at_most(max_x);
             // TODO: when we support it, we should maybe auto-enable
             // horizontal scrolling if this limit is reached

--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -262,7 +262,7 @@ impl Prepared {
                 Rect::from_min_size(inner_rect.min, vec2(width, inner_rect.height()));
 
             // The window that egui sits in can't be expanded by egui, so we need to respect it:
-            let max_x = ui.ctx().available_rect().right() - current_scroll_bar_width;
+            let max_x = ui.input().screen_rect().right() - current_scroll_bar_width;
             inner_rect.max.x = inner_rect.max.x.at_most(max_x);
             // TODO: when we support it, we should maybe auto-enable
             // horizontal scrolling if this limit is reached


### PR DESCRIPTION
This is an alternative attempt to fix the bug mentioned in https://github.com/emilk/egui/pull/392

egui expects that the container can always be made wider, which is true for all egui Ui:s, but not true for the outer frame/chrome that egui ultimately needs to sit within.

This handles the example of resizing the Color Test too narrow.

PTAL @parasyte 