### PR TITLE
Revert "Don't constrain immovable egui windows to native window (#1049)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 
 ### Fixed 🐛
 * Context menu now respects the theme ([#1043](https://github.com/emilk/egui/pull/1043))
-* Immovable windows can no longer incorrectly move ([#1049](https://github.com/emilk/egui/pull/1049))
 
 ## 0.16.1 - 2021-12-31 - Add back `CtxRef::begin_frame,end_frame`
 

--- a/egui/src/containers/window.rs
+++ b/egui/src/containers/window.rs
@@ -399,11 +399,9 @@ impl<'open> Window<'open> {
             content_inner
         };
 
-        if area.movable {
-            area.state_mut().pos = ctx
-                .constrain_window_rect_to_area(area.state().rect(), area.drag_bounds())
-                .min;
-        }
+        area.state_mut().pos = ctx
+            .constrain_window_rect_to_area(area.state().rect(), area.drag_bounds())
+            .min;
 
         let full_response = area.end(ctx, area_content_ui);
 
@@ -510,11 +508,7 @@ fn interact(
     let new_rect = move_and_resize_window(ctx, &window_interaction)?;
     let new_rect = ctx.round_rect_to_pixels(new_rect);
 
-    let new_rect = if area.movable {
-        ctx.constrain_window_rect_to_area(new_rect, area.drag_bounds())
-    } else {
-        new_rect
-    };
+    let new_rect = ctx.constrain_window_rect_to_area(new_rect, area.drag_bounds());
 
     // TODO: add this to a Window state instead as a command "move here next frame"
     area.state_mut().pos = new_rect.min;


### PR DESCRIPTION
This reverts commit 7b641be7b06be8b81b66d63968f081718acc7c89.
It accidentally disabled constraining for all windows.

While making the commit I did not notice this line:
https://github.com/emilk/egui/blob/342737e2f0510873493d9e397b985501a82cb269/egui/src/containers/window.rs#L278

..so I accidentally turned off constraining for all windows. Interestingly enough I did not observe this in the project I used for testing the fix.

Sorry for the inconvenience!

Hopefully I can come up with a proper fix for https://github.com/emilk/egui/issues/1048. Though I'm not quite sure what would be the best fix, which is why I am just reverting for now.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and it is green.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->
