### PR TITLE
Fix a bug on Windows where minimizing adjusts all of the egui window positions.

### DIFF
--- a/egui_glium/CHANGELOG.md
+++ b/egui_glium/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the `egui_glium` integration will be noted in this file.
 
 ## Unreleased
 
+### Fixed 🐛
+* [Fix minimize on Windows](https://github.com/emilk/egui/issues/518)
+
 
 ## 0.13.0 - 2021-06-24
 

--- a/egui_glium/src/lib.rs
+++ b/egui_glium/src/lib.rs
@@ -523,10 +523,19 @@ impl EguiGlium {
             .unwrap_or_else(|| self.egui_ctx.pixels_per_point());
 
         self.input_state.raw.time = Some(self.start_time.elapsed().as_nanos() as f64 * 1e-9);
-        self.input_state.raw.screen_rect = Some(Rect::from_min_size(
-            Default::default(),
-            screen_size_in_pixels(display) / pixels_per_point,
-        ));
+
+        // On Windows, a minimized window will have 0 width and height.
+        // See: https://github.com/rust-windowing/winit/issues/208
+        // This solves an issue where egui window positions would be changed when minimizing on Windows.
+        let screen_size = screen_size_in_pixels(display);
+        self.input_state.raw.screen_rect = if screen_size.x > 0.0 && screen_size.y > 0.0 {
+            Some(Rect::from_min_size(
+                Default::default(),
+                screen_size / pixels_per_point,
+            ))
+        } else {
+            None
+        };
 
         self.egui_ctx.begin_frame(self.input_state.raw.take());
     }


### PR DESCRIPTION
- Closes #518
- This bug is caused by an issue in winit where minimized windows will be given 0 width and height on Windows.
- See: https://github.com/rust-windowing/winit/issues/208
- See also: https://github.com/hasenbanck/egui_winit_platform/pull/19