### PR TITLE
egui_glow: Optimize Painter::set_texture

### DIFF
--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -432,19 +432,17 @@ impl Painter {
             "Mismatch between texture size and texel count"
         );
 
-        // TODO: optimize
-        let pixels: Vec<u8> = image
-            .pixels
-            .iter()
-            .flat_map(|srgba| Vec::from(srgba.to_array()))
-            .collect();
+        let mut data = Vec::with_capacity(image.pixels.len() * 4);
+        for srgba in &image.pixels {
+            data.extend_from_slice(&srgba.to_array());
+        }
 
         let gl_texture = srgb_texture2d(
             gl,
             self.is_webgl_1,
             self.srgb_support,
             self.texture_filter,
-            &pixels,
+            &data,
             image.size[0],
             image.size[1],
         );


### PR DESCRIPTION
`Painter::set_texture` for some reason was allocating new Vec for every single pixel in image. For 1280x720 image, there was about a million `malloc` calls. By optimizing this code to allocate Vec only once, I got this function running 20x faster on my machine.