### PR TITLE
Fix #972: ScrollArea::stick_to_bottom() has no effect if ScrollArea is too little content

### DIFF
--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -707,13 +707,16 @@ impl Prepared {
         state.offset = state.offset.min(available_offset);
         state.offset = state.offset.max(Vec2::ZERO);
 
-        // Is scroll handle at end of content? If so enter sticky mode.
+        // Is scroll handle at end of content, or is there no scrollbar
+        // yet (not enough content), but sticking is requested? If so, enter sticky mode.
         // Only has an effect if stick_to_end is enabled but we save in
         // state anyway so that entering sticky mode at an arbitrary time
         // has appropriate effect.
         state.scroll_stuck_to_end = [
-            state.offset[0] == available_offset[0],
-            state.offset[1] == available_offset[1],
+            (state.offset[0] == available_offset[0])
+                || (self.stick_to_end[0] && available_offset[0] < 0.),
+            (state.offset[1] == available_offset[1])
+                || (self.stick_to_end[1] && available_offset[1] < 0.),
         ];
 
         state.show_scroll = show_scroll_this_frame;


### PR DESCRIPTION
The fix is a bit rough, but, I guess, acceptable.

Before the change:
![scrollarea-stick-bottom-fillup](https://user-images.githubusercontent.com/151199/146690104-972983b5-f400-4466-bb16-e99f2e210b78.gif)

After:
![scrollarea-stick-bottom-fillup-fixed](https://user-images.githubusercontent.com/151199/146690112-5bdee88c-9d1c-4b73-ac74-0f1844a79733.gif)

