### PR TITLE
Context Menu: Return owned Response from Response::context_menu

### DIFF
--- a/egui/src/response.rs
+++ b/egui/src/response.rs
@@ -487,8 +487,8 @@ impl Response {
     ///     }
     /// });
     /// ```
-    pub fn context_menu(&self, add_contents: impl FnOnce(&mut Ui)) -> &Self {
-        self.ctx.show_context_menu(self, add_contents);
+    pub fn context_menu(self, add_contents: impl FnOnce(&mut Ui)) -> Self {
+        self.ctx.show_context_menu(&self, add_contents);
         self
     }
 }

--- a/egui_demo_lib/src/apps/demo/drag_and_drop.rs
+++ b/egui_demo_lib/src/apps/demo/drag_and_drop.rs
@@ -145,7 +145,7 @@ impl super::View for DragAndDropDemo {
                 })
                 .response;
 
-                response.context_menu(|ui| {
+                let response = response.context_menu(|ui| {
                     if ui.button("New Item").clicked() {
                         self.columns[col_idx].push("New Item".to_string());
                         ui.close_menu();


### PR DESCRIPTION
Just a minor inconvenience I noticed, `response.context_menu()` returns a `&Response`. This can lead to annoying reference type errors because you may not be able to just move out of the reference.

I think I did this in the first place to avoid having to write `let response = response.context_menu();` but I don't think this is a concern actually.
