### PR TITLE
Fix dead-lock in TextEdit on touch-screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 
 ### Changed 🔧
 * ⚠️ `Context::input` and `Ui::input` now locks a mutex. This can lead to a dead-lock is used in an `if let` binding!
-  * `if let Some(pos) = ui.input().pointer.latest_pos()` and similar must now be rewritten on two lines, or with added `{}` around the righ-hand-side.
+  * `if let Some(pos) = ui.input().pointer.latest_pos()` and similar must now be rewritten on two lines.
   * Search for this problem in your code using the regex `if let .*input`.
 * Renamed `CtxRef` to `Context` ([#1050](https://github.com/emilk/egui/pull/1050)).
 * `Context` can now be cloned and stored between frames ([#1050](https://github.com/emilk/egui/pull/1050)).

--- a/egui/src/widgets/text_edit/builder.rs
+++ b/egui/src/widgets/text_edit/builder.rs
@@ -390,7 +390,7 @@ impl<'t> TextEdit<'t> {
         // dragging select text, or scroll the enclosing `ScrollArea` (if any)?
         // Since currently copying selected text in not supported on `egui_web`,
         // we prioritize touch-scrolling:
-        let any_touches = ui.input().any_touches();  // separate line to avoid double-locking the same mutex
+        let any_touches = ui.input().any_touches(); // separate line to avoid double-locking the same mutex
         let allow_drag_to_select = !any_touches || ui.memory().has_focus(id);
 
         let sense = if interactive {

--- a/egui/src/widgets/text_edit/builder.rs
+++ b/egui/src/widgets/text_edit/builder.rs
@@ -390,7 +390,8 @@ impl<'t> TextEdit<'t> {
         // dragging select text, or scroll the enclosing `ScrollArea` (if any)?
         // Since currently copying selected text in not supported on `egui_web`,
         // we prioritize touch-scrolling:
-        let allow_drag_to_select = !ui.input().any_touches() || ui.memory().has_focus(id);
+        let any_touches = ui.input().any_touches();  // separate line to avoid double-locking the same mutex
+        let allow_drag_to_select = !any_touches || ui.memory().has_focus(id);
 
         let sense = if interactive {
             if allow_drag_to_select {


### PR DESCRIPTION
Introduced in https://github.com/emilk/egui/pull/1035

Fixes https://github.com/emilk/egui/issues/1116

It is pretty annoying that the scope of a Mutex lock extends outside the need for it.