### PR TITLE
Import winit::platform::windows::WindowBuilderExtWindows

### DIFF
--- a/egui-winit/src/epi.rs
+++ b/egui-winit/src/epi.rs
@@ -1,3 +1,6 @@
+#[cfg(target_os = "windows")]
+use winit::platform::windows::WindowBuilderExtWindows;
+
 pub fn window_builder(
     native_options: &epi::NativeOptions,
     window_settings: &Option<crate::WindowSettings>,


### PR DESCRIPTION
Hi! The `winit::platform::windows::WindowBuilderExtWindows` trait was missing from epi.rs causing Windows builds to fail with the following error:

```
error[E0599]: no method named `with_drag_and_drop` found for struct `WindowBuilder` in the current scope
   --> egui-winit\src\epi.rs:41:20
    |
41  |     window_builder.with_drag_and_drop(enable)
    |                    ^^^^^^^^^^^^^^^^^^ method not found in `WindowBuilder`
    |
   ::: C:\Users\david\.cargo\registry\src\github.com-1ecc6299db9ec823\winit-0.25.0\src\platform\windows.rs:175:8
    |
175 |     fn with_drag_and_drop(self, flag: bool) -> WindowBuilder;
    |        ------------------ the method is available for `WindowBuilder` here
    |
    = help: items from traits can only be used if the trait is in scope
    = note: the following trait is implemented but not in scope; perhaps add a `use` for it:
            `use winit::platform::windows::WindowBuilderExtWindows;`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0599`.
error: could not compile `egui-winit`
```

I've added it to the top of epi.rs behind the target_os cfg gate and that fixed the problem.

