### PR TITLE
implement stick-to-end scroll

### DIFF
--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -22,6 +22,11 @@ pub(crate) struct State {
 
     /// Mouse offset relative to the top of the handle when started moving the handle.
     scroll_start_offset_from_top_left: [Option<f32>; 2],
+
+    /// Is the scroll sticky. This is true while scroll handle is in the end position
+    /// and remains that way until the user moves the scroll_handle. Once unstuck (false)
+    /// it remains false until the scroll touches the end position, which reenables stickiness.
+    scroll_stuck_to_end: [bool; 2],
 }
 
 impl Default for State {
@@ -31,6 +36,7 @@ impl Default for State {
             show_scroll: [false; 2],
             vel: Vec2::ZERO,
             scroll_start_offset_from_top_left: [None; 2],
+            scroll_stuck_to_end: [true; 2],
         }
     }
 }
@@ -54,6 +60,11 @@ pub struct ScrollArea {
     offset: Option<Vec2>,
     /// If false, we ignore scroll events.
     scrolling_enabled: bool,
+
+    /// If true for vertical or horizontal the scroll wheel will stick to the
+    /// end position until user manually changes position. It will become true
+    /// again once scroll handle makes contact with end.
+    stick_to_end: [bool; 2],
 }
 
 impl ScrollArea {
@@ -89,6 +100,7 @@ impl ScrollArea {
             id_source: None,
             offset: None,
             scrolling_enabled: true,
+            stick_to_end: [false; 2],
         }
     }
 
@@ -188,6 +200,40 @@ impl ScrollArea {
     pub(crate) fn has_any_bar(&self) -> bool {
         self.has_bar[0] || self.has_bar[1]
     }
+
+    /// The scroll handle will stick to the horizontal end position even while the content size
+    /// changes dynamically. This can be useful to simulate text scrollers coming in from right
+    /// hand side. The scroll handle remains stuck until user manually changes position. Once "unstuck"
+    /// it will remain focused on whatever content viewport the user left it on. If the scroll
+    /// handle is dragged all the way to the right it will again become stuck and remain there
+    /// until manually pulled from the end position.
+    pub fn stick_to_horizontal_end(mut self) -> Self {
+        self.stick_to_end[0] = true;
+        self
+    }
+
+    /// The scroll handle will stick to the vertical end position even while the content size
+    /// changes dynamically. This can be useful to simulate terminal UIs or log/info scrollers.
+    /// The scroll handle remains stuck until user manually changes position. Once "unstuck"
+    /// it will remain focused on whatever content viewport the user left it on. If the scroll
+    /// handle is dragged to the bottom it will again become stuck and remain there until manually
+    /// pulled from the end position.
+    pub fn stick_to_vertical_end(mut self) -> Self {
+        self.stick_to_end[1] = true;
+        self
+    }
+
+    /// The scroll handle will stick to the horizontal and vertical end positions even
+    /// while the content size changes dynamically. This can be useful to simulate terminal
+    /// UIs or log/info scrollers. The scroll handle remains stuck until user manually
+    /// changes position. Once "unstuck" it will remain focused on whatever content viewport
+    /// the user left it on. If the scroll handle is dragged to either end again, it will become
+    /// stuck and remain there until manually pulled from the end position.
+    pub fn stick_to_both(mut self) -> Self {
+        self.stick_to_end[0] = true;
+        self.stick_to_end[1] = true;
+        self
+    }
 }
 
 struct Prepared {
@@ -205,6 +251,7 @@ struct Prepared {
     /// `viewport.min == ZERO` means we scrolled to the top.
     viewport: Rect,
     scrolling_enabled: bool,
+    stick_to_end: [bool; 2],
 }
 
 impl ScrollArea {
@@ -217,6 +264,7 @@ impl ScrollArea {
             id_source,
             offset,
             scrolling_enabled,
+            stick_to_end,
         } = self;
 
         let ctx = ui.ctx().clone();
@@ -297,6 +345,7 @@ impl ScrollArea {
             content_ui,
             viewport,
             scrolling_enabled,
+            stick_to_end,
         }
     }
 
@@ -385,6 +434,7 @@ impl Prepared {
             content_ui,
             viewport: _,
             scrolling_enabled,
+            stick_to_end,
         } = self;
 
         let content_size = content_ui.min_size();
@@ -547,6 +597,11 @@ impl Prepared {
                 )
             };
 
+            // maybe force increase in offset to keep scroll stuck to end position
+            if stick_to_end[d] && state.scroll_stuck_to_end[d] {
+                state.offset[d] = content_size[d] - inner_rect.size()[d];
+            }
+
             let from_content =
                 |content| remap_clamp(content, 0.0..=content_size[d], min_main..=max_main);
 
@@ -589,6 +644,9 @@ impl Prepared {
 
                 let new_handle_top = pointer_pos[d] - *scroll_start_offset_from_top_left;
                 state.offset[d] = remap(new_handle_top, min_main..=max_main, 0.0..=content_size[d]);
+
+                // some manual action taken, scroll not stuck
+                state.scroll_stuck_to_end[d] = false;
             } else {
                 state.scroll_start_offset_from_top_left[d] = None;
             }
@@ -653,8 +711,19 @@ impl Prepared {
             ui.ctx().request_repaint();
         }
 
-        state.offset = state.offset.min(content_size - inner_rect.size());
+        let available_offset = content_size - inner_rect.size();
+        state.offset = state.offset.min(available_offset);
         state.offset = state.offset.max(Vec2::ZERO);
+
+        // Is scroll handle at end of content? If so enter sticky mode.
+        // Only has an effect if stick_to_end is enabled but we save in
+        // state anyway so that entering sticky mode at an arbitrary time
+        // has appropriate effect.
+        state.scroll_stuck_to_end = [
+            state.offset[0] == available_offset[0],
+            state.offset[1] == available_offset[1],
+        ];
+
         state.show_scroll = show_scroll_this_frame;
 
         ui.memory().id_data.insert(id, state);

--- a/egui_demo_lib/src/apps/demo/scrolling.rs
+++ b/egui_demo_lib/src/apps/demo/scrolling.rs
@@ -6,6 +6,7 @@ enum ScrollDemo {
     ScrollTo,
     ManyLines,
     LargeCanvas,
+    StickToEnd,
 }
 
 impl Default for ScrollDemo {
@@ -20,6 +21,7 @@ impl Default for ScrollDemo {
 pub struct Scrolling {
     demo: ScrollDemo,
     scroll_to: ScrollTo,
+    scroll_stick_to: ScrollStickTo,
 }
 
 impl super::Demo for Scrolling {
@@ -52,6 +54,7 @@ impl super::View for Scrolling {
                 ScrollDemo::LargeCanvas,
                 "Scroll a large canvas",
             );
+            ui.selectable_value(&mut self.demo, ScrollDemo::StickToEnd, "Stick to end");
         });
         ui.separator();
         match self.demo {
@@ -63,6 +66,9 @@ impl super::View for Scrolling {
             }
             ScrollDemo::LargeCanvas => {
                 huge_content_painter(ui);
+            }
+            ScrollDemo::StickToEnd => {
+                self.scroll_stick_to.ui(ui);
             }
         }
     }
@@ -228,5 +234,42 @@ impl super::View for ScrollTo {
             egui::reset_button(ui, self);
             ui.add(crate::__egui_github_link_file!());
         });
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(default))]
+#[derive(PartialEq)]
+struct ScrollStickTo {
+    n_items: usize,
+}
+
+impl Default for ScrollStickTo {
+    fn default() -> Self {
+        Self { n_items: 0 }
+    }
+}
+
+impl super::View for ScrollStickTo {
+    fn ui(&mut self, ui: &mut Ui) {
+        ui.label("Rows enter from the bottom, we want the scrollhandle to start and stay at bottom unless moved");
+
+        ui.add_space(4.0);
+
+        let text_style = TextStyle::Body;
+        let row_height = ui.fonts()[text_style].row_height();
+        ScrollArea::vertical().stick_to_vertical_end().show_rows(
+            ui,
+            row_height,
+            self.n_items,
+            |ui, row_range| {
+                for row in row_range {
+                    let text = format!("This is row {}/{}", row + 1, self.n_items);
+                    ui.label(text);
+                }
+            },
+        );
+
+        self.n_items += 1;
     }
 }


### PR DESCRIPTION
Closes https://github.com/emilk/egui/issues/757

Implements sticky scroll, for example:
```rust
 ScrollArea::vertical().stick_to_vertical_end().show_rows()
 ```

Behaviour: 
The scroll handle will stick to the horizontal and/or vertical end positions even while the content size changes dynamically. This can be useful to simulate terminal UIs or log/info scrollers or text scrolling right to left. The scroll handle remains stuck until user manually changes position. Once "unstuck" it will remain focused on whatever content viewport the user left it on. If the scroll handle is dragged to either end again, it will become stuck and remain there until manually pulled from the end position.
