### PR TITLE
Fix an issue where losing focus could prevent the event loop from receiving events for releasing modifier keys

### DIFF
--- a/egui_glium/src/lib.rs
+++ b/egui_glium/src/lib.rs
@@ -172,6 +172,11 @@ pub fn input_to_egui(
                 }
             }
         }
+        WindowEvent::Focused(_) => {
+            // We will not be given a KeyboardInput event when the modifiers are released while
+            // the window does not have focus. Unset all modifier state to be safe.
+            input_state.raw.modifiers = Modifiers::default();
+        }
         WindowEvent::MouseWheel { delta, .. } => {
             let mut delta = match delta {
                 glutin::event::MouseScrollDelta::LineDelta(x, y) => {


### PR DESCRIPTION
- This issue was made apparent on macOS since 67c6002578b73aa01872a3378cc5b7debe93a0a7
- Repro:
  1. Cmd+Tab away from the window (this will keep the Cmd modifier state `true` until it is pressed again)
  2. Cmd+Tab back to the window
  3. Try to scroll with the trackpad or mouse wheel ... it won't work until you press and release the Cmd key!
  4. Also the plot widget will be stuck in "zoom mode" while the Cmd modifier state is true.
- I was not able to reproduce the issue with `egui_web`