### PR TITLE
Collapsing header improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ NOTE: [`eframe`](eframe/CHANGELOG.md), [`egui_web`](egui_web/CHANGELOG.md), [`eg
 * MSRV (Minimum Supported Rust Version) is now `1.54.0`.
 * By default, `DragValue`:s no longer show a tooltip when hovered. Change with `Style::explanation_tooltips`.
 * `CollapsingHeader` is now opening or closing only when clicking the arrow icon
+* `CollapsingHeader` is now filling all the available horizontal space
+
 
 ### Fixed 🐛
 * Fix wrongly sized multiline `TextEdit` in justified layouts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ NOTE: [`eframe`](eframe/CHANGELOG.md), [`egui_web`](egui_web/CHANGELOG.md), [`eg
 * By default, `DragValue`:s no longer show a tooltip when hovered. Change with `Style::explanation_tooltips`.
 * `CollapsingHeader` is now opening or closing only when clicking the arrow icon
 * `CollapsingHeader` is now filling all the available horizontal space
+* Emit clicks on `CollapsingHeader`'s header only when NOT clicking the icon
 
 
 ### Fixed 🐛

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ NOTE: [`eframe`](eframe/CHANGELOG.md), [`egui_web`](egui_web/CHANGELOG.md), [`eg
 * `Painter`/`Fonts`: text layout now expect color when creating a `Galley`. You may override that color with `Painter::galley_with_color`.
 * MSRV (Minimum Supported Rust Version) is now `1.54.0`.
 * By default, `DragValue`:s no longer show a tooltip when hovered. Change with `Style::explanation_tooltips`.
+* `CollapsingHeader` is now opening or closing only when clicking the arrow icon
 
 ### Fixed 🐛
 * Fix wrongly sized multiline `TextEdit` in justified layouts.

--- a/egui/src/containers/collapsing_header.rs
+++ b/egui/src/containers/collapsing_header.rs
@@ -330,6 +330,12 @@ impl CollapsingHeader {
         if header_response.clicked() {
             if icon_response.clicked() {
                 state.toggle(ui);
+
+                // If we click the icon we don't want to emit the clicked and double clicked
+                // events.
+                header_response.clicked = [false; 3];
+                header_response.double_clicked = [false; 3];
+
                 header_response.mark_changed();
             }
         }

--- a/egui/src/containers/collapsing_header.rs
+++ b/egui/src/containers/collapsing_header.rs
@@ -370,39 +370,44 @@ impl CollapsingHeader {
     ) -> CollapsingResponse<R> {
         // Make sure contents are bellow header,
         // and make sure it is one unit (necessary for putting a `CollapsingHeader` in a grid).
-        ui.vertical(|ui| {
-            ui.set_enabled(self.enabled);
+        ui.with_layout(
+            Layout::top_down(Align::LEFT).with_cross_justify(true),
+            |ui| {
+                ui.set_enabled(self.enabled);
 
-            let Prepared {
-                id,
-                header_response,
-                mut state,
-            } = self.begin(ui);
-
-            let ret_response = state.add_contents(ui, id, |ui| {
-                ui.indent(id, |ui| {
-                    // make as wide as the header:
-                    ui.expand_to_include_x(header_response.rect.right());
-                    add_contents(ui)
-                })
-                .inner
-            });
-            ui.memory().id_data.insert(id, state);
-
-            if let Some(ret_response) = ret_response {
-                CollapsingResponse {
+                let Prepared {
+                    id,
                     header_response,
-                    body_response: Some(ret_response.response),
-                    body_returned: Some(ret_response.inner),
+                    mut state,
+                } = self.begin(ui);
+
+                let ret_response = state.add_contents(ui, id, |ui| {
+                    ui.indent(id, |ui| {
+                        // make as wide as the header:
+                        ui.expand_to_include_x(header_response.rect.right());
+
+                        ui.with_layout(Layout::top_down(Align::LEFT), |ui| add_contents(ui))
+                            .inner
+                    })
+                    .inner
+                });
+                ui.memory().id_data.insert(id, state);
+
+                if let Some(ret_response) = ret_response {
+                    CollapsingResponse {
+                        header_response,
+                        body_response: Some(ret_response.response),
+                        body_returned: Some(ret_response.inner),
+                    }
+                } else {
+                    CollapsingResponse {
+                        header_response,
+                        body_response: None,
+                        body_returned: None,
+                    }
                 }
-            } else {
-                CollapsingResponse {
-                    header_response,
-                    body_response: None,
-                    body_returned: None,
-                }
-            }
-        })
+            },
+        )
         .inner
     }
 }


### PR DESCRIPTION
This is a PR without a backing issue.

This PR changes `CollapsingHeader` container like this:
* `CollapsingHeader` is now opening or closing only when clicking the arrow icon
* `CollapsingHeader` is now filling all the available horizontal space
* Emit clicks on `CollapsingHeader`'s header only when NOT clicking the icon

Visual display:
![collapsing_header_improvement](https://user-images.githubusercontent.com/512152/135226419-45204235-b2da-4b31-9523-16112fd28798.gif)
