### PR TITLE
Increase scroll speed for glium backend

### DIFF
--- a/egui_glium/src/lib.rs
+++ b/egui_glium/src/lib.rs
@@ -252,7 +252,8 @@ pub fn input_to_egui(
             let mut delta = match *delta {
                 glutin::event::MouseScrollDelta::LineDelta(x, y) => {
                     let line_height = 8.0; // magic value!
-                    vec2(x, y) * line_height
+                    let number_of_lines = 5.0;  // number of lines per one scroller click
+                    vec2(x, y) * line_height * number_of_lines
                 }
                 glutin::event::MouseScrollDelta::PixelDelta(delta) => {
                     vec2(delta.x as f32, delta.y as f32) / pixels_per_point


### PR DESCRIPTION
Each so called "line" of the MuseScrollDelta::LineDelta de-facto represents
a single scroller click which in most cases equals to 15 degrees of wheel
rotation.

Currently, one scroller click scrolls exactly one line of the text,
which is very slow.

This change multiplies the scroll rate by 5. So, with one click of the
scroller, 5 lines scrolled. This number is taken from the "iced" GUI
library and feels quite balanced.

Closes #461