### PR TITLE
add back repaint_signal in epi::Frame

### DIFF
--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -319,6 +319,11 @@ impl Frame {
         self.lock().output.drag_window = true;
     }
 
+    /// If you need to request a repaint from another thread, send it to that other thread.
+    pub fn repaint_signal(&self) -> Arc<dyn backend::RepaintSignal> {
+        self.lock().repaint_signal.clone()
+    }
+
     /// This signals the [`egui`] integration that a repaint is required.
     ///
     /// Call this e.g. when a background process finishes in an async context and/or background thread.


### PR DESCRIPTION
repaint_signal was removed from epi::Frame in version 0.16
I was using that to trigger repaints at a frequency below the screen refresh rate.

Is there a better way to do that these days?
