### PR TITLE
Fix typo "the close" -> "this close" in style.rs

### DIFF
--- a/egui/src/style.rs
+++ b/egui/src/style.rs
@@ -154,10 +154,10 @@ impl Spacing {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct Interaction {
-    /// Mouse must be the close to the side of a window to resize
+    /// Mouse must be this close to the side of a window to resize
     pub resize_grab_radius_side: f32,
 
-    /// Mouse must be the close to the corner of a window to resize
+    /// Mouse must be this close to the corner of a window to resize
     pub resize_grab_radius_corner: f32,
 
     /// If `false`, tooltips will show up anytime you hover anything, even is mouse is still moving


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and it is green.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Fixes a typo in the doc strings for `resize_grab_radius_side` and `resize_grab_radius_corner`.
