### PR TITLE
Add example of displaying an image from source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "egui_glium",
  "egui_web",
  "epi",
+ "image",
 ]
 
 [[package]]
@@ -989,6 +990,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a668f699973d0f573d15749b7002a9ac9e1f9c6b220e7b165601334c173d8de"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gimli"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,11 +1163,14 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
+ "gif",
  "jpeg-decoder",
  "num-iter",
  "num-rational",
  "num-traits",
  "png",
+ "scoped_threadpool",
+ "tiff",
 ]
 
 [[package]]
@@ -1218,6 +1232,9 @@ name = "jpeg-decoder"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "js-sys"
@@ -1991,6 +2008,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
+name = "scoped_threadpool"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,6 +2263,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tiff"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a53f4706d65497df0c4349241deddf35f84cee19c87ed86ea8ca590f4464437"
+dependencies = [
+ "jpeg-decoder",
+ "miniz_oxide 0.4.4",
+ "weezl",
 ]
 
 [[package]]
@@ -2603,6 +2637,12 @@ checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
  "webpki",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b77fdfd5a253be4ab714e4ffa3c49caf146b4de743e97510c0656cf90f1e8e"
 
 [[package]]
 name = "which"

--- a/eframe/Cargo.toml
+++ b/eframe/Cargo.toml
@@ -34,6 +34,9 @@ egui_glium = { version = "0.14.0", path = "../egui_glium", default-features = fa
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 egui_web = { version = "0.14.0", path = "../egui_web", default-features = false }
 
+[dev-dependencies]
+image = "0.23.14"
+
 [features]
 default = ["default_fonts"]
 

--- a/eframe/examples/show_image.rs
+++ b/eframe/examples/show_image.rs
@@ -1,0 +1,76 @@
+use eframe::{
+    egui::{self, CtxRef, TextureId, Vec2},
+    epi,
+    epi::{Frame, Storage},
+};
+use image::{DynamicImage, GenericImageView};
+
+pub struct DisplayImage {
+    texture_id: TextureId,
+    size: Vec2,
+}
+impl DisplayImage {
+    pub fn new(texture_id: TextureId, size: Vec2) -> DisplayImage {
+        DisplayImage { texture_id, size }
+    }
+}
+pub struct App {
+    name: String,
+    dynamic_image: DynamicImage,
+    display_image: DisplayImage,
+}
+impl App {
+    pub fn new(dynamic_image: DynamicImage) -> Self {
+        App {
+            name: String::from("EGUI image example"),
+            dynamic_image,
+            display_image: DisplayImage::new(egui::TextureId::Egui, Vec2::default()),
+        }
+    }
+}
+impl epi::App for App {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn setup(&mut self, _ctx: &CtxRef, frame: &mut Frame<'_>, _storage: Option<&dyn Storage>) {
+        let Self { dynamic_image, .. } = self;
+        let size = Vec2::from([dynamic_image.width() as f32, dynamic_image.height() as f32]);
+        let pixels = {
+            let image_bytes = dynamic_image.as_bytes();
+            let mut pixels = Vec::with_capacity(image_bytes.len() / 4);
+            for rgba in image_bytes.chunks_exact(4) {
+                match rgba {
+                    &[r, g, b, a] => pixels.push(egui::Color32::from_rgba_unmultiplied(r, g, b, a)),
+                    _ => (),
+                }
+            }
+            pixels
+        };
+        let image_texture_id = frame.tex_allocator().alloc_srgba_premultiplied(
+            (
+                dynamic_image.width() as usize,
+                dynamic_image.height() as usize,
+            ),
+            &*pixels,
+        );
+        self.display_image = DisplayImage::new(image_texture_id, size);
+    }
+    fn update(&mut self, ctx: &CtxRef, _frame: &mut Frame<'_>) {
+        let Self { display_image, .. } = self;
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.image(display_image.texture_id, display_image.size);
+        });
+    }
+}
+fn main() {
+    let dynamic_image = image::open("media/egui-0.10-plot.gif").expect("failed to open image file");
+    let window_size = Vec2::from(&[
+        (dynamic_image.width() + 15) as f32,
+        (dynamic_image.height() + 15) as f32,
+    ]);
+    let app = App::new(dynamic_image);
+    let mut native_options = eframe::NativeOptions::default();
+    native_options.initial_window_size = Option::from(window_size);
+
+    eframe::run_native(Box::new(app), native_options);
+}


### PR DESCRIPTION
Hello

I was wondering how I could paint a simple image.

Then I stumbled upon this issue: https://github.com/emilk/egui/issues/447


But I wanted to do it without egui_glium. Main struggle was to get a TextureId

I needed to paint srgba pixels. I didn't have a from_rgba_unmultiplied. But after emils mention of https://docs.rs/epi/0.14.0/epi/struct.Frame.html#method.tex_allocator

and looking at https://docs.rs/epi/0.14.0/epi/trait.TextureAllocator.html I saw https://docs.rs/epi/0.14.0/epi/trait.TextureAllocator.html#tymethod.alloc_srgba_premultiplied

which is exactly what I wanted.

So I thought it could be useful for other new comers as well:

![egui-image-show](https://user-images.githubusercontent.com/3002925/132093316-eb166095-0dbc-4907-bfb0-21fe547bcbe1.PNG)
