### PR TITLE
Split `Event::Text` into `Text` and `Paste`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 
 ### Changed 🔧
 * Renamed `Ui::visible` to `Ui::is_visible`.
+* Split `Event::Text` into `Event::Text` and `Event::Paste` ([#1057](https://github.com/emilk/egui/issues/1057).
 
 ### Fixed 🐛
 * Context menu now respects the theme ([#1043](https://github.com/emilk/egui/pull/1043))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 
 ### Changed 🔧
 * Renamed `Ui::visible` to `Ui::is_visible`.
-* Split `Event::Text` into `Event::Text` and `Event::Paste` ([#1057](https://github.com/emilk/egui/issues/1057).
+* Split `Event::Text` into `Event::Text` and `Event::Paste` ([#1058](https://github.com/emilk/egui/pull/1058)).
 
 ### Fixed 🐛
 * Context menu now respects the theme ([#1043](https://github.com/emilk/egui/pull/1043))

--- a/egui-winit/src/lib.rs
+++ b/egui-winit/src/lib.rs
@@ -484,7 +484,7 @@ impl State {
                     if let Some(contents) = self.clipboard.get() {
                         self.egui_input
                             .events
-                            .push(egui::Event::Text(contents.replace("\r\n", "\n")));
+                            .push(egui::Event::Paste(contents.replace("\r\n", "\n")));
                     }
                 }
             }

--- a/egui/src/data/input.rs
+++ b/egui/src/data/input.rs
@@ -148,7 +148,9 @@ pub enum Event {
     Copy,
     /// The integration detected a "cut" event (e.g. Cmd+X).
     Cut,
-    /// Text input, e.g. via keyboard or paste action.
+    /// The integration detected a "paste" event (e.g. Cmd+V).
+    Paste(String),
+    /// Text input, e.g. via keyboard.
     ///
     /// When the user presses enter/return, do not send a `Text` (just [`Key::Enter`]).
     Text(String),

--- a/egui/src/widgets/text_edit/builder.rs
+++ b/egui/src/widgets/text_edit/builder.rs
@@ -684,6 +684,15 @@ fn events(
                     Some(CCursorRange::one(delete_selected(text, &cursor_range)))
                 }
             }
+            Event::Paste(text_to_insert) => {
+                if !text_to_insert.is_empty() {
+                    let mut ccursor = delete_selected(text, &cursor_range);
+                    insert_text(&mut ccursor, text, text_to_insert);
+                    Some(CCursorRange::one(ccursor))
+                } else {
+                    None
+                }
+            }
             Event::Text(text_to_insert) => {
                 // Newlines are handled by `Key::Enter`.
                 if !text_to_insert.is_empty() && text_to_insert != "\n" && text_to_insert != "\r" {

--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -622,7 +622,7 @@ fn install_document_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
                         .input
                         .raw
                         .events
-                        .push(egui::Event::Text(text.replace("\r\n", "\n")));
+                        .push(egui::Event::Paste(text.replace("\r\n", "\n")));
                     runner_lock.needs_repaint.set_true();
                     event.stop_propagation();
                     event.prevent_default();


### PR DESCRIPTION
As lightly discussed on Discord.  Here is the draft PR for separating a `Paste` event and `Text` input event. The purpose is such that we can paste text into the window, without needing to be in a text box, and then we know that it's paste event, and not just keyboard input.

Note: This will likely break some applications which rely on the `Text` input event for a paste.

Closes <https://github.com/emilk/egui/issues/1057>.

