### PR TITLE
Use old 1.51 toolchain instead of bleeding edge

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.51.0
           override: true
       - run: sudo apt-get install libspeechd-dev
       - uses: actions-rs/cargo@v1
@@ -32,7 +32,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.51.0
           override: true
       - run: sudo apt-get install libspeechd-dev
       - uses: actions-rs/cargo@v1
@@ -48,7 +48,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.51.0
           override: true
       - run: rustup target add wasm32-unknown-unknown
       - uses: actions-rs/cargo@v1
@@ -64,7 +64,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.51.0
           override: true
       - run: rustup target add wasm32-unknown-unknown
       - uses: actions-rs/cargo@v1
@@ -80,7 +80,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.51.0
           override: true
       - run: sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev
       - uses: actions-rs/cargo@v1
@@ -96,7 +96,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.51.0
           override: true
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
@@ -112,7 +112,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.51.0
           override: true
       - run: rustup component add clippy
       - run: sudo apt-get install libspeechd-dev
@@ -129,7 +129,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.51.0
           override: true
       - run: sudo apt-get install libspeechd-dev
       - run: cargo doc -p emath -p epaint -p egui -p eframe -p epi -p egui_web -p egui_glium --lib --no-deps --all-features
@@ -142,7 +142,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.51.0
           override: true
       - run: sudo apt-get install libspeechd-dev
       - run: rustup target add wasm32-unknown-unknown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ NOTE: [`eframe`](eframe/CHANGELOG.md), [`egui_web`](egui_web/CHANGELOG.md) and [
 * Add `ScrollArea::enable_scrolling` to allow freezing scrolling when editing TextEdit widgets within it
 
 ### Changed 🔧
+* Minimum Rust version is now 1.51 (used to be 1.52)
 * [Tweaked the default visuals style](https://github.com/emilk/egui/pull/450).
 * Plot: Changed `Curve` to `Line`.
 * `TopPanel::top` is now `TopBottomPanel::top`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,9 +296,9 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "cint"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00709959bb62458ca8d7f043b1039e0d99e91f5500f004164ec371f546eadc47"
+checksum = "5d83feae28854d73f33659f9018546157422ddf5b84264ce171a766d8547d77b"
 
 [[package]]
 name = "clang-sys"

--- a/eframe/src/lib.rs
+++ b/eframe/src/lib.rs
@@ -11,13 +11,15 @@
 //!
 //! `eframe` is implemented using [`egui_web`](https://docs.rs/egui_web) and [`egui_glium`](https://docs.rs/egui_glium).
 
-#![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
-#![deny(
-    rustdoc::broken_intra_doc_links,
-    rustdoc::invalid_codeblock_attributes,
-    rustdoc::missing_crate_level_docs,
-    rustdoc::private_intra_doc_links
-)]
+// Forbid warnings in release builds:
+#![cfg_attr(not(debug_assertions), deny(warnings))]
+// Disabled so we can support rust 1.51:
+// #![deny(
+//     rustdoc::broken_intra_doc_links,
+//     rustdoc::invalid_codeblock_attributes,
+//     rustdoc::missing_crate_level_docs,
+//     rustdoc::private_intra_doc_links
+// )]
 #![forbid(unsafe_code)]
 #![warn(clippy::all, missing_docs, rust_2018_idioms)]
 

--- a/egui/src/lib.rs
+++ b/egui/src/lib.rs
@@ -3,7 +3,7 @@
 //! Try the live web demo: <https://emilk.github.io/egui/index.html>. Read more about egui at <https://github.com/emilk/egui>.
 //!
 //! `egui` is in heavy development, with each new version having breaking changes.
-//! You need to have the latest stable version of `rustc` to use `egui`.
+//! You need to have rust 1.51.0 or later to use `egui`.
 //!
 //! To quickly get started with egui, you can take a look at [`egui_template`](https://github.com/emilk/egui_template)
 //! which uses [`eframe`](https://docs.rs/eframe).
@@ -239,13 +239,15 @@
 //! }); // the temporary settings are reverted here
 //! ```
 
-#![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
-#![deny(
-    rustdoc::broken_intra_doc_links,
-    rustdoc::invalid_codeblock_attributes,
-    rustdoc::missing_crate_level_docs,
-    rustdoc::private_intra_doc_links
-)]
+// Forbid warnings in release builds:
+#![cfg_attr(not(debug_assertions), deny(warnings))]
+// Disabled so we can support rust 1.51:
+// #![deny(
+//     rustdoc::broken_intra_doc_links,
+//     rustdoc::invalid_codeblock_attributes,
+//     rustdoc::missing_crate_level_docs,
+//     rustdoc::private_intra_doc_links
+// )]
 #![forbid(unsafe_code)]
 #![warn(
     clippy::all,

--- a/egui_demo_app/src/lib.rs
+++ b/egui_demo_app/src/lib.rs
@@ -1,10 +1,12 @@
-#![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
-#![deny(
-    rustdoc::broken_intra_doc_links,
-    rustdoc::invalid_codeblock_attributes,
-    rustdoc::missing_crate_level_docs,
-    rustdoc::private_intra_doc_links
-)]
+// Forbid warnings in release builds:
+#![cfg_attr(not(debug_assertions), deny(warnings))]
+// Disabled so we can support rust 1.51:
+// #![deny(
+//     rustdoc::broken_intra_doc_links,
+//     rustdoc::invalid_codeblock_attributes,
+//     rustdoc::missing_crate_level_docs,
+//     rustdoc::private_intra_doc_links
+// )]
 #![forbid(unsafe_code)]
 #![warn(clippy::all, rust_2018_idioms)]
 

--- a/egui_demo_app/src/main.rs
+++ b/egui_demo_app/src/main.rs
@@ -1,10 +1,12 @@
-#![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
-#![deny(
-    rustdoc::broken_intra_doc_links,
-    rustdoc::invalid_codeblock_attributes,
-    rustdoc::missing_crate_level_docs,
-    rustdoc::private_intra_doc_links
-)]
+// Forbid warnings in release builds:
+#![cfg_attr(not(debug_assertions), deny(warnings))]
+// Disabled so we can support rust 1.51:
+// #![deny(
+//     rustdoc::broken_intra_doc_links,
+//     rustdoc::invalid_codeblock_attributes,
+//     rustdoc::missing_crate_level_docs,
+//     rustdoc::private_intra_doc_links
+// )]
 #![forbid(unsafe_code)]
 #![warn(clippy::all, rust_2018_idioms)]
 

--- a/egui_demo_lib/src/lib.rs
+++ b/egui_demo_lib/src/lib.rs
@@ -2,13 +2,15 @@
 //!
 //! The demo-code is also used in benchmarks and tests.
 
-#![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
-#![deny(
-    rustdoc::broken_intra_doc_links,
-    rustdoc::invalid_codeblock_attributes,
-    rustdoc::missing_crate_level_docs,
-    rustdoc::private_intra_doc_links
-)]
+// Forbid warnings in release builds:
+#![cfg_attr(not(debug_assertions), deny(warnings))]
+// Disabled so we can support rust 1.51:
+// #![deny(
+//     rustdoc::broken_intra_doc_links,
+//     rustdoc::invalid_codeblock_attributes,
+//     rustdoc::missing_crate_level_docs,
+//     rustdoc::private_intra_doc_links
+// )]
 #![forbid(unsafe_code)]
 #![warn(
     clippy::all,

--- a/egui_glium/src/lib.rs
+++ b/egui_glium/src/lib.rs
@@ -5,13 +5,15 @@
 //! This library is an [`epi`] backend.
 //! If you are writing an app, you may want to look at [`eframe`](https://docs.rs/eframe) instead.
 
-#![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
-#![deny(
-    rustdoc::broken_intra_doc_links,
-    rustdoc::invalid_codeblock_attributes,
-    rustdoc::missing_crate_level_docs,
-    rustdoc::private_intra_doc_links
-)]
+// Forbid warnings in release builds:
+#![cfg_attr(not(debug_assertions), deny(warnings))]
+// Disabled so we can support rust 1.51:
+// #![deny(
+//     rustdoc::broken_intra_doc_links,
+//     rustdoc::invalid_codeblock_attributes,
+//     rustdoc::missing_crate_level_docs,
+//     rustdoc::private_intra_doc_links
+// )]
 #![forbid(unsafe_code)]
 #![warn(clippy::all, rust_2018_idioms)]
 #![allow(clippy::manual_range_contains, clippy::single_match)]

--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -9,13 +9,15 @@
 //! fill the whole width of the browser.
 //! This can be changed by overriding [`epi::App::max_size_points`].
 
-#![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
-#![deny(
-    rustdoc::broken_intra_doc_links,
-    rustdoc::invalid_codeblock_attributes,
-    rustdoc::missing_crate_level_docs,
-    rustdoc::private_intra_doc_links
-)]
+// Forbid warnings in release builds:
+#![cfg_attr(not(debug_assertions), deny(warnings))]
+// Disabled so we can support rust 1.51:
+// #![deny(
+//     rustdoc::broken_intra_doc_links,
+//     rustdoc::invalid_codeblock_attributes,
+//     rustdoc::missing_crate_level_docs,
+//     rustdoc::private_intra_doc_links
+// )]
 #![forbid(unsafe_code)]
 #![warn(clippy::all, rust_2018_idioms)]
 

--- a/emath/src/lib.rs
+++ b/emath/src/lib.rs
@@ -9,13 +9,15 @@
 //! * (0,0) is left top.
 //! * Dimension order is always `x y`
 
-#![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
-#![deny(
-    rustdoc::broken_intra_doc_links,
-    rustdoc::invalid_codeblock_attributes,
-    rustdoc::missing_crate_level_docs,
-    rustdoc::private_intra_doc_links
-)]
+// Forbid warnings in release builds:
+#![cfg_attr(not(debug_assertions), deny(warnings))]
+// Disabled so we can support rust 1.51:
+// #![deny(
+//     rustdoc::broken_intra_doc_links,
+//     rustdoc::invalid_codeblock_attributes,
+//     rustdoc::missing_crate_level_docs,
+//     rustdoc::private_intra_doc_links
+// )]
 #![forbid(unsafe_code)]
 #![warn(
     clippy::all,

--- a/epaint/Cargo.toml
+++ b/epaint/Cargo.toml
@@ -26,7 +26,7 @@ emath = { version = "0.12.0", path = "../emath" }
 
 ahash = { version = "0.7", features = ["std"], default-features = false }
 atomic_refcell = { version = "0.1", optional = true } # Used instead of parking_lot when you are always using epaint in a single thread. About as fast as parking_lot. Panics on multi-threaded use.
-cint = { version = "^0.2.1", optional = true }
+cint = { version = "^0.2.2", optional = true }
 ordered-float = { version = "2", default-features = false }
 parking_lot = { version = "0.11", optional = true } # Using parking_lot over std::sync::Mutex gives 50% speedups in some real-world scenarios.
 rusttype = "0.9"

--- a/epaint/src/lib.rs
+++ b/epaint/src/lib.rs
@@ -1,12 +1,14 @@
 //! 2D graphics/rendering. Fonts, textures, color, geometry, tessellation etc.
 
-#![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
-#![deny(
-    rustdoc::broken_intra_doc_links,
-    rustdoc::invalid_codeblock_attributes,
-    rustdoc::missing_crate_level_docs,
-    rustdoc::private_intra_doc_links
-)]
+// Forbid warnings in release builds:
+#![cfg_attr(not(debug_assertions), deny(warnings))]
+// Disabled so we can support rust 1.51:
+// #![deny(
+//     rustdoc::broken_intra_doc_links,
+//     rustdoc::invalid_codeblock_attributes,
+//     rustdoc::missing_crate_level_docs,
+//     rustdoc::private_intra_doc_links
+// )]
 #![forbid(unsafe_code)]
 #![warn(
     clippy::all,

--- a/epaint/src/text/galley.rs
+++ b/epaint/src/text/galley.rs
@@ -583,8 +583,6 @@ impl Galley {
 
 #[test]
 fn test_text_layout() {
-    #![allow(clippy::bool_assert_comparison)]
-
     impl PartialEq for Cursor {
         fn eq(&self, other: &Cursor) -> bool {
             (self.ccursor, self.rcursor, self.pcursor)

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -6,13 +6,15 @@
 //!
 //! Start by looking at the [`App`] trait, and implement [`App::update`].
 
-#![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
-#![deny(
-    rustdoc::broken_intra_doc_links,
-    rustdoc::invalid_codeblock_attributes,
-    rustdoc::missing_crate_level_docs,
-    rustdoc::private_intra_doc_links
-)]
+// Forbid warnings in release builds:
+#![cfg_attr(not(debug_assertions), deny(warnings))]
+// Disabled so we can support rust 1.51:
+// #![deny(
+//     rustdoc::broken_intra_doc_links,
+//     rustdoc::invalid_codeblock_attributes,
+//     rustdoc::missing_crate_level_docs,
+//     rustdoc::private_intra_doc_links
+// )]
 #![forbid(unsafe_code)]
 #![warn(
     clippy::all,

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,10 @@
+# If you see this, run "rustup self update" to get rustup 1.23 or newer.
+
+# NOTE: above comment is for older `rustup` (before TOML support was added),
+# which will treat the first line as the toolchain name, and therefore show it
+# to the user in the error, instead of "error: invalid channel name '[toolchain]'".
+
+[toolchain]
+channel = "1.51.0"
+components = [ "rustfmt", "clippy" ]
+targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
1.52 and 1.53 has incremental compilation turned off, so some people choose to stay on 1.51 for now.

So let's make sure egui supports 1.51 for a while!