### PR TITLE
feat: Set whether to show decorations

### DIFF
--- a/eframe/CHANGELOG.md
+++ b/eframe/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to the `eframe` crate.
 
 
 ## Unreleased
+* `Frame` now provides `set_decorations` to set whether to show window decorations.
 
 
 ## 0.14.0 - 2021-08-24

--- a/egui_glium/src/backend.rs
+++ b/egui_glium/src/backend.rs
@@ -202,6 +202,7 @@ pub fn run(mut app: Box<dyn epi::App>, native_options: epi::NativeOptions) {
             http: http.clone(),
             output: &mut app_output,
             repaint_signal: repaint_signal.clone(),
+            decorated: native_options.decorated,
         }
         .build();
         app.setup(ctx, &mut frame, storage.as_deref());
@@ -226,6 +227,7 @@ pub fn run(mut app: Box<dyn epi::App>, native_options: epi::NativeOptions) {
             http: http.clone(),
             output: &mut app_output,
             repaint_signal: repaint_signal.clone(),
+            decorated: native_options.decorated,
         }
         .build();
 
@@ -323,6 +325,7 @@ pub fn run(mut app: Box<dyn epi::App>, native_options: epi::NativeOptions) {
                 http: http.clone(),
                 output: &mut app_output,
                 repaint_signal: repaint_signal.clone(),
+                decorated: native_options.decorated,
             }
             .build();
             app.update(ctx, &mut frame);
@@ -346,7 +349,9 @@ pub fn run(mut app: Box<dyn epi::App>, native_options: epi::NativeOptions) {
             }
 
             {
-                let epi::backend::AppOutput { quit, window_size } = app_output;
+                let epi::backend::AppOutput { quit, window_size, decorated } = app_output;
+
+                display.gl_window().window().set_decorations(decorated);
 
                 if let Some(window_size) = window_size {
                     display.gl_window().window().set_inner_size(

--- a/egui_glium/src/backend.rs
+++ b/egui_glium/src/backend.rs
@@ -349,7 +349,11 @@ pub fn run(mut app: Box<dyn epi::App>, native_options: epi::NativeOptions) {
             }
 
             {
-                let epi::backend::AppOutput { quit, window_size, decorated } = app_output;
+                let epi::backend::AppOutput {
+                    quit,
+                    window_size,
+                    decorated,
+                } = app_output;
 
                 display.gl_window().window().set_decorations(decorated);
 

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -182,6 +182,7 @@ impl AppRunner {
                 http: runner.http.clone(),
                 output: &mut app_output,
                 repaint_signal: runner.needs_repaint.clone(),
+                decorated: false,
             }
             .build();
             runner.app.setup(
@@ -254,6 +255,7 @@ impl AppRunner {
             http: self.http.clone(),
             output: &mut app_output,
             repaint_signal: self.needs_repaint.clone(),
+            decorated: false,
         }
         .build();
 
@@ -269,6 +271,7 @@ impl AppRunner {
             let epi::backend::AppOutput {
                 quit: _,        // Can't quit a web page
                 window_size: _, // Can't resize a web page
+                decorated: _, // Can't show decorations
             } = app_output;
         }
 

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -271,7 +271,7 @@ impl AppRunner {
             let epi::backend::AppOutput {
                 quit: _,        // Can't quit a web page
                 window_size: _, // Can't resize a web page
-                decorated: _, // Can't show decorations
+                decorated: _,   // Can't show decorations
             } = app_output;
         }
 

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -251,6 +251,11 @@ impl<'a> Frame<'a> {
         self.0.output.window_size = Some(size);
     }
 
+    /// Set window decorations
+    pub fn set_decorations(&mut self, decorated: bool) {
+        self.0.output.decorated = decorated;
+    }
+
     /// If you need to request a repaint from another thread, clone this and send it to that other thread.
     pub fn repaint_signal(&self) -> std::sync::Arc<dyn RepaintSignal> {
         self.0.repaint_signal.clone()
@@ -486,6 +491,8 @@ pub mod backend {
         pub output: &'a mut AppOutput,
         /// If you need to request a repaint from another thread, clone this and send it to that other thread.
         pub repaint_signal: std::sync::Arc<dyn RepaintSignal>,
+        /// If the window has decorations
+        pub decorated: bool,
     }
 
     impl<'a> FrameBuilder<'a> {
@@ -504,5 +511,8 @@ pub mod backend {
 
         /// Set to some size to resize the outer window (e.g. glium window) to this size.
         pub window_size: Option<egui::Vec2>,
+
+        /// If the window has decorations
+        pub decorated: bool,
     }
 }

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -251,7 +251,8 @@ impl<'a> Frame<'a> {
         self.0.output.window_size = Some(size);
     }
 
-    /// Set window decorations
+    /// Set whether to show window decorations (i.e. a frame around you app).
+    /// If false it will be difficult to move and resize the app.
     pub fn set_decorations(&mut self, decorated: bool) {
         self.0.output.decorated = decorated;
     }


### PR DESCRIPTION
Set whether to show decorations when update frame.

```rust
frame.set_decorations(false);
```

I have tested it on my project: https://github.com/zu1k/copy-translator/blob/6eca80ca32593f2d55eda0fc950e1f1ff0cd52eb/src/ui.rs#L252