### PR TITLE
checkbox without a text label

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,6 +852,7 @@ dependencies = [
 name = "egui_glow"
 version = "0.16.0"
 dependencies = [
+ "bytemuck",
  "egui",
  "egui-winit",
  "epi",

--- a/egui/src/widgets/button.rs
+++ b/egui/src/widgets/button.rs
@@ -239,7 +239,10 @@ impl<'a> Widget for Checkbox<'a> {
         let icon_width = spacing.icon_width;
         let icon_spacing = ui.spacing().icon_spacing;
         let button_padding = spacing.button_padding;
-        let total_extra = button_padding + vec2(icon_width + icon_spacing, 0.0) + button_padding;
+        let mut total_extra = button_padding;
+        if !text.is_empty() {
+            total_extra += vec2(icon_width + icon_spacing, 0.0) + button_padding;
+        }
 
         let wrap_width = ui.available_width() - total_extra.x;
 
@@ -247,11 +250,11 @@ impl<'a> Widget for Checkbox<'a> {
         let text = if !text.text().is_empty() {
             let text = text.into_galley(ui, None, wrap_width, TextStyle::Button);
             desired_size += text.size();
-            desired_size = desired_size.at_least(spacing.interact_size); //Here I'm unsure - what is interacting size?
             Some(text)
         } else {
             None
         };
+        desired_size = desired_size.at_least(Vec2::splat(spacing.interact_size.y));
         desired_size.y = desired_size.y.max(icon_width);
         let (rect, mut response) = ui.allocate_exact_size(desired_size, Sense::click());
 

--- a/egui/src/widgets/button.rs
+++ b/egui/src/widgets/button.rs
@@ -239,21 +239,18 @@ impl<'a> Widget for Checkbox<'a> {
         let icon_width = spacing.icon_width;
         let icon_spacing = ui.spacing().icon_spacing;
         let button_padding = spacing.button_padding;
-        let mut total_extra = button_padding;
-        if !text.is_empty() {
+        let (text, mut desired_size) = if !text.is_empty() {
+            let mut total_extra = button_padding;
             total_extra += vec2(icon_width + icon_spacing, 0.0) + button_padding;
-        }
-
-        let wrap_width = ui.available_width() - total_extra.x;
-
-        let mut desired_size = total_extra;
-        let text = if !text.text().is_empty() {
+            let wrap_width = ui.available_width() - total_extra.x;
             let text = text.into_galley(ui, None, wrap_width, TextStyle::Button);
+            let mut desired_size = total_extra;
             desired_size += text.size();
-            Some(text)
+            (Some(text), desired_size)
         } else {
-            None
+            (None, button_padding)
         };
+
         desired_size = desired_size.at_least(Vec2::splat(spacing.interact_size.y));
         desired_size.y = desired_size.y.max(icon_width);
         let (rect, mut response) = ui.allocate_exact_size(desired_size, Sense::click());


### PR DESCRIPTION

This fixes the empty-space layout for a checkbox with empty label.
Note that the radio-button is NOT done, since I'm unsure about line 250:
   What is the meaning of 'spacing.interact_size'?
If my adjustment is ok, I will be happy to do the same for radiobutton.


Closes <https://github.com/emilk/egui/issues/1047>.

