### PR TITLE
implement vertical slider orientation

### DIFF
--- a/egui/src/widgets/slider.rs
+++ b/egui/src/widgets/slider.rs
@@ -109,7 +109,7 @@ impl<'a> Slider<'a> {
         }
     }
 
-    /// Control wether or not the slider shows the current value.
+    /// Control whether or not the slider shows the current value.
     /// Default: `true`.
     pub fn show_value(mut self, show_value: bool) -> Self {
         self.show_value = show_value;

--- a/egui_demo_lib/src/apps/demo/sliders.rs
+++ b/egui_demo_lib/src/apps/demo/sliders.rs
@@ -105,9 +105,9 @@ impl super::View for Sliders {
                 You can always see the full precision value by hovering the value.",
             );
 
-            // if ui.button("Assign PI").clicked() {
-            //     self.value = std::f64::consts::PI;
-            // }
+            if ui.button("Assign PI").clicked() {
+                self.value = std::f64::consts::PI;
+            }
         }
 
         ui.separator();

--- a/egui_demo_lib/src/apps/demo/sliders.rs
+++ b/egui_demo_lib/src/apps/demo/sliders.rs
@@ -12,6 +12,7 @@ pub struct Sliders {
     pub clamp_to_range: bool,
     pub smart_aim: bool,
     pub integer: bool,
+    pub vertical: bool,
     pub value: f64,
 }
 
@@ -24,6 +25,7 @@ impl Default for Sliders {
             clamp_to_range: false,
             smart_aim: true,
             integer: false,
+            vertical: false,
             value: 10.0,
         }
     }
@@ -54,6 +56,7 @@ impl super::View for Sliders {
             clamp_to_range,
             smart_aim,
             integer,
+            vertical,
             value,
         } = self;
 
@@ -70,6 +73,12 @@ impl super::View for Sliders {
         *min = min.clamp(type_min, type_max);
         *max = max.clamp(type_min, type_max);
 
+        let orientation = if *vertical {
+            SliderOrientation::Vertical
+        } else {
+            SliderOrientation::Horizontal
+        };
+
         if *integer {
             let mut value_i32 = *value as i32;
             ui.add(
@@ -77,6 +86,7 @@ impl super::View for Sliders {
                     .logarithmic(*logarithmic)
                     .clamp_to_range(*clamp_to_range)
                     .smart_aim(*smart_aim)
+                    .orientation(orientation)
                     .text("i32 demo slider"),
             );
             *value = value_i32 as f64;
@@ -86,6 +96,7 @@ impl super::View for Sliders {
                     .logarithmic(*logarithmic)
                     .clamp_to_range(*clamp_to_range)
                     .smart_aim(*smart_aim)
+                    .orientation(orientation)
                     .text("f64 demo slider"),
             );
 
@@ -94,12 +105,13 @@ impl super::View for Sliders {
                 You can always see the full precision value by hovering the value.",
             );
 
-            if ui.button("Assign PI").clicked() {
-                self.value = std::f64::consts::PI;
-            }
+            // if ui.button("Assign PI").clicked() {
+            //     self.value = std::f64::consts::PI;
+            // }
         }
 
         ui.separator();
+
         ui.label("Slider range:");
         ui.add(
             Slider::new(min, type_min..=type_max)
@@ -120,6 +132,11 @@ impl super::View for Sliders {
             ui.label("Slider type:");
             ui.radio_value(integer, true, "i32");
             ui.radio_value(integer, false, "f64");
+        });
+        ui.horizontal(|ui| {
+            ui.label("Slider orientation:");
+            ui.radio_value(vertical, false, "Horizontal");
+            ui.radio_value(vertical, true, "Vertical");
         });
         ui.label("(f32, usize etc are also possible)");
         ui.add_space(8.0);


### PR DESCRIPTION
This PR implements a vertical orientation for `Slider`. Closes #589.

# What's new
- Sliders demo now includes a radio button toggle for orientation
- New enum `SliderOrientation` with variants `Horizontal` and `Vertical`
- New mutator function `.orientation` to set the slider orientation
- New constructor functions, `new_vertical` and `from_get_set_vertical` to instantiate with vertical orientation.
- Vertical Sliders use alternate keycodes for increment/decrement (up/down instead of right/left).

# What's changed
- Replaces horizontal-specific Slider logic with some functions matching on `orientation` instead. Some functions and parameters are renamed (e.g. `x_range` -> `position_range`).
- Some helper functions are now methods on `Slider` which match on the Slider's orientation.

# Alternatives
- If API breakage is ok, we could add an orientation argument to existing constructor functions (instead of creating new constructor functions).
- We could expose only the `.orientation` mutator function (instead of changing or creating constructor functions).
- We could expose a vertical slider as a different widget. The logic is similar enough that I think the sharing here is appropriate.