### PR TITLE
eframe: don't prettify stored values

### DIFF
--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -413,10 +413,7 @@ pub fn get_value<T: serde::de::DeserializeOwned>(storage: &dyn Storage, key: &st
 /// Serialize the given value as [RON](https://github.com/ron-rs/ron) and store with the given key.
 #[cfg(feature = "ron")]
 pub fn set_value<T: serde::Serialize>(storage: &mut dyn Storage, key: &str, value: &T) {
-    storage.set_string(
-        key,
-        ron::ser::to_string_pretty(value, Default::default()).unwrap(),
-    );
+    storage.set_string(key, ron::ser::to_string(value).unwrap());
 }
 
 /// [`Storage`] key used for app


### PR DESCRIPTION
What ultimately ends up stored into a file is the
HashMap<String, String>, which when prettified only nets three
(depending on the settings) lines of "string": "long prettified
string that's really hard to read because of the extra indentation and
literal \n characters that are all just on one single line".

Not prettifying the values in the first place makes it somewhat easier
to read and also saves a bit of space.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and it is green.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Closes <https://github.com/emilk/egui/issues/THE_RELEVANT_ISSUE>.

