### PR TITLE
Make `color_picker_hsva_2d` public.

### DIFF
--- a/egui/src/widgets/color_picker.rs
+++ b/egui/src/widgets/color_picker.rs
@@ -308,8 +308,10 @@ fn color_picker_hsvag_2d(ui: &mut Ui, hsva: &mut HsvaGamma, alpha: Alpha) {
     color_slider_2d(ui, v, s, |v, s| HsvaGamma { s, v, ..opaque }.into());
 }
 
+//// Shows a color picker where the user can change the given Hsva color.
+///
 /// Returns `true` on change.
-fn color_picker_hsva_2d(ui: &mut Ui, hsva: &mut Hsva, alpha: Alpha) -> bool {
+pub fn color_picker_hsva_2d(ui: &mut Ui, hsva: &mut Hsva, alpha: Alpha) -> bool {
     let mut hsvag = HsvaGamma::from(*hsva);
     ui.vertical(|ui| {
         color_picker_hsvag_2d(ui, &mut hsvag, alpha);
@@ -323,7 +325,7 @@ fn color_picker_hsva_2d(ui: &mut Ui, hsva: &mut Hsva, alpha: Alpha) -> bool {
     }
 }
 
-/// Shows a color picker where the user can change the given color.
+/// Shows a color picker where the user can change the given Color32 color.
 ///
 /// Returns `true` on change.
 pub fn color_picker_color32(ui: &mut Ui, srgba: &mut Color32, alpha: Alpha) -> bool {

--- a/egui/src/widgets/color_picker.rs
+++ b/egui/src/widgets/color_picker.rs
@@ -308,7 +308,7 @@ fn color_picker_hsvag_2d(ui: &mut Ui, hsva: &mut HsvaGamma, alpha: Alpha) {
     color_slider_2d(ui, v, s, |v, s| HsvaGamma { s, v, ..opaque }.into());
 }
 
-//// Shows a color picker where the user can change the given Hsva color.
+//// Shows a color picker where the user can change the given [`Hsva`] color.
 ///
 /// Returns `true` on change.
 pub fn color_picker_hsva_2d(ui: &mut Ui, hsva: &mut Hsva, alpha: Alpha) -> bool {

--- a/egui/src/widgets/color_picker.rs
+++ b/egui/src/widgets/color_picker.rs
@@ -325,7 +325,7 @@ pub fn color_picker_hsva_2d(ui: &mut Ui, hsva: &mut Hsva, alpha: Alpha) -> bool 
     }
 }
 
-/// Shows a color picker where the user can change the given Color32 color.
+/// Shows a color picker where the user can change the given [`Color32`] color.
 ///
 /// Returns `true` on change.
 pub fn color_picker_color32(ui: &mut Ui, srgba: &mut Color32, alpha: Alpha) -> bool {


### PR DESCRIPTION
Exposes `color_picker_hsva_2d`, so the color picker can be shown without an egui button. A similar public function exists, but it converts the color to `Color32`.

I use this to show the color picker on top of a custom UI.

<img width="1392" alt="Screen Shot 2022-01-10 at 11 24 20" src="https://user-images.githubusercontent.com/1069462/148826783-90dfd8b7-2d97-49f3-abd4-df99065eb9fe.png">


