### PR TITLE
make next_widget_position public

### DIFF
--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -748,7 +748,7 @@ impl Ui {
     }
 
     /// Where do we expect a zero-sized widget to be placed?
-    pub(crate) fn next_widget_position(&self) -> Pos2 {
+    pub fn next_widget_position(&self) -> Pos2 {
         self.placer.next_widget_position()
     }
 


### PR DESCRIPTION
I'm implementing this viewport layout
![grafik](https://user-images.githubusercontent.com/22177966/148821078-29ff8e32-2692-40f9-afea-6c14c769e065.png)
In order to provide the 3d camera with the correct viewport I need to know where and how large the inner space is.

```rust
let position = ui.next_widget_position();
let size = ui.available_size();
```
does excactly what I want, sadly the first method is private.

This PR would allow me to use it :)