### PR TITLE
Fix case where `Plot`'s `min_auto_bounds` can be ignored after first instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ NOTE: [`eframe`](eframe/CHANGELOG.md), [`egui_web`](egui_web/CHANGELOG.md) and [
 
 ### Fixed 🐛
 * Fix custom font definitions getting replaced when `pixels_per_point` is changed.
+* Fix case where `Plot`'s `min_auto_bounds` could be ignored after the first call to `Plot::ui`.
 
 
 ## 0.13.1 - 2021-06-28 - Plot fixes

--- a/egui/src/widgets/plot/mod.rs
+++ b/egui/src/widgets/plot/mod.rs
@@ -358,8 +358,8 @@ impl Widget for Plot {
                 bounds: min_auto_bounds,
                 auto_bounds: !min_auto_bounds.is_valid(),
                 hovered_entry: None,
-                hidden_items: HashSet::new(),
                 min_auto_bounds,
+                ..memory
             };
             ui.memory().id_data.insert(plot_id, memory.clone());
         }

--- a/egui/src/widgets/plot/mod.rs
+++ b/egui/src/widgets/plot/mod.rs
@@ -28,6 +28,7 @@ struct PlotMemory {
     auto_bounds: bool,
     hovered_entry: Option<String>,
     hidden_items: HashSet<String>,
+    min_auto_bounds: Bounds,
 }
 
 // ----------------------------------------------------------------------------
@@ -339,7 +340,7 @@ impl Widget for Plot {
         } = self;
 
         let plot_id = ui.make_persistent_id(id_source);
-        let memory = ui
+        let mut memory = ui
             .memory()
             .id_data
             .get_mut_or_insert_with(plot_id, || PlotMemory {
@@ -347,14 +348,28 @@ impl Widget for Plot {
                 auto_bounds: !min_auto_bounds.is_valid(),
                 hovered_entry: None,
                 hidden_items: HashSet::new(),
+                min_auto_bounds,
             })
             .clone();
+
+        // If the min bounds changed, recalculate everything.
+        if min_auto_bounds != memory.min_auto_bounds {
+            memory = PlotMemory {
+                bounds: min_auto_bounds,
+                auto_bounds: !min_auto_bounds.is_valid(),
+                hovered_entry: None,
+                hidden_items: HashSet::new(),
+                min_auto_bounds,
+            };
+            ui.memory().id_data.insert(plot_id, memory.clone());
+        }
 
         let PlotMemory {
             mut bounds,
             mut auto_bounds,
             mut hovered_entry,
             mut hidden_items,
+            ..
         } = memory;
 
         // Determine the size of the plot in the UI
@@ -497,6 +512,7 @@ impl Widget for Plot {
                 auto_bounds,
                 hovered_entry,
                 hidden_items,
+                min_auto_bounds,
             },
         );
 


### PR DESCRIPTION
I ran into an issue using `Plot` within my timeline widget where if I
zoom in and out of the timeline (not the plot), the `Plot` instances
would ignore the necessary changes to the `include_x` calls and in turn
would become skewed and misaligned with the timeline below.

This changes the `Plot` to check whether or not `min_auto_bounds` have
changed and, if so, reset the memory and recalculate the bounds.

See #562 for an image of my current use case.