### PR TITLE
OrderedFloat refactor

### DIFF
--- a/egui/src/util/mod.rs
+++ b/egui/src/util/mod.rs
@@ -2,7 +2,6 @@
 
 pub mod cache;
 pub(crate) mod fixed_cache;
-pub(crate) mod float_ord;
 mod history;
 pub mod id_type_map;
 pub mod undoer;

--- a/egui/src/widgets/plot/items/mod.rs
+++ b/egui/src/widgets/plot/items/mod.rs
@@ -2,9 +2,9 @@
 
 use std::ops::RangeInclusive;
 
+use epaint::util::FloatOrd;
 use epaint::Mesh;
 
-use crate::util::float_ord::FloatOrd;
 use crate::*;
 
 use super::{PlotBounds, ScreenTransform};

--- a/egui/src/widgets/plot/mod.rs
+++ b/egui/src/widgets/plot/mod.rs
@@ -1,9 +1,9 @@
 //! Simple plotting library.
 
-use crate::util::float_ord::FloatOrd;
 use crate::*;
-use color::Hsva;
 use epaint::ahash::AHashSet;
+use epaint::color::Hsva;
+use epaint::util::FloatOrd;
 use items::PlotItem;
 use legend::LegendWidget;
 use transform::{PlotBounds, ScreenTransform};

--- a/epaint/src/lib.rs
+++ b/epaint/src/lib.rs
@@ -196,3 +196,15 @@ pub(crate) fn f32_hash<H: std::hash::Hasher>(state: &mut H, f: f32) {
         f.to_bits().hash(state);
     }
 }
+
+#[inline(always)]
+pub(crate) fn f64_hash<H: std::hash::Hasher>(state: &mut H, f: f64) {
+    if f == 0.0 {
+        state.write_u8(0);
+    } else if f.is_nan() {
+        state.write_u8(1);
+    } else {
+        use std::hash::Hash;
+        f.to_bits().hash(state);
+    }
+}

--- a/epaint/src/util/mod.rs
+++ b/epaint/src/util/mod.rs
@@ -1,3 +1,7 @@
+mod ordered_float;
+
+pub use ordered_float::*;
+
 /// Hash the given value with a predictable hasher.
 #[inline]
 pub fn hash(value: impl std::hash::Hash) -> u64 {

--- a/epaint/src/util/ordered_float.rs
+++ b/epaint/src/util/ordered_float.rs
@@ -1,11 +1,11 @@
-//! Total order on floating point types, assuming absence of NaN.
+//! Total order on floating point types.
 //! Can be used for sorting, min/max computation, and other collection algorithms.
 
 use std::cmp::Ordering;
 
 /// Totally orderable floating-point value
 /// For not `f32` is supported; could be made generic if necessary.
-pub(crate) struct OrderedFloat(f32);
+pub struct OrderedFloat(f32);
 
 impl Eq for OrderedFloat {}
 
@@ -42,7 +42,7 @@ impl Ord for OrderedFloat {
 }
 
 /// Extension trait to provide `ord` method
-pub(crate) trait FloatOrd {
+pub trait FloatOrd {
     /// Type to provide total order, useful as key in sorted contexts.
     fn ord(self) -> OrderedFloat;
 }

--- a/epaint/src/util/ordered_float.rs
+++ b/epaint/src/util/ordered_float.rs
@@ -2,6 +2,7 @@
 //! Can be used for sorting, min/max computation, and other collection algorithms.
 
 use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
 
 /// Totally orderable floating-point value
 /// For not `f32` is supported; could be made generic if necessary.
@@ -40,6 +41,14 @@ impl Ord for OrderedFloat {
         }
     }
 }
+
+impl Hash for OrderedFloat {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        crate::f32_hash(state, self.0);
+    }
+}
+
+// ----------------------------------------------------------------------------
 
 /// Extension trait to provide `ord` method
 pub trait FloatOrd {

--- a/epaint/src/util/ordered_float.rs
+++ b/epaint/src/util/ordered_float.rs
@@ -4,16 +4,18 @@
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 
-/// Totally orderable floating-point value
-/// For not `f32` is supported; could be made generic if necessary.
-pub struct OrderedFloat(f32);
+/// Wraps a floating-point value to add total order and hash.
+/// Possible types for `T` are `f32` and `f64`.
+///
+/// See also [`FloatOrd`].
+pub struct OrderedFloat<T>(T);
 
-impl Eq for OrderedFloat {}
+impl<T: Float> Eq for OrderedFloat<T> {}
 
-impl PartialEq<Self> for OrderedFloat {
+impl<T: Float> PartialEq<Self> for OrderedFloat<T> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        // NaNs are considered equal (equivalent when it comes to ordering
+        // NaNs are considered equal (equivalent) when it comes to ordering
         if self.0.is_nan() {
             other.0.is_nan()
         } else {
@@ -22,7 +24,7 @@ impl PartialEq<Self> for OrderedFloat {
     }
 }
 
-impl PartialOrd<Self> for OrderedFloat {
+impl<T: Float> PartialOrd<Self> for OrderedFloat<T> {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match self.0.partial_cmp(&other.0) {
@@ -32,7 +34,7 @@ impl PartialOrd<Self> for OrderedFloat {
     }
 }
 
-impl Ord for OrderedFloat {
+impl<T: Float> Ord for OrderedFloat<T> {
     #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         match self.partial_cmp(other) {
@@ -42,32 +44,84 @@ impl Ord for OrderedFloat {
     }
 }
 
-impl Hash for OrderedFloat {
+impl<T: Float> Hash for OrderedFloat<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        crate::f32_hash(state, self.0);
+        self.0.hash(state);
     }
 }
 
 // ----------------------------------------------------------------------------
 
-/// Extension trait to provide `ord` method
+/// Extension trait to provide `ord()` method.
+///
+/// Example with `f64`:
+/// ```
+/// use epaint::util::FloatOrd;
+///
+/// let array = [1.0, 2.5, 2.0];
+/// let max = array.iter().max_by_key(|val| val.ord());
+///
+/// assert_eq!(max, Some(&2.5));
+/// ```
 pub trait FloatOrd {
     /// Type to provide total order, useful as key in sorted contexts.
-    fn ord(self) -> OrderedFloat;
+    fn ord(self) -> OrderedFloat<Self>
+    where
+        Self: Sized;
 }
 
 impl FloatOrd for f32 {
     #[inline]
-    fn ord(self) -> OrderedFloat {
+    fn ord(self) -> OrderedFloat<f32> {
         OrderedFloat(self)
     }
 }
 
-// TODO ordering may break down at least significant digits due to f64 -> f32 conversion
-// Possible solutions: generic OrderedFloat<T>, always OrderedFloat(f64)
 impl FloatOrd for f64 {
     #[inline]
-    fn ord(self) -> OrderedFloat {
-        OrderedFloat(self as f32)
+    fn ord(self) -> OrderedFloat<f64> {
+        OrderedFloat(self)
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+/// Internal abstraction over floating point types
+#[doc(hidden)]
+pub trait Float: PartialOrd + PartialEq + private::FloatImpl {}
+impl Float for f32 {}
+impl Float for f64 {}
+
+// Keep this trait in private module, to avoid exposing its methods as extensions in user code
+mod private {
+    use super::*;
+
+    pub trait FloatImpl {
+        fn is_nan(&self) -> bool;
+        fn hash<H: Hasher>(&self, state: &mut H);
+    }
+
+    impl FloatImpl for f32 {
+        #[inline]
+        fn is_nan(&self) -> bool {
+            f32::is_nan(*self)
+        }
+
+        #[inline]
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            crate::f32_hash(state, *self);
+        }
+    }
+
+    impl FloatImpl for f64 {
+        #[inline]
+        fn is_nan(&self) -> bool {
+            f64::is_nan(*self)
+        }
+
+        #[inline]
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            crate::f64_hash(state, *self);
+        }
     }
 }


### PR DESCRIPTION
Following https://github.com/emilk/egui/pull/863#discussion_r757770991, this moves `egui/util/float_ord.rs` -> `epaint/util/ordered_float.rs` and implements `Hash` based on `epaint::f32_hash()`.

Open questions:
1. Currently, `f64::ord()` simply truncates to `f32`, which may yield incorrect results for high precision floats. I see three solutions:
   * Make `OrderedFloat` generic on the float type. A bit more complex implementation, as we need to create traits to abstract over `f32` and `f64` for `is_nan()` etc.
   * Use always `f32` (status quo) -- not recommended, can cause really nasty bugs
   * Use always `f64` -- safe, but might incur minor performance penalty
   
2. Should this be part of the public API?
   I moved it to a different crate, so it can't be `pub(crate)` anymore. However, we can mark it `#[doc(hidden)]` if it should stay an implementation detail.