### PR TITLE
Improved plot interaction methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * You can now read and write the cursor of a `TextEdit` ([#848](https://github.com/emilk/egui/pull/848)).
 * Most widgets containing text (`Label`, `Button` etc) now supports rich text ([#855](https://github.com/emilk/egui/pull/855)).
 * When using a custom font you can now specify a font index ([#873](https://github.com/emilk/egui/pull/873)).
-* You can now read the plot coordinates of the mouse when building a `Plot` ([#766](https://github.com/emilk/egui/pull/766)).
+* You can now query information about the plot (e.g. get the mouse position in plot coordinates, or the plot
+  bounds) while adding items. `Plot` ([#766](https://github.com/emilk/egui/pull/766) and
+  [#892](https://github.com/emilk/egui/pull/892)).
 * Add vertical sliders with `Slider::new(…).vertical()` ([#875](https://github.com/emilk/egui/pull/875)).
 * Add `Button::image_and_text` ([#832](https://github.com/emilk/egui/pull/832)).
 
@@ -36,7 +38,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * [5225225](https://github.com/5225225): ([#849](https://github.com/emilk/egui/pull/849)).
 * [B-Reif](https://github.com/B-Reif) ([#875](https://github.com/emilk/egui/pull/875)).
 * [d10sfan](https://github.com/d10sfan) ([#832](https://github.com/emilk/egui/pull/832)).
-* [EmbersArc](https://github.com/EmbersArc): ([#766](https://github.com/emilk/egui/pull/766)).
+* [EmbersArc](https://github.com/EmbersArc): ([#766](https://github.com/emilk/egui/pull/766), [#892](https://github.com/emilk/egui/pull/892)).
 * [mankinskin](https://github.com/mankinskin) ([#543](https://github.com/emilk/egui/pull/543)).
 * [sumibi-yakitori](https://github.com/sumibi-yakitori) ([#830](https://github.com/emilk/egui/pull/830)).
 * [t18b219k](https://github.com/t18b219k): ([#868](https://github.com/emilk/egui/pull/868), [#888](https://github.com/emilk/egui/pull/888)).

--- a/egui/src/widgets/plot/items.rs
+++ b/egui/src/widgets/plot/items.rs
@@ -4,7 +4,7 @@ use std::ops::{Bound, RangeBounds, RangeInclusive};
 
 use epaint::Mesh;
 
-use super::transform::{Bounds, ScreenTransform};
+use super::transform::{PlotBounds, ScreenTransform};
 use crate::*;
 
 const DEFAULT_FILL_ALPHA: f32 = 0.05;
@@ -233,8 +233,8 @@ impl PlotItem for HLine {
         None
     }
 
-    fn get_bounds(&self) -> Bounds {
-        let mut bounds = Bounds::NOTHING;
+    fn get_bounds(&self) -> PlotBounds {
+        let mut bounds = PlotBounds::NOTHING;
         bounds.min[1] = self.y;
         bounds.max[1] = self.y;
         bounds
@@ -343,8 +343,8 @@ impl PlotItem for VLine {
         None
     }
 
-    fn get_bounds(&self) -> Bounds {
-        let mut bounds = Bounds::NOTHING;
+    fn get_bounds(&self) -> PlotBounds {
+        let mut bounds = PlotBounds::NOTHING;
         bounds.min[0] = self.x;
         bounds.max[0] = self.x;
         bounds
@@ -360,7 +360,7 @@ pub(super) trait PlotItem {
     fn highlight(&mut self);
     fn highlighted(&self) -> bool;
     fn values(&self) -> Option<&Values>;
-    fn get_bounds(&self) -> Bounds;
+    fn get_bounds(&self) -> PlotBounds;
 }
 
 // ----------------------------------------------------------------------------
@@ -503,8 +503,8 @@ impl Values {
         (start < end).then(|| start..=end)
     }
 
-    pub(super) fn get_bounds(&self) -> Bounds {
-        let mut bounds = Bounds::NOTHING;
+    pub(super) fn get_bounds(&self) -> PlotBounds {
+        let mut bounds = PlotBounds::NOTHING;
         self.values
             .iter()
             .for_each(|value| bounds.extend_with(value));
@@ -710,7 +710,7 @@ impl PlotItem for Line {
         Some(&self.series)
     }
 
-    fn get_bounds(&self) -> Bounds {
+    fn get_bounds(&self) -> PlotBounds {
         self.series.get_bounds()
     }
 }
@@ -840,7 +840,7 @@ impl PlotItem for Polygon {
         Some(&self.series)
     }
 
-    fn get_bounds(&self) -> Bounds {
+    fn get_bounds(&self) -> PlotBounds {
         self.series.get_bounds()
     }
 }
@@ -953,8 +953,8 @@ impl PlotItem for Text {
         None
     }
 
-    fn get_bounds(&self) -> Bounds {
-        let mut bounds = Bounds::NOTHING;
+    fn get_bounds(&self) -> PlotBounds {
+        let mut bounds = PlotBounds::NOTHING;
         bounds.extend_with(&self.position);
         bounds
     }
@@ -1186,7 +1186,7 @@ impl PlotItem for Points {
         Some(&self.series)
     }
 
-    fn get_bounds(&self) -> Bounds {
+    fn get_bounds(&self) -> PlotBounds {
         self.series.get_bounds()
     }
 }
@@ -1301,7 +1301,7 @@ impl PlotItem for Arrows {
         Some(&self.origins)
     }
 
-    fn get_bounds(&self) -> Bounds {
+    fn get_bounds(&self) -> PlotBounds {
         self.origins.get_bounds()
     }
 }
@@ -1431,8 +1431,8 @@ impl PlotItem for PlotImage {
         None
     }
 
-    fn get_bounds(&self) -> Bounds {
-        let mut bounds = Bounds::NOTHING;
+    fn get_bounds(&self) -> PlotBounds {
+        let mut bounds = PlotBounds::NOTHING;
         let left_top = Value::new(
             self.position.x as f32 - self.size.x / 2.0,
             self.position.y as f32 - self.size.y / 2.0,

--- a/egui/src/widgets/plot/mod.rs
+++ b/egui/src/widgets/plot/mod.rs
@@ -460,7 +460,8 @@ impl PlotUi {
     }
 
     /// The plot bounds as they were in the last frame. If called on the first frame and the bounds were not
-    /// further specified in the plot builder, this will return bounds centered on the origin.
+    /// further specified in the plot builder, this will return bounds centered on the origin. The bounds do
+    /// not change until the plot is drawn.
     pub fn plot_bounds(&self) -> PlotBounds {
         *self.last_screen_transform.bounds()
     }

--- a/egui/src/widgets/plot/mod.rs
+++ b/egui/src/widgets/plot/mod.rs
@@ -11,7 +11,8 @@ pub use items::{
 };
 use legend::LegendWidget;
 pub use legend::{Corner, Legend};
-use transform::{Bounds, ScreenTransform};
+pub use transform::PlotBounds;
+use transform::ScreenTransform;
 
 use crate::*;
 use color::Hsva;
@@ -23,12 +24,11 @@ use epaint::ahash::AHashSet;
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Clone)]
 struct PlotMemory {
-    bounds: Bounds,
     auto_bounds: bool,
     hovered_entry: Option<String>,
     hidden_items: AHashSet<String>,
-    min_auto_bounds: Bounds,
-    last_screen_transform: Option<ScreenTransform>,
+    min_auto_bounds: PlotBounds,
+    last_screen_transform: ScreenTransform,
 }
 
 impl PlotMemory {
@@ -65,7 +65,7 @@ pub struct Plot {
     center_y_axis: bool,
     allow_zoom: bool,
     allow_drag: bool,
-    min_auto_bounds: Bounds,
+    min_auto_bounds: PlotBounds,
     margin_fraction: Vec2,
 
     min_size: Vec2,
@@ -91,7 +91,7 @@ impl Plot {
             center_y_axis: false,
             allow_zoom: true,
             allow_drag: true,
-            min_auto_bounds: Bounds::NOTHING,
+            min_auto_bounds: PlotBounds::NOTHING,
             margin_fraction: Vec2::splat(0.05),
 
             min_size: Vec2::splat(64.0),
@@ -219,7 +219,11 @@ impl Plot {
     }
 
     /// Interact with and add items to the plot and finally draw it.
-    pub fn show(self, ui: &mut Ui, build_fn: impl FnOnce(&mut PlotUi)) -> Response {
+    pub fn show<R>(
+        self,
+        ui: &mut Ui,
+        build_fn: impl FnOnce(&mut PlotUi<'_>) -> R,
+    ) -> InnerResponse<R> {
         let Self {
             id_source,
             center_x_axis,
@@ -239,37 +243,6 @@ impl Plot {
             show_background,
             show_axes,
         } = self;
-
-        let plot_id = ui.make_persistent_id(id_source);
-        let mut memory = PlotMemory::load(ui.ctx(), plot_id).unwrap_or_else(|| PlotMemory {
-            bounds: min_auto_bounds,
-            auto_bounds: !min_auto_bounds.is_valid(),
-            hovered_entry: None,
-            hidden_items: Default::default(),
-            min_auto_bounds,
-            last_screen_transform: None,
-        });
-
-        // If the min bounds changed, recalculate everything.
-        if min_auto_bounds != memory.min_auto_bounds {
-            memory = PlotMemory {
-                bounds: min_auto_bounds,
-                auto_bounds: !min_auto_bounds.is_valid(),
-                hovered_entry: None,
-                min_auto_bounds,
-                ..memory
-            };
-            memory.clone().store(ui.ctx(), plot_id);
-        }
-
-        let PlotMemory {
-            mut bounds,
-            mut auto_bounds,
-            mut hovered_entry,
-            mut hidden_items,
-            last_screen_transform,
-            ..
-        } = memory;
 
         // Determine the size of the plot in the UI
         let size = {
@@ -295,8 +268,42 @@ impl Plot {
             vec2(width, height)
         };
 
+        // Allocate the space.
         let (rect, response) = ui.allocate_exact_size(size, Sense::drag());
-        let plot_painter = ui.painter().sub_region(rect);
+
+        // Load or initialize the memory.
+        let plot_id = ui.make_persistent_id(id_source);
+        let mut memory = PlotMemory::load(ui.ctx(), plot_id).unwrap_or_else(|| PlotMemory {
+            auto_bounds: !min_auto_bounds.is_valid(),
+            hovered_entry: None,
+            hidden_items: Default::default(),
+            min_auto_bounds,
+            last_screen_transform: ScreenTransform::new(
+                rect,
+                min_auto_bounds,
+                center_x_axis,
+                center_y_axis,
+            ),
+        });
+
+        // If the min bounds changed, recalculate everything.
+        if min_auto_bounds != memory.min_auto_bounds {
+            memory = PlotMemory {
+                auto_bounds: !min_auto_bounds.is_valid(),
+                hovered_entry: None,
+                min_auto_bounds,
+                ..memory
+            };
+            memory.clone().store(ui.ctx(), plot_id);
+        }
+
+        let PlotMemory {
+            mut auto_bounds,
+            mut hovered_entry,
+            mut hidden_items,
+            last_screen_transform,
+            ..
+        } = memory;
 
         // Call the plot build function.
         let mut plot_ui = PlotUi {
@@ -304,17 +311,19 @@ impl Plot {
             next_auto_color_idx: 0,
             last_screen_transform,
             response,
+            ctx: ui.ctx(),
         };
-        build_fn(&mut plot_ui);
+        let inner = build_fn(&mut plot_ui);
         let PlotUi {
             mut items,
-            response,
+            mut response,
+            last_screen_transform,
             ..
         } = plot_ui;
 
         // Background
         if show_background {
-            plot_painter.add(epaint::RectShape {
+            ui.painter().sub_region(rect).add(epaint::RectShape {
                 rect,
                 corner_radius: 2.0,
                 fill: ui.visuals().extreme_bg_color,
@@ -322,7 +331,7 @@ impl Plot {
             });
         }
 
-        // Legend
+        // --- Legend ---
         let legend = legend_config
             .and_then(|config| LegendWidget::try_new(rect, config, &items, &hidden_items));
         // Don't show hover cursor when hovering over legend.
@@ -341,6 +350,9 @@ impl Plot {
         }
         // Move highlighted items to front.
         items.sort_by_key(|item| item.highlighted());
+
+        // --- Bound computation ---
+        let mut bounds = *last_screen_transform.bounds();
 
         // Allow double clicking to reset to automatic bounds.
         auto_bounds |= response.double_clicked_by(PointerButton::Primary);
@@ -363,6 +375,7 @@ impl Plot {
 
         // Dragging
         if allow_drag && response.dragged_by(PointerButton::Primary) {
+            response = response.on_hover_cursor(CursorIcon::Grabbing);
             transform.translate_bounds(-response.drag_delta());
             auto_bounds = false;
         }
@@ -393,8 +406,6 @@ impl Plot {
             .iter_mut()
             .for_each(|item| item.initialize(transform.bounds().range_x()));
 
-        let bounds = *transform.bounds();
-
         let prepared = PreparedPlot {
             items,
             show_x,
@@ -411,33 +422,35 @@ impl Plot {
         }
 
         let memory = PlotMemory {
-            bounds,
             auto_bounds,
             hovered_entry,
             hidden_items,
             min_auto_bounds,
-            last_screen_transform: Some(transform),
+            last_screen_transform: transform,
         };
         memory.store(ui.ctx(), plot_id);
 
-        if show_x || show_y {
+        let response = if show_x || show_y {
             response.on_hover_cursor(CursorIcon::Crosshair)
         } else {
             response
-        }
+        };
+
+        InnerResponse { inner, response }
     }
 }
 
 /// Provides methods to interact with a plot while building it. It is the single argument of the closure
 /// provided to `Plot::show`. See [`Plot`] for an example of how to use it.
-pub struct PlotUi {
+pub struct PlotUi<'ctx> {
     items: Vec<Box<dyn PlotItem>>,
     next_auto_color_idx: usize,
-    last_screen_transform: Option<ScreenTransform>,
+    last_screen_transform: ScreenTransform,
     response: Response,
+    ctx: &'ctx CtxRef,
 }
 
-impl PlotUi {
+impl PlotUi<'_> {
     fn auto_color(&mut self) -> Color32 {
         let i = self.next_auto_color_idx;
         self.next_auto_color_idx += 1;
@@ -446,35 +459,43 @@ impl PlotUi {
         Hsva::new(h, 0.85, 0.5, 1.0).into() // TODO: OkLab or some other perspective color space
     }
 
-    /// The pointer position in plot coordinates, if the pointer is inside the plot area.
+    pub fn ctx(&self) -> &CtxRef {
+        self.ctx
+    }
+
+    /// The plot bounds as they were in the last frame.
+    pub fn plot_bounds(&self) -> PlotBounds {
+        *self.last_screen_transform.bounds()
+    }
+
+    /// Returns `true` if the plot area is currently hovered.
+    pub fn plot_hovered(&self) -> bool {
+        self.response.hovered()
+    }
+
+    /// The pointer position in plot coordinates. Independent of whether the pointer is in the plot area.
     pub fn pointer_coordinate(&self) -> Option<Value> {
-        let last_screen_transform = self.last_screen_transform.as_ref()?;
         // We need to subtract the drag delta to keep in sync with the frame-delayed screen transform:
-        let last_pos = self.response.hover_pos()? - self.response.drag_delta();
-        let value = last_screen_transform.value_from_position(last_pos);
+        let last_pos = self.ctx().input().pointer.latest_pos()? - self.response.drag_delta();
+        let value = self.plot_from_screen(last_pos);
         Some(value)
     }
 
     /// The pointer drag delta in plot coordinates.
     pub fn pointer_coordinate_drag_delta(&self) -> Vec2 {
-        self.last_screen_transform
-            .as_ref()
-            .map_or(Vec2::ZERO, |tf| {
-                let delta = self.response.drag_delta();
-                let dp_dv = tf.dpos_dvalue();
-                Vec2::new(delta.x / dp_dv[0] as f32, delta.y / dp_dv[1] as f32)
-            })
+        let delta = self.response.drag_delta();
+        let dp_dv = self.last_screen_transform.dpos_dvalue();
+        Vec2::new(delta.x / dp_dv[0] as f32, delta.y / dp_dv[1] as f32)
+    }
+
+    /// Transform the plot coordinates to screen coordinates.
+    pub fn screen_from_plot(&self, position: Value) -> Pos2 {
+        self.last_screen_transform.position_from_value(&position)
     }
 
     /// Transform the screen coordinates to plot coordinates.
-    pub fn plot_from_screen(&self, position: Pos2) -> Pos2 {
-        self.last_screen_transform
-            .as_ref()
-            .map_or(Pos2::ZERO, |tf| {
-                tf.position_from_value(&Value::new(position.x as f64, position.y as f64))
-            })
-            // We need to subtract the drag delta since the last frame.
-            - self.response.drag_delta()
+    pub fn plot_from_screen(&self, position: Pos2) -> Value {
+        self.last_screen_transform.value_from_position(position)
     }
 
     /// Add a data line.

--- a/egui_demo_lib/src/apps/demo/context_menu.rs
+++ b/egui_demo_lib/src/apps/demo/context_menu.rs
@@ -131,6 +131,7 @@ impl ContextMenus {
             .height(self.height)
             .data_aspect(1.0)
             .show(ui, |plot_ui| plot_ui.line(line))
+            .response
     }
 
     fn nested_menus(ui: &mut egui::Ui) {

--- a/egui_demo_lib/src/apps/demo/plot_demo.rs
+++ b/egui_demo_lib/src/apps/demo/plot_demo.rs
@@ -390,25 +390,27 @@ impl Widget for &mut InteractionDemo {
 
         let InnerResponse {
             response,
-            inner: (screen_pos, pointer_coordinate, pointer_coordinate_drag_delta, bounds),
+            inner: (screen_pos, pointer_coordinate, pointer_coordinate_drag_delta, bounds, hovered),
         } = plot.show(ui, |plot_ui| {
             (
                 plot_ui.screen_from_plot(Value::new(0.0, 0.0)),
                 plot_ui.pointer_coordinate(),
                 plot_ui.pointer_coordinate_drag_delta(),
                 plot_ui.plot_bounds(),
+                plot_ui.plot_hovered(),
             )
         });
 
         ui.label(format!(
-            "Plot bounds: min: {:.02?}, max: {:.02?}",
+            "plot bounds: min: {:.02?}, max: {:.02?}",
             bounds.min(),
             bounds.max()
         ));
         ui.label(format!(
-            "Origin in screen coordinates: x: {:.02}, y: {:.02}",
+            "origin in screen coordinates: x: {:.02}, y: {:.02}",
             screen_pos.x, screen_pos.y
         ));
+        ui.label(format!("plot hovered: {}", hovered));
         let coordinate_text = if let Some(coordinate) = pointer_coordinate {
             format!("x: {:.02}, y: {:.02}", coordinate.x, coordinate.y)
         } else {

--- a/egui_demo_lib/src/apps/demo/plot_demo.rs
+++ b/egui_demo_lib/src/apps/demo/plot_demo.rs
@@ -155,6 +155,7 @@ impl Widget for &mut LineDemo {
             plot_ui.line(self.sin());
             plot_ui.line(self.thingy());
         })
+        .response
     }
 }
 
@@ -225,11 +226,13 @@ impl Widget for &mut MarkerDemo {
         let markers_plot = Plot::new("markers_demo")
             .data_aspect(1.0)
             .legend(Legend::default());
-        markers_plot.show(ui, |plot_ui| {
-            for marker in self.markers() {
-                plot_ui.points(marker);
-            }
-        })
+        markers_plot
+            .show(ui, |plot_ui| {
+                for marker in self.markers() {
+                    plot_ui.points(marker);
+                }
+            })
+            .response
     }
 }
 
@@ -289,13 +292,15 @@ impl Widget for &mut LegendDemo {
         });
 
         let legend_plot = Plot::new("legend_demo").legend(*config).data_aspect(1.0);
-        legend_plot.show(ui, |plot_ui| {
-            plot_ui.line(LegendDemo::line_with_slope(0.5).name("lines"));
-            plot_ui.line(LegendDemo::line_with_slope(1.0).name("lines"));
-            plot_ui.line(LegendDemo::line_with_slope(2.0).name("lines"));
-            plot_ui.line(LegendDemo::sin().name("sin(x)"));
-            plot_ui.line(LegendDemo::cos().name("cos(x)"));
-        })
+        legend_plot
+            .show(ui, |plot_ui| {
+                plot_ui.line(LegendDemo::line_with_slope(0.5).name("lines"));
+                plot_ui.line(LegendDemo::line_with_slope(1.0).name("lines"));
+                plot_ui.line(LegendDemo::line_with_slope(2.0).name("lines"));
+                plot_ui.line(LegendDemo::sin().name("sin(x)"));
+                plot_ui.line(LegendDemo::cos().name("cos(x)"));
+            })
+            .response
     }
 }
 
@@ -366,45 +371,60 @@ impl Widget for &mut ItemsDemo {
             plot_ui.image(image.name("Image"));
             plot_ui.arrows(arrows.name("Arrows"));
         })
+        .response
     }
 }
 
 #[derive(PartialEq)]
-struct InteractionDemo {
-    pointer_coordinate: Option<Value>,
-    pointer_coordinate_drag_delta: Vec2,
-}
+struct InteractionDemo {}
 
 impl Default for InteractionDemo {
     fn default() -> Self {
-        Self {
-            pointer_coordinate: None,
-            pointer_coordinate_drag_delta: Vec2::ZERO,
-        }
+        Self {}
     }
 }
 
 impl Widget for &mut InteractionDemo {
     fn ui(self, ui: &mut Ui) -> Response {
-        let coordinate_text = if let Some(coordinate) = self.pointer_coordinate {
-            format!("x: {:.03}, y: {:.03}", coordinate.x, coordinate.y)
+        let plot = Plot::new("interaction_demo").height(300.0);
+
+        let InnerResponse {
+            response,
+            inner: (screen_pos, pointer_coordinate, pointer_coordinate_drag_delta, bounds),
+        } = plot.show(ui, |plot_ui| {
+            (
+                plot_ui.screen_from_plot(Value::new(0.0, 0.0)),
+                plot_ui.pointer_coordinate(),
+                plot_ui.pointer_coordinate_drag_delta(),
+                plot_ui.plot_bounds(),
+            )
+        });
+
+        ui.label(format!(
+            "Plot bounds: min: {:.02?}, max: {:.02?}",
+            bounds.min(),
+            bounds.max()
+        ));
+        ui.label(format!(
+            "Origin in screen coordinates: x: {:.02}, y: {:.02}",
+            screen_pos.x, screen_pos.y
+        ));
+        let coordinate_text = if let Some(coordinate) = pointer_coordinate {
+            format!("x: {:.02}, y: {:.02}", coordinate.x, coordinate.y)
         } else {
             "None".to_string()
         };
         ui.label(format!("pointer coordinate: {}", coordinate_text));
         let coordinate_text = format!(
-            "x: {:.03}, y: {:.03}",
-            self.pointer_coordinate_drag_delta.x, self.pointer_coordinate_drag_delta.y
+            "x: {:.02}, y: {:.02}",
+            pointer_coordinate_drag_delta.x, pointer_coordinate_drag_delta.y
         );
         ui.label(format!(
             "pointer coordinate drag delta: {}",
             coordinate_text
         ));
-        let plot = Plot::new("interaction_demo");
-        plot.show(ui, |plot_ui| {
-            self.pointer_coordinate = plot_ui.pointer_coordinate();
-            self.pointer_coordinate_drag_delta = plot_ui.pointer_coordinate_drag_delta();
-        })
+
+        response
     }
 }
 

--- a/egui_demo_lib/src/apps/demo/widget_gallery.rs
+++ b/egui_demo_lib/src/apps/demo/widget_gallery.rs
@@ -238,6 +238,7 @@ fn example_plot(ui: &mut egui::Ui) -> egui::Response {
         .height(32.0)
         .data_aspect(1.0)
         .show(ui, |plot_ui| plot_ui.line(line))
+        .response
 }
 
 fn doc_link_label<'a>(title: &'a str, search_term: &'a str) -> impl egui::Widget + 'a {


### PR DESCRIPTION
Closes #891 

Changes:
* Added access to the context with `plot_ui.ctx()` inside the plot `show` closure.
* More `PlotUi` methods: `ctx`, `plot_bounds`, `plot_hovered` and `screen_from_plot`.
* Simplified the way plot bounds and the screen transform are initialized.
* Fixed the `plot_from_screen` function.
* `Plot::show` now returns an `InnerResponse` to be consistent with similar functions.
* Improved demo

@emilk I noticed that the plot demo instructions say "Pan by dragging, or scroll (+ shift = horizontal).". This does not work on my system though. Is this a bug or is the note outdated?