### PR TITLE
Allow adding Vec<Line> instead of one by one

### DIFF
--- a/egui/src/widgets/plot/mod.rs
+++ b/egui/src/widgets/plot/mod.rs
@@ -123,14 +123,8 @@ impl Plot {
     }
 
     pub fn lines(mut self, lines: Vec<Line>) -> Self {
-        for mut line in lines{
-            if line.series.is_empty(){
-                return self;
-            }
-            if line.stroke.color == Color32::TRANSPARENT {
-                line.stroke.color = self.auto_color();
-            }
-            self.items.push(Box::new(line));
+        for line in lines {
+            self = self.line(line);
         }
         self
     }

--- a/egui/src/widgets/plot/mod.rs
+++ b/egui/src/widgets/plot/mod.rs
@@ -122,6 +122,19 @@ impl Plot {
         self
     }
 
+    pub fn lines(mut self, lines: Vec<Line>) -> Self {
+        for mut line in lines{
+            if line.series.is_empty(){
+                return self;
+            }
+            if line.stroke.color == Color32::TRANSPARENT {
+                line.stroke.color = self.auto_color();
+            }
+            self.items.push(Box::new(line));
+        }
+        self
+    }
+    
     /// Add a polygon. The polygon has to be convex.
     pub fn polygon(mut self, mut polygon: Polygon) -> Self {
         if polygon.series.is_empty() {


### PR DESCRIPTION
Lets me add a vec<line> instead of.. well, without this, there's no way to add lines that aren't known at compile time AFAIK. 