### PR TITLE
Add methods for optionally displaying the background/axes of a `Plot`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ NOTE: [`eframe`](eframe/CHANGELOG.md), [`egui_web`](egui_web/CHANGELOG.md) and [
   * [Line styles](https://github.com/emilk/egui/pull/482)
 * [Progress bar](https://github.com/emilk/egui/pull/519)
 * `Grid::num_columns`: allow the last column to take up the rest of the space of the parent `Ui`.
+* Add `show_background` and `show_axes` methods to `Plot`.
 
 ### Changed 🔧
 * Return closure return value from `Area::show`, `ComboBox::show_ui`, `ComboBox::combo_box_with_label`, `Window::show`, `popup::*`, `menu::menu`.

--- a/egui/src/widgets/plot/mod.rs
+++ b/egui/src/widgets/plot/mod.rs
@@ -71,6 +71,8 @@ pub struct Plot {
     show_x: bool,
     show_y: bool,
     legend_config: Option<Legend>,
+    show_background: bool,
+    show_axes: bool,
 }
 
 impl Plot {
@@ -98,6 +100,8 @@ impl Plot {
             show_x: true,
             show_y: true,
             legend_config: None,
+            show_background: true,
+            show_axes: true,
         }
     }
 
@@ -315,6 +319,22 @@ impl Plot {
         self.legend_config = Some(legend);
         self
     }
+
+    /// Whether or not to show the background `Rect`.
+    /// Can be useful to disable if the plot is overlaid over existing content.
+    /// Default: `true`.
+    pub fn show_background(mut self, show: bool) -> Self {
+        self.show_background = show;
+        self
+    }
+
+    /// Show the axes.
+    /// Can be useful to disable if the plot is overlaid over an existing grid or content.
+    /// Default: `true`.
+    pub fn show_axes(mut self, show: bool) -> Self {
+        self.show_axes = show;
+        self
+    }
 }
 
 impl Widget for Plot {
@@ -337,6 +357,8 @@ impl Widget for Plot {
             mut show_x,
             mut show_y,
             legend_config,
+            show_background,
+            show_axes,
         } = self;
 
         let plot_id = ui.make_persistent_id(id_source);
@@ -400,16 +422,19 @@ impl Widget for Plot {
         let plot_painter = ui.painter().sub_region(rect);
 
         // Background
-        plot_painter.add(Shape::Rect {
-            rect,
-            corner_radius: 2.0,
-            fill: ui.visuals().extreme_bg_color,
-            stroke: ui.visuals().widgets.noninteractive.bg_stroke,
-        });
+        if show_background {
+            plot_painter.add(Shape::Rect {
+                rect,
+                corner_radius: 2.0,
+                fill: ui.visuals().extreme_bg_color,
+                stroke: ui.visuals().widgets.noninteractive.bg_stroke,
+            });
+        }
 
         // Legend
         let legend = legend_config
             .and_then(|config| LegendWidget::try_new(rect, config, &items, &hidden_items));
+
         // Don't show hover cursor when hovering over legend.
         if hovered_entry.is_some() {
             show_x = false;
@@ -495,6 +520,7 @@ impl Widget for Plot {
             items,
             show_x,
             show_y,
+            show_axes,
             transform,
         };
         prepared.ui(ui, &response);
@@ -528,6 +554,7 @@ struct Prepared {
     items: Vec<Box<dyn PlotItem>>,
     show_x: bool,
     show_y: bool,
+    show_axes: bool,
     transform: ScreenTransform,
 }
 
@@ -535,8 +562,10 @@ impl Prepared {
     fn ui(self, ui: &mut Ui, response: &Response) {
         let mut shapes = Vec::new();
 
-        for d in 0..2 {
-            self.paint_axis(ui, d, &mut shapes);
+        if self.show_axes {
+            for d in 0..2 {
+                self.paint_axis(ui, d, &mut shapes);
+            }
         }
 
         let transform = &self.transform;

--- a/egui/src/widgets/plot/mod.rs
+++ b/egui/src/widgets/plot/mod.rs
@@ -72,7 +72,7 @@ pub struct Plot {
     show_y: bool,
     legend_config: Option<Legend>,
     show_background: bool,
-    show_axes: bool,
+    show_axes: [bool; 2],
 }
 
 impl Plot {
@@ -101,7 +101,7 @@ impl Plot {
             show_y: true,
             legend_config: None,
             show_background: true,
-            show_axes: true,
+            show_axes: [true; 2],
         }
     }
 
@@ -330,8 +330,8 @@ impl Plot {
 
     /// Show the axes.
     /// Can be useful to disable if the plot is overlaid over an existing grid or content.
-    /// Default: `true`.
-    pub fn show_axes(mut self, show: bool) -> Self {
+    /// Default: `[true; 2]`.
+    pub fn show_axes(mut self, show: [bool; 2]) -> Self {
         self.show_axes = show;
         self
     }
@@ -554,7 +554,7 @@ struct Prepared {
     items: Vec<Box<dyn PlotItem>>,
     show_x: bool,
     show_y: bool,
-    show_axes: bool,
+    show_axes: [bool; 2],
     transform: ScreenTransform,
 }
 
@@ -562,8 +562,8 @@ impl Prepared {
     fn ui(self, ui: &mut Ui, response: &Response) {
         let mut shapes = Vec::new();
 
-        if self.show_axes {
-            for d in 0..2 {
+        for d in 0..2 {
+            if self.show_axes[d] {
                 self.paint_axis(ui, d, &mut shapes);
             }
         }


### PR DESCRIPTION
These are particularly useful when using the `Plot` widget as an overlay
over an existing grid or some other content.

---

Here's a screenshot of one of my intended use cases - using a `Plot` tool to visualise signals/patterns over a custom `egui_timeline` widget:

![egui-plot-no-bg-or-axes-example](https://user-images.githubusercontent.com/4587373/125684200-5d73b3bd-0452-4ea3-9381-fc4087c442ad.png)

---

PS thanks for the awesome work on this lib! I'm the original author of `conrod`, which I made out of necessity back around Rust 0.9 as there were literally zero other GUI libraries out there at the time :) So nice to see a much more serious and well-thought-out immediate mode GUI lib! I'm blown away at how feature-full it is already. I especially appreciate the ease of integrating into different event loops and graphics backends :ok_hand: It has made it a breeze to integrate into `nannou` projects.