### PR TITLE
Fix HyperLink click event not being generated

### DIFF
--- a/egui_demo_lib/src/easy_mark/easy_mark_viewer.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_viewer.rs
@@ -42,7 +42,7 @@ pub fn item_ui(ui: &mut Ui, item: easy_mark::Item<'_>) {
             ui.add(label_from_style(text, &style));
         }
         easy_mark::Item::Hyperlink(style, text, url) => {
-            let label = label_from_style(text, &style);
+            let label = label_from_style(text, &style).sense(Sense::click());
             ui.add(Hyperlink::from_label_and_url(label, url));
         }
 


### PR DESCRIPTION
Add `Sense::click` to the `HyperLink` widget