### PR TITLE
eframe: Add `clipboard` and `links` features

### DIFF
--- a/eframe/Cargo.toml
+++ b/eframe/Cargo.toml
@@ -30,8 +30,8 @@ epi = { version = "0.16.0", path = "../epi" }
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 egui-winit = { version = "0.16.0", path = "../egui-winit", default-features = false }
-egui_glium = { version = "0.16.0", path = "../egui_glium", default-features = false, features = ["clipboard", "epi", "links"], optional = true }
-egui_glow = { version = "0.16.0", path = "../egui_glow", default-features = false, features = ["clipboard", "epi", "links", "winit"], optional = true }
+egui_glium = { version = "0.16.0", path = "../egui_glium", default-features = false, features = ["epi"], optional = true }
+egui_glow = { version = "0.16.0", path = "../egui_glow", default-features = false, features = ["epi", "winit"], optional = true }
 
 # web:
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -42,11 +42,15 @@ image = { version = "0.23", default-features = false, features = ["png"] }
 rfd = "0.6"
 
 [features]
-default = ["default_fonts", "egui_glow"]
+default = ["default_fonts", "egui_glow", "clipboard", "links"]
 
 # If set, egui will use `include_bytes!` to bundle some fonts.
 # If you plan on specifying your own fonts you may disable this feature.
 default_fonts = ["egui/default_fonts"]
+
+clipboard = ["egui_glium/clipboard", "egui_glow/clipboard"]
+
+links = ["egui_glium/links", "egui_glow/links"]
 
 # Enable saving app state to disk.
 persistence = [


### PR DESCRIPTION
Rather than enabling them in the backends for all users, introduce
`clipboard` and `links` as eframe's top-level features and make them
default.

That way, people who don't want to use them (e.g. because of
clipboard's extra system dependencies) can disable default features
and bring in only what they need.