### PR TITLE
Fix empty side panels not dragging properly

### DIFF
--- a/egui/src/containers/panel.rs
+++ b/egui/src/containers/panel.rs
@@ -208,6 +208,7 @@ impl SidePanel {
         let inner_response = frame.show(&mut panel_ui, |ui| {
             ui.set_min_height(ui.max_rect_finite().height()); // Make sure the frame fills the full height
             ui.set_width_range(width_range);
+            ui.allocate_space(Vec2::new(ui.available_width(), 0.0));
             add_contents(ui)
         });
 


### PR DESCRIPTION
I noticed when a side panel is empty, dragging the side of it to widen it doesn't work properly. The demo seems to work because there are widgets in the side panels that allocate space (for example the centered header text). Modifying the demo's side panels to be empty reproduces the same problem I was seeing in my app.

I don't know if this is the correct fix, but I think this is the minimal change necessary to make an empty panel act like a panel with contents that do allocate space. 