### PR TITLE
Add new function to animate f32 values

### DIFF
--- a/egui/src/animation_manager.rs
+++ b/egui/src/animation_manager.rs
@@ -3,12 +3,22 @@ use crate::{emath::remap_clamp, Id, IdMap, InputState};
 #[derive(Clone, Default)]
 pub(crate) struct AnimationManager {
     bools: IdMap<BoolAnim>,
+    values: IdMap<ValueAnim>,
 }
 
 #[derive(Clone, Debug)]
 struct BoolAnim {
     value: bool,
     /// when did `value` last toggle?
+    toggle_time: f64,
+}
+
+#[derive(Clone, Debug)]
+struct ValueAnim {
+    from_value: f32,
+    to_value: f32,
+    /// when did `value` last toggle?
+   
     toggle_time: f64,
 }
 
@@ -53,6 +63,43 @@ impl AnimationManager {
                 } else {
                     remap_clamp(time_since_toggle, 0.0..=animation_time, 1.0..=0.0)
                 }
+            }
+        }
+    }
+
+    pub fn animate_value(
+        &mut self,
+        input: &InputState,
+        animation_time: f32,
+        id: Id,
+       value:f32
+    ) -> f32 {
+        match self.values.get_mut(&id) {
+            None => {
+                self.values.insert(
+                    id,
+                    ValueAnim {
+                        from_value: value,
+                        to_value: value,
+                        toggle_time: -f64::INFINITY, // long time ago
+                    },
+                );
+                value
+            }
+            Some(anim) => {
+                let time_since_toggle = (input.time - anim.toggle_time) as f32;
+                // On the frame we toggle we don't want to return the old value,
+                // so we extrapolate forwards:
+                let time_since_toggle = time_since_toggle + input.predicted_dt;
+                let current_value=   remap_clamp(time_since_toggle, 0.0..=animation_time, anim.from_value..=anim.to_value);
+                if anim.to_value != value  {
+                    
+                    anim.from_value=current_value; //start new animation from current position of playing animation
+                    anim.to_value=value;
+                    anim.toggle_time = input.time;
+                } 
+                 current_value
+              
             }
         }
     }

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -828,6 +828,22 @@ impl Context {
         animated_value
     }
 
+    /// Allows you to smoothly change the f32 value. 
+    /// At the first call the value is written to memory. 
+    /// When it is called with a new Value, it comes to it smoothly in a given time.
+     pub fn animate_value_with_time(&self, id: Id, value: f32, animation_time: f32) -> f32 {
+        let animated_value =
+            self.animation_manager
+                .lock()
+                .animate_value(&self.input, animation_time, id, value);
+        let animation_in_progress = animated_value != value;
+        if animation_in_progress {
+            self.request_repaint();
+        } 
+        
+        animated_value
+    }
+
     /// Clear memory of any animations.
     pub fn clear_animations(&self) {
         *self.animation_manager.lock() = Default::default();


### PR DESCRIPTION
Add new function animate_value.
It makes the change in value not a step change, but a continuous one.