### PR TITLE
Add clear to webgl1 and webgl2 backends

### DIFF
--- a/egui_web/src/webgl1.rs
+++ b/egui_web/src/webgl1.rs
@@ -666,6 +666,8 @@ impl PostProcess {
         }
 
         gl.bind_framebuffer(Gl::FRAMEBUFFER, Some(&self.fbo));
+        gl.clear_color(0.0, 0.0, 0.0, 0.0);
+        gl.clear(Gl::COLOR_BUFFER_BIT);
 
         Ok(())
     }

--- a/egui_web/src/webgl2.rs
+++ b/egui_web/src/webgl2.rs
@@ -653,6 +653,8 @@ impl PostProcess {
         }
 
         gl.bind_framebuffer(Gl::FRAMEBUFFER, Some(&self.fbo));
+        gl.clear_color(0.0, 0.0, 0.0, 0.0);
+        gl.clear(Gl::COLOR_BUFFER_BIT);
 
         Ok(())
     }


### PR DESCRIPTION
Closes #815.

Added an explicit clear_color in case the user changes it from the default elsewhere (yay gl state machine).

Any chance of getting this out in a patch release? If not it's not a terribly big deal, it'd just be nice to have.

