### PR TITLE
Fix custom font definitions getting replaced when `pixels_per_point` is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ NOTE: [`eframe`](eframe/CHANGELOG.md), [`egui_web`](egui_web/CHANGELOG.md) and [
 * [Progress bar](https://github.com/emilk/egui/pull/519)
 * `Grid::num_columns`: allow the last column to take up the rest of the space of the parent `Ui`.
 
+### Fixed 🐛
+* Fix custom font definitions getting replaced when `pixels_per_point` is changed.
+
 
 ## 0.13.1 - 2021-06-28 - Plot fixes
 

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -578,7 +578,12 @@ impl Context {
             if self.fonts.is_none() || new_font_definitions.is_some() || pixels_per_point_changed {
                 self.fonts = Some(Arc::new(Fonts::from_definitions(
                     pixels_per_point,
-                    new_font_definitions.unwrap_or_default(),
+                    new_font_definitions.unwrap_or_else(|| {
+                        self.fonts
+                            .as_ref()
+                            .map(|font| font.definitions().clone())
+                            .unwrap_or_default()
+                    }),
                 )));
             }
         }


### PR DESCRIPTION
Fixes a bug where any custom font definitions are replaced with the default font definitions when `pixels_per_point` is changed.

I noticed that all text would disappear on my app when I changed the UI scale. This happens because I use `default-features = false` to disable the `default_fonts` feature. The default font definitions are completely empty when default fonts are disabled.
