### PR TITLE
egui_glow: Add function to set the texture filter

### DIFF
--- a/egui_glow/CHANGELOG.md
+++ b/egui_glow/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to the `egui_glow` integration will be noted in this file.
 
 
 ## Unreleased
-* Added `set_scale_filter` method to `Painter`.
+* Added `set_texture_filter` method to `Painter`.
 
 ## 0.16.0 - 2021-12-29
 * Made winit/glutin an optional dependency ([#868](https://github.com/emilk/egui/pull/868)).

--- a/egui_glow/CHANGELOG.md
+++ b/egui_glow/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to the `egui_glow` integration will be noted in this file.
 
 
 ## Unreleased
-
+* Added `set_scale_filter` method to `Painter`.
 
 ## 0.16.0 - 2021-12-29
 * Made winit/glutin an optional dependency ([#868](https://github.com/emilk/egui/pull/868)).

--- a/egui_glow/CHANGELOG.md
+++ b/egui_glow/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to the `egui_glow` integration will be noted in this file.
 
 
 ## Unreleased
-* Added `set_texture_filter` method to `Painter`.
+* Added `set_texture_filter` method to `Painter` ((#1041)[https://github.com/emilk/egui/pull/1041]).
 
 ## 0.16.0 - 2021-12-29
 * Made winit/glutin an optional dependency ([#868](https://github.com/emilk/egui/pull/868)).

--- a/egui_glow/src/misc_util.rs
+++ b/egui_glow/src/misc_util.rs
@@ -6,7 +6,7 @@ pub(crate) fn srgbtexture2d(
     gl: &glow::Context,
     is_webgl_1: bool,
     srgb_support: bool,
-    scale_filter: u32,
+    texture_filter: u32,
     data: &[u8],
     w: usize,
     h: usize,
@@ -21,12 +21,12 @@ pub(crate) fn srgbtexture2d(
         gl.tex_parameter_i32(
             glow::TEXTURE_2D,
             glow::TEXTURE_MAG_FILTER,
-            scale_filter as i32,
+            texture_filter as i32,
         );
         gl.tex_parameter_i32(
             glow::TEXTURE_2D,
             glow::TEXTURE_MIN_FILTER,
-            scale_filter as i32,
+            texture_filter as i32,
         );
         gl.tex_parameter_i32(
             glow::TEXTURE_2D,

--- a/egui_glow/src/misc_util.rs
+++ b/egui_glow/src/misc_util.rs
@@ -6,6 +6,7 @@ pub(crate) fn srgbtexture2d(
     gl: &glow::Context,
     is_webgl_1: bool,
     srgb_support: bool,
+    scale_filter: u32,
     data: &[u8],
     w: usize,
     h: usize,
@@ -20,12 +21,12 @@ pub(crate) fn srgbtexture2d(
         gl.tex_parameter_i32(
             glow::TEXTURE_2D,
             glow::TEXTURE_MAG_FILTER,
-            glow::LINEAR as i32,
+            scale_filter as i32,
         );
         gl.tex_parameter_i32(
             glow::TEXTURE_2D,
             glow::TEXTURE_MIN_FILTER,
-            glow::LINEAR as i32,
+            scale_filter as i32,
         );
         gl.tex_parameter_i32(
             glow::TEXTURE_2D,

--- a/egui_glow/src/misc_util.rs
+++ b/egui_glow/src/misc_util.rs
@@ -2,11 +2,13 @@
 use glow::HasContext;
 use std::option::Option::Some;
 
+use crate::painter::TextureFilter;
+
 pub(crate) fn srgbtexture2d(
     gl: &glow::Context,
     is_webgl_1: bool,
     srgb_support: bool,
-    texture_filter: u32,
+    texture_filter: TextureFilter,
     data: &[u8],
     w: usize,
     h: usize,
@@ -21,12 +23,12 @@ pub(crate) fn srgbtexture2d(
         gl.tex_parameter_i32(
             glow::TEXTURE_2D,
             glow::TEXTURE_MAG_FILTER,
-            texture_filter as i32,
+            texture_filter.glow_code() as i32,
         );
         gl.tex_parameter_i32(
             glow::TEXTURE_2D,
             glow::TEXTURE_MIN_FILTER,
-            texture_filter as i32,
+            texture_filter.glow_code() as i32,
         );
         gl.tex_parameter_i32(
             glow::TEXTURE_2D,

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -413,7 +413,7 @@ impl Painter {
     }
 
     // Set the filter to be used for any subsequent textures loaded via
-    // `set_texture`.
+    // [`Self::set_texture`].
     pub fn set_texture_filter(&mut self, texture_filter: TextureFilter) {
         self.texture_filter = texture_filter;
     }

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -36,7 +36,7 @@ pub struct Painter {
     vertex_array: crate::misc_util::VAO,
     srgb_support: bool,
     /// The filter used for subsequent textures.
-    texture_filter: u32,
+    texture_filter: TextureFilter,
     post_process: Option<PostProcess>,
     vertex_buffer: glow::Buffer,
     element_array_buffer: glow::Buffer,
@@ -67,7 +67,7 @@ impl Default for TextureFilter {
 }
 
 impl TextureFilter {
-    fn glow_code(&self) -> u32 {
+    pub(crate) fn glow_code(&self) -> u32 {
         match self {
             TextureFilter::Linear => glow::LINEAR,
             TextureFilter::Nearest => glow::NEAREST,
@@ -213,7 +213,7 @@ impl Painter {
                 is_embedded: matches!(shader_version, ShaderVersion::Es100 | ShaderVersion::Es300),
                 vertex_array,
                 srgb_support,
-                texture_filter: TextureFilter::default().glow_code(),
+                texture_filter: Default::default(),
                 post_process,
                 vertex_buffer,
                 element_array_buffer,
@@ -415,7 +415,7 @@ impl Painter {
     // Set the filter to be used for any subsequent textures loaded via
     // `set_texture`.
     pub fn set_texture_filter(&mut self, texture_filter: TextureFilter) {
-        self.texture_filter = texture_filter.glow_code();
+        self.texture_filter = texture_filter;
     }
 
     // ------------------------------------------------------------------------

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -35,7 +35,8 @@ pub struct Painter {
     is_embedded: bool,
     vertex_array: crate::misc_util::VAO,
     srgb_support: bool,
-    scale_filter: u32,
+    /// The filter used for subsequent textures.
+    texture_filter: u32,
     post_process: Option<PostProcess>,
     vertex_buffer: glow::Buffer,
     element_array_buffer: glow::Buffer,
@@ -54,22 +55,22 @@ pub struct Painter {
 }
 
 #[derive(Copy, Clone)]
-pub enum ScaleFilter {
+pub enum TextureFilter {
     Linear,
     Nearest,
 }
 
-impl Default for ScaleFilter {
+impl Default for TextureFilter {
     fn default() -> Self {
-        ScaleFilter::Linear
+        TextureFilter::Linear
     }
 }
 
-impl ScaleFilter {
+impl TextureFilter {
     fn glow_code(&self) -> u32 {
         match self {
-            ScaleFilter::Linear => glow::LINEAR,
-            ScaleFilter::Nearest => glow::NEAREST,
+            TextureFilter::Linear => glow::LINEAR,
+            TextureFilter::Nearest => glow::NEAREST,
         }
     }
 }
@@ -212,7 +213,7 @@ impl Painter {
                 is_embedded: matches!(shader_version, ShaderVersion::Es100 | ShaderVersion::Es300),
                 vertex_array,
                 srgb_support,
-                scale_filter: ScaleFilter::default().glow_code(),
+                texture_filter: TextureFilter::default().glow_code(),
                 post_process,
                 vertex_buffer,
                 element_array_buffer,
@@ -247,7 +248,7 @@ impl Painter {
                 gl,
                 self.is_webgl_1,
                 self.srgb_support,
-                self.scale_filter,
+                self.texture_filter,
                 &pixels,
                 font_image.width,
                 font_image.height,
@@ -413,8 +414,8 @@ impl Painter {
 
     // Set the filter to be used for any subsequent textures loaded via
     // `set_texture`.
-    pub fn set_scale_filter(&mut self, scale_filter: ScaleFilter) {
-        self.scale_filter = scale_filter.glow_code();
+    pub fn set_texture_filter(&mut self, texture_filter: TextureFilter) {
+        self.texture_filter = texture_filter.glow_code();
     }
 
     // ------------------------------------------------------------------------
@@ -440,7 +441,7 @@ impl Painter {
             gl,
             self.is_webgl_1,
             self.srgb_support,
-            self.scale_filter,
+            self.texture_filter,
             &pixels,
             image.size[0],
             image.size[1],


### PR DESCRIPTION
This commit adds a `set_scale_filter` method to the `glow` painter so that
textures can be set to scale using nearest-neighbour scaling rather than
linear. This is useful for pixel art.

I wasn't entirely sure what kind of API you want for this kind of change so I
went with what seemed least intrusive, I don't mind doing something more
holistic if this isn't what you had in mind.

Linear:
<img width="474" alt="image" src="https://user-images.githubusercontent.com/409075/148183351-2e337611-1254-4921-9af4-ce49585f8471.png">


Nearest:
<img width="484" alt="image" src="https://user-images.githubusercontent.com/409075/148183291-f840bfdc-c189-4f38-b524-12749ac8f816.png">


<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and it is green.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

