### PR TITLE
Create & show CollapsingHeader with the given Id...

### DIFF
--- a/egui/src/containers/collapsing_header.rs
+++ b/egui/src/containers/collapsing_header.rs
@@ -171,7 +171,7 @@ impl CollapsingHeader {
             show_background: false,
         }
     }
-    
+
     /// By default [`CollapsingHeader`] uses label as [`Id`], here you can set a
     /// custom `Id` for it.
     ///

--- a/egui/src/containers/collapsing_header.rs
+++ b/egui/src/containers/collapsing_header.rs
@@ -171,6 +171,25 @@ impl CollapsingHeader {
             show_background: false,
         }
     }
+    
+    /// By default [`CollapsingHeader`] uses label as [`Id`], here you can set a
+    /// custom `Id` for it.
+    ///
+    /// Except the above statement, everyhthing is the same with [`Self::new` ]
+    /// constructor function.
+    pub fn with_id(text: impl Into<WidgetText>, id: impl std::hash::Hash) -> Self {
+        let text = text.into();
+        let id_source = Id::new(id);
+        Self {
+            text,
+            default_open: false,
+            id_source,
+            enabled: true,
+            selectable: false,
+            selected: false,
+            show_background: false,
+        }
+    }
 
     /// By default, the `CollapsingHeader` is collapsed.
     /// Call `.default_open(true)` to change this.

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -1420,6 +1420,16 @@ impl Ui {
         CollapsingHeader::new(heading).show(self, add_contents)
     }
 
+    /// Show [`CollapsedHeader`] with a custom [`Id`] parameter.
+    pub fn collapsing_with_id<R>(
+        &mut self,
+        heading: impl Into<WidgetText>,
+        id: impl std::hash::Hash,
+        add_contents: impl FnOnce(&mut Ui) -> R,
+    ) -> CollapsingResponse<R> {
+        CollapsingHeader::with_id(heading, id).show(self, add_contents)
+    }
+
     /// Create a child ui which is indented to the right.
     ///
     /// The `id_source` here be anything at all.


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and it is green.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->
Hi, I loved your work of art, the `egui`. It's perfect.

In my case I'm using `ui.collapse` with the same label twice, this of course id crashes, I've created two functions in order to solve this problem:

1. `CollapsingHeader::with_id(text: impl Into<WidgetText>, id: impl std::hash::Hash)`: create an Instance of the `CollapsingHeader` with the `id`. 
2. `ui.collapsing_with_id(&mut self, heading: impl Into<WidgetText>, id: impl std::hash::Hash, add_contents: impl FnOnce(&mut Ui))`: Create and show the `CollapsingHeader` with the given id.

Basically, they're almost the same functions as the constructor functions... 

Anyway, you got the point, thanks, take care!
