### PR TITLE
Fix when a string containing CRLF is pasted from the clipboard

### DIFF
--- a/egui-winit/src/lib.rs
+++ b/egui-winit/src/lib.rs
@@ -490,7 +490,9 @@ impl State {
                     self.egui_input.events.push(egui::Event::Copy);
                 } else if is_paste_command(self.egui_input.modifiers, keycode) {
                     if let Some(contents) = self.clipboard.get() {
-                        self.egui_input.events.push(egui::Event::Text(contents));
+                        self.egui_input
+                            .events
+                            .push(egui::Event::Text(contents.replace("\r\n", "\n")));
                     }
                 }
             }

--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -642,7 +642,11 @@ fn install_document_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
             if let Some(data) = event.clipboard_data() {
                 if let Ok(text) = data.get_data("text") {
                     let mut runner_lock = runner_ref.0.lock();
-                    runner_lock.input.raw.events.push(egui::Event::Text(text));
+                    runner_lock
+                        .input
+                        .raw
+                        .events
+                        .push(egui::Event::Text(text.replace("\r\n", "\n")));
                     runner_lock.needs_repaint.set_true();
                     event.stop_propagation();
                     event.prevent_default();


### PR DESCRIPTION
Currently, when I paste a multi-line string into TextEdit on Windows, extra garbage sticks to the display of the string due to line feed code issues.

This PR will fix this.

![2021-10-21 024212](https://user-images.githubusercontent.com/1794232/138144012-4fdd070c-3653-42fe-a182-59dc252a7172.png)


