### PR TITLE
Disable glow scissor test after painting

### DIFF
--- a/egui_glow/examples/pure_glow.rs
+++ b/egui_glow/examples/pure_glow.rs
@@ -37,6 +37,8 @@ fn create_display(
 }
 
 fn main() {
+    let mut clear_color = [0.1, 0.1, 0.1];
+
     let event_loop = glutin::event_loop::EventLoop::with_user_event();
     let (gl_window, gl) = create_display(&event_loop);
 
@@ -52,6 +54,7 @@ fn main() {
                     if ui.button("Quit").clicked() {
                         quit = true;
                     }
+                    ui.color_edit_button_rgb(&mut clear_color);
                 });
             });
 
@@ -65,10 +68,9 @@ fn main() {
             };
 
             {
-                let color = egui::Rgba::from_rgb(0.1, 0.3, 0.2);
                 unsafe {
                     use glow::HasContext as _;
-                    gl.clear_color(color[0], color[1], color[2], color[3]);
+                    gl.clear_color(clear_color[0], clear_color[1], clear_color[2], 1.0);
                     gl.clear(glow::COLOR_BUFFER_BIT);
                 }
 

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -326,7 +326,7 @@ impl Painter {
             }
 
             gl.disable(glow::SCISSOR_TEST);
-            
+
             assert_eq!(glow::NO_ERROR, gl.get_error(), "GL error occurred!");
         }
     }

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -264,8 +264,8 @@ impl Painter {
         let width_in_points = width_in_pixels as f32 / pixels_per_point;
         let height_in_points = height_in_pixels as f32 / pixels_per_point;
 
-        gl.viewport(0, 0, width_in_pixels as i32, height_in_pixels as i32);
-
+        // gl.viewport(0, 0, width_in_pixels as i32, height_in_pixels as i32);
+        // gl.viewport(0, 0, 300, 300);
         gl.use_program(Some(self.program));
 
         gl.uniform_2_f32(Some(&self.u_screen_size), width_in_points, height_in_points);
@@ -324,6 +324,9 @@ impl Painter {
             if let Some(ref post_process) = self.post_process {
                 post_process.end(gl);
             }
+
+            gl.disable(glow::SCISSOR_TEST);
+            
             assert_eq!(glow::NO_ERROR, gl.get_error(), "GL error occurred!");
         }
     }

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -264,8 +264,7 @@ impl Painter {
         let width_in_points = width_in_pixels as f32 / pixels_per_point;
         let height_in_points = height_in_pixels as f32 / pixels_per_point;
 
-        // gl.viewport(0, 0, width_in_pixels as i32, height_in_pixels as i32);
-        // gl.viewport(0, 0, 300, 300);
+        gl.viewport(0, 0, width_in_pixels as i32, height_in_pixels as i32);
         gl.use_program(Some(self.program));
 
         gl.uniform_2_f32(Some(&self.u_screen_size), width_in_points, height_in_points);


### PR DESCRIPTION
Hello, this PR solved the issue better described in #904

basically if you don't disable the scissor test after drawing all the ui, the framebuffer goes bananas.

