### PR TITLE
Small plot-relates fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ NOTE: [`eframe`](eframe/CHANGELOG.md), [`egui_web`](egui_web/CHANGELOG.md) and [
 
 ## Unreleased
 
+### Added ⭐
+* Plot: you can now set the stroke of a `HLine/VLine`.
+
+### Changed 🔧
+* `Plot::new` now takes an `id_source: impl Hash` instead of a `name: impl ToString`. Functionally it is the same.
+
+
 
 ## 0.13.0 - 2021-06-24 - Better panels, plots and new visual style
 

--- a/egui/src/widgets/plot/items.rs
+++ b/egui/src/widgets/plot/items.rs
@@ -53,6 +53,24 @@ impl HLine {
         }
     }
 
+    /// Set the stroke.
+    pub fn stroke(mut self, stroke: impl Into<Stroke>) -> Self {
+        self.stroke = stroke.into();
+        self
+    }
+
+    /// Stroke width. A high value means the plot thickens.
+    pub fn width(mut self, width: impl Into<f32>) -> Self {
+        self.stroke.width = width.into();
+        self
+    }
+
+    /// Stroke color. Default is `Color32::TRANSPARENT` which means a color will be auto-assigned.
+    pub fn color(mut self, color: impl Into<Color32>) -> Self {
+        self.stroke.color = color.into();
+        self
+    }
+
     /// Name of this horizontal line.
     ///
     /// This name will show up in the plot legend, if legends are turned on.
@@ -131,6 +149,24 @@ impl VLine {
             name: String::default(),
             highlight: false,
         }
+    }
+
+    /// Set the stroke.
+    pub fn stroke(mut self, stroke: impl Into<Stroke>) -> Self {
+        self.stroke = stroke.into();
+        self
+    }
+
+    /// Stroke width. A high value means the plot thickens.
+    pub fn width(mut self, width: impl Into<f32>) -> Self {
+        self.stroke.width = width.into();
+        self
+    }
+
+    /// Stroke color. Default is `Color32::TRANSPARENT` which means a color will be auto-assigned.
+    pub fn color(mut self, color: impl Into<Color32>) -> Self {
+        self.stroke.color = color.into();
+        self
     }
 
     /// Name of this vertical line.

--- a/egui/src/widgets/plot/mod.rs
+++ b/egui/src/widgets/plot/mod.rs
@@ -43,11 +43,11 @@ struct PlotMemory {
 /// });
 /// let line = Line::new(Values::from_values_iter(sin));
 /// ui.add(
-///     Plot::new("Test Plot").line(line).view_aspect(2.0)
+///     Plot::new("my_plot").line(line).view_aspect(2.0)
 /// );
 /// ```
 pub struct Plot {
-    name: String,
+    id_source: Id,
     next_auto_color_idx: usize,
 
     items: Vec<Box<dyn PlotItem>>,
@@ -71,10 +71,10 @@ pub struct Plot {
 }
 
 impl Plot {
-    #[allow(clippy::needless_pass_by_value)]
-    pub fn new(name: impl ToString) -> Self {
+    /// Give a unique id for each plot within the same `Ui`.
+    pub fn new(id_source: impl std::hash::Hash) -> Self {
         Self {
-            name: name.to_string(),
+            id_source: Id::new(id_source),
             next_auto_color_idx: 0,
 
             items: Default::default(),
@@ -317,7 +317,7 @@ impl Plot {
 impl Widget for Plot {
     fn ui(self, ui: &mut Ui) -> Response {
         let Self {
-            name,
+            id_source,
             next_auto_color_idx: _,
             mut items,
             center_x_axis,
@@ -336,7 +336,7 @@ impl Widget for Plot {
             legend_config,
         } = self;
 
-        let plot_id = ui.make_persistent_id(name);
+        let plot_id = ui.make_persistent_id(id_source);
         let memory = ui
             .memory()
             .id_data

--- a/egui_demo_lib/src/apps/demo/plot_demo.rs
+++ b/egui_demo_lib/src/apps/demo/plot_demo.rs
@@ -121,7 +121,7 @@ impl Widget for &mut LineDemo {
             ui.ctx().request_repaint();
             self.time += ui.input().unstable_dt.at_most(1.0 / 30.0) as f64;
         };
-        let mut plot = Plot::new("Lines Demo")
+        let mut plot = Plot::new("lines_demo")
             .line(self.circle())
             .line(self.sin())
             .line(self.thingy())
@@ -201,7 +201,7 @@ impl Widget for &mut MarkerDemo {
             }
         });
 
-        let mut markers_plot = Plot::new("Markers Demo")
+        let mut markers_plot = Plot::new("markers_demo")
             .data_aspect(1.0)
             .legend(Legend::default());
         for marker in self.markers() {
@@ -266,7 +266,7 @@ impl Widget for &mut LegendDemo {
             ui.end_row();
         });
 
-        let legend_plot = Plot::new("Legend Demo")
+        let legend_plot = Plot::new("legend_demo")
             .line(LegendDemo::line_with_slope(0.5).name("lines"))
             .line(LegendDemo::line_with_slope(1.0).name("lines"))
             .line(LegendDemo::line_with_slope(2.0).name("lines"))
@@ -325,7 +325,7 @@ impl Widget for &mut ItemsDemo {
             ],
         );
 
-        let plot = Plot::new("Items Demo")
+        let plot = Plot::new("items_demo")
             .hline(HLine::new(9.0).name("Lines horizontal"))
             .hline(HLine::new(-9.0).name("Lines horizontal"))
             .vline(VLine::new(9.0).name("Lines vertical"))

--- a/egui_demo_lib/src/apps/demo/widget_gallery.rs
+++ b/egui_demo_lib/src/apps/demo/widget_gallery.rs
@@ -219,7 +219,7 @@ fn example_plot() -> egui::plot::Plot {
         let x = egui::remap(i as f64, 0.0..=(n as f64), -TAU..=TAU);
         Value::new(x, x.sin())
     })));
-    Plot::new("Example Plot")
+    Plot::new("example_plot")
         .line(line)
         .height(32.0)
         .data_aspect(1.0)


### PR DESCRIPTION
`Plot::new` took a `name`, but it was really used as an id source. Since we now persist data based on this ID, I think it is worth expressing explicitly that this is what it is for, and also make it easier for users to give another id source than a string (e.g. an integer).