### PR TITLE
egui_web: constrain the IME text agent to the canvas for single-line text input widget

### DIFF
--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -1242,13 +1242,13 @@ fn move_text_cursor(cursor: &Option<egui::Pos2>, canvas_id: &str) -> Option<()> 
     if is_mobile() == Some(false) {
         cursor.as_ref().and_then(|&egui::Pos2 { x, y }| {
             let canvas = canvas_element(canvas_id)?;
-            let y = (y + (canvas.scroll_top() + canvas.offset_top()) as f32).min(
-                canvas.client_height() as f32
-                    - text_agent().get_bounding_client_rect().height() as f32,
-            );
+            let bounding_rect = text_agent().get_bounding_client_rect();
+            let y = (y + (canvas.scroll_top() + canvas.offset_top()) as f32)
+                .min(canvas.client_height() as f32 - bounding_rect.height() as f32);
             let x = x + (canvas.scroll_left() + canvas.offset_left()) as f32;
             // Canvas is translated 50% horizontally in html.
-            let x = x - canvas.offset_width() as f32 / 2.0;
+            let x = (x - canvas.offset_width() as f32 / 2.0)
+                .min(canvas.client_width() as f32 - bounding_rect.width() as f32);
             style.set_property("position", "absolute").ok()?;
             style.set_property("top", &(y.to_string() + "px")).ok()?;
             style.set_property("left", &(x.to_string() + "px")).ok()


### PR DESCRIPTION
Closes #869

I didn't restrict the X position of the text agent in #830, so I missed the problem with single line text input as well.

To make it more perfect, I think that the X position of the text agent needs to be limited by the right edge of the text input widget that is currently being entered.
However, I am not familiar with the structure of egui and do not know how to get the currently inputting widget in this code.

Hence, this PR is a tentatively fix for this problem.