### PR TITLE
Faster galley cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,6 +898,7 @@ dependencies = [
  "atomic_refcell",
  "cint",
  "emath",
+ "nohash-hasher",
  "parking_lot",
  "serde",
 ]
@@ -1491,6 +1492,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ ui.label(format!("Hello '{}', age {}", name, age));
 * Extensible: [easy to write your own widgets for egui](https://github.com/emilk/egui/blob/master/egui_demo_lib/src/apps/demo/toggle_switch.rs)
 * Modular: You should be able to use small parts of egui and combine them in new ways
 * Safe: there is no `unsafe` code in egui
-* Minimal dependencies: [`ab_glyph`](https://crates.io/crates/ab_glyph) [`ahash`](https://crates.io/crates/ahash) [`atomic_refcell`](https://crates.io/crates/atomic_refcell)
+* Minimal dependencies: [`ab_glyph`](https://crates.io/crates/ab_glyph) [`ahash`](https://crates.io/crates/ahash) [`atomic_refcell`](https://crates.io/crates/atomic_refcell), [`nohash-hasher`](https://crates.io/crates/nohash-hasher)
 
 egui is *not* a framework. egui is a library you call into, not an environment you program for.
 

--- a/egui_demo_lib/src/apps/demo/code_editor.rs
+++ b/egui_demo_lib/src/apps/demo/code_editor.rs
@@ -223,6 +223,7 @@ struct Highligher {}
 
 #[cfg(not(feature = "syntect"))]
 impl Highligher {
+    #[allow(clippy::unused_self, clippy::unnecessary_wraps)]
     fn highlight(&self, is_dark_mode: bool, mut text: &str, _language: &str) -> Option<LayoutJob> {
         // Extremely simple syntax highlighter for when we compile without syntect
 
@@ -269,7 +270,7 @@ impl Highligher {
 
         while !text.is_empty() {
             if text.starts_with("//") {
-                let end = text.find('\n').unwrap_or(text.len());
+                let end = text.find('\n').unwrap_or_else(|| text.len());
                 job.append(&text[..end], 0.0, comment_format);
                 text = &text[end..];
             } else if text.starts_with('"') {
@@ -277,14 +278,14 @@ impl Highligher {
                     .find('"')
                     .map(|i| i + 2)
                     .or_else(|| text.find('\n'))
-                    .unwrap_or(text.len());
+                    .unwrap_or_else(|| text.len());
                 job.append(&text[..end], 0.0, quoted_string_format);
                 text = &text[end..];
             } else if text.starts_with(|c: char| c.is_ascii_alphanumeric()) {
                 let end = text[1..]
                     .find(|c: char| !c.is_ascii_alphanumeric())
                     .map(|i| i + 1)
-                    .unwrap_or(text.len());
+                    .unwrap_or_else(|| text.len());
                 let word = &text[..end];
                 if is_keyword(word) {
                     job.append(word, 0.0, keyword_format);
@@ -296,7 +297,7 @@ impl Highligher {
                 let end = text[1..]
                     .find(|c: char| !c.is_ascii_whitespace())
                     .map(|i| i + 1)
-                    .unwrap_or(text.len());
+                    .unwrap_or_else(|| text.len());
                 job.append(&text[..end], 0.0, whitespace_format);
                 text = &text[end..];
             } else {

--- a/epaint/Cargo.toml
+++ b/epaint/Cargo.toml
@@ -31,6 +31,7 @@ ab_glyph = "0.2.11"
 ahash = { version = "0.7", features = ["std"], default-features = false }
 atomic_refcell = { version = "0.1", optional = true } # Used instead of parking_lot when you are always using epaint in a single thread. About as fast as parking_lot. Panics on multi-threaded use.
 cint = { version = "^0.2.2", optional = true }
+nohash-hasher = "0.2"
 parking_lot = { version = "0.11", optional = true } # Using parking_lot over std::sync::Mutex gives 50% speedups in some real-world scenarios.
 serde = { version = "1", features = ["derive"], optional = true }
 

--- a/epaint/src/lib.rs
+++ b/epaint/src/lib.rs
@@ -189,12 +189,3 @@ pub(crate) fn f32_hash<H: std::hash::Hasher>(state: &mut H, f: f32) {
         f.to_bits().hash(state)
     }
 }
-
-#[inline(always)]
-pub(crate) fn f32_eq(a: f32, b: f32) -> bool {
-    if a.is_nan() && b.is_nan() {
-        true
-    } else {
-        a == b
-    }
-}

--- a/epaint/src/stroke.rs
+++ b/epaint/src/stroke.rs
@@ -3,7 +3,7 @@ use super::*;
 /// Describes the width and color of a line.
 ///
 /// The default stroke is the same as [`Stroke::none`].
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "persistence", derive(serde::Deserialize, serde::Serialize))]
 pub struct Stroke {
     pub width: f32,
@@ -44,12 +44,3 @@ impl std::hash::Hash for Stroke {
         color.hash(state);
     }
 }
-
-impl PartialEq for Stroke {
-    #[inline(always)]
-    fn eq(&self, other: &Self) -> bool {
-        self.color == other.color && crate::f32_eq(self.width, other.width)
-    }
-}
-
-impl std::cmp::Eq for Stroke {}

--- a/epaint/src/stroke.rs
+++ b/epaint/src/stroke.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::derive_hash_xor_eq)] // We need to impl Hash for f32, but we don't implement Eq, which is fine
+
 use super::*;
 
 /// Describes the width and color of a line.

--- a/epaint/src/text/text_layout_types.rs
+++ b/epaint/src/text/text_layout_types.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::derive_hash_xor_eq)] // We need to impl Hash for f32, but we don't implement Eq, which is fine
+
 use std::ops::Range;
 use std::sync::Arc;
 

--- a/epaint/src/text/text_layout_types.rs
+++ b/epaint/src/text/text_layout_types.rs
@@ -10,7 +10,7 @@ use emath::*;
 /// This supports mixing different fonts, color and formats (underline etc).
 ///
 /// Pass this to [`Fonts::layout_job]` or [`crate::text::layout`].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct LayoutJob {
     /// The complete text of this job, referenced by `LayoutSection`.
     pub text: String, // TODO: Cow<'static, str>
@@ -120,22 +120,9 @@ impl std::hash::Hash for LayoutJob {
     }
 }
 
-impl PartialEq for LayoutJob {
-    #[inline(always)]
-    fn eq(&self, other: &Self) -> bool {
-        self.text == other.text
-            && self.sections == other.sections
-            && crate::f32_eq(self.wrap_width, other.wrap_width)
-            && crate::f32_eq(self.first_row_min_height, other.first_row_min_height)
-            && self.break_on_newline == other.break_on_newline
-    }
-}
-
-impl std::cmp::Eq for LayoutJob {}
-
 // ----------------------------------------------------------------------------
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct LayoutSection {
     /// Can be used for first row indentation.
     pub leading_space: f32,
@@ -158,20 +145,9 @@ impl std::hash::Hash for LayoutSection {
     }
 }
 
-impl PartialEq for LayoutSection {
-    #[inline(always)]
-    fn eq(&self, other: &Self) -> bool {
-        crate::f32_eq(self.leading_space, other.leading_space)
-            && self.byte_range == other.byte_range
-            && self.format == other.format
-    }
-}
-
-impl std::cmp::Eq for LayoutSection {}
-
 // ----------------------------------------------------------------------------
 
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq)]
 pub struct TextFormat {
     pub style: TextStyle,
     /// Text color


### PR DESCRIPTION
This hashes the job but doesn't compare them with `Eq`, which speeds up the benchmark `demo_with_tessellate__realistic` by 5-6%, winning back all the performance lost in #682