### PR TITLE
Fix hover sensing

### DIFF
--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -281,10 +281,6 @@ impl CtxRef {
             response.interact_pointer_pos = self.input().pointer.interact_pos();
         }
 
-        if self.input.pointer.any_down() {
-            response.hovered &= response.is_pointer_button_down_on; // we don't hover widgets while interacting with *other* widgets
-        }
-
         if response.has_focus() && response.clicked_elsewhere() {
             self.memory().surrender_focus(id);
         }

--- a/emath/src/pos2.rs
+++ b/emath/src/pos2.rs
@@ -1,7 +1,6 @@
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 
-use crate::*;
-use crate::vec2::{Vec2, vec2};
+use crate::vec2::Vec2;
 
 /// A position on screen.
 ///

--- a/emath/src/pos2.rs
+++ b/emath/src/pos2.rs
@@ -122,7 +122,7 @@ impl Pos2 {
     /// `p.to_vec2()` is equivalent to `p - Pos2::default()`.
     #[inline(always)]
     pub fn to_vec2(self) -> Vec2 {
-        Vec2::from(self)
+        Vec2::new(self.x, self.y)
     }
 
     #[inline]

--- a/emath/src/pos2.rs
+++ b/emath/src/pos2.rs
@@ -1,6 +1,7 @@
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 
 use crate::*;
+use crate::vec2::{Vec2, vec2};
 
 /// A position on screen.
 ///
@@ -122,10 +123,7 @@ impl Pos2 {
     /// `p.to_vec2()` is equivalent to `p - Pos2::default()`.
     #[inline(always)]
     pub fn to_vec2(self) -> Vec2 {
-        Vec2 {
-            x: self.x,
-            y: self.y,
-        }
+        Vec2::from(self)
     }
 
     #[inline]

--- a/emath/src/vec2.rs
+++ b/emath/src/vec2.rs
@@ -1,5 +1,7 @@
 use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
+use crate::pos2::{Pos2, pos2};
+
 /// A vector has a direction and length.
 /// A [`Vec2`] is often used to represent a size.
 ///
@@ -80,7 +82,18 @@ impl From<&Vec2> for (f32, f32) {
         (v.x, v.y)
     }
 }
-
+// ----------------------------------------------------------------------------
+// Compatibility and convenience conversions to and from Pos2:
+impl From<Pos2> for Vec2 {
+    fn from(pos: Pos2) -> Self {
+        vec2(pos.x, pos.y)
+    }
+}
+impl From<Vec2> for Pos2 {
+    fn from(pos: Vec2) -> Self {
+        pos2(pos.x, pos.y)
+    }
+}
 // ----------------------------------------------------------------------------
 // Mint compatibility and convenience conversions
 
@@ -125,6 +138,13 @@ impl Vec2 {
     #[inline(always)]
     pub const fn new(x: f32, y: f32) -> Self {
         Self { x, y }
+    }
+
+    /// The position this vector points to.
+    /// `v.to_pos2()` is equivalent to `Pos2::default() + v`.
+    #[inline(always)]
+    pub fn to_pos2(self) -> Pos2 {
+        Pos2::from(self)
     }
 
     /// Set both `x` and `y` to the same value.

--- a/emath/src/vec2.rs
+++ b/emath/src/vec2.rs
@@ -1,6 +1,6 @@
 use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use crate::pos2::{Pos2, pos2};
+use crate::pos2::Pos2;
 
 /// A vector has a direction and length.
 /// A [`Vec2`] is often used to represent a size.
@@ -83,18 +83,6 @@ impl From<&Vec2> for (f32, f32) {
     }
 }
 // ----------------------------------------------------------------------------
-// Compatibility and convenience conversions to and from Pos2:
-impl From<Pos2> for Vec2 {
-    fn from(pos: Pos2) -> Self {
-        vec2(pos.x, pos.y)
-    }
-}
-impl From<Vec2> for Pos2 {
-    fn from(pos: Vec2) -> Self {
-        pos2(pos.x, pos.y)
-    }
-}
-// ----------------------------------------------------------------------------
 // Mint compatibility and convenience conversions
 
 #[cfg(feature = "mint")]
@@ -144,7 +132,7 @@ impl Vec2 {
     /// `v.to_pos2()` is equivalent to `Pos2::default() + v`.
     #[inline(always)]
     pub fn to_pos2(self) -> Pos2 {
-        Pos2::from(self)
+        Pos2::new(self.x, self.y)
     }
 
     /// Set both `x` and `y` to the same value.


### PR DESCRIPTION
Hovers were ignored when sense.click was not enabled. This was due to a piece of code which only allows hover in a response that had also been clicked.

