### PR TITLE
egui_glow: Reduce memory allocations in Painter::set_texture

### DIFF
--- a/egui_glow/Cargo.toml
+++ b/egui_glow/Cargo.toml
@@ -23,11 +23,12 @@ include = [
 all-features = true
 
 [dependencies]
-egui = { version = "0.16.0", path = "../egui", default-features = false, features = ["single_threaded"] }
+egui = { version = "0.16.0", path = "../egui", default-features = false, features = ["single_threaded", "convert_bytemuck"] }
 
 epi = { version = "0.16.0", path = "../epi", optional = true }
 glow = "0.11"
 memoffset = "0.6"
+bytemuck = "1.7"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 egui-winit = { version = "0.16.0", path = "../egui-winit", default-features = false, features = ["epi"], optional = true }

--- a/egui_glow/Cargo.toml
+++ b/egui_glow/Cargo.toml
@@ -25,10 +25,10 @@ all-features = true
 [dependencies]
 egui = { version = "0.16.0", path = "../egui", default-features = false, features = ["single_threaded", "convert_bytemuck"] }
 
+bytemuck = "1.7"
 epi = { version = "0.16.0", path = "../epi", optional = true }
 glow = "0.11"
 memoffset = "0.6"
-bytemuck = "1.7"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 egui-winit = { version = "0.16.0", path = "../egui-winit", default-features = false, features = ["epi"], optional = true }

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -2,13 +2,13 @@
 
 use std::collections::HashMap;
 
+use bytemuck::cast_slice;
 use egui::{
     emath::Rect,
     epaint::{Color32, Mesh, Vertex},
 };
 use glow::HasContext;
 use memoffset::offset_of;
-use bytemuck::cast_slice;
 
 use crate::misc_util::{
     as_u8_slice, check_for_gl_error, compile_shader, glow_print, link_program, srgb_texture2d,

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -8,6 +8,7 @@ use egui::{
 };
 use glow::HasContext;
 use memoffset::offset_of;
+use bytemuck::cast_slice;
 
 use crate::misc_util::{
     as_u8_slice, check_for_gl_error, compile_shader, glow_print, link_program, srgb_texture2d,
@@ -434,17 +435,14 @@ impl Painter {
             "Mismatch between texture size and texel count"
         );
 
-        let mut data = Vec::with_capacity(image.pixels.len() * 4);
-        for srgba in &image.pixels {
-            data.extend_from_slice(&srgba.to_array());
-        }
+        let data: &[u8] = cast_slice(image.pixels.as_ref());
 
         let gl_texture = srgb_texture2d(
             gl,
             self.is_webgl_1,
             self.srgb_support,
             self.texture_filter,
-            &data,
+            data,
             image.size[0],
             image.size[1],
         );


### PR DESCRIPTION
Use `bytemuck::cast_slice` to cast `image.pixels`. Thanks @emilk for this solution.