### PR TITLE
Fix disabled textedit blocking focus shift.

### DIFF
--- a/egui/src/widgets/text_edit.rs
+++ b/egui/src/widgets/text_edit.rs
@@ -417,7 +417,7 @@ impl<'t, S: TextBuffer> Widget for TextEdit<'t, S> {
         let frame_rect = response.rect.expand2(margin);
         ui.allocate_space(frame_rect.size());
         if enabled {
-            response = response | ui.interact(frame_rect, id, Sense::click());
+            response |= ui.interact(frame_rect, id, Sense::click())
         }
         if response.clicked() && !response.lost_focus() {
             ui.memory().request_focus(response.id);

--- a/egui/src/widgets/text_edit.rs
+++ b/egui/src/widgets/text_edit.rs
@@ -406,24 +406,26 @@ impl<'t, S: TextBuffer> TextEdit<'t, S> {
 impl<'t, S: TextBuffer> Widget for TextEdit<'t, S> {
     fn ui(self, ui: &mut Ui) -> Response {
         let frame = self.frame;
+        let enabled = self.enabled;
         let where_to_put_background = ui.painter().add(Shape::Noop);
 
         let margin = Vec2::new(4.0, 2.0);
         let max_rect = ui.available_rect_before_wrap().shrink2(margin);
         let mut content_ui = ui.child_ui(max_rect, *ui.layout());
-        let response = self.content_ui(&mut content_ui);
+        let mut response = self.content_ui(&mut content_ui);
         let id = response.id;
         let frame_rect = response.rect.expand2(margin);
-        ui.allocate_rect(frame_rect, Sense::hover());
-        let frame_response = ui.interact(frame_rect, id, Sense::click());
-        let response = response | frame_response;
+        ui.allocate_space(frame_rect.size());
+        if enabled {
+            response = response | ui.interact(frame_rect, id, Sense::click());
+        }
         if response.clicked() && !response.lost_focus() {
             ui.memory().request_focus(response.id);
         }
 
         if frame {
             let visuals = ui.style().interact(&response);
-            let frame_rect = response.rect.expand(visuals.expansion);
+            let frame_rect = frame_rect.expand(visuals.expansion);
             let shape = if response.has_focus() {
                 Shape::Rect {
                     rect: frame_rect,


### PR DESCRIPTION
Fixes #732. Ui::interact was being called twice for the frame rect
regardless of enabled status which was causing problems for kb focus.
Now the interact function is called zero or one time.
#Before
![Screenshot 2021-09-28 123605](https://user-images.githubusercontent.com/1425156/135025706-3bcc3ffa-5724-49af-9757-32fdf2e8f7c6.png)
#After
![Screenshot 2021-09-28 124443](https://user-images.githubusercontent.com/1425156/135025759-34d167cc-509e-457a-a6ca-8f502f7b5c17.png)

The change in looks is because widget visuals now used for the disabled textedit is the noninteractive version, which I'm thinking is actually correct.

<!--



Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Open the PR as a draft until you have self-reviewed it and it is green.
* If it is a noteworthy change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Closes <https://github.com/emilk/egui/issues/732>.

