### PR TITLE
added splitter

### DIFF
--- a/egui/src/containers/mod.rs
+++ b/egui/src/containers/mod.rs
@@ -10,6 +10,7 @@ pub mod panel;
 pub mod popup;
 pub(crate) mod resize;
 pub(crate) mod scroll_area;
+pub(crate) mod splitter;
 pub(crate) mod window;
 
 pub use {
@@ -21,5 +22,6 @@ pub use {
     popup::*,
     resize::Resize,
     scroll_area::ScrollArea,
+    splitter::{Splitter, SplitterOrientation},
     window::Window,
 };

--- a/egui/src/containers/splitter.rs
+++ b/egui/src/containers/splitter.rs
@@ -1,0 +1,157 @@
+use epaint::{
+    emath::{lerp, Align},
+    pos2, vec2,
+};
+
+use crate::{egui_assert, Layout, Response, Sense, Ui};
+
+/// A splitter which can separate the UI into 2 parts either vertically or horizontally.
+///
+/// ```
+/// # egui::__run_test_ui(|ui| {
+/// egui::Splitter::vertical().show(ui |ui_left, ui_right| {
+///     ui_left.label("I'm on the left!");
+///     ui_right.label("I'm on the right!");
+/// })
+/// # });
+/// ```
+#[must_use = "You should call .show()"]
+pub struct Splitter {
+    orientation: SplitterOrientation,
+    ratio: f32,
+}
+
+impl Splitter {
+    /// Create a new splitter with the given orientation and a ratio of 0.5.
+    pub fn with_orientation(orientation: SplitterOrientation) -> Self {
+        Self {
+            orientation,
+            ratio: 0.5,
+        }
+    }
+
+    /// Create a new vertical splitter with a ratio of 0.5.
+    #[inline]
+    pub fn vertical() -> Self {
+        Self::with_orientation(SplitterOrientation::Vertical)
+    }
+
+    /// Create a new horizontal splitter with a ratio of 0.5.
+    #[inline]
+    pub fn horizontal() -> Self {
+        Self::with_orientation(SplitterOrientation::Horizontal)
+    }
+
+    /// Set the ratio of the splitter.
+    ///
+    /// The ratio sets where the splitter splits the current UI, where, depending on the
+    /// orientation, 0.0 would mean split at the very top/left and 1.0 would mean split at the very
+    /// bottom/right respectively. The ratio must be in the range 0.0..=1.0.
+    pub fn ratio(mut self, ratio: f32) -> Self {
+        self.ratio = ratio;
+        self
+    }
+
+    #[inline]
+    pub fn show<R>(
+        self,
+        ui: &mut Ui,
+        add_contents: impl FnOnce(&mut Ui, &mut Ui) -> R,
+    ) -> SplitterResponse<R> {
+        self.show_dyn(ui, Box::new(add_contents))
+    }
+
+    pub fn show_dyn<'c, R>(
+        self,
+        ui: &mut Ui,
+        add_contents: Box<dyn FnOnce(&mut Ui, &mut Ui) -> R + 'c>,
+    ) -> SplitterResponse<R> {
+        let Self { orientation, ratio } = self;
+
+        egui_assert!((0.0..=1.0).contains(&ratio));
+
+        let (rect, splitter_response) =
+            ui.allocate_exact_size(ui.available_size_before_wrap(), Sense::hover());
+
+        let line_pos_1 = match orientation {
+            SplitterOrientation::Vertical => pos2(lerp(rect.min.x..=rect.max.x, ratio), rect.min.y),
+            SplitterOrientation::Horizontal => {
+                pos2(rect.min.x, lerp(rect.min.y..=rect.max.y, ratio))
+            }
+        };
+
+        let line_pos_2 = match orientation {
+            SplitterOrientation::Vertical => line_pos_1 + vec2(0.0, rect.height()),
+            SplitterOrientation::Horizontal => line_pos_1 + vec2(rect.width(), 0.0),
+        };
+
+        let line_pos_1 = ui.painter().round_pos_to_pixels(line_pos_1);
+        let line_pos_2 = ui.painter().round_pos_to_pixels(line_pos_2);
+
+        ui.painter().line_segment(
+            [line_pos_1, line_pos_2],
+            ui.visuals().widgets.noninteractive.bg_stroke,
+        );
+
+        let top_left_rect = match orientation {
+            SplitterOrientation::Vertical => {
+                let mut rect = rect;
+                rect.max.x = line_pos_1.x - ui.style().spacing.item_spacing.x;
+                rect
+            }
+            SplitterOrientation::Horizontal => {
+                let mut rect = rect;
+                rect.max.y = line_pos_1.y - ui.style().spacing.item_spacing.y;
+                rect
+            }
+        };
+
+        let bottom_right_rect = match orientation {
+            SplitterOrientation::Vertical => {
+                let mut rect = rect;
+                rect.min.x = line_pos_1.x + ui.style().spacing.item_spacing.x;
+                rect
+            }
+            SplitterOrientation::Horizontal => {
+                let mut rect = rect;
+                rect.min.y = line_pos_1.y + ui.style().spacing.item_spacing.y;
+                rect
+            }
+        };
+
+        let mut top_left_ui = ui.child_ui(top_left_rect, Layout::top_down(Align::Min));
+        let mut bottom_right_ui = ui.child_ui(bottom_right_rect, Layout::top_down(Align::Min));
+
+        let body_returned = add_contents(&mut top_left_ui, &mut bottom_right_ui);
+
+        SplitterResponse {
+            splitter_response,
+            body_returned,
+            top_left_response: ui.interact(top_left_rect, top_left_ui.id(), Sense::hover()),
+            bottom_right_response: ui.interact(
+                bottom_right_rect,
+                bottom_right_ui.id(),
+                Sense::hover(),
+            ),
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum SplitterOrientation {
+    Horizontal,
+    Vertical,
+}
+
+/// The response of showing a Splitter
+pub struct SplitterResponse<R> {
+    /// The return value of the closure passed into show.
+    pub body_returned: R,
+    /// The response of the top or left UI depending on the splitter's orientation.
+    pub top_left_response: Response,
+    /// The response of the bottom or right UI depending on the splitter's orientation.
+    pub bottom_right_response: Response,
+    /// The response of the whole splitter widget.
+    pub splitter_response: Response,
+}

--- a/egui/src/containers/splitter.rs
+++ b/egui/src/containers/splitter.rs
@@ -9,10 +9,10 @@ use crate::{egui_assert, Layout, Response, Sense, Ui};
 ///
 /// ```
 /// # egui::__run_test_ui(|ui| {
-/// egui::Splitter::vertical().show(ui |ui_left, ui_right| {
+/// egui::Splitter::vertical().show(ui, |ui_left, ui_right| {
 ///     ui_left.label("I'm on the left!");
 ///     ui_right.label("I'm on the right!");
-/// })
+/// });
 /// # });
 /// ```
 #[must_use = "You should call .show()"]

--- a/egui_demo_lib/src/apps/demo/misc_demo_window.rs
+++ b/egui_demo_lib/src/apps/demo/misc_demo_window.rs
@@ -11,6 +11,8 @@ pub struct MiscDemoWindow {
     colors: ColorWidgets,
     tree: Tree,
     box_painting: BoxPainting,
+    splitter_orientation: SplitterOrientation,
+    splitter_ratio: f32,
 }
 
 impl Default for MiscDemoWindow {
@@ -22,10 +24,11 @@ impl Default for MiscDemoWindow {
             colors: Default::default(),
             tree: Tree::demo(),
             box_painting: Default::default(),
+            splitter_orientation: SplitterOrientation::Vertical,
+            splitter_ratio: 0.5,
         }
     }
 }
-
 impl Demo for MiscDemoWindow {
     fn name(&self) -> &'static str {
         "✨ Misc Demos"
@@ -109,6 +112,37 @@ impl View for MiscDemoWindow {
                     painter.line_segment([c, c + r * Vec2::angled(TAU * 1.0 / 8.0)], stroke);
                     painter.line_segment([c, c + r * Vec2::angled(TAU * 3.0 / 8.0)], stroke);
                 });
+            });
+
+        CollapsingHeader::new("Splitter")
+            .default_open(false)
+            .show(ui, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label("Orientation");
+                    ui.radio_value(
+                        &mut self.splitter_orientation,
+                        SplitterOrientation::Vertical,
+                        "Vertical",
+                    );
+                    ui.radio_value(
+                        &mut self.splitter_orientation,
+                        SplitterOrientation::Horizontal,
+                        "Horizontal",
+                    );
+                });
+
+                ui.add(Slider::new(&mut self.splitter_ratio, 0.0..=1.0).text("Ratio"));
+
+                Splitter::with_orientation(self.splitter_orientation)
+                    .ratio(self.splitter_ratio)
+                    .show(ui, |ui_1, ui_2| {
+                        ui_1.label("Left/Top");
+                        ui_1.label("Left/Top");
+                        ui_1.label("Left/Top");
+                        ui_2.label("Right/Bottom");
+                        ui_2.label("Right/Bottom");
+                        ui_2.label("Right/Bottom");
+                    });
             });
     }
 }


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and it is green.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Closes #944.

![image](https://user-images.githubusercontent.com/28735087/147855510-6e431ee3-512d-4a90-b034-627657c057c0.png)

The splitter currently still has some issues, which I'm not quite sure how to fix:
- Elements can overlap when the splitter is made too small
- The splitter only allocates the current available size, and not the size the containing widgets actually need.

Guidance would be much appreciated!