### PR TITLE
Texture loading in egui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 ## Unreleased
 
 ### Added ⭐
+* `Context::load_texture` to convert an image into a texture which can be displayed using e.g. `ui.image(texture, size)` ([#1110](https://github.com/emilk/egui/pull/1110)).
 * Added `Ui::add_visible` and `Ui::add_visible_ui`.
 
 ### Changed 🔧
@@ -18,6 +19,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * `Context` can now be cloned and stored between frames ([#1050](https://github.com/emilk/egui/pull/1050)).
 * Renamed `Ui::visible` to `Ui::is_visible`.
 * Split `Event::Text` into `Event::Text` and `Event::Paste` ([#1058](https://github.com/emilk/egui/pull/1058)).
+* For integrations: `FontImage` has been replaced by `TexturesDelta` (found in `Output`), describing what textures were loaded and freed each frame ([#1110](https://github.com/emilk/egui/pull/1110)).
 
 ### Fixed 🐛
 * Context menu now respects the theme ([#1043](https://github.com/emilk/egui/pull/1043))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,6 +841,7 @@ dependencies = [
 name = "egui_glium"
 version = "0.16.0"
 dependencies = [
+ "ahash",
  "egui",
  "egui-winit",
  "epi",
@@ -852,6 +853,7 @@ dependencies = [
 name = "egui_glow"
 version = "0.16.0"
 dependencies = [
+ "bytemuck",
  "egui",
  "egui-winit",
  "epi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,7 @@ dependencies = [
 name = "egui_web"
 version = "0.16.0"
 dependencies = [
+ "bytemuck",
  "egui",
  "egui_glow",
  "epi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,6 +842,7 @@ name = "egui_glium"
 version = "0.16.0"
 dependencies = [
  "ahash",
+ "bytemuck",
  "egui",
  "egui-winit",
  "epi",

--- a/eframe/CHANGELOG.md
+++ b/eframe/CHANGELOG.md
@@ -5,6 +5,7 @@ NOTE: [`egui_web`](egui_web/CHANGELOG.md), [`egui-winit`](egui-winit/CHANGELOG.m
 
 
 ## Unreleased
+* Removed `Frame::alloc_texture`. Use `egui::Context::load_texture` instead ([#1110](https://github.com/emilk/egui/pull/1110)).
 * The default native backend is now `egui_glow` (instead of `egui_glium`) ([#1020](https://github.com/emilk/egui/pull/1020)).
 * The default web painter is now `egui_glow` (instead of WebGL) ([#1020](https://github.com/emilk/egui/pull/1020)).
 

--- a/eframe/examples/image.rs
+++ b/eframe/examples/image.rs
@@ -15,7 +15,7 @@ impl epi::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
         let texture: &egui::TextureHandle = self.texture.get_or_insert_with(|| {
             let image = load_image(include_bytes!("rust-logo-256x256.png"));
-            ctx.alloc_texture("rust-logo", image)
+            ctx.load_texture("rust-logo", image)
         });
 
         egui::CentralPanel::default().show(ctx, |ui| {

--- a/eframe/examples/image.rs
+++ b/eframe/examples/image.rs
@@ -14,7 +14,7 @@ impl epi::App for MyApp {
 
     fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
         let texture: &egui::TextureHandle = self.texture.get_or_insert_with(|| {
-            let image = load_image(include_bytes!("rust-logo-256x256.png"));
+            let image = load_image(include_bytes!("rust-logo-256x256.png")).unwrap();
             ctx.load_texture("rust-logo", image)
         });
 
@@ -33,11 +33,14 @@ fn main() {
     eframe::run_native(Box::new(MyApp::default()), options);
 }
 
-fn load_image(image_data: &[u8]) -> egui::ColorImage {
-    use image::GenericImageView;
-    let image = image::load_from_memory(image_data).expect("Failed to load image");
+fn load_image(image_data: &[u8]) -> Result<egui::ColorImage, image::ImageError> {
+    use image::GenericImageView as _;
+    let image = image::load_from_memory(image_data)?;
+    let size = [image.width() as _, image.height() as _];
     let image_buffer = image.to_rgba8();
-    let size = [image.width() as usize, image.height() as usize];
-    let pixels = image_buffer.into_vec();
-    egui::ColorImage::from_rgba_unmultiplied(size, &pixels)
+    let pixels = image_buffer.as_flat_samples();
+    Ok(egui::ColorImage::from_rgba_unmultiplied(
+        size,
+        pixels.as_slice(),
+    ))
 }

--- a/eframe/examples/image.rs
+++ b/eframe/examples/image.rs
@@ -4,7 +4,7 @@ use eframe::{egui, epi};
 
 #[derive(Default)]
 struct MyApp {
-    texture: Option<(egui::Vec2, egui::TextureId)>,
+    texture: Option<egui::TextureHandle>,
 }
 
 impl epi::App for MyApp {
@@ -12,31 +12,18 @@ impl epi::App for MyApp {
         "Show an image with eframe/egui"
     }
 
-    fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
-        if self.texture.is_none() {
-            // Load the image:
-            let image_data = include_bytes!("rust-logo-256x256.png");
-            use image::GenericImageView;
-            let image = image::load_from_memory(image_data).expect("Failed to load image");
-            let image_buffer = image.to_rgba8();
-            let size = [image.width() as usize, image.height() as usize];
-            let pixels = image_buffer.into_vec();
-            let image = egui::ImageData::from_rgba_unmultiplied(size, &pixels);
-
-            // Allocate a texture:
-            let texture = frame.alloc_texture(image);
-            let size = egui::Vec2::new(size[0] as f32, size[1] as f32);
-            self.texture = Some((size, texture));
-        }
+    fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
+        let texture: &egui::TextureHandle = self.texture.get_or_insert_with(|| {
+            let image = load_image(include_bytes!("rust-logo-256x256.png"));
+            ctx.alloc_texture("rust-logo", image)
+        });
 
         egui::CentralPanel::default().show(ctx, |ui| {
-            if let Some((size, texture)) = self.texture {
-                ui.heading("This is an image:");
-                ui.image(texture, size);
+            ui.heading("This is an image:");
+            ui.image(texture, texture.size_vec2());
 
-                ui.heading("This is an image you can click:");
-                ui.add(egui::ImageButton::new(texture, size));
-            }
+            ui.heading("This is an image you can click:");
+            ui.add(egui::ImageButton::new(texture, texture.size_vec2()));
         });
     }
 }
@@ -44,4 +31,13 @@ impl epi::App for MyApp {
 fn main() {
     let options = eframe::NativeOptions::default();
     eframe::run_native(Box::new(MyApp::default()), options);
+}
+
+fn load_image(image_data: &[u8]) -> egui::ColorImage {
+    use image::GenericImageView;
+    let image = image::load_from_memory(image_data).expect("Failed to load image");
+    let image_buffer = image.to_rgba8();
+    let size = [image.width() as usize, image.height() as usize];
+    let pixels = image_buffer.into_vec();
+    egui::ColorImage::from_rgba_unmultiplied(size, &pixels)
 }

--- a/eframe/examples/image.rs
+++ b/eframe/examples/image.rs
@@ -21,7 +21,7 @@ impl epi::App for MyApp {
             let image_buffer = image.to_rgba8();
             let size = [image.width() as usize, image.height() as usize];
             let pixels = image_buffer.into_vec();
-            let image = epi::Image::from_rgba_unmultiplied(size, &pixels);
+            let image = egui::ImageData::from_rgba_unmultiplied(size, &pixels);
 
             // Allocate a texture:
             let texture = frame.alloc_texture(image);

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -178,7 +178,7 @@ impl Context {
     ///
     /// You can alternatively run [`Self::begin_frame`] and [`Context::end_frame`].
     ///
-    /// ``` rust
+    /// ```
     /// // One egui context that you keep reusing:
     /// let mut ctx = egui::Context::default();
     ///
@@ -204,7 +204,7 @@ impl Context {
 
     /// An alternative to calling [`Self::run`].
     ///
-    /// ``` rust
+    /// ```
     /// // One egui context that you keep reusing:
     /// let mut ctx = egui::Context::default();
     ///

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -608,10 +608,32 @@ impl Context {
 
     /// Allocate a texture.
     ///
+    /// In order to display an image you must convert it to a texture using this function.
+    ///
     /// Make sure to only call this once for each image, i.e. NOT in your main GUI code.
     ///
     /// The given name can be useful for later debugging, and will be visible if you call [`Self::texture_ui`].
-    pub fn alloc_texture(
+    ///
+    /// ```
+    /// struct MyImage {
+    ///     texture: Option<egui::TextureHandle>,
+    /// }
+    ///
+    /// impl MyImage {
+    ///     fn ui(&mut self, ui: &mut egui::Ui) {
+    ///         let texture: &egui::TextureHandle = self.texture.get_or_insert_with(|| {
+    ///             // Load the texture only once.
+    ///             ui.ctx().load_texture("my-image", egui::ColorImage::example())
+    ///         });
+    ///
+    ///         // Show the image:
+    ///         ui.image(texture, texture.size_vec2());
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Se also [`crate::TextureData`], [`crate::Ui::image`] and [`crate::ImageButton`].
+    pub fn load_texture(
         &self,
         name: impl Into<String>,
         image: impl Into<ImageData>,
@@ -623,7 +645,7 @@ impl Context {
 
     /// Low-level texture manager.
     ///
-    /// In general it is easier to use [`Self::alloc_texture`] and [`TextureHandle`].
+    /// In general it is easier to use [`Self::load_texture`] and [`TextureHandle`].
     ///
     /// You can show stats about the allocated textures using [`Self::texture_ui`].
     pub fn tex_manager(&self) -> Arc<Mutex<epaint::textures::TextureManager>> {

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -632,7 +632,7 @@ impl Context {
     /// }
     /// ```
     ///
-    /// Se also [`crate::TextureData`], [`crate::Ui::image`] and [`crate::ImageButton`].
+    /// Se also [`crate::ImageData`], [`crate::Ui::image`] and [`crate::ImageButton`].
     pub fn load_texture(
         &self,
         name: impl Into<String>,

--- a/egui/src/data/input.rs
+++ b/egui/src/data/input.rs
@@ -375,10 +375,13 @@ impl RawInput {
         }
         ui.label(format!("predicted_dt: {:.1} ms", 1e3 * predicted_dt));
         ui.label(format!("modifiers: {:#?}", modifiers));
-        ui.label(format!("events: {:?}", events))
-            .on_hover_text("key presses etc");
         ui.label(format!("hovered_files: {}", hovered_files.len()));
         ui.label(format!("dropped_files: {}", dropped_files.len()));
+        ui.scope(|ui| {
+            ui.set_min_height(150.0);
+            ui.label(format!("events: {:#?}", events))
+                .on_hover_text("key presses etc");
+        });
     }
 }
 

--- a/egui/src/data/output.rs
+++ b/egui/src/data/output.rs
@@ -35,6 +35,9 @@ pub struct Output {
 
     /// Screen-space position of text edit cursor (used for IME).
     pub text_cursor_pos: Option<crate::Pos2>,
+
+    /// Texture changes since last frame.
+    pub textures_delta: epaint::textures::TexturesDelta,
 }
 
 impl Output {
@@ -71,6 +74,7 @@ impl Output {
             mut events,
             mutable_text_under_cursor,
             text_cursor_pos,
+            textures_delta,
         } = newer;
 
         self.cursor_icon = cursor_icon;
@@ -84,6 +88,7 @@ impl Output {
         self.events.append(&mut events);
         self.mutable_text_under_cursor = mutable_text_under_cursor;
         self.text_cursor_pos = text_cursor_pos.or(self.text_cursor_pos);
+        self.textures_delta.append(textures_delta);
     }
 
     /// Take everything ephemeral (everything except `cursor_icon` currently)

--- a/egui/src/input_state.rs
+++ b/egui/src/input_state.rs
@@ -730,8 +730,11 @@ impl InputState {
         ui.label(format!("predicted_dt: {:.1} ms", 1e3 * predicted_dt));
         ui.label(format!("modifiers: {:#?}", modifiers));
         ui.label(format!("keys_down: {:?}", keys_down));
-        ui.label(format!("events: {:?}", events))
-            .on_hover_text("key presses etc");
+        ui.scope(|ui| {
+            ui.set_min_height(150.0);
+            ui.label(format!("events: {:#?}", events))
+                .on_hover_text("key presses etc");
+        });
     }
 }
 

--- a/egui/src/introspection.rs
+++ b/egui/src/introspection.rs
@@ -7,14 +7,16 @@ impl Widget for &epaint::FontImage {
 
         ui.vertical(|ui| {
             // Show font texture in demo Ui
+            let [width, height] = self.size();
+
             ui.label(format!(
                 "Texture size: {} x {} (hover to zoom)",
-                self.width, self.height
+                width, height
             ));
-            if self.width <= 1 || self.height <= 1 {
+            if width <= 1 || height <= 1 {
                 return;
             }
-            let mut size = vec2(self.width as f32, self.height as f32);
+            let mut size = vec2(width as f32, height as f32);
             if size.x > ui.available_width() {
                 size *= ui.available_width() / size.x;
             }
@@ -27,7 +29,7 @@ impl Widget for &epaint::FontImage {
             );
             ui.painter().add(Shape::mesh(mesh));
 
-            let (tex_w, tex_h) = (self.width as f32, self.height as f32);
+            let (tex_w, tex_h) = (width as f32, height as f32);
 
             response
                 .on_hover_cursor(CursorIcon::ZoomIn)

--- a/egui/src/lib.rs
+++ b/egui/src/lib.rs
@@ -386,7 +386,8 @@ pub use emath::{lerp, pos2, remap, remap_clamp, vec2, Align, Align2, NumExt, Pos
 pub use epaint::{
     color, mutex,
     text::{FontData, FontDefinitions, FontFamily, TextStyle},
-    ClippedMesh, Color32, FontImage, Rgba, Shape, Stroke, TextureId,
+    textures::TexturesDelta,
+    ClippedMesh, Color32, FontImage, ImageData, Rgba, Shape, Stroke, TextureId,
 };
 
 pub mod text {

--- a/egui/src/lib.rs
+++ b/egui/src/lib.rs
@@ -58,7 +58,7 @@
 //!
 //! ### Quick start
 //!
-//! ``` rust
+//! ```
 //! # egui::__run_test_ui(|ui| {
 //! # let mut my_string = String::new();
 //! # let mut my_boolean = true;
@@ -218,7 +218,7 @@
 //! 2. Wrap your panel contents in a [`ScrollArea`], or use [`Window::vscroll`] and [`Window::hscroll`].
 //! 3. Use a justified layout:
 //!
-//! ``` rust
+//! ```
 //! # egui::__run_test_ui(|ui| {
 //! ui.with_layout(egui::Layout::top_down_justified(egui::Align::Center), |ui| {
 //!     ui.button("I am becoming wider as needed");
@@ -228,7 +228,7 @@
 //!
 //! 4. Fill in extra space with emptiness:
 //!
-//! ``` rust
+//! ```
 //! # egui::__run_test_ui(|ui| {
 //! ui.allocate_space(ui.available_size()); // put this LAST in your panel/window code
 //! # });
@@ -374,7 +374,6 @@ pub(crate) mod placer;
 mod response;
 mod sense;
 pub mod style;
-mod texture_handle;
 mod ui;
 pub mod util;
 mod widget_text;
@@ -388,7 +387,8 @@ pub use epaint::{
     color, mutex,
     text::{FontData, FontDefinitions, FontFamily, TextStyle},
     textures::TexturesDelta,
-    AlphaImage, ClippedMesh, Color32, ColorImage, ImageData, Rgba, Shape, Stroke, TextureId,
+    AlphaImage, ClippedMesh, Color32, ColorImage, ImageData, Rgba, Shape, Stroke, TextureHandle,
+    TextureId,
 };
 
 pub mod text {
@@ -416,7 +416,6 @@ pub use {
     sense::Sense,
     style::{Style, Visuals},
     text::{Galley, TextFormat},
-    texture_handle::TextureHandle,
     ui::Ui,
     widget_text::{RichText, WidgetText},
     widgets::*,

--- a/egui/src/lib.rs
+++ b/egui/src/lib.rs
@@ -374,6 +374,7 @@ pub(crate) mod placer;
 mod response;
 mod sense;
 pub mod style;
+mod texture_handle;
 mod ui;
 pub mod util;
 mod widget_text;
@@ -387,7 +388,7 @@ pub use epaint::{
     color, mutex,
     text::{FontData, FontDefinitions, FontFamily, TextStyle},
     textures::TexturesDelta,
-    ClippedMesh, Color32, FontImage, ImageData, Rgba, Shape, Stroke, TextureId,
+    AlphaImage, ClippedMesh, Color32, ColorImage, ImageData, Rgba, Shape, Stroke, TextureId,
 };
 
 pub mod text {
@@ -415,6 +416,7 @@ pub use {
     sense::Sense,
     style::{Style, Visuals},
     text::{Galley, TextFormat},
+    texture_handle::TextureHandle,
     ui::Ui,
     widget_text::{RichText, WidgetText},
     widgets::*,

--- a/egui/src/response.rs
+++ b/egui/src/response.rs
@@ -480,7 +480,7 @@ impl Response {
 
     /// Response to secondary clicks (right-clicks) by showing the given menu.
     ///
-    /// ``` rust
+    /// ```
     /// # egui::__run_test_ui(|ui| {
     /// let response = ui.label("Right-click me!");
     /// response.context_menu(|ui| {

--- a/egui/src/texture_handle.rs
+++ b/egui/src/texture_handle.rs
@@ -1,0 +1,79 @@
+use epaint::{
+    mutex::{Arc, Mutex},
+    ImageData, TextureId,
+};
+
+/// Used to show images in egui.
+///
+/// To show an image in egui, allocate a texture with
+/// [`crate::Context::alloc_texture`] and store the [`TextureHandle`].
+/// You can then pass it to e.g. [`Ui::image`].
+///
+/// The [`TextureHandle`] can be cloned cheaply.
+/// When the last [`TextureHandle`] for specific texture is dropped, the texture is freed.
+#[must_use]
+pub struct TextureHandle {
+    tex_mngr: Arc<Mutex<epaint::TextureManager>>,
+    id: TextureId,
+}
+
+impl Drop for TextureHandle {
+    fn drop(&mut self) {
+        self.tex_mngr.lock().free(self.id);
+    }
+}
+
+impl Clone for TextureHandle {
+    fn clone(&self) -> Self {
+        self.tex_mngr.lock().retain(self.id);
+        Self {
+            tex_mngr: self.tex_mngr.clone(),
+            id: self.id,
+        }
+    }
+}
+
+impl TextureHandle {
+    pub(crate) fn new(tex_mngr: Arc<Mutex<epaint::TextureManager>>, id: TextureId) -> Self {
+        Self { tex_mngr, id }
+    }
+
+    pub fn id(&self) -> TextureId {
+        self.id
+    }
+
+    /// Assign a new image to an existing texture.
+    pub fn set(&mut self, image: impl Into<ImageData>) {
+        self.tex_mngr.lock().set(self.id, image.into());
+    }
+
+    /// width x height
+    pub fn size(&self) -> [usize; 2] {
+        self.tex_mngr.lock().meta(self.id).unwrap().size
+    }
+
+    /// width x height
+    pub fn size_vec2(&self) -> crate::Vec2 {
+        let [w, h] = self.size();
+        crate::Vec2::new(w as f32, h as f32)
+    }
+
+    /// Debug-name.
+    pub fn name(&self) -> String {
+        self.tex_mngr.lock().meta(self.id).unwrap().name.clone()
+    }
+}
+
+impl From<&TextureHandle> for TextureId {
+    #[inline(always)]
+    fn from(handle: &TextureHandle) -> Self {
+        handle.id()
+    }
+}
+
+impl From<&mut TextureHandle> for TextureId {
+    #[inline(always)]
+    fn from(handle: &mut TextureHandle) -> Self {
+        handle.id()
+    }
+}

--- a/egui/src/texture_handle.rs
+++ b/egui/src/texture_handle.rs
@@ -8,7 +8,7 @@ use epaint::{
 ///
 /// To show an image in egui, allocate a texture with
 /// [`crate::Context::load_texture`] and store the [`TextureHandle`].
-/// You can then pass it to e.g. [`Ui::image`].
+/// You can then pass it to e.g. [`crate::Ui::image`].
 ///
 /// The [`TextureHandle`] can be cloned cheaply.
 /// When the last [`TextureHandle`] for specific texture is dropped, the texture is freed.

--- a/egui/src/texture_handle.rs
+++ b/egui/src/texture_handle.rs
@@ -1,4 +1,5 @@
 use epaint::{
+    emath::NumExt,
     mutex::{Arc, Mutex},
     ImageData, TextureId,
 };
@@ -33,11 +34,28 @@ impl Clone for TextureHandle {
     }
 }
 
+impl PartialEq for TextureHandle {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for TextureHandle {}
+
+impl std::hash::Hash for TextureHandle {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
 impl TextureHandle {
     pub(crate) fn new(tex_mngr: Arc<Mutex<epaint::TextureManager>>, id: TextureId) -> Self {
         Self { tex_mngr, id }
     }
 
+    #[inline]
     pub fn id(&self) -> TextureId {
         self.id
     }
@@ -56,6 +74,12 @@ impl TextureHandle {
     pub fn size_vec2(&self) -> crate::Vec2 {
         let [w, h] = self.size();
         crate::Vec2::new(w as f32, h as f32)
+    }
+
+    /// width / height
+    pub fn aspect_ratio(&self) -> f32 {
+        let [w, h] = self.size();
+        w as f32 / h.at_least(1) as f32
     }
 
     /// Debug-name.

--- a/egui/src/texture_handle.rs
+++ b/egui/src/texture_handle.rs
@@ -7,7 +7,7 @@ use epaint::{
 /// Used to show images in egui.
 ///
 /// To show an image in egui, allocate a texture with
-/// [`crate::Context::alloc_texture`] and store the [`TextureHandle`].
+/// [`crate::Context::load_texture`] and store the [`TextureHandle`].
 /// You can then pass it to e.g. [`Ui::image`].
 ///
 /// The [`TextureHandle`] can be cloned cheaply.

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -1343,7 +1343,7 @@ impl Ui {
     ///
     /// See also [`Image`].
     #[inline]
-    pub fn image(&mut self, texture_id: TextureId, size: impl Into<Vec2>) -> Response {
+    pub fn image(&mut self, texture_id: impl Into<TextureId>, size: impl Into<Vec2>) -> Response {
         Image::new(texture_id, size).ui(self)
     }
 }

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -1341,7 +1341,28 @@ impl Ui {
 
     /// Show an image here with the given size.
     ///
-    /// See also [`Image`].
+    /// In order to display an image you must first acquire a [`TextureHandle`]
+    /// using [`Context::load_texture`].
+    ///
+    /// ```
+    /// struct MyImage {
+    ///     texture: Option<egui::TextureHandle>,
+    /// }
+    ///
+    /// impl MyImage {
+    ///     fn ui(&mut self, ui: &mut egui::Ui) {
+    ///         let texture: &egui::TextureHandle = self.texture.get_or_insert_with(|| {
+    ///             // Load the texture only once.
+    ///             ui.ctx().load_texture("my-image", egui::ColorImage::example())
+    ///         });
+    ///
+    ///         // Show the image:
+    ///         ui.image(texture, texture.size_vec2());
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Se also [`crate::Image`] and [`crate::ImageButton`].
     #[inline]
     pub fn image(&mut self, texture_id: impl Into<TextureId>, size: impl Into<Vec2>) -> Response {
         Image::new(texture_id, size).ui(self)

--- a/egui/src/util/history.rs
+++ b/egui/src/util/history.rs
@@ -109,11 +109,11 @@ where
     /// `(time, value)` pairs
     /// Time difference between values can be zero, but never negative.
     // TODO: impl IntoIter
-    pub fn iter(&'_ self) -> impl Iterator<Item = (f64, T)> + '_ {
+    pub fn iter(&'_ self) -> impl ExactSizeIterator<Item = (f64, T)> + '_ {
         self.values.iter().map(|(time, value)| (*time, *value))
     }
 
-    pub fn values(&'_ self) -> impl Iterator<Item = T> + '_ {
+    pub fn values(&'_ self) -> impl ExactSizeIterator<Item = T> + '_ {
         self.values.iter().map(|(_time, value)| *value)
     }
 

--- a/egui/src/widgets/button.rs
+++ b/egui/src/widgets/button.rs
@@ -394,7 +394,7 @@ pub struct ImageButton {
 }
 
 impl ImageButton {
-    pub fn new(texture_id: TextureId, size: impl Into<Vec2>) -> Self {
+    pub fn new(texture_id: impl Into<TextureId>, size: impl Into<Vec2>) -> Self {
         Self {
             image: widgets::Image::new(texture_id, size),
             sense: Sense::click(),

--- a/egui/src/widgets/image.rs
+++ b/egui/src/widgets/image.rs
@@ -25,9 +25,9 @@ pub struct Image {
 }
 
 impl Image {
-    pub fn new(texture_id: TextureId, size: impl Into<Vec2>) -> Self {
+    pub fn new(texture_id: impl Into<TextureId>, size: impl Into<Vec2>) -> Self {
         Self {
-            texture_id,
+            texture_id: texture_id.into(),
             uv: Rect::from_min_max(pos2(0.0, 0.0), pos2(1.0, 1.0)),
             size: size.into(),
             bg_fill: Default::default(),

--- a/egui/src/widgets/image.rs
+++ b/egui/src/widgets/image.rs
@@ -2,17 +2,31 @@ use crate::*;
 
 /// An widget to show an image of a given size.
 ///
-/// ```
-/// # egui::__run_test_ui(|ui| {
-/// # let my_texture_id = egui::TextureId::User(0);
-/// ui.add(egui::Image::new(my_texture_id, [640.0, 480.0]));
+/// In order to display an image you must first acquire a [`TextureHandle`]
+/// using [`Context::load_texture`].
 ///
-/// // Shorter version:
-/// ui.image(my_texture_id, [640.0, 480.0]);
-/// # });
+/// ```
+/// struct MyImage {
+///     texture: Option<egui::TextureHandle>,
+/// }
+///
+/// impl MyImage {
+///     fn ui(&mut self, ui: &mut egui::Ui) {
+///         let texture: &egui::TextureHandle = self.texture.get_or_insert_with(|| {
+///             // Load the texture only once.
+///             ui.ctx().load_texture("my-image", egui::ColorImage::example())
+///         });
+///
+///         // Show the image:
+///         ui.add(egui::Image::new(texture, texture.size_vec2()));
+///
+///         // Shorter version:
+///         ui.image(texture, texture.size_vec2());
+///     }
+/// }
 /// ```
 ///
-/// Se also [`crate::ImageButton`].
+/// Se also [`crate::Ui::image`] and [`crate::ImageButton`].
 #[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
 #[derive(Clone, Copy, Debug)]
 pub struct Image {

--- a/egui/src/widgets/label.rs
+++ b/egui/src/widgets/label.rs
@@ -49,7 +49,7 @@ impl Label {
     /// By calling this you can turn the label into a button of sorts.
     /// This will also give the label the hover-effect of a button, but without the frame.
     ///
-    /// ``` rust
+    /// ```
     /// # use egui::{Label, Sense};
     /// # egui::__run_test_ui(|ui| {
     /// if ui.add(Label::new("click me").sense(Sense::click())).clicked() {

--- a/egui/src/widgets/label.rs
+++ b/egui/src/widgets/label.rs
@@ -82,7 +82,9 @@ impl Label {
         }
 
         let valign = ui.layout().vertical_align();
-        let mut text_job = self.text.into_text_job(ui.style(), TextStyle::Body, valign);
+        let mut text_job = self
+            .text
+            .into_text_job(ui.style(), ui.style().body_text_style, valign);
 
         let should_wrap = self.wrap.unwrap_or_else(|| ui.wrap_text());
         let available_width = ui.available_width();

--- a/egui/src/widgets/plot/items/mod.rs
+++ b/egui/src/widgets/plot/items/mod.rs
@@ -1087,12 +1087,12 @@ pub struct PlotImage {
 
 impl PlotImage {
     /// Create a new image with position and size in plot coordinates.
-    pub fn new(texture_id: TextureId, position: Value, size: impl Into<Vec2>) -> Self {
+    pub fn new(texture_id: impl Into<TextureId>, position: Value, size: impl Into<Vec2>) -> Self {
         Self {
             position,
             name: Default::default(),
             highlight: false,
-            texture_id,
+            texture_id: texture_id.into(),
             uv: Rect::from_min_max(pos2(0.0, 0.0), pos2(1.0, 1.0)),
             size: size.into(),
             bg_fill: Default::default(),

--- a/egui/src/widgets/plot/items/values.rs
+++ b/egui/src/widgets/plot/items/values.rs
@@ -297,7 +297,7 @@ pub enum MarkerShape {
 
 impl MarkerShape {
     /// Get a vector containing all marker shapes.
-    pub fn all() -> impl Iterator<Item = MarkerShape> {
+    pub fn all() -> impl ExactSizeIterator<Item = MarkerShape> {
         [
             Self::Circle,
             Self::Diamond,

--- a/egui_demo_lib/src/apps/color_test.rs
+++ b/egui_demo_lib/src/apps/color_test.rs
@@ -343,7 +343,7 @@ impl TextureManager {
             let pixels = gradient.to_pixel_row();
             let width = pixels.len();
             let height = 1;
-            ctx.alloc_texture(
+            ctx.load_texture(
                 "color_test_gradient",
                 epaint::ColorImage {
                     size: [width, height],

--- a/egui_demo_lib/src/apps/color_test.rs
+++ b/egui_demo_lib/src/apps/color_test.rs
@@ -98,7 +98,7 @@ impl ColorTest {
 
             ui.horizontal(|ui| {
                 let g = Gradient::one_color(Color32::from(tex_color));
-                let tex = self.tex_mngr.get(&mut ui.ctx().tex_manager(), &g);
+                let tex = self.tex_mngr.get(ui.ctx(), &g);
                 let texel_offset = 0.5 / (g.0.len() as f32);
                 let uv = Rect::from_min_max(pos2(texel_offset, 0.0), pos2(1.0 - texel_offset, 1.0));
                 ui.add(Image::new(tex, GRADIENT_SIZE).tint(vertex_color).uv(uv))
@@ -219,7 +219,7 @@ impl ColorTest {
             return;
         }
         ui.horizontal(|ui| {
-            let tex = self.tex_mngr.get(&mut ui.ctx().tex_manager(), gradient);
+            let tex = self.tex_mngr.get(ui.ctx(), gradient);
             let texel_offset = 0.5 / (gradient.0.len() as f32);
             let uv = Rect::from_min_max(pos2(texel_offset, 0.0), pos2(1.0 - texel_offset, 1.0));
             ui.add(Image::new(tex, GRADIENT_SIZE).bg_fill(bg_fill).uv(uv))
@@ -335,18 +335,21 @@ impl Gradient {
 }
 
 #[derive(Default)]
-struct TextureManager(HashMap<Gradient, TextureId>);
+struct TextureManager(HashMap<Gradient, TextureHandle>);
 
 impl TextureManager {
-    fn get(&mut self, tex_mngr: &mut epaint::TextureManager, gradient: &Gradient) -> TextureId {
-        *self.0.entry(gradient.clone()).or_insert_with(|| {
+    fn get(&mut self, ctx: &egui::Context, gradient: &Gradient) -> &TextureHandle {
+        self.0.entry(gradient.clone()).or_insert_with(|| {
             let pixels = gradient.to_pixel_row();
             let width = pixels.len();
             let height = 1;
-            tex_mngr.alloc(epaint::ColorImage {
-                size: [width, height],
-                pixels,
-            })
+            ctx.alloc_texture(
+                "color_test_gradient",
+                epaint::ColorImage {
+                    size: [width, height],
+                    pixels,
+                },
+            )
         })
     }
 }

--- a/egui_demo_lib/src/apps/color_test.rs
+++ b/egui_demo_lib/src/apps/color_test.rs
@@ -43,14 +43,14 @@ impl epi::App for ColorTest {
                 ui.separator();
             }
             ScrollArea::both().auto_shrink([false; 2]).show(ui, |ui| {
-                self.ui(ui, Some(frame));
+                self.ui(ui);
             });
         });
     }
 }
 
 impl ColorTest {
-    pub fn ui(&mut self, ui: &mut Ui, tex_allocator: Option<&dyn epi::TextureAllocator>) {
+    pub fn ui(&mut self, ui: &mut Ui) {
         ui.set_max_width(680.0);
 
         ui.vertical_centered(|ui| {
@@ -70,13 +70,7 @@ impl ColorTest {
             ui.spacing_mut().item_spacing.y = 0.0; // No spacing between gradients
             let g = Gradient::one_color(Color32::from_rgb(255, 165, 0));
             self.vertex_gradient(ui, "orange rgb(255, 165, 0) - vertex", WHITE, &g);
-            self.tex_gradient(
-                ui,
-                tex_allocator,
-                "orange rgb(255, 165, 0) - texture",
-                WHITE,
-                &g,
-            );
+            self.tex_gradient(ui, "orange rgb(255, 165, 0) - texture", WHITE, &g);
         });
 
         ui.separator();
@@ -99,20 +93,18 @@ impl ColorTest {
             {
                 let g = Gradient::one_color(Color32::from(tex_color * vertex_color));
                 self.vertex_gradient(ui, "Ground truth (vertices)", WHITE, &g);
-                self.tex_gradient(ui, tex_allocator, "Ground truth (texture)", WHITE, &g);
+                self.tex_gradient(ui, "Ground truth (texture)", WHITE, &g);
             }
-            if let Some(tex_allocator) = tex_allocator {
-                ui.horizontal(|ui| {
-                    let g = Gradient::one_color(Color32::from(tex_color));
-                    let tex = self.tex_mngr.get(tex_allocator, &g);
-                    let texel_offset = 0.5 / (g.0.len() as f32);
-                    let uv =
-                        Rect::from_min_max(pos2(texel_offset, 0.0), pos2(1.0 - texel_offset, 1.0));
-                    ui.add(Image::new(tex, GRADIENT_SIZE).tint(vertex_color).uv(uv))
-                        .on_hover_text(format!("A texture that is {} texels wide", g.0.len()));
-                    ui.label("GPU result");
-                });
-            }
+
+            ui.horizontal(|ui| {
+                let g = Gradient::one_color(Color32::from(tex_color));
+                let tex = self.tex_mngr.get(&mut ui.ctx().tex_manager(), &g);
+                let texel_offset = 0.5 / (g.0.len() as f32);
+                let uv = Rect::from_min_max(pos2(texel_offset, 0.0), pos2(1.0 - texel_offset, 1.0));
+                ui.add(Image::new(tex, GRADIENT_SIZE).tint(vertex_color).uv(uv))
+                    .on_hover_text(format!("A texture that is {} texels wide", g.0.len()));
+                ui.label("GPU result");
+            });
         });
 
         ui.separator();
@@ -120,18 +112,18 @@ impl ColorTest {
         // TODO: test color multiplication (image tint),
         // to make sure vertex and texture color multiplication is done in linear space.
 
-        self.show_gradients(ui, tex_allocator, WHITE, (RED, GREEN));
+        self.show_gradients(ui, WHITE, (RED, GREEN));
         if self.srgb {
             ui.label("Notice the darkening in the center of the naive sRGB interpolation.");
         }
 
         ui.separator();
 
-        self.show_gradients(ui, tex_allocator, RED, (TRANSPARENT, GREEN));
+        self.show_gradients(ui, RED, (TRANSPARENT, GREEN));
 
         ui.separator();
 
-        self.show_gradients(ui, tex_allocator, WHITE, (TRANSPARENT, GREEN));
+        self.show_gradients(ui, WHITE, (TRANSPARENT, GREEN));
         if self.srgb {
             ui.label(
             "Notice how the linear blend stays green while the naive sRGBA interpolation looks gray in the middle.",
@@ -142,15 +134,14 @@ impl ColorTest {
 
         // TODO: another ground truth where we do the alpha-blending against the background also.
         // TODO: exactly the same thing, but with vertex colors (no textures)
-        self.show_gradients(ui, tex_allocator, WHITE, (TRANSPARENT, BLACK));
+        self.show_gradients(ui, WHITE, (TRANSPARENT, BLACK));
         ui.separator();
-        self.show_gradients(ui, tex_allocator, BLACK, (TRANSPARENT, WHITE));
+        self.show_gradients(ui, BLACK, (TRANSPARENT, WHITE));
         ui.separator();
 
         ui.label("Additive blending: add more and more blue to the red background:");
         self.show_gradients(
             ui,
-            tex_allocator,
             RED,
             (TRANSPARENT, Color32::from_rgb_additive(0, 0, 255)),
         );
@@ -160,13 +151,7 @@ impl ColorTest {
         pixel_test(ui);
     }
 
-    fn show_gradients(
-        &mut self,
-        ui: &mut Ui,
-        tex_allocator: Option<&dyn epi::TextureAllocator>,
-        bg_fill: Color32,
-        (left, right): (Color32, Color32),
-    ) {
+    fn show_gradients(&mut self, ui: &mut Ui, bg_fill: Color32, (left, right): (Color32, Color32)) {
         let is_opaque = left.is_opaque() && right.is_opaque();
 
         ui.horizontal(|ui| {
@@ -186,13 +171,7 @@ impl ColorTest {
             if is_opaque {
                 let g = Gradient::ground_truth_linear_gradient(left, right);
                 self.vertex_gradient(ui, "Ground Truth (CPU gradient) - vertices", bg_fill, &g);
-                self.tex_gradient(
-                    ui,
-                    tex_allocator,
-                    "Ground Truth (CPU gradient) - texture",
-                    bg_fill,
-                    &g,
-                );
+                self.tex_gradient(ui, "Ground Truth (CPU gradient) - texture", bg_fill, &g);
             } else {
                 let g = Gradient::ground_truth_linear_gradient(left, right).with_bg_fill(bg_fill);
                 self.vertex_gradient(
@@ -203,20 +182,13 @@ impl ColorTest {
                 );
                 self.tex_gradient(
                     ui,
-                    tex_allocator,
                     "Ground Truth (CPU gradient, CPU blending) - texture",
                     bg_fill,
                     &g,
                 );
                 let g = Gradient::ground_truth_linear_gradient(left, right);
                 self.vertex_gradient(ui, "CPU gradient, GPU blending - vertices", bg_fill, &g);
-                self.tex_gradient(
-                    ui,
-                    tex_allocator,
-                    "CPU gradient, GPU blending - texture",
-                    bg_fill,
-                    &g,
-                );
+                self.tex_gradient(ui, "CPU gradient, GPU blending - texture", bg_fill, &g);
             }
 
             let g = Gradient::texture_gradient(left, right);
@@ -226,13 +198,7 @@ impl ColorTest {
                 bg_fill,
                 &g,
             );
-            self.tex_gradient(
-                ui,
-                tex_allocator,
-                "Texture of width 2 (test texture sampler)",
-                bg_fill,
-                &g,
-            );
+            self.tex_gradient(ui, "Texture of width 2 (test texture sampler)", bg_fill, &g);
 
             if self.srgb {
                 let g =
@@ -243,41 +209,26 @@ impl ColorTest {
                     bg_fill,
                     &g,
                 );
-                self.tex_gradient(
-                    ui,
-                    tex_allocator,
-                    "Naive sRGBA interpolation (WRONG)",
-                    bg_fill,
-                    &g,
-                );
+                self.tex_gradient(ui, "Naive sRGBA interpolation (WRONG)", bg_fill, &g);
             }
         });
     }
 
-    fn tex_gradient(
-        &mut self,
-        ui: &mut Ui,
-        tex_allocator: Option<&dyn epi::TextureAllocator>,
-        label: &str,
-        bg_fill: Color32,
-        gradient: &Gradient,
-    ) {
+    fn tex_gradient(&mut self, ui: &mut Ui, label: &str, bg_fill: Color32, gradient: &Gradient) {
         if !self.texture_gradients {
             return;
         }
-        if let Some(tex_allocator) = tex_allocator {
-            ui.horizontal(|ui| {
-                let tex = self.tex_mngr.get(tex_allocator, gradient);
-                let texel_offset = 0.5 / (gradient.0.len() as f32);
-                let uv = Rect::from_min_max(pos2(texel_offset, 0.0), pos2(1.0 - texel_offset, 1.0));
-                ui.add(Image::new(tex, GRADIENT_SIZE).bg_fill(bg_fill).uv(uv))
-                    .on_hover_text(format!(
-                        "A texture that is {} texels wide",
-                        gradient.0.len()
-                    ));
-                ui.label(label);
-            });
-        }
+        ui.horizontal(|ui| {
+            let tex = self.tex_mngr.get(&mut ui.ctx().tex_manager(), gradient);
+            let texel_offset = 0.5 / (gradient.0.len() as f32);
+            let uv = Rect::from_min_max(pos2(texel_offset, 0.0), pos2(1.0 - texel_offset, 1.0));
+            ui.add(Image::new(tex, GRADIENT_SIZE).bg_fill(bg_fill).uv(uv))
+                .on_hover_text(format!(
+                    "A texture that is {} texels wide",
+                    gradient.0.len()
+                ));
+            ui.label(label);
+        });
     }
 
     fn vertex_gradient(&mut self, ui: &mut Ui, label: &str, bg_fill: Color32, gradient: &Gradient) {
@@ -387,12 +338,12 @@ impl Gradient {
 struct TextureManager(HashMap<Gradient, TextureId>);
 
 impl TextureManager {
-    fn get(&mut self, tex_allocator: &dyn epi::TextureAllocator, gradient: &Gradient) -> TextureId {
+    fn get(&mut self, tex_mngr: &mut epaint::TextureManager, gradient: &Gradient) -> TextureId {
         *self.0.entry(gradient.clone()).or_insert_with(|| {
             let pixels = gradient.to_pixel_row();
             let width = pixels.len();
             let height = 1;
-            tex_allocator.alloc(epi::Image {
+            tex_mngr.alloc(epaint::ColorImage {
                 size: [width, height],
                 pixels,
             })

--- a/egui_demo_lib/src/apps/demo/plot_demo.rs
+++ b/egui_demo_lib/src/apps/demo/plot_demo.rs
@@ -306,9 +306,9 @@ impl Widget for &mut LegendDemo {
 }
 
 #[derive(PartialEq, Default)]
-struct ItemsDemo {}
-
-impl ItemsDemo {}
+struct ItemsDemo {
+    texture: Option<egui::TextureHandle>,
+}
 
 impl Widget for &mut ItemsDemo {
     fn ui(self, ui: &mut Ui) -> Response {
@@ -343,8 +343,13 @@ impl Widget for &mut ItemsDemo {
             );
             Arrows::new(arrow_origins, arrow_tips)
         };
+
+        let texture: &egui::TextureHandle = self.texture.get_or_insert_with(|| {
+            ui.ctx()
+                .alloc_texture("plot_demo", egui::ColorImage::example())
+        });
         let image = PlotImage::new(
-            TextureId::default(), // TODO: custom image using TextureHandle
+            texture,
             Value::new(0.0, 10.0),
             [
                 ui.fonts().font_image().width() as f32 / 100.0,

--- a/egui_demo_lib/src/apps/demo/plot_demo.rs
+++ b/egui_demo_lib/src/apps/demo/plot_demo.rs
@@ -344,11 +344,11 @@ impl Widget for &mut ItemsDemo {
             Arrows::new(arrow_origins, arrow_tips)
         };
         let image = PlotImage::new(
-            TextureId::Egui,
+            TextureId::default(), // TODO: custom image using TextureHandle
             Value::new(0.0, 10.0),
             [
-                ui.fonts().font_image().width as f32 / 100.0,
-                ui.fonts().font_image().height as f32 / 100.0,
+                ui.fonts().font_image().width() as f32 / 100.0,
+                ui.fonts().font_image().height() as f32 / 100.0,
             ],
         );
 

--- a/egui_demo_lib/src/apps/demo/plot_demo.rs
+++ b/egui_demo_lib/src/apps/demo/plot_demo.rs
@@ -346,7 +346,7 @@ impl Widget for &mut ItemsDemo {
 
         let texture: &egui::TextureHandle = self.texture.get_or_insert_with(|| {
             ui.ctx()
-                .alloc_texture("plot_demo", egui::ColorImage::example())
+                .load_texture("plot_demo", egui::ColorImage::example())
         });
         let image = PlotImage::new(
             texture,

--- a/egui_demo_lib/src/apps/demo/widget_gallery.rs
+++ b/egui_demo_lib/src/apps/demo/widget_gallery.rs
@@ -180,14 +180,16 @@ impl WidgetGallery {
         ui.color_edit_button_srgba(color);
         ui.end_row();
 
+        let texture = egui::TextureId::default(); // TODO: custom image using TextureHandle
+
         ui.add(doc_link_label("Image", "Image"));
-        ui.image(egui::TextureId::Egui, [24.0, 16.0])
+        ui.image(texture, [24.0, 16.0])
             .on_hover_text("The egui font texture was the convenient choice to show here.");
         ui.end_row();
 
         ui.add(doc_link_label("ImageButton", "ImageButton"));
         if ui
-            .add(egui::ImageButton::new(egui::TextureId::Egui, [24.0, 16.0]))
+            .add(egui::ImageButton::new(texture, [24.0, 16.0]))
             .on_hover_text("The egui font texture was the convenient choice to show here.")
             .clicked()
         {

--- a/egui_demo_lib/src/apps/demo/widget_gallery.rs
+++ b/egui_demo_lib/src/apps/demo/widget_gallery.rs
@@ -107,7 +107,7 @@ impl WidgetGallery {
 
         let texture: &egui::TextureHandle = texture.get_or_insert_with(|| {
             ui.ctx()
-                .alloc_texture("example", egui::ColorImage::example())
+                .load_texture("example", egui::ColorImage::example())
         });
 
         ui.add(doc_link_label("Label", "label,heading"));

--- a/egui_demo_lib/src/apps/demo/widget_gallery.rs
+++ b/egui_demo_lib/src/apps/demo/widget_gallery.rs
@@ -17,6 +17,8 @@ pub struct WidgetGallery {
     string: String,
     color: egui::Color32,
     animate_progress_bar: bool,
+    #[cfg_attr(feature = "serde", serde(skip))]
+    texture: Option<egui::TextureHandle>,
 }
 
 impl Default for WidgetGallery {
@@ -30,6 +32,7 @@ impl Default for WidgetGallery {
             string: Default::default(),
             color: egui::Color32::LIGHT_BLUE.linear_multiply(0.5),
             animate_progress_bar: false,
+            texture: None,
         }
     }
 }
@@ -99,7 +102,13 @@ impl WidgetGallery {
             string,
             color,
             animate_progress_bar,
+            texture,
         } = self;
+
+        let texture: &egui::TextureHandle = texture.get_or_insert_with(|| {
+            ui.ctx()
+                .alloc_texture("example", egui::ColorImage::example())
+        });
 
         ui.add(doc_link_label("Label", "label,heading"));
         ui.label("Welcome to the widget gallery!");
@@ -180,19 +189,14 @@ impl WidgetGallery {
         ui.color_edit_button_srgba(color);
         ui.end_row();
 
-        let texture = egui::TextureId::default(); // TODO: custom image using TextureHandle
+        let img_size = 16.0 * texture.size_vec2() / texture.size_vec2().y;
 
         ui.add(doc_link_label("Image", "Image"));
-        ui.image(texture, [24.0, 16.0])
-            .on_hover_text("The egui font texture was the convenient choice to show here.");
+        ui.image(texture, img_size);
         ui.end_row();
 
         ui.add(doc_link_label("ImageButton", "ImageButton"));
-        if ui
-            .add(egui::ImageButton::new(texture, [24.0, 16.0]))
-            .on_hover_text("The egui font texture was the convenient choice to show here.")
-            .clicked()
-        {
+        if ui.add(egui::ImageButton::new(texture, img_size)).clicked() {
             *boolean = !*boolean;
         }
         ui.end_row();

--- a/egui_demo_lib/src/apps/http_app.rs
+++ b/egui_demo_lib/src/apps/http_app.rs
@@ -303,7 +303,7 @@ impl TexMngr {
         image: &egui::ImageData,
     ) -> &egui::TextureHandle {
         if self.loaded_url != url || self.texture.is_none() {
-            self.texture = Some(ctx.alloc_texture(url, image.clone()));
+            self.texture = Some(ctx.load_texture(url, image.clone()));
             self.loaded_url = url.to_owned();
         }
         self.texture.as_ref().unwrap()

--- a/egui_demo_lib/src/apps/http_app.rs
+++ b/egui_demo_lib/src/apps/http_app.rs
@@ -7,7 +7,7 @@ struct Resource {
     text: Option<String>,
 
     /// If set, the response was an image.
-    image: Option<epi::Image>,
+    image: Option<egui::ImageData>,
 
     /// If set, the response was text with some supported syntax highlighting (e.g. ".rs" or ".md").
     colored_text: Option<ColoredText>,
@@ -301,7 +301,7 @@ impl TexMngr {
         &mut self,
         frame: &epi::Frame,
         url: &str,
-        image: &epi::Image,
+        image: &egui::ImageData,
     ) -> Option<egui::TextureId> {
         if self.loaded_url != url {
             if let Some(texture_id) = self.texture_id.take() {
@@ -315,11 +315,11 @@ impl TexMngr {
     }
 }
 
-fn decode_image(bytes: &[u8]) -> Option<epi::Image> {
+fn decode_image(bytes: &[u8]) -> Option<egui::ImageData> {
     use image::GenericImageView;
     let image = image::load_from_memory(bytes).ok()?;
     let image_buffer = image.to_rgba8();
     let size = [image.width() as usize, image.height() as usize];
     let pixels = image_buffer.into_vec();
-    Some(epi::Image::from_rgba_unmultiplied(size, &pixels))
+    Some(egui::ImageData::from_rgba_unmultiplied(size, &pixels))
 }

--- a/egui_demo_lib/src/syntax_highlighting.rs
+++ b/egui_demo_lib/src/syntax_highlighting.rs
@@ -66,7 +66,7 @@ enum SyntectTheme {
 
 #[cfg(feature = "syntect")]
 impl SyntectTheme {
-    fn all() -> impl Iterator<Item = Self> {
+    fn all() -> impl ExactSizeIterator<Item = Self> {
         [
             Self::Base16EightiesDark,
             Self::Base16MochaDark,

--- a/egui_glium/CHANGELOG.md
+++ b/egui_glium/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to the `egui_glium` integration will be noted in this file.
 
 
 ## Unreleased
+* `EguiGlium::run` no longer returns the shapes to paint, but stores them internally until you call `EguiGlium::paint` ([#1110](https://github.com/emilk/egui/pull/1110)).
+* Optimize the painter and texture uploading ([#1110](https://github.com/emilk/egui/pull/1110)).
 
 
 ## 0.16.0 - 2021-12-29

--- a/egui_glium/Cargo.toml
+++ b/egui_glium/Cargo.toml
@@ -27,6 +27,7 @@ egui = { version = "0.16.0", path = "../egui", default-features = false, feature
 egui-winit = { version = "0.16.0", path = "../egui-winit", default-features = false, features = ["epi"] }
 epi = { version = "0.16.0", path = "../epi", optional = true }
 
+ahash = "0.7"
 glium = "0.31"
 
 [dev-dependencies]

--- a/egui_glium/Cargo.toml
+++ b/egui_glium/Cargo.toml
@@ -23,11 +23,15 @@ include = [
 all-features = true
 
 [dependencies]
-egui = { version = "0.16.0", path = "../egui", default-features = false, features = ["single_threaded"] }
+egui = { version = "0.16.0", path = "../egui", default-features = false, features = [
+  "convert_bytemuck",
+  "single_threaded",
+] }
 egui-winit = { version = "0.16.0", path = "../egui-winit", default-features = false, features = ["epi"] }
 epi = { version = "0.16.0", path = "../epi", optional = true }
 
 ahash = "0.7"
+bytemuck = "1.7"
 glium = "0.31"
 
 [dev-dependencies]

--- a/egui_glium/examples/native_texture.rs
+++ b/egui_glium/examples/native_texture.rs
@@ -62,7 +62,7 @@ fn main() {
         let mut redraw = || {
             let mut quit = false;
 
-            let (needs_repaint, shapes) = egui_glium.run(&display, |egui_ctx| {
+            let needs_repaint = egui_glium.run(&display, |egui_ctx| {
                 egui::SidePanel::left("my_side_panel").show(egui_ctx, |ui| {
                     if ui
                         .add(egui::Button::image_and_text(
@@ -98,7 +98,7 @@ fn main() {
 
                 // draw things behind egui here
 
-                egui_glium.paint(&display, &mut target, shapes);
+                egui_glium.paint(&display, &mut target);
 
                 // draw things on top of egui here
 

--- a/egui_glium/examples/pure_glium.rs
+++ b/egui_glium/examples/pure_glium.rs
@@ -32,7 +32,7 @@ fn main() {
         let mut redraw = || {
             let mut quit = false;
 
-            let (needs_repaint, shapes) = egui_glium.run(&display, |egui_ctx| {
+            let needs_repaint = egui_glium.run(&display, |egui_ctx| {
                 egui::SidePanel::left("my_side_panel").show(egui_ctx, |ui| {
                     ui.heading("Hello World!");
                     if ui.button("Quit").clicked() {
@@ -59,7 +59,7 @@ fn main() {
 
                 // draw things behind egui here
 
-                egui_glium.paint(&display, &mut target, shapes);
+                egui_glium.paint(&display, &mut target);
 
                 // draw things on top of egui here
 

--- a/egui_glium/src/epi_backend.rs
+++ b/egui_glium/src/epi_backend.rs
@@ -66,11 +66,11 @@ pub fn run(app: Box<dyn epi::App>, native_options: &epi::NativeOptions) -> ! {
                 std::thread::sleep(std::time::Duration::from_millis(10));
             }
 
-            let (needs_repaint, mut tex_allocation_data, shapes) =
+            let (needs_repaint, mut textures_delta, shapes) =
                 integration.update(display.gl_window().window());
             let clipped_meshes = integration.egui_ctx.tessellate(shapes);
 
-            for (id, image) in tex_allocation_data.creations {
+            for (id, image) in textures_delta.set {
                 painter.set_texture(&display, id, &image);
             }
 
@@ -86,13 +86,12 @@ pub fn run(app: Box<dyn epi::App>, native_options: &epi::NativeOptions) -> ! {
                     &mut target,
                     integration.egui_ctx.pixels_per_point(),
                     clipped_meshes,
-                    &integration.egui_ctx.font_image(),
                 );
 
                 target.finish().unwrap();
             }
 
-            for id in tex_allocation_data.destructions.drain(..) {
+            for id in textures_delta.free.drain(..) {
                 painter.free_texture(id);
             }
 

--- a/egui_glium/src/painter.rs
+++ b/egui_glium/src/painter.rs
@@ -95,7 +95,7 @@ impl Painter {
             let vertices: &[Vertex] = bytemuck::cast_slice(&mesh.vertices);
 
             // TODO: we should probably reuse the `VertexBuffer` instead of allocating a new one each frame.
-            glium::VertexBuffer::new(display, &vertices).unwrap()
+            glium::VertexBuffer::new(display, vertices).unwrap()
         };
 
         // TODO: we should probably reuse the `IndexBuffer` instead of allocating a new one each frame.
@@ -205,7 +205,7 @@ impl Painter {
             }
         };
         let glium_image = glium::texture::RawImage2d {
-            data: std::borrow::Cow::Owned(pixels.into()),
+            data: std::borrow::Cow::Owned(pixels),
             width: image.width() as _,
             height: image.height() as _,
             format: glium::texture::ClientFormat::U8U8U8U8,

--- a/egui_glium/src/painter.rs
+++ b/egui_glium/src/painter.rs
@@ -3,10 +3,7 @@
 
 use {
     ahash::AHashMap,
-    egui::{
-        emath::Rect,
-        epaint::{Color32, Mesh},
-    },
+    egui::{emath::Rect, epaint::Mesh},
     glium::{
         implement_vertex,
         index::PrimitiveType,
@@ -191,7 +188,6 @@ impl Painter {
 
     // ------------------------------------------------------------------------
 
-    #[cfg(feature = "epi")]
     pub fn set_texture(
         &mut self,
         facade: &dyn glium::backend::Facade,
@@ -216,7 +212,7 @@ impl Painter {
                 .chunks(image.width() as usize)
                 .map(|row| {
                     row.iter()
-                        .map(|&a| Color32::from_white_alpha(a).to_tuple())
+                        .map(|&a| egui::Color32::from_white_alpha(a).to_tuple())
                         .collect()
                 })
                 .collect(),

--- a/egui_glow/CHANGELOG.md
+++ b/egui_glow/CHANGELOG.md
@@ -3,8 +3,10 @@ All notable changes to the `egui_glow` integration will be noted in this file.
 
 
 ## Unreleased
+* `EguiGlow::run` no longer returns the shapes to paint, but stores them internally until you call `EguiGlow::paint` ([#1110](https://github.com/emilk/egui/pull/1110)).
 * Added `set_texture_filter` method to `Painter` ((#1041)[https://github.com/emilk/egui/pull/1041]).
 * Fix failure to run in Chrome ((#1092)[https://github.com/emilk/egui/pull/1092]).
+
 
 ## 0.16.0 - 2021-12-29
 * Made winit/glutin an optional dependency ([#868](https://github.com/emilk/egui/pull/868)).

--- a/egui_glow/Cargo.toml
+++ b/egui_glow/Cargo.toml
@@ -23,10 +23,13 @@ include = [
 all-features = true
 
 [dependencies]
-egui = { version = "0.16.0", path = "../egui", default-features = false, features = ["single_threaded", "convert_bytemuck"] }
+egui = { version = "0.16.0", path = "../egui", default-features = false, features = [
+  "convert_bytemuck",
+  "single_threaded",
+] }
+epi = { version = "0.16.0", path = "../epi", optional = true }
 
 bytemuck = "1.7"
-epi = { version = "0.16.0", path = "../epi", optional = true }
 glow = "0.11"
 memoffset = "0.6"
 

--- a/egui_glow/examples/pure_glow.rs
+++ b/egui_glow/examples/pure_glow.rs
@@ -50,7 +50,7 @@ fn main() {
         let mut redraw = || {
             let mut quit = false;
 
-            let (needs_repaint, shapes) = egui_glow.run(gl_window.window(), |egui_ctx| {
+            let needs_repaint = egui_glow.run(gl_window.window(), |egui_ctx| {
                 egui::SidePanel::left("my_side_panel").show(egui_ctx, |ui| {
                     ui.heading("Hello World!");
                     if ui.button("Quit").clicked() {
@@ -78,7 +78,7 @@ fn main() {
 
                 // draw things behind egui here
 
-                egui_glow.paint(&gl_window, &gl, shapes);
+                egui_glow.paint(&gl_window, &gl);
 
                 // draw things on top of egui here
 

--- a/egui_glow/src/epi_backend.rs
+++ b/egui_glow/src/epi_backend.rs
@@ -82,11 +82,11 @@ pub fn run(app: Box<dyn epi::App>, native_options: &epi::NativeOptions) -> ! {
                 std::thread::sleep(std::time::Duration::from_millis(10));
             }
 
-            let (needs_repaint, mut tex_allocation_data, shapes) =
+            let (needs_repaint, mut textures_delta, shapes) =
                 integration.update(gl_window.window());
             let clipped_meshes = integration.egui_ctx.tessellate(shapes);
 
-            for (id, image) in tex_allocation_data.creations {
+            for (id, image) in textures_delta.set {
                 painter.set_texture(&gl, id, &image);
             }
 
@@ -99,7 +99,6 @@ pub fn run(app: Box<dyn epi::App>, native_options: &epi::NativeOptions) -> ! {
                     gl.clear_color(color[0], color[1], color[2], color[3]);
                     gl.clear(glow::COLOR_BUFFER_BIT);
                 }
-                painter.upload_egui_texture(&gl, &integration.egui_ctx.font_image());
                 painter.paint_meshes(
                     &gl,
                     gl_window.window().inner_size().into(),
@@ -110,8 +109,8 @@ pub fn run(app: Box<dyn epi::App>, native_options: &epi::NativeOptions) -> ! {
                 gl_window.swap_buffers().unwrap();
             }
 
-            for id in tex_allocation_data.destructions.drain(..) {
-                painter.free_texture(id);
+            for id in textures_delta.free.drain(..) {
+                painter.free_texture(&gl, id);
             }
 
             {

--- a/egui_glow/src/misc_util.rs
+++ b/egui_glow/src/misc_util.rs
@@ -86,10 +86,6 @@ pub fn check_for_gl_error(gl: &glow::Context, context: &str) {
     }
 }
 
-pub(crate) unsafe fn as_u8_slice<T>(s: &[T]) -> &[u8] {
-    std::slice::from_raw_parts(s.as_ptr().cast::<u8>(), s.len() * std::mem::size_of::<T>())
-}
-
 pub(crate) fn glow_print(s: impl std::fmt::Display) {
     #[cfg(target_arch = "wasm32")]
     web_sys::console::log_1(&format!("egui_glow: {}", s).into());

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -420,7 +420,7 @@ impl Painter {
                 };
                 let data: Vec<u8> = image
                     .srgba_pixels(gamma)
-                    .flat_map(|a| Vec::from(a.to_array()))
+                    .flat_map(|a| a.to_array())
                     .collect();
 
                 srgb_texture2d(

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -10,7 +10,7 @@ use glow::HasContext;
 use memoffset::offset_of;
 
 use crate::misc_util::{
-    as_u8_slice, check_for_gl_error, compile_shader, glow_print, link_program, srgb_texture2d,
+    check_for_gl_error, compile_shader, glow_print, link_program, srgb_texture2d,
 };
 use crate::post_process::PostProcess;
 use crate::shader_version::ShaderVersion;
@@ -329,14 +329,14 @@ impl Painter {
                 gl.bind_buffer(glow::ARRAY_BUFFER, Some(self.vertex_buffer));
                 gl.buffer_data_u8_slice(
                     glow::ARRAY_BUFFER,
-                    as_u8_slice(mesh.vertices.as_slice()),
+                    bytemuck::cast_slice(&mesh.vertices),
                     glow::STREAM_DRAW,
                 );
 
                 gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(self.element_array_buffer));
                 gl.buffer_data_u8_slice(
                     glow::ELEMENT_ARRAY_BUFFER,
-                    as_u8_slice(mesh.indices.as_slice()),
+                    bytemuck::cast_slice(&mesh.indices),
                     glow::STREAM_DRAW,
                 );
 

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -384,7 +384,6 @@ impl Painter {
 
     // ------------------------------------------------------------------------
 
-    #[cfg(feature = "epi")]
     pub fn set_texture(
         &mut self,
         gl: &glow::Context,

--- a/egui_glow/src/post_process.rs
+++ b/egui_glow/src/post_process.rs
@@ -116,7 +116,7 @@ impl PostProcess {
         gl.bind_buffer(glow::ARRAY_BUFFER, Some(pos_buffer));
         gl.buffer_data_u8_slice(
             glow::ARRAY_BUFFER,
-            crate::misc_util::as_u8_slice(&positions),
+            bytemuck::cast_slice(&positions),
             glow::STATIC_DRAW,
         );
 

--- a/egui_web/Cargo.toml
+++ b/egui_web/Cargo.toml
@@ -27,10 +27,13 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 egui = { version = "0.16.0", path = "../egui", default-features = false, features = [
+  "convert_bytemuck",
   "single_threaded",
 ] }
 egui_glow = { version = "0.16.0",path = "../egui_glow", default-features = false, optional = true }
 epi = { version = "0.16.0", path = "../epi" }
+
+bytemuck = "1.7"
 js-sys = "0.3"
 ron = { version = "0.7", optional = true }
 serde = { version = "1", optional = true }

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -259,7 +259,7 @@ impl AppRunner {
 
         #[cfg(web_sys_unstable_apis)]
         if !copied_text.is_empty() {
-            set_clipboard_text(copied_text);
+            set_clipboard_text(&copied_text);
         }
 
         #[cfg(not(web_sys_unstable_apis))]

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -218,7 +218,7 @@ impl AppRunner {
         Ok((needs_repaint, clipped_meshes))
     }
 
-    /// Paint the results of the last call to [`Self::run`].
+    /// Paint the results of the last call to [`Self::logic`].
     pub fn paint(&mut self, clipped_meshes: Vec<egui::ClippedMesh>) -> Result<(), JsValue> {
         let textures_delta = std::mem::take(&mut self.textures_delta);
         for (id, image) in textures_delta.set {

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -1,5 +1,6 @@
 use crate::*;
 
+use egui::TexturesDelta;
 pub use egui::{pos2, Color32};
 
 // ----------------------------------------------------------------------------
@@ -92,7 +93,7 @@ pub struct AppRunner {
     screen_reader: crate::screen_reader::ScreenReader,
     pub(crate) text_cursor_pos: Option<egui::Pos2>,
     pub(crate) mutable_text_under_cursor: bool,
-    pending_texture_destructions: Vec<u64>,
+    textures_delta: TexturesDelta,
 }
 
 impl AppRunner {
@@ -139,7 +140,7 @@ impl AppRunner {
             screen_reader: Default::default(),
             text_cursor_pos: None,
             mutable_text_under_cursor: false,
-            pending_texture_destructions: Default::default(),
+            textures_delta: Default::default(),
         };
 
         {
@@ -183,7 +184,10 @@ impl AppRunner {
         Ok(())
     }
 
-    pub fn logic(&mut self) -> Result<(egui::Output, Vec<egui::ClippedMesh>), JsValue> {
+    /// Returns `true` if egui requests a repaint.
+    ///
+    /// Call [`Self::paint`] later to paint
+    pub fn logic(&mut self) -> Result<(bool, Vec<egui::ClippedMesh>), JsValue> {
         let frame_start = now_sec();
 
         resize_canvas_to_screen_size(self.canvas_id(), self.app.max_size_points());
@@ -195,7 +199,9 @@ impl AppRunner {
         });
         let clipped_meshes = self.egui_ctx.tessellate(shapes);
 
-        self.handle_egui_output(&egui_output);
+        let needs_repaint = egui_output.needs_repaint;
+        let textures_delta = self.handle_egui_output(egui_output);
+        self.textures_delta.append(textures_delta);
 
         {
             let app_output = self.frame.take_app_output();
@@ -205,32 +211,32 @@ impl AppRunner {
                 window_title: _, // TODO: change title of window
                 decorated: _,    // Can't toggle decorations
                 drag_window: _,  // Can't be dragged
-                tex_allocation_data,
             } = app_output;
-
-            for (id, image) in tex_allocation_data.creations {
-                self.painter.set_texture(id, image);
-            }
-            self.pending_texture_destructions = tex_allocation_data.destructions;
         }
 
         self.frame.lock().info.cpu_usage = Some((now_sec() - frame_start) as f32);
-        Ok((egui_output, clipped_meshes))
+        Ok((needs_repaint, clipped_meshes))
     }
 
+    /// Paint the results of the last call to [`Self::run`].
     pub fn paint(&mut self, clipped_meshes: Vec<egui::ClippedMesh>) -> Result<(), JsValue> {
-        self.painter
-            .upload_egui_texture(&self.egui_ctx.font_image());
+        let textures_delta = std::mem::take(&mut self.textures_delta);
+        for (id, image) in textures_delta.set {
+            self.painter.set_texture(id, image);
+        }
+
         self.painter.clear(self.app.clear_color());
         self.painter
             .paint_meshes(clipped_meshes, self.egui_ctx.pixels_per_point())?;
-        for id in self.pending_texture_destructions.drain(..) {
+
+        for id in textures_delta.free {
             self.painter.free_texture(id);
         }
+
         Ok(())
     }
 
-    fn handle_egui_output(&mut self, output: &egui::Output) {
+    fn handle_egui_output(&mut self, output: egui::Output) -> egui::TexturesDelta {
         if self.egui_ctx.memory().options.screen_reader {
             self.screen_reader.speak(&output.events_description());
         }
@@ -243,9 +249,10 @@ impl AppRunner {
             events: _,        // already handled
             mutable_text_under_cursor,
             text_cursor_pos,
+            textures_delta,
         } = output;
 
-        set_cursor_icon(*cursor_icon);
+        set_cursor_icon(cursor_icon);
         if let Some(open) = open_url {
             crate::open_url(&open.url, open.new_tab);
         }
@@ -258,12 +265,14 @@ impl AppRunner {
         #[cfg(not(web_sys_unstable_apis))]
         let _ = copied_text;
 
-        self.mutable_text_under_cursor = *mutable_text_under_cursor;
+        self.mutable_text_under_cursor = mutable_text_under_cursor;
 
-        if &self.text_cursor_pos != text_cursor_pos {
+        if self.text_cursor_pos != text_cursor_pos {
             move_text_cursor(text_cursor_pos, self.canvas_id());
-            self.text_cursor_pos = *text_cursor_pos;
+            self.text_cursor_pos = text_cursor_pos;
         }
+
+        textures_delta
     }
 }
 

--- a/egui_web/src/glow_wrapping.rs
+++ b/egui_web/src/glow_wrapping.rs
@@ -1,5 +1,5 @@
 use crate::{canvas_element_or_die, console_error};
-use egui::{ClippedMesh, FontImage, Rgba};
+use egui::{ClippedMesh, Rgba};
 use egui_glow::glow;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
@@ -40,12 +40,12 @@ impl WrappedGlowPainter {
 }
 
 impl crate::Painter for WrappedGlowPainter {
-    fn set_texture(&mut self, tex_id: u64, image: epi::Image) {
+    fn set_texture(&mut self, tex_id: egui::TextureId, image: egui::ImageData) {
         self.painter.set_texture(&self.glow_ctx, tex_id, &image);
     }
 
-    fn free_texture(&mut self, tex_id: u64) {
-        self.painter.free_texture(tex_id);
+    fn free_texture(&mut self, tex_id: egui::TextureId) {
+        self.painter.free_texture(&self.glow_ctx, tex_id);
     }
 
     fn debug_info(&self) -> String {
@@ -58,10 +58,6 @@ impl crate::Painter for WrappedGlowPainter {
 
     fn canvas_id(&self) -> &str {
         &self.canvas_id
-    }
-
-    fn upload_egui_texture(&mut self, font_image: &FontImage) {
-        self.painter.upload_egui_texture(&self.glow_ctx, font_image)
     }
 
     fn clear(&mut self, clear_color: Rgba) {

--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -482,9 +482,9 @@ fn paint_and_schedule(runner_ref: AppRunnerRef) -> Result<(), JsValue> {
     fn paint_if_needed(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
         let mut runner_lock = runner_ref.0.lock();
         if runner_lock.needs_repaint.fetch_and_clear() {
-            let (output, clipped_meshes) = runner_lock.logic()?;
+            let (needs_repaint, clipped_meshes) = runner_lock.logic()?;
             runner_lock.paint(clipped_meshes)?;
-            if output.needs_repaint {
+            if needs_repaint {
                 runner_lock.needs_repaint.set_true();
             }
             runner_lock.auto_save();
@@ -1214,7 +1214,7 @@ fn is_mobile() -> Option<bool> {
 // candidate window moves following text element (agent),
 // so it appears that the IME candidate window moves with text cursor.
 // On mobile devices, there is no need to do that.
-fn move_text_cursor(cursor: &Option<egui::Pos2>, canvas_id: &str) -> Option<()> {
+fn move_text_cursor(cursor: Option<egui::Pos2>, canvas_id: &str) -> Option<()> {
     let style = text_agent().style();
     // Note: movint agent on mobile devices will lead to unpredictable scroll.
     if is_mobile() == Some(false) {

--- a/egui_web/src/painter.rs
+++ b/egui_web/src/painter.rs
@@ -1,16 +1,14 @@
 use wasm_bindgen::prelude::JsValue;
 
 pub trait Painter {
-    fn set_texture(&mut self, tex_id: u64, image: epi::Image);
+    fn set_texture(&mut self, tex_id: egui::TextureId, image: egui::ImageData);
 
-    fn free_texture(&mut self, tex_id: u64);
+    fn free_texture(&mut self, tex_id: egui::TextureId);
 
     fn debug_info(&self) -> String;
 
     /// id of the canvas html element containing the rendering
     fn canvas_id(&self) -> &str;
-
-    fn upload_egui_texture(&mut self, font_image: &egui::FontImage);
 
     fn clear(&mut self, clear_color: egui::Rgba);
 

--- a/egui_web/src/webgl1.rs
+++ b/egui_web/src/webgl1.rs
@@ -289,14 +289,11 @@ impl crate::Painter for WebGlPainter {
                 } else {
                     1.0 // post process enables linear blending
                 };
-                let mut pixels: Vec<u8> = Vec::with_capacity(image.pixels.len() * 4);
-                for srgba in image.srgba_pixels(gamma) {
-                    pixels.push(srgba.r());
-                    pixels.push(srgba.g());
-                    pixels.push(srgba.b());
-                    pixels.push(srgba.a());
-                }
-                self.set_texture_rgba(tex_id, image.size, &pixels);
+                let data: Vec<u8> = image
+                    .srgba_pixels(gamma)
+                    .flat_map(|a| a.to_array())
+                    .collect();
+                self.set_texture_rgba(tex_id, image.size, &data);
             }
         };
     }

--- a/egui_web/src/webgl2.rs
+++ b/egui_web/src/webgl2.rs
@@ -269,15 +269,12 @@ impl crate::Painter for WebGl2Painter {
                 self.set_texture_rgba(tex_id, image.size, data);
             }
             egui::ImageData::Alpha(image) => {
-                let mut pixels: Vec<u8> = Vec::with_capacity(image.pixels.len() * 4);
                 let gamma = 1.0;
-                for srgba in image.srgba_pixels(gamma) {
-                    pixels.push(srgba.r());
-                    pixels.push(srgba.g());
-                    pixels.push(srgba.b());
-                    pixels.push(srgba.a());
-                }
-                self.set_texture_rgba(tex_id, image.size, &pixels);
+                let data: Vec<u8> = image
+                    .srgba_pixels(gamma)
+                    .flat_map(|a| a.to_array())
+                    .collect();
+                self.set_texture_rgba(tex_id, image.size, &data);
             }
         };
     }

--- a/egui_web/src/webgl2.rs
+++ b/egui_web/src/webgl2.rs
@@ -31,10 +31,8 @@ pub struct WebGl2Painter {
     egui_texture: WebGlTexture,
     egui_texture_version: Option<u64>,
 
-    /// Index is the same as in [`egui::TextureId::User`].
-    user_textures: HashMap<u64, WebGlTexture>,
-
-    next_native_tex_id: u64, // TODO: 128-bit texture space?
+    textures: HashMap<egui::TextureId, WebGlTexture>,
+    next_native_tex_id: u64,
 }
 
 impl WebGl2Painter {
@@ -87,16 +85,13 @@ impl WebGl2Painter {
             post_process,
             egui_texture,
             egui_texture_version: None,
-            user_textures: Default::default(),
+            textures: Default::default(),
             next_native_tex_id: 1 << 32,
         })
     }
 
     fn get_texture(&self, texture_id: egui::TextureId) -> Option<&WebGlTexture> {
-        match texture_id {
-            egui::TextureId::Egui => Some(&self.egui_texture),
-            egui::TextureId::User(id) => self.user_textures.get(&id),
-        }
+        self.textures.get(&id)
     }
 
     fn paint_mesh(&self, mesh: &egui::epaint::Mesh16) -> Result<(), JsValue> {
@@ -224,23 +219,19 @@ impl epi::NativeTexture for WebGl2Painter {
     type Texture = WebGlTexture;
 
     fn register_native_texture(&mut self, native: Self::Texture) -> egui::TextureId {
-        let id = self.next_native_tex_id;
+        let id = egui::TextureId::User(self.next_native_tex_id);
         self.next_native_tex_id += 1;
-        self.user_textures.insert(id, native);
-        egui::TextureId::User(id as u64)
+        self.textures.insert(id, native);
+        id
     }
 
-    fn replace_native_texture(&mut self, id: egui::TextureId, replacing: Self::Texture) {
-        if let egui::TextureId::User(id) = id {
-            if let Some(user_texture) = self.user_textures.get_mut(&id) {
-                *user_texture = replacing;
-            }
-        }
+    fn replace_native_texture(&mut self, id: egui::TextureId, native: Self::Texture) {
+        self.textures.insert(id, native);
     }
 }
 
 impl crate::Painter for WebGl2Painter {
-    fn set_texture(&mut self, tex_id: u64, image: epi::Image) {
+    fn set_texture(&mut self, tex_id: egui::TextureId, image: egui::ImageData) {
         assert_eq!(
             image.size[0] * image.size[1],
             image.pixels.len(),
@@ -284,11 +275,11 @@ impl crate::Painter for WebGl2Painter {
         )
         .unwrap();
 
-        self.user_textures.insert(tex_id, gl_texture);
+        self.textures.insert(tex_id, gl_texture);
     }
 
-    fn free_texture(&mut self, tex_id: u64) {
-        self.user_textures.remove(&tex_id);
+    fn free_texture(&mut self, tex_id: egui::TextureId) {
+        self.textures.remove(&tex_id);
     }
 
     fn debug_info(&self) -> String {

--- a/egui_web/src/webgl2.rs
+++ b/egui_web/src/webgl2.rs
@@ -10,10 +10,7 @@ use {
     },
 };
 
-use egui::{
-    emath::vec2,
-    epaint::{Color32, FontImage},
-};
+use egui::{emath::vec2, epaint::Color32};
 
 type Gl = WebGl2RenderingContext;
 
@@ -27,9 +24,6 @@ pub struct WebGl2Painter {
     tc_buffer: WebGlBuffer,
     color_buffer: WebGlBuffer,
     post_process: PostProcess,
-
-    egui_texture: WebGlTexture,
-    egui_texture_version: Option<u64>,
 
     textures: HashMap<egui::TextureId, WebGlTexture>,
     next_native_tex_id: u64,
@@ -83,15 +77,13 @@ impl WebGl2Painter {
             tc_buffer,
             color_buffer,
             post_process,
-            egui_texture,
-            egui_texture_version: None,
             textures: Default::default(),
             next_native_tex_id: 1 << 32,
         })
     }
 
     fn get_texture(&self, texture_id: egui::TextureId) -> Option<&WebGlTexture> {
-        self.textures.get(&id)
+        self.textures.get(&texture_id)
     }
 
     fn paint_mesh(&self, mesh: &egui::epaint::Mesh16) -> Result<(), JsValue> {
@@ -213,6 +205,39 @@ impl WebGl2Painter {
 
         Ok(())
     }
+
+    fn set_texture_rgba(&mut self, tex_id: egui::TextureId, size: [usize; 2], pixels: &[u8]) {
+        let gl = &self.gl;
+        let gl_texture = gl.create_texture().unwrap();
+        gl.bind_texture(Gl::TEXTURE_2D, Some(&gl_texture));
+        gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_S, Gl::CLAMP_TO_EDGE as _);
+        gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_T, Gl::CLAMP_TO_EDGE as _);
+        gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MIN_FILTER, Gl::LINEAR as _);
+        gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MAG_FILTER, Gl::LINEAR as _);
+
+        gl.bind_texture(Gl::TEXTURE_2D, Some(&gl_texture));
+
+        let level = 0;
+        let internal_format = Gl::SRGB8_ALPHA8;
+        let border = 0;
+        let src_format = Gl::RGBA;
+        let src_type = Gl::UNSIGNED_BYTE;
+        gl.pixel_storei(Gl::UNPACK_ALIGNMENT, 1);
+        gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
+            Gl::TEXTURE_2D,
+            level,
+            internal_format as i32,
+            size[0] as i32,
+            size[1] as i32,
+            border,
+            src_format,
+            src_type,
+            Some(pixels),
+        )
+        .unwrap();
+
+        self.textures.insert(tex_id, gl_texture);
+    }
 }
 
 impl epi::NativeTexture for WebGl2Painter {
@@ -232,50 +257,29 @@ impl epi::NativeTexture for WebGl2Painter {
 
 impl crate::Painter for WebGl2Painter {
     fn set_texture(&mut self, tex_id: egui::TextureId, image: egui::ImageData) {
-        assert_eq!(
-            image.size[0] * image.size[1],
-            image.pixels.len(),
-            "Mismatch between texture size and texel count"
-        );
+        match image {
+            egui::ImageData::Color(image) => {
+                assert_eq!(
+                    image.width() * image.height(),
+                    image.pixels.len(),
+                    "Mismatch between texture size and texel count"
+                );
 
-        // TODO: optimize
-        let mut pixels: Vec<u8> = Vec::with_capacity(image.pixels.len() * 4);
-        for srgba in image.pixels {
-            pixels.push(srgba.r());
-            pixels.push(srgba.g());
-            pixels.push(srgba.b());
-            pixels.push(srgba.a());
-        }
-
-        let gl = &self.gl;
-        let gl_texture = gl.create_texture().unwrap();
-        gl.bind_texture(Gl::TEXTURE_2D, Some(&gl_texture));
-        gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_S, Gl::CLAMP_TO_EDGE as _);
-        gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_T, Gl::CLAMP_TO_EDGE as _);
-        gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MIN_FILTER, Gl::LINEAR as _);
-        gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MAG_FILTER, Gl::LINEAR as _);
-
-        gl.bind_texture(Gl::TEXTURE_2D, Some(&gl_texture));
-
-        let level = 0;
-        let internal_format = Gl::SRGB8_ALPHA8;
-        let border = 0;
-        let src_format = Gl::RGBA;
-        let src_type = Gl::UNSIGNED_BYTE;
-        gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
-            Gl::TEXTURE_2D,
-            level,
-            internal_format as _,
-            image.size[0] as _,
-            image.size[1] as _,
-            border,
-            src_format,
-            src_type,
-            Some(&pixels),
-        )
-        .unwrap();
-
-        self.textures.insert(tex_id, gl_texture);
+                let data: &[u8] = bytemuck::cast_slice(image.pixels.as_ref());
+                self.set_texture_rgba(tex_id, image.size, data);
+            }
+            egui::ImageData::Alpha(image) => {
+                let mut pixels: Vec<u8> = Vec::with_capacity(image.pixels.len() * 4);
+                let gamma = 1.0;
+                for srgba in image.srgba_pixels(gamma) {
+                    pixels.push(srgba.r());
+                    pixels.push(srgba.g());
+                    pixels.push(srgba.b());
+                    pixels.push(srgba.a());
+                }
+                self.set_texture_rgba(tex_id, image.size, &pixels);
+            }
+        };
     }
 
     fn free_texture(&mut self, tex_id: egui::TextureId) {
@@ -296,44 +300,6 @@ impl crate::Painter for WebGl2Painter {
     /// id of the canvas html element containing the rendering
     fn canvas_id(&self) -> &str {
         &self.canvas_id
-    }
-
-    fn upload_egui_texture(&mut self, font_image: &FontImage) {
-        if self.egui_texture_version == Some(font_image.version) {
-            return; // No change
-        }
-
-        let mut pixels: Vec<u8> = Vec::with_capacity(font_image.pixels.len() * 4);
-        for srgba in font_image.srgba_pixels(1.0) {
-            pixels.push(srgba.r());
-            pixels.push(srgba.g());
-            pixels.push(srgba.b());
-            pixels.push(srgba.a());
-        }
-
-        let gl = &self.gl;
-        gl.bind_texture(Gl::TEXTURE_2D, Some(&self.egui_texture));
-
-        let level = 0;
-        let internal_format = Gl::SRGB8_ALPHA8;
-        let border = 0;
-        let src_format = Gl::RGBA;
-        let src_type = Gl::UNSIGNED_BYTE;
-        gl.pixel_storei(Gl::UNPACK_ALIGNMENT, 1);
-        gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
-            Gl::TEXTURE_2D,
-            level,
-            internal_format as i32,
-            font_image.width as i32,
-            font_image.height as i32,
-            border,
-            src_format,
-            src_type,
-            Some(&pixels),
-        )
-        .unwrap();
-
-        self.egui_texture_version = Some(font_image.version);
     }
 
     fn clear(&mut self, clear_color: egui::Rgba) {

--- a/emath/src/align.rs
+++ b/emath/src/align.rs
@@ -47,7 +47,7 @@ impl Align {
         }
     }
 
-    /// ``` rust
+    /// ```
     /// assert_eq!(emath::Align::Min.align_size_within_range(2.0, 10.0..=20.0), 10.0..=12.0);
     /// assert_eq!(emath::Align::Center.align_size_within_range(2.0, 10.0..=20.0), 14.0..=16.0);
     /// assert_eq!(emath::Align::Max.align_size_within_range(2.0, 10.0..=20.0), 18.0..=20.0);

--- a/epaint/CHANGELOG.md
+++ b/epaint/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to the epaint crate will be documented in this file.
 
 
 ## Unreleased
-
 * Added `Shape::dashed_line_many` ([#1027](https://github.com/emilk/egui/pull/1027)).
+* Add `ImageData` and `TextureManager` for loading images into textures ([#1110](https://github.com/emilk/egui/pull/1110)).
+
 
 ## 0.16.0 - 2021-12-29
 * Anti-alias path ends  ([#893](https://github.com/emilk/egui/pull/893)).

--- a/epaint/src/image.rs
+++ b/epaint/src/image.rs
@@ -46,6 +46,23 @@ impl ColorImage {
         }
     }
 
+    /// An example color image
+    pub fn example() -> Self {
+        let width = 128;
+        let height = 64;
+        let mut img = Self::new([width, height], Color32::TRANSPARENT);
+        for y in 0..height {
+            for x in 0..width {
+                let h = x as f32 / width as f32;
+                let s = 1.0;
+                let v = 1.0;
+                let a = y as f32 / height as f32;
+                img[(x, y)] = crate::color::Hsva { h, s, v, a }.into();
+            }
+        }
+        img
+    }
+
     #[inline]
     pub fn width(&self) -> usize {
         self.size[0]
@@ -66,6 +83,26 @@ impl ColorImage {
             .map(|p| Color32::from_rgba_unmultiplied(p[0], p[1], p[2], p[3]))
             .collect();
         Self { size, pixels }
+    }
+}
+
+impl std::ops::Index<(usize, usize)> for ColorImage {
+    type Output = Color32;
+
+    #[inline]
+    fn index(&self, (x, y): (usize, usize)) -> &Color32 {
+        let [w, h] = self.size;
+        assert!(x < w && y < h);
+        &self.pixels[y * w + x]
+    }
+}
+
+impl std::ops::IndexMut<(usize, usize)> for ColorImage {
+    #[inline]
+    fn index_mut(&mut self, (x, y): (usize, usize)) -> &mut Color32 {
+        let [w, h] = self.size;
+        assert!(x < w && y < h);
+        &mut self.pixels[y * w + x]
     }
 }
 

--- a/epaint/src/image.rs
+++ b/epaint/src/image.rs
@@ -152,7 +152,10 @@ impl AlphaImage {
     /// `gamma` should normally be set to 1.0.
     /// If you are having problems with text looking skinny and pixelated, try
     /// setting a lower gamma, e.g. `0.5`.
-    pub fn srgba_pixels(&'_ self, gamma: f32) -> impl Iterator<Item = super::Color32> + '_ {
+    pub fn srgba_pixels(
+        &'_ self,
+        gamma: f32,
+    ) -> impl ExactSizeIterator<Item = super::Color32> + '_ {
         let srgba_from_alpha_lut: Vec<Color32> = (0..=255)
             .map(|a| {
                 let a = super::color::linear_f32_from_linear_u8(a).powf(gamma);

--- a/epaint/src/image.rs
+++ b/epaint/src/image.rs
@@ -1,6 +1,8 @@
 use crate::Color32;
 
 /// An image stored in RAM.
+///
+/// See also: [`ColorImage`], [`AlphaImage`].
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum ImageData {

--- a/epaint/src/image.rs
+++ b/epaint/src/image.rs
@@ -10,6 +10,22 @@ pub enum ImageData {
     Alpha(AlphaImage),
 }
 
+impl ImageData {
+    pub fn size(&self) -> [usize; 2] {
+        match self {
+            Self::Color(image) => image.size,
+            Self::Alpha(image) => image.size,
+        }
+    }
+
+    pub fn bytes_per_pixel(&self) -> usize {
+        match self {
+            Self::Color(_) => 4,
+            Self::Alpha(_) => 1,
+        }
+    }
+}
+
 // ----------------------------------------------------------------------------
 
 /// A 2D RGBA color image in RAM.

--- a/epaint/src/image.rs
+++ b/epaint/src/image.rs
@@ -1,0 +1,141 @@
+use crate::Color32;
+
+/// An image stored in RAM.
+#[derive(Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum ImageData {
+    /// RGBA image.
+    Color(ColorImage),
+    /// Used for the font texture.
+    Alpha(AlphaImage),
+}
+
+// ----------------------------------------------------------------------------
+
+/// A 2D RGBA color image in RAM.
+#[derive(Clone, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct ColorImage {
+    /// width, height
+    pub size: [usize; 2],
+    /// The pixels, row by row, from top to bottom.
+    pub pixels: Vec<Color32>,
+}
+
+impl ColorImage {
+    pub fn new(size: [usize; 2], color: Color32) -> Self {
+        Self {
+            size,
+            pixels: vec![color; size[0] * size[1]],
+        }
+    }
+
+    #[inline]
+    pub fn width(&self) -> usize {
+        self.size[0]
+    }
+
+    #[inline]
+    pub fn height(&self) -> usize {
+        self.size[1]
+    }
+
+    /// Create an `Image` from flat RGBA data.
+    /// Panics unless `size[0] * size[1] * 4 == rgba.len()`.
+    /// This is usually what you want to use after having loaded an image.
+    pub fn from_rgba_unmultiplied(size: [usize; 2], rgba: &[u8]) -> Self {
+        assert_eq!(size[0] * size[1] * 4, rgba.len());
+        let pixels = rgba
+            .chunks_exact(4)
+            .map(|p| Color32::from_rgba_unmultiplied(p[0], p[1], p[2], p[3]))
+            .collect();
+        Self { size, pixels }
+    }
+}
+
+impl From<ColorImage> for ImageData {
+    #[inline(always)]
+    fn from(image: ColorImage) -> Self {
+        Self::Color(image)
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+/// An 8-bit image, representing difference levels of transparent white.
+///
+/// Used for the font texture
+#[derive(Clone, Default, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct AlphaImage {
+    /// width, height
+    pub size: [usize; 2],
+    /// The alpha (linear space 0-255) of something white.
+    ///
+    /// One byte per pixel. Often you want to use [`Self::srgba_pixels`] instead.
+    pub pixels: Vec<u8>,
+}
+
+impl AlphaImage {
+    pub fn new(size: [usize; 2]) -> Self {
+        Self {
+            size,
+            pixels: vec![0; size[0] * size[1]],
+        }
+    }
+
+    #[inline]
+    pub fn width(&self) -> usize {
+        self.size[0]
+    }
+
+    #[inline]
+    pub fn height(&self) -> usize {
+        self.size[1]
+    }
+
+    /// Returns the textures as `sRGBA` premultiplied pixels, row by row, top to bottom.
+    ///
+    /// `gamma` should normally be set to 1.0.
+    /// If you are having problems with text looking skinny and pixelated, try
+    /// setting a lower gamma, e.g. `0.5`.
+    pub fn srgba_pixels(&'_ self, gamma: f32) -> impl Iterator<Item = super::Color32> + '_ {
+        let srgba_from_alpha_lut: Vec<Color32> = (0..=255)
+            .map(|a| {
+                let a = super::color::linear_f32_from_linear_u8(a).powf(gamma);
+                super::Rgba::from_white_alpha(a).into()
+            })
+            .collect();
+
+        self.pixels
+            .iter()
+            .map(move |&a| srgba_from_alpha_lut[a as usize])
+    }
+}
+
+impl std::ops::Index<(usize, usize)> for AlphaImage {
+    type Output = u8;
+
+    #[inline]
+    fn index(&self, (x, y): (usize, usize)) -> &u8 {
+        let [w, h] = self.size;
+        assert!(x < w && y < h);
+        &self.pixels[y * w + x]
+    }
+}
+
+impl std::ops::IndexMut<(usize, usize)> for AlphaImage {
+    #[inline]
+    fn index_mut(&mut self, (x, y): (usize, usize)) -> &mut u8 {
+        let [w, h] = self.size;
+        assert!(x < w && y < h);
+        &mut self.pixels[y * w + x]
+    }
+}
+
+impl From<AlphaImage> for ImageData {
+    #[inline(always)]
+    fn from(image: AlphaImage) -> Self {
+        Self::Alpha(image)
+    }
+}

--- a/epaint/src/image.rs
+++ b/epaint/src/image.rs
@@ -20,6 +20,14 @@ impl ImageData {
         }
     }
 
+    pub fn width(&self) -> usize {
+        self.size()[0]
+    }
+
+    pub fn height(&self) -> usize {
+        self.size()[1]
+    }
+
     pub fn bytes_per_pixel(&self) -> usize {
         match self {
             Self::Color(_) => 4,

--- a/epaint/src/image.rs
+++ b/epaint/src/image.rs
@@ -69,7 +69,19 @@ impl ColorImage {
     ///
     /// ## Example using the [`image`](crates.io/crates/image) crate:
     /// ``` ignore
-    /// fn load_image(image_data: &[u8]) -> Result<ColorImage, image::ImageError> {
+    /// fn load_image_from_path(path: &std::path::Path) -> Result<egui::ColorImage, image::ImageError> {
+    ///     use image::GenericImageView as _;
+    ///     let image = image::io::Reader::open(path)?.decode()?;
+    ///     let size = [image.width() as _, image.height() as _];
+    ///     let image_buffer = image.to_rgba8();
+    ///     let pixels = image_buffer.as_flat_samples();
+    ///     Ok(egui::ColorImage::from_rgba_unmultiplied(
+    ///         size,
+    ///         pixels.as_slice(),
+    ///     ))
+    /// }
+    ///
+    /// fn load_image_from_memory(image_data: &[u8]) -> Result<ColorImage, image::ImageError> {
     ///     use image::GenericImageView as _;
     ///     let image = image::load_from_memory(image_data)?;
     ///     let size = [image.width() as _, image.height() as _];

--- a/epaint/src/lib.rs
+++ b/epaint/src/lib.rs
@@ -133,7 +133,7 @@ pub const WHITE_UV: emath::Pos2 = emath::pos2(0.0, 0.0);
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum TextureId {
-    /// Textures allocated using [`TextureAllocator`].
+    /// Textures allocated using [`TextureManager`].
     ///
     /// The first texture (`TextureId::Epaint(0)`) is used for the font data.
     Managed(u64),

--- a/epaint/src/lib.rs
+++ b/epaint/src/lib.rs
@@ -128,15 +128,15 @@ pub use emath;
 pub const WHITE_UV: emath::Pos2 = emath::pos2(0.0, 0.0);
 
 /// What texture to use in a [`Mesh`] mesh.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+///
+/// If you don't want to use a texture, use `TextureId::Epaint(0)` and the [`WHITE_UV`] for uv-coord.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum TextureId {
     /// Textures allocated using [`TextureAllocator`].
     ///
     /// The first texture (`TextureId::Epaint(0)`) is used for the font data.
-    ///
-    /// If you don't want to use a texture, use `TextureId::Epaint(0)` and the [`WHITE_UV`] for uv-coord.
-    Epaint(u64),
+    Managed(u64),
 
     /// Your own texture, defined in any which way you want.
     /// The backend renderer will presumably use this to look up what texture to use.
@@ -146,7 +146,7 @@ pub enum TextureId {
 impl Default for TextureId {
     /// The epaint font texture.
     fn default() -> Self {
-        Self::Epaint(0)
+        Self::Managed(0)
     }
 }
 

--- a/epaint/src/lib.rs
+++ b/epaint/src/lib.rs
@@ -99,6 +99,7 @@ mod stroke;
 pub mod tessellator;
 pub mod text;
 mod texture_atlas;
+mod texture_handle;
 pub mod textures;
 pub mod util;
 
@@ -113,6 +114,7 @@ pub use {
     tessellator::{tessellate_shapes, TessellationOptions, Tessellator},
     text::{Fonts, Galley, TextStyle},
     texture_atlas::{FontImage, TextureAtlas},
+    texture_handle::TextureHandle,
     textures::TextureManager,
 };
 

--- a/epaint/src/lib.rs
+++ b/epaint/src/lib.rs
@@ -88,6 +88,7 @@
 #![allow(clippy::manual_range_contains)]
 
 pub mod color;
+pub mod image;
 mod mesh;
 pub mod mutex;
 mod shadow;
@@ -98,10 +99,12 @@ mod stroke;
 pub mod tessellator;
 pub mod text;
 mod texture_atlas;
+pub mod textures;
 pub mod util;
 
 pub use {
     color::{Color32, Rgba},
+    image::{AlphaImage, ColorImage, ImageData},
     mesh::{Mesh, Mesh16, Vertex},
     shadow::Shadow,
     shape::{CircleShape, PathShape, RectShape, Shape, TextShape},
@@ -110,6 +113,7 @@ pub use {
     tessellator::{tessellate_shapes, TessellationOptions, Tessellator},
     text::{Fonts, Galley, TextStyle},
     texture_atlas::{FontImage, TextureAtlas},
+    textures::TextureManager,
 };
 
 pub use emath::{pos2, vec2, Pos2, Rect, Vec2};
@@ -127,18 +131,22 @@ pub const WHITE_UV: emath::Pos2 = emath::pos2(0.0, 0.0);
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum TextureId {
-    /// The egui font texture.
-    /// If you don't want to use a texture, pick this and the [`WHITE_UV`] for uv-coord.
-    Egui,
+    /// Textures allocated using [`TextureAllocator`].
+    ///
+    /// The first texture (`TextureId::Epaint(0)`) is used for the font data.
+    ///
+    /// If you don't want to use a texture, use `TextureId::Epaint(0)` and the [`WHITE_UV`] for uv-coord.
+    Epaint(u64),
 
     /// Your own texture, defined in any which way you want.
-    /// egui won't care. The backend renderer will presumably use this to look up what texture to use.
+    /// The backend renderer will presumably use this to look up what texture to use.
     User(u64),
 }
 
 impl Default for TextureId {
+    /// The epaint font texture.
     fn default() -> Self {
-        Self::Egui
+        Self::Epaint(0)
     }
 }
 

--- a/epaint/src/mesh.rs
+++ b/epaint/src/mesh.rs
@@ -105,7 +105,7 @@ impl Mesh {
 
     #[inline(always)]
     pub fn colored_vertex(&mut self, pos: Pos2, color: Color32) {
-        crate::epaint_assert!(self.texture_id == TextureId::Egui);
+        crate::epaint_assert!(self.texture_id == TextureId::default());
         self.vertices.push(Vertex {
             pos,
             uv: WHITE_UV,
@@ -168,7 +168,7 @@ impl Mesh {
     /// Uniformly colored rectangle.
     #[inline(always)]
     pub fn add_colored_rect(&mut self, rect: Rect, color: Color32) {
-        crate::epaint_assert!(self.texture_id == TextureId::Egui);
+        crate::epaint_assert!(self.texture_id == TextureId::default());
         self.add_rect_with_uv(rect, [WHITE_UV, WHITE_UV].into(), color);
     }
 

--- a/epaint/src/shape.rs
+++ b/epaint/src/shape.rs
@@ -149,7 +149,7 @@ impl Shape {
         if let Shape::Mesh(mesh) = self {
             mesh.texture_id
         } else {
-            super::TextureId::Egui
+            super::TextureId::default()
         }
     }
 

--- a/epaint/src/text/font.rs
+++ b/epaint/src/text/font.rs
@@ -376,12 +376,12 @@ fn allocate_glyph(
         } else {
             let glyph_pos = atlas.allocate((glyph_width, glyph_height));
 
-            let texture = atlas.image_mut();
+            let image = atlas.image_mut();
             glyph.draw(|x, y, v| {
                 if v > 0.0 {
                     let px = glyph_pos.0 + x as usize;
                     let py = glyph_pos.1 + y as usize;
-                    texture[(px, py)] = (v * 255.0).round() as u8;
+                    image.image[(px, py)] = (v * 255.0).round() as u8;
                 }
             });
 

--- a/epaint/src/text/fonts.rs
+++ b/epaint/src/text/fonts.rs
@@ -253,13 +253,13 @@ impl Fonts {
 
         // We want an atlas big enough to be able to include all the Emojis in the `TextStyle::Heading`,
         // so we can show the Emoji picker demo window.
-        let mut atlas = TextureAtlas::new(2048, 64);
+        let mut atlas = TextureAtlas::new([2048, 64]);
 
         {
             // Make the top left pixel fully white:
             let pos = atlas.allocate((1, 1));
             assert_eq!(pos, (0, 0));
-            atlas.image_mut()[pos] = 255;
+            atlas.image_mut().image[pos] = 255;
         }
 
         let atlas = Arc::new(Mutex::new(atlas));
@@ -287,7 +287,7 @@ impl Fonts {
             let mut atlas = atlas.lock();
             let texture = atlas.image_mut();
             // Make sure we seed the texture version with something unique based on the default characters:
-            texture.version = crate::util::hash(&texture.pixels);
+            texture.version = crate::util::hash(&texture.image);
         }
 
         Self {
@@ -295,7 +295,7 @@ impl Fonts {
             definitions,
             fonts,
             atlas,
-            buffered_font_image: Default::default(), //atlas.lock().texture().clone();
+            buffered_font_image: Default::default(),
             galley_cache: Default::default(),
         }
     }

--- a/epaint/src/text/fonts.rs
+++ b/epaint/src/text/fonts.rs
@@ -28,7 +28,7 @@ pub enum TextStyle {
 }
 
 impl TextStyle {
-    pub fn all() -> impl Iterator<Item = TextStyle> {
+    pub fn all() -> impl ExactSizeIterator<Item = TextStyle> {
         [
             TextStyle::Small,
             TextStyle::Body,

--- a/epaint/src/texture_handle.rs
+++ b/epaint/src/texture_handle.rs
@@ -1,20 +1,23 @@
-use epaint::{
+use crate::{
     emath::NumExt,
     mutex::{Arc, Mutex},
-    ImageData, TextureId,
+    ImageData, TextureId, TextureManager,
 };
 
-/// Used to show images in egui.
+/// Used to paint images.
 ///
-/// To show an image in egui, allocate a texture with
-/// [`crate::Context::load_texture`] and store the [`TextureHandle`].
-/// You can then pass it to e.g. [`crate::Ui::image`].
+/// An _image_ is pixels stored in RAM, and represented using [`ImageData`].
+/// Before you can paint it however, you need to convert it to a _texture_.
+///
+/// If you are using egui, use `egui::Context::load_texture`.
 ///
 /// The [`TextureHandle`] can be cloned cheaply.
 /// When the last [`TextureHandle`] for specific texture is dropped, the texture is freed.
+///
+/// See also [`TextureManager`].
 #[must_use]
 pub struct TextureHandle {
-    tex_mngr: Arc<Mutex<epaint::TextureManager>>,
+    tex_mngr: Arc<Mutex<TextureManager>>,
     id: TextureId,
 }
 
@@ -51,7 +54,8 @@ impl std::hash::Hash for TextureHandle {
 }
 
 impl TextureHandle {
-    pub(crate) fn new(tex_mngr: Arc<Mutex<epaint::TextureManager>>, id: TextureId) -> Self {
+    /// If you are using egui, use `egui::Context::load_texture` instead.
+    pub fn new(tex_mngr: Arc<Mutex<TextureManager>>, id: TextureId) -> Self {
         Self { tex_mngr, id }
     }
 

--- a/epaint/src/textures.rs
+++ b/epaint/src/textures.rs
@@ -106,6 +106,11 @@ impl TextureManager {
     pub fn allocated(&self) -> impl ExactSizeIterator<Item = (&TextureId, &TextureMeta)> {
         self.metas.iter()
     }
+
+    /// Total number of allocated textures.
+    pub fn num_allocated(&self) -> usize {
+        self.metas.len()
+    }
 }
 
 /// Meta-data about an allocated texture.
@@ -125,6 +130,8 @@ pub struct TextureMeta {
 }
 
 impl TextureMeta {
+    /// Size in bytes.
+    /// width x height x [`Self::bytes_per_pixel`].
     pub fn bytes_used(&self) -> usize {
         self.size[0] * self.size[1] * self.bytes_per_pixel
     }

--- a/epaint/src/textures.rs
+++ b/epaint/src/textures.rs
@@ -103,7 +103,7 @@ impl TextureManager {
     }
 
     /// Get meta-data about all allocated textures in some arbitrary order.
-    pub fn allocated(&self) -> impl Iterator<Item = (&TextureId, &TextureMeta)> {
+    pub fn allocated(&self) -> impl ExactSizeIterator<Item = (&TextureId, &TextureMeta)> {
         self.metas.iter()
     }
 }

--- a/epaint/src/textures.rs
+++ b/epaint/src/textures.rs
@@ -1,0 +1,68 @@
+use crate::{image::ImageData, TextureId};
+use ahash::AHashMap;
+
+// ----------------------------------------------------------------------------
+
+/// The data needed in order to allocate and free textures/images.
+pub struct TextureManager {
+    /// We allocate texture id:s linearly.
+    next_id: u64,
+    delta: TexturesDelta,
+}
+
+impl Default for TextureManager {
+    fn default() -> Self {
+        Self {
+            next_id: 1, // reserve 0 for the font texture
+            delta: Default::default(),
+        }
+    }
+}
+
+impl TextureManager {
+    /// Allocate a new texture.
+    pub fn alloc(&mut self, image: impl Into<ImageData>) -> TextureId {
+        let id = TextureId::Epaint(self.next_id);
+        self.next_id += 1;
+        self.delta.set.insert(id, image.into());
+        id
+    }
+
+    /// Assign a new image to an existing texture.
+    pub fn set(&mut self, id: TextureId, image: impl Into<ImageData>) {
+        self.delta.set.insert(id, image.into());
+    }
+
+    /// Free an existing texture.
+    pub fn free(&mut self, id: TextureId) {
+        self.delta.free.push(id);
+    }
+
+    /// Get changes since last frame, and reset it.
+    pub fn take_delta(&mut self) -> TexturesDelta {
+        std::mem::take(&mut self.delta)
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+/// What has been allocated and freed during the last period.
+///
+/// These are commands given to the integration painter.
+#[derive(Clone, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[must_use = "The painter must take care of this"]
+pub struct TexturesDelta {
+    /// New or changed textures. Apply before rendering.
+    pub set: AHashMap<TextureId, ImageData>,
+
+    /// Texture ID:s to free after rendering.
+    pub free: Vec<TextureId>,
+}
+
+impl TexturesDelta {
+    pub fn append(&mut self, mut newer: TexturesDelta) {
+        self.set.extend(newer.set.into_iter());
+        self.free.append(&mut newer.free);
+    }
+}

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -328,31 +328,7 @@ impl Frame {
 
     /// for integrations only: call once per frame
     pub fn take_app_output(&self) -> crate::backend::AppOutput {
-        let mut lock = self.lock();
-        let next_id = lock.output.tex_allocation_data.next_id;
-        let app_output = std::mem::take(&mut lock.output);
-        lock.output.tex_allocation_data.next_id = next_id;
-        app_output
-    }
-
-    /// Allocate a texture. Free it again with [`Self::free_texture`].
-    pub fn alloc_texture(&self, image: Image) -> egui::TextureId {
-        self.lock().output.tex_allocation_data.alloc(image)
-    }
-
-    /// Free a texture that has been previously allocated with [`Self::alloc_texture`]. Idempotent.
-    pub fn free_texture(&self, id: egui::TextureId) {
-        self.lock().output.tex_allocation_data.free(id);
-    }
-}
-
-impl TextureAllocator for Frame {
-    fn alloc(&self, image: Image) -> egui::TextureId {
-        self.lock().output.tex_allocation_data.alloc(image)
-    }
-
-    fn free(&self, id: egui::TextureId) {
-        self.lock().output.tex_allocation_data.free(id);
+        std::mem::take(&mut self.lock().output)
     }
 }
 
@@ -384,41 +360,6 @@ pub struct IntegrationInfo {
 
     /// The OS native pixels-per-point
     pub native_pixels_per_point: Option<f32>,
-}
-
-/// How to allocate textures (images) to use in [`egui`].
-pub trait TextureAllocator {
-    /// Allocate a new user texture.
-    ///
-    /// There is no way to change a texture.
-    /// Instead allocate a new texture and free the previous one with [`Self::free`].
-    fn alloc(&self, image: Image) -> egui::TextureId;
-
-    /// Free the given texture.
-    fn free(&self, id: egui::TextureId);
-}
-
-/// A 2D color image in RAM.
-#[derive(Clone, Default)]
-pub struct Image {
-    /// width, height
-    pub size: [usize; 2],
-    /// The pixels, row by row, from top to bottom.
-    pub pixels: Vec<egui::Color32>,
-}
-
-impl Image {
-    /// Create an `Image` from flat RGBA data.
-    /// Panics unless `size[0] * size[1] * 4 == rgba.len()`.
-    /// This is usually what you want to use after having loaded an image.
-    pub fn from_rgba_unmultiplied(size: [usize; 2], rgba: &[u8]) -> Self {
-        assert_eq!(size[0] * size[1] * 4, rgba.len());
-        let pixels = rgba
-            .chunks_exact(4)
-            .map(|p| egui::Color32::from_rgba_unmultiplied(p[0], p[1], p[2], p[3]))
-            .collect();
-        Self { size, pixels }
-    }
 }
 
 /// Abstraction for platform dependent texture reference
@@ -482,8 +423,6 @@ pub const APP_KEY: &str = "app";
 
 /// You only need to look here if you are writing a backend for `epi`.
 pub mod backend {
-    use std::collections::HashMap;
-
     use super::*;
 
     /// How to signal the [`egui`] integration that a repaint is required.
@@ -498,47 +437,12 @@ pub mod backend {
     pub struct FrameData {
         /// Information about the integration.
         pub info: IntegrationInfo,
+
         /// Where the app can issue commands back to the integration.
         pub output: AppOutput,
+
         /// If you need to request a repaint from another thread, clone this and send it to that other thread.
         pub repaint_signal: std::sync::Arc<dyn RepaintSignal>,
-    }
-
-    /// The data needed in order to allocate and free textures/images.
-    #[derive(Default)]
-    #[must_use]
-    pub struct TexAllocationData {
-        /// We allocate texture id linearly.
-        pub(crate) next_id: u64,
-        /// New creations this frame
-        pub creations: HashMap<u64, Image>,
-        /// destructions this frame.
-        pub destructions: Vec<u64>,
-    }
-
-    impl TexAllocationData {
-        /// Should only be used by integrations
-        pub fn take(&mut self) -> Self {
-            let next_id = self.next_id;
-            let ret = std::mem::take(self);
-            self.next_id = next_id;
-            ret
-        }
-
-        /// Allocate a new texture.
-        pub fn alloc(&mut self, image: Image) -> egui::TextureId {
-            let id = self.next_id;
-            self.next_id += 1;
-            self.creations.insert(id, image);
-            egui::TextureId::User(id)
-        }
-
-        /// Free an existing texture.
-        pub fn free(&mut self, id: egui::TextureId) {
-            if let egui::TextureId::User(id) = id {
-                self.destructions.push(id);
-            }
-        }
     }
 
     /// Action that can be taken by the user app.
@@ -560,8 +464,5 @@ pub mod backend {
 
         /// Set to true to drag window while primary mouse button is down.
         pub drag_window: bool,
-
-        /// A way to allocate textures (on integrations that support it).
-        pub tex_allocation_data: TexAllocationData,
     }
 }


### PR DESCRIPTION
This continues https://github.com/emilk/egui/pull/999 by moving texture allocation from `epi` into `egui` proper.

With this PR you can convert an image into a texture using `egui::Context::load_texture`. This returns an `egui::TextureHandle` which can be used with e.g. `ui.image(…)`. This makes it far more ergonomic and convenient to show images in `egui`.

Backend integrations need to adapt by handling the new `epaint::TexturesDelta` each frame, a struct that specifies what textures were loaded and freed each frame.
