### PR TITLE
egui-winit: fix AltGr characters on windows/linux

### DIFF
--- a/egui-winit/src/lib.rs
+++ b/egui-winit/src/lib.rs
@@ -225,10 +225,12 @@ impl State {
                 }
             }
             WindowEvent::ReceivedCharacter(ch) => {
-                if is_printable_char(*ch)
-                    && !self.egui_input.modifiers.ctrl
-                    && !self.egui_input.modifiers.mac_cmd
-                {
+                // On Mac we get here when the user presses Cmd-C (copy), ctrl-W, etc.
+                // We need to ignore these characters that are side-effects of commands.
+                let is_mac_cmd = cfg!(target_os = "macos")
+                    && (self.egui_input.modifiers.ctrl || self.egui_input.modifiers.mac_cmd);
+
+                if is_printable_char(*ch) && !is_mac_cmd {
                     self.egui_input
                         .events
                         .push(egui::Event::Text(ch.to_string()));


### PR DESCRIPTION
Closes https://github.com/emilk/egui/issues/351
Closes https://github.com/emilk/egui/pull/785

Please try this @DrOptix 

Does Ctrl-C, Ctrl-A etc work as expected on Windows and Linux?