### PR TITLE
Fix blocking when using custom large font files

### DIFF
--- a/epaint/src/text/font.rs
+++ b/epaint/src/text/font.rs
@@ -193,7 +193,7 @@ pub struct Font {
     text_style: TextStyle,
     fonts: Vec<Arc<FontImpl>>,
     /// Lazily calculated.
-    characters: Option<std::collections::BTreeSet<char>>,
+    characters: RwLock<Option<std::collections::BTreeSet<char>>>,
     replacement_glyph: (FontIndex, GlyphInfo),
     pixels_per_point: f32,
     row_height: f32,
@@ -206,7 +206,7 @@ impl Font {
             return Self {
                 text_style,
                 fonts,
-                characters: None,
+                characters: RwLock::new(None),
                 replacement_glyph: Default::default(),
                 pixels_per_point: 0.0,
                 row_height: 0.0,
@@ -220,7 +220,7 @@ impl Font {
         let mut slf = Self {
             text_style,
             fonts,
-            characters: None,
+            characters: RwLock::new(None),
             replacement_glyph: Default::default(),
             pixels_per_point,
             row_height,
@@ -254,15 +254,15 @@ impl Font {
     }
 
     /// All supported characters
-    pub fn characters(&mut self) -> &BTreeSet<char> {
-        if self.characters.is_none() {
+    pub fn characters(&self) -> BTreeSet<char> {
+        if self.characters.read().is_none(){
             let mut characters = BTreeSet::new();
             for font in &self.fonts {
                 characters.extend(font.characters());
             }
-            self.characters = Some(characters);
+            self.characters.write().replace(characters);
         }
-        self.characters.as_ref().unwrap()
+        self.characters.read().clone().unwrap()
     }
 
     #[inline(always)]

--- a/epaint/src/text/font.rs
+++ b/epaint/src/text/font.rs
@@ -192,7 +192,7 @@ type FontIndex = usize;
 pub struct Font {
     text_style: TextStyle,
     fonts: Vec<Arc<FontImpl>>,
-    characters: std::collections::BTreeSet<char>,
+    characters: Option<std::collections::BTreeSet<char>>,
     replacement_glyph: (FontIndex, GlyphInfo),
     pixels_per_point: f32,
     row_height: f32,
@@ -201,16 +201,11 @@ pub struct Font {
 
 impl Font {
     pub fn new(text_style: TextStyle, fonts: Vec<Arc<FontImpl>>) -> Self {
-        let mut characters = BTreeSet::new();
-        for font in &fonts {
-            characters.extend(font.characters());
-        }
-
         if fonts.is_empty() {
             return Self {
                 text_style,
                 fonts,
-                characters,
+                characters: None,
                 replacement_glyph: Default::default(),
                 pixels_per_point: 0.0,
                 row_height: 0.0,
@@ -224,7 +219,7 @@ impl Font {
         let mut slf = Self {
             text_style,
             fonts,
-            characters,
+            characters: None,
             replacement_glyph: Default::default(),
             pixels_per_point,
             row_height,
@@ -258,8 +253,15 @@ impl Font {
     }
 
     /// All supported characters
-    pub fn characters(&self) -> &BTreeSet<char> {
-        &self.characters
+    pub fn characters(&mut self) -> &BTreeSet<char> {
+        if self.characters.is_none() {
+            let mut characters = BTreeSet::new();
+            for font in &self.fonts {
+                characters.extend(font.characters());
+            }
+            self.characters = Some(characters);
+        }
+        self.characters.as_ref().unwrap()
     }
 
     #[inline(always)]

--- a/epaint/src/text/font.rs
+++ b/epaint/src/text/font.rs
@@ -255,7 +255,7 @@ impl Font {
 
     /// All supported characters
     pub fn characters(&self) -> BTreeSet<char> {
-        if self.characters.read().is_none(){
+        if self.characters.read().is_none() {
             let mut characters = BTreeSet::new();
             for font in &self.fonts {
                 characters.extend(font.characters());

--- a/epaint/src/text/font.rs
+++ b/epaint/src/text/font.rs
@@ -192,6 +192,7 @@ type FontIndex = usize;
 pub struct Font {
     text_style: TextStyle,
     fonts: Vec<Arc<FontImpl>>,
+    /// Lazily calculated.
     characters: Option<std::collections::BTreeSet<char>>,
     replacement_glyph: (FontIndex, GlyphInfo),
     pixels_per_point: f32,


### PR DESCRIPTION
Fix blocking on startup when using large font files. 
I use the lazy strategy to delay all font character set calculations.

Closes <https://github.com/emilk/egui/issues/571>.

