### PR TITLE
0.16.1 patch release: Add back CtxRef::begin_frame/end_frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 ## Unreleased
 
 
+## 0.16.1 - 2021-12-31 - Add back `CtxRef::begin_frame,end_frame`
+
+### Added ⭐
+* Add back `CtxRef::begin_frame,end_frame` as an alternative to `CtxRef::run`.
+
+
 ## 0.16.0 - 2021-12-29 - Context menus and rich text
 
 ### Added ⭐

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "ahash",
  "epaint",

--- a/egui/Cargo.toml
+++ b/egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 description = "Simple, portable immediate mode GUI library for Rust"
 edition = "2021"

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -100,9 +100,6 @@ impl CtxRef {
     /// This will modify the internal reference to point to a new generation of [`Context`].
     /// Any old clones of this [`CtxRef`] will refer to the old [`Context`], which will not get new input.
     ///
-    /// In the future [`Self::run`] may be extended to do multi-pass,
-    /// i.e. call the application code twice. This will make
-    ///
     /// You can alternatively run [`Self::begin_single_pass_frame`] and [`Self::end_single_pass_frame`].
     ///
     /// ``` rust


### PR DESCRIPTION
`begin_frame`, `end_frame` is more convenient when using egui in a game engine. In particular, 0.16.0 was incompatible with <https://github.com/mvlabat/bevy_egui>.
