### PR TITLE
Fix wrong gamma in WebkitGTK

### DIFF
--- a/egui_glow/CHANGELOG.md
+++ b/egui_glow/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to the `egui_glow` integration will be noted in this file.
 
 
 ## Unreleased
+* Add `workarounds` to `Painter::new` to pass GLSL macro to fix platform specific behavior.
 * Make winit/glutin an optional dependency ([#868](https://github.com/emilk/egui/pull/868)).
 * Simplify `EguiGlow` interface ([#871](https://github.com/emilk/egui/pull/871)).
 * Remove `EguiGlow::is_quit_event` ([#881](https://github.com/emilk/egui/pull/881)).

--- a/egui_glow/CHANGELOG.md
+++ b/egui_glow/CHANGELOG.md
@@ -3,7 +3,6 @@ All notable changes to the `egui_glow` integration will be noted in this file.
 
 
 ## Unreleased
-* Add `workarounds` to `Painter::new` to pass GLSL macro to fix platform specific behavior.
 * Make winit/glutin an optional dependency ([#868](https://github.com/emilk/egui/pull/868)).
 * Simplify `EguiGlow` interface ([#871](https://github.com/emilk/egui/pull/871)).
 * Remove `EguiGlow::is_quit_event` ([#881](https://github.com/emilk/egui/pull/881)).

--- a/egui_glow/src/epi_backend.rs
+++ b/egui_glow/src/epi_backend.rs
@@ -58,7 +58,7 @@ pub fn run(app: Box<dyn epi::App>, native_options: &epi::NativeOptions) -> ! {
         event_loop.create_proxy(),
     )));
 
-    let mut painter = crate::Painter::new(&gl, None)
+    let mut painter = crate::Painter::new(&gl, None, vec![])
         .map_err(|error| eprintln!("some OpenGL error occurred {}\n", error))
         .unwrap();
     let mut integration = egui_winit::epi::EpiIntegration::new(

--- a/egui_glow/src/epi_backend.rs
+++ b/egui_glow/src/epi_backend.rs
@@ -58,7 +58,7 @@ pub fn run(app: Box<dyn epi::App>, native_options: &epi::NativeOptions) -> ! {
         event_loop.create_proxy(),
     )));
 
-    let mut painter = crate::Painter::new(&gl, None, vec![])
+    let mut painter = crate::Painter::new(&gl, None, &[])
         .map_err(|error| eprintln!("some OpenGL error occurred {}\n", error))
         .unwrap();
     let mut integration = egui_winit::epi::EpiIntegration::new(

--- a/egui_glow/src/epi_backend.rs
+++ b/egui_glow/src/epi_backend.rs
@@ -58,7 +58,7 @@ pub fn run(app: Box<dyn epi::App>, native_options: &epi::NativeOptions) -> ! {
         event_loop.create_proxy(),
     )));
 
-    let mut painter = crate::Painter::new(&gl, None, &[])
+    let mut painter = crate::Painter::new(&gl, None, "")
         .map_err(|error| eprintln!("some OpenGL error occurred {}\n", error))
         .unwrap();
     let mut integration = egui_winit::epi::EpiIntegration::new(

--- a/egui_glow/src/lib.rs
+++ b/egui_glow/src/lib.rs
@@ -123,7 +123,7 @@ impl EguiGlow {
         Self {
             egui_ctx: Default::default(),
             egui_winit: egui_winit::State::new(gl_window.window()),
-            painter: crate::Painter::new(gl, None)
+            painter: crate::Painter::new(gl, None, vec![])
                 .map_err(|error| {
                     eprintln!("some error occurred in initializing painter\n{}", error);
                 })

--- a/egui_glow/src/lib.rs
+++ b/egui_glow/src/lib.rs
@@ -123,7 +123,7 @@ impl EguiGlow {
         Self {
             egui_ctx: Default::default(),
             egui_winit: egui_winit::State::new(gl_window.window()),
-            painter: crate::Painter::new(gl, None, vec![])
+            painter: crate::Painter::new(gl, None, &[])
                 .map_err(|error| {
                     eprintln!("some error occurred in initializing painter\n{}", error);
                 })

--- a/egui_glow/src/lib.rs
+++ b/egui_glow/src/lib.rs
@@ -123,7 +123,7 @@ impl EguiGlow {
         Self {
             egui_ctx: Default::default(),
             egui_winit: egui_winit::State::new(gl_window.window()),
-            painter: crate::Painter::new(gl, None, &[])
+            painter: crate::Painter::new(gl, None, "")
                 .map_err(|error| {
                     eprintln!("some error occurred in initializing painter\n{}", error);
                 })

--- a/egui_glow/src/misc_util.rs
+++ b/egui_glow/src/misc_util.rs
@@ -184,7 +184,8 @@ impl VAO {
     }
 }
 
-pub(crate) unsafe fn need_to_emulate_vao(gl: &glow::Context) -> bool {
+/// If returned true no need to emulate vao
+pub(crate) unsafe fn support_vao(gl: &glow::Context) -> bool {
     let web_sig = "WebGL ";
     let es_sig = "OpenGL ES ";
     let version_string = gl.get_parameter_string(glow::VERSION);
@@ -197,10 +198,10 @@ pub(crate) unsafe fn need_to_emulate_vao(gl: &glow::Context) -> bool {
         ));
         if version_str.contains("1.0") {
             //need to test OES_vertex_array_object .
-            !gl.supported_extensions()
+            gl.supported_extensions()
                 .contains("OES_vertex_array_object")
         } else {
-            false
+            true
         }
     } else if let Some(pos) = version_string.rfind(es_sig) {
         //glow targets es2.0+ so we don't concern about OpenGL ES-CM,OpenGL ES-CL
@@ -211,10 +212,10 @@ pub(crate) unsafe fn need_to_emulate_vao(gl: &glow::Context) -> bool {
         ));
         if version_string.contains("2.0") {
             //need to test OES_vertex_array_object .
-            !gl.supported_extensions()
+            gl.supported_extensions()
                 .contains("OES_vertex_array_object")
         } else {
-            false
+            true
         }
     } else {
         glow_debug_print(format!("detected OpenGL:{}", version_string));
@@ -222,10 +223,10 @@ pub(crate) unsafe fn need_to_emulate_vao(gl: &glow::Context) -> bool {
         if version_string.starts_with('2') {
             // I found APPLE_vertex_array_object , GL_ATI_vertex_array_object ,ARB_vertex_array_object
             // but APPLE's and ATI's very old extension.
-            !gl.supported_extensions()
+            gl.supported_extensions()
                 .contains("ARB_vertex_array_object")
         } else {
-            false
+            true
         }
     }
 }

--- a/egui_glow/src/misc_util.rs
+++ b/egui_glow/src/misc_util.rs
@@ -197,7 +197,7 @@ pub(crate) unsafe fn need_to_emulate_vao(gl: &glow::Context) -> bool {
         ));
         if version_str.contains("1.0") {
             //need to test OES_vertex_array_object .
-            gl.supported_extensions()
+            !gl.supported_extensions()
                 .contains("OES_vertex_array_object")
         } else {
             false
@@ -211,7 +211,7 @@ pub(crate) unsafe fn need_to_emulate_vao(gl: &glow::Context) -> bool {
         ));
         if version_string.contains("2.0") {
             //need to test OES_vertex_array_object .
-            gl.supported_extensions()
+            !gl.supported_extensions()
                 .contains("OES_vertex_array_object")
         } else {
             false
@@ -222,7 +222,7 @@ pub(crate) unsafe fn need_to_emulate_vao(gl: &glow::Context) -> bool {
         if version_string.starts_with('2') {
             // I found APPLE_vertex_array_object , GL_ATI_vertex_array_object ,ARB_vertex_array_object
             // but APPLE's and ATI's very old extension.
-            gl.supported_extensions()
+            !gl.supported_extensions()
                 .contains("ARB_vertex_array_object")
         } else {
             false

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -84,7 +84,7 @@ impl Painter {
         let workaround = workarounds
             .iter()
             .fold("".to_owned(), |mut list_of_wr, workaround| {
-                list_of_wr.push_str(&workaround);
+                list_of_wr.push_str(workaround);
                 list_of_wr.push('\n');
                 list_of_wr
             });

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -61,7 +61,7 @@ impl Painter {
     /// Create painter.
     ///
     /// Set `pp_fb_extent` to the framebuffer size to enable `sRGB` support on OpenGL ES and WebGL.
-    /// Set `workaround` if you want to turn on shader workaround like `&vec!["#define EPIPHANY_WORKAROUND".to_owned()]`.
+    /// Set `workaround` if you want to turn on shader workaround e.g. `&vec!["#define EPIPHANY_WORKAROUND".to_owned()]`.
     ///
     /// this fix [Everything is super dark in epiphany](https://github.com/emilk/egui/issues/794)
     /// # Errors

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -74,7 +74,7 @@ impl Painter {
         pp_fb_extent: Option<[i32; 2]>,
         shader_prefix: &str,
     ) -> Result<Painter, String> {
-        let need_to_emulate_vao = unsafe { crate::misc_util::need_to_emulate_vao(gl) };
+        let support_vao = unsafe { crate::misc_util::support_vao(gl) };
         let shader_version = ShaderVersion::get(gl);
         let is_webgl_1 = shader_version == ShaderVersion::Es100;
         let header = shader_version.version();
@@ -92,7 +92,7 @@ impl Painter {
                         Some(PostProcess::new(
                             gl,
                             shader_prefix,
-                            need_to_emulate_vao,
+                            support_vao,
                             is_webgl_1,
                             width,
                             height,
@@ -147,10 +147,10 @@ impl Painter {
             let a_pos_loc = gl.get_attrib_location(program, "a_pos").unwrap();
             let a_tc_loc = gl.get_attrib_location(program, "a_tc").unwrap();
             let a_srgba_loc = gl.get_attrib_location(program, "a_srgba").unwrap();
-            let mut vertex_array = if need_to_emulate_vao {
-                crate::misc_util::VAO::emulated()
-            } else {
+            let mut vertex_array = if support_vao {
                 crate::misc_util::VAO::native(gl)
+            } else {
+                crate::misc_util::VAO::emulated()
             };
             vertex_array.bind_vertex_array(gl);
             vertex_array.bind_buffer(gl, &vertex_buffer);

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -61,7 +61,7 @@ impl Painter {
     /// Create painter.
     ///
     /// Set `pp_fb_extent` to the framebuffer size to enable `sRGB` support on OpenGL ES and WebGL.
-    /// Set `workaround` if you want to turn on shader workaround like `vec!["#define EPIPHANY_WORKAROUND".to_owned()]`.
+    /// Set `workaround` if you want to turn on shader workaround like `&vec!["#define EPIPHANY_WORKAROUND".to_owned()]`.
     ///
     /// this fix [Everything is super dark in epiphany](https://github.com/emilk/egui/issues/794)
     /// # Errors
@@ -72,7 +72,7 @@ impl Painter {
     pub fn new(
         gl: &glow::Context,
         pp_fb_extent: Option<[i32; 2]>,
-        workarounds: Vec<String>,
+        workarounds: &[String],
     ) -> Result<Painter, String> {
         let need_to_emulate_vao = unsafe { crate::misc_util::need_to_emulate_vao(gl) };
         let shader_version = ShaderVersion::get(gl);
@@ -83,8 +83,10 @@ impl Painter {
         // format to insert to shader source.
         let workaround = workarounds
             .iter()
-            .fold("".to_owned(), |list_of_wr, work_around| {
-                list_of_wr + work_around + "\n"
+            .fold("".to_owned(), |mut list_of_wr, workaround| {
+                list_of_wr.push_str(&workaround);
+                list_of_wr.push('\n');
+                list_of_wr
             });
         let (post_process, srgb_support_define) = match (shader_version, srgb_support) {
             //WebGL2 support sRGB default

--- a/egui_glow/src/post_process.rs
+++ b/egui_glow/src/post_process.rs
@@ -19,7 +19,7 @@ pub(crate) struct PostProcess {
 impl PostProcess {
     pub(crate) unsafe fn new(
         gl: &glow::Context,
-        workarounds: &str,
+        shader_prefix: &str,
         need_to_emulate_vao: bool,
         is_webgl_1: bool,
         width: i32,
@@ -98,8 +98,8 @@ impl PostProcess {
             gl,
             glow::VERTEX_SHADER,
             &format!(
-                "{}{}",
-                workarounds,
+                "{}\n{}",
+                shader_prefix,
                 include_str!("shader/post_vertex_100es.glsl")
             ),
         )?;
@@ -107,8 +107,8 @@ impl PostProcess {
             gl,
             glow::FRAGMENT_SHADER,
             &format!(
-                "{}{}",
-                workarounds,
+                "{}\n{}",
+                shader_prefix,
                 include_str!("shader/post_fragment_100es.glsl")
             ),
         )?;

--- a/egui_glow/src/post_process.rs
+++ b/egui_glow/src/post_process.rs
@@ -19,6 +19,7 @@ pub(crate) struct PostProcess {
 impl PostProcess {
     pub(crate) unsafe fn new(
         gl: &glow::Context,
+        workarounds: &str,
         need_to_emulate_vao: bool,
         is_webgl_1: bool,
         width: i32,
@@ -96,12 +97,20 @@ impl PostProcess {
         let vert_shader = compile_shader(
             gl,
             glow::VERTEX_SHADER,
-            include_str!("shader/post_vertex_100es.glsl"),
+            &format!(
+                "{}{}",
+                workarounds,
+                include_str!("shader/post_vertex_100es.glsl")
+            ),
         )?;
         let frag_shader = compile_shader(
             gl,
             glow::FRAGMENT_SHADER,
-            include_str!("shader/post_fragment_100es.glsl"),
+            &format!(
+                "{}{}",
+                workarounds,
+                include_str!("shader/post_fragment_100es.glsl")
+            ),
         )?;
         let program = link_program(gl, [vert_shader, frag_shader].iter())?;
 

--- a/egui_glow/src/shader/post_fragment_100es.glsl
+++ b/egui_glow/src/shader/post_fragment_100es.glsl
@@ -19,7 +19,8 @@ void main() {
     gl_FragColor = texture2D(u_sampler, v_tc);
 
     gl_FragColor = srgba_from_linear(gl_FragColor) / 255.;
-    #ifdef EPIPHANY_WORKAROUND
-    gl_FragColor = srgba_from_linear(gl_FragColor) / 255.;
+    #ifdef WEBKITGTK_WORKAROUND
+    //this is better than double apply
+    gl_FragColor = vec4(pow(gl_FragColor.rgb,vec3(1.0/2.2)),gl_FragColor.a);
     #endif
 }

--- a/egui_glow/src/shader/post_fragment_100es.glsl
+++ b/egui_glow/src/shader/post_fragment_100es.glsl
@@ -19,4 +19,7 @@ void main() {
     gl_FragColor = texture2D(u_sampler, v_tc);
 
     gl_FragColor = srgba_from_linear(gl_FragColor) / 255.;
+    #ifdef EPIPHANY_WORKAROUND
+    gl_FragColor = srgba_from_linear(gl_FragColor) / 255.;
+    #endif
 }

--- a/egui_web/CHANGELOG.md
+++ b/egui_web/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to the `egui_web` integration will be noted in this file.
 
 
 ## Unreleased
-*Add feature `glow` to switch to a [`glow`](https://github.com/grovesNL/glow) based painter ([#868](https://github.com/emilk/egui/pull/868)).
+* fix [Everything super dark in epiphany](https://github.com/emilk/egui/issues/794) for webgl1 and glow based painter
+* Add feature `glow` to switch to a [`glow`](https://github.com/grovesNL/glow) based painter ([#868](https://github.com/emilk/egui/pull/868)).
 
 ## 0.15.0 - 2021-10-24
 ### Added

--- a/egui_web/Cargo.toml
+++ b/egui_web/Cargo.toml
@@ -88,6 +88,7 @@ features = [
   "TouchList",
   "WebGl2RenderingContext",
   "WebGlBuffer",
+  "WebglDebugRendererInfo",
   "WebGlFramebuffer",
   "WebGlProgram",
   "WebGlRenderingContext",

--- a/egui_web/src/glow_wrapping.rs
+++ b/egui_web/src/glow_wrapping.rs
@@ -19,14 +19,14 @@ impl WrappedGlowPainter {
         let user_agent = web_sys::window().unwrap().navigator().user_agent().unwrap();
         let epiphany_wr = if user_agent.contains("Epiphany") {
             console_log("Enabling epiphany workaround");
-            vec!["#define EPIPHANY_WORKAROUND".to_owned()]
+            "#define EPIPHANY_WORKAROUND"
         } else {
-            vec![]
+            ""
         };
         let canvas = canvas_element_or_die(canvas_id);
         let gl_ctx = init_glow_context_from_canvas(&canvas);
         let dimension = [canvas.width() as i32, canvas.height() as i32];
-        let painter = egui_glow::Painter::new(&gl_ctx, Some(dimension), &epiphany_wr)
+        let painter = egui_glow::Painter::new(&gl_ctx, Some(dimension), epiphany_wr)
             .map_err(|error| {
                 console_error(format!(
                     "some error occurred in initializing glow painter\n {}",

--- a/egui_web/src/glow_wrapping.rs
+++ b/egui_web/src/glow_wrapping.rs
@@ -26,7 +26,7 @@ impl WrappedGlowPainter {
         let canvas = canvas_element_or_die(canvas_id);
         let gl_ctx = init_glow_context_from_canvas(&canvas);
         let dimension = [canvas.width() as i32, canvas.height() as i32];
-        let painter = egui_glow::Painter::new(&gl_ctx, Some(dimension), epiphany_wr)
+        let painter = egui_glow::Painter::new(&gl_ctx, Some(dimension), &epiphany_wr)
             .map_err(|error| {
                 console_error(format!(
                     "some error occurred in initializing glow painter\n {}",

--- a/egui_web/src/shader/post_fragment_100es.glsl
+++ b/egui_web/src/shader/post_fragment_100es.glsl
@@ -19,7 +19,8 @@ void main() {
     gl_FragColor = texture2D(u_sampler, v_tc);
 
     gl_FragColor = srgba_from_linear(gl_FragColor) / 255.;
-    #ifdef EPIPHANY_WORKAROUND
-    gl_FragColor = srgba_from_linear(gl_FragColor) / 255.;
+    #ifdef WEBKITGTK_WORKAROUND
+    //this is better than double apply
+    gl_FragColor = vec4(pow(gl_FragColor.rgb,vec3(1.0/2.2)),gl_FragColor.a);
     #endif
 }

--- a/egui_web/src/shader/post_fragment_100es.glsl
+++ b/egui_web/src/shader/post_fragment_100es.glsl
@@ -19,4 +19,7 @@ void main() {
     gl_FragColor = texture2D(u_sampler, v_tc);
 
     gl_FragColor = srgba_from_linear(gl_FragColor) / 255.;
+    #ifdef EPIPHANY_WORKAROUND
+    gl_FragColor = srgba_from_linear(gl_FragColor) / 255.;
+    #endif
 }

--- a/egui_web/src/webgl1.rs
+++ b/egui_web/src/webgl1.rs
@@ -766,6 +766,7 @@ fn link_program<'a, T: IntoIterator<Item = &'a WebGlShader>>(
             .unwrap_or_else(|| "Unknown error creating program object".into()))
     }
 }
+
 /// detecting Safari and webkitGTK.
 ///
 /// Safari and webkitGTK use unmasked renderer :Apple GPU

--- a/egui_web/src/webgl1.rs
+++ b/egui_web/src/webgl1.rs
@@ -593,7 +593,7 @@ impl PostProcess {
         gl.bind_texture(Gl::TEXTURE_2D, None);
         gl.bind_framebuffer(Gl::FRAMEBUFFER, None);
         // currently epiphany only support webgl1
-        let epiphany_workaround = if web_sys::window()
+        let frag_shader_prefix = if web_sys::window()
             .unwrap()
             .navigator()
             .user_agent()
@@ -615,7 +615,7 @@ impl PostProcess {
             Gl::FRAGMENT_SHADER,
             &format!(
                 "{}{}",
-                epiphany_workaround,
+                frag_shader_prefix,
                 include_str!("shader/post_fragment_100es.glsl")
             ),
         )?;


### PR DESCRIPTION
Epiphany's incorrect sRGB handling  cause  same result as displaying linear image on other browsers.
I fixed this issue by double sRGB correcting in post process. 
Glitched image
![color difference](https://user-images.githubusercontent.com/48007646/140709974-c473cad4-17ff-4f24-8adf-fef2fe4232ef.png)
fixed result
![スクリーンショット 2021-11-08 174650](https://user-images.githubusercontent.com/48007646/140711248-c00fcac3-fd18-443e-9ae4-e19089a7036c.png)
 
