### PR TITLE
Add hovered_anyway() to Response to deal with child widgets events when hovered

### DIFF
--- a/egui/src/response.rs
+++ b/egui/src/response.rs
@@ -185,12 +185,14 @@ impl Response {
         self.hovered
     }
 
+    /// The pointer is hovering above this widget or the widget was clicked/tapped this frame.
+    /// this can help to deal with child widgets events
     pub fn hovered_anyway(&self) -> bool {
         let pointer = &self.ctx.input().pointer;
         if let Some(pos) = pointer.interact_pos() {
             self.rect.contains(pos)
         } else {
-            false
+            self.hovered
         }
     }
 

--- a/egui/src/response.rs
+++ b/egui/src/response.rs
@@ -185,6 +185,15 @@ impl Response {
         self.hovered
     }
 
+    pub fn hovered_anyway(&self) -> bool {
+        let pointer = &self.ctx.input().pointer;
+        if let Some(pos) = pointer.interact_pos() {
+            self.rect.contains(pos)
+        } else {
+            false
+        }
+    }
+
     /// This widget has the keyboard focus (i.e. is receiving key presses).
     pub fn has_focus(&self) -> bool {
         self.ctx.memory().has_focus(self.id)


### PR DESCRIPTION
Add hovered_anyway() to Response, this can help to deal with child widgets events when current widget is hovered

## usage

![image](https://user-images.githubusercontent.com/14890680/142961548-bffd7192-3937-4b86-a8c6-0fb502380d97.png)

![image](https://user-images.githubusercontent.com/14890680/142961409-2960ff4a-e38b-4ace-a01a-48023d4e0c99.png)

