### PR TITLE
Fix hard-coded corner radii

### DIFF
--- a/egui/src/containers/collapsing_header.rs
+++ b/egui/src/containers/collapsing_header.rs
@@ -331,9 +331,8 @@ impl CollapsingHeader {
             {
                 let rect = rect.expand(visuals.expansion);
 
-                let corner_radius = 2.0;
                 ui.painter()
-                    .rect(rect, corner_radius, visuals.bg_fill, visuals.bg_stroke);
+                    .rect(rect, visuals.corner_radius, visuals.bg_fill, visuals.bg_stroke);
             }
 
             {

--- a/egui/src/containers/collapsing_header.rs
+++ b/egui/src/containers/collapsing_header.rs
@@ -331,8 +331,12 @@ impl CollapsingHeader {
             {
                 let rect = rect.expand(visuals.expansion);
 
-                ui.painter()
-                    .rect(rect, visuals.corner_radius, visuals.bg_fill, visuals.bg_stroke);
+                ui.painter().rect(
+                    rect,
+                    visuals.corner_radius,
+                    visuals.bg_fill,
+                    visuals.bg_stroke,
+                );
             }
 
             {

--- a/egui/src/widgets/selected_label.rs
+++ b/egui/src/widgets/selected_label.rs
@@ -64,8 +64,12 @@ impl Widget for SelectableLabel {
             if selected || response.hovered() || response.has_focus() {
                 let rect = rect.expand(visuals.expansion);
 
-                ui.painter()
-                    .rect(rect, visuals.corner_radius, visuals.bg_fill, visuals.bg_stroke);
+                ui.painter().rect(
+                    rect,
+                    visuals.corner_radius,
+                    visuals.bg_fill,
+                    visuals.bg_stroke,
+                );
             }
 
             text.paint_with_visuals(ui.painter(), text_pos, &visuals);

--- a/egui/src/widgets/selected_label.rs
+++ b/egui/src/widgets/selected_label.rs
@@ -64,9 +64,8 @@ impl Widget for SelectableLabel {
             if selected || response.hovered() || response.has_focus() {
                 let rect = rect.expand(visuals.expansion);
 
-                let corner_radius = 2.0;
                 ui.painter()
-                    .rect(rect, corner_radius, visuals.bg_fill, visuals.bg_stroke);
+                    .rect(rect, visuals.corner_radius, visuals.bg_fill, visuals.bg_stroke);
             }
 
             text.paint_with_visuals(ui.painter(), text_pos, &visuals);


### PR DESCRIPTION
# Problem

Two widgets had hard-coded corner radius instead of using the WidgetVisuals value.

# Solution

Remove the hard-coded values and use the style instead.

# Context

I tried to make a style with non rounded corners and noticed that certain widgets kept their roundness. 

It turned out that there were two widgets with hard-coded values. This PR uses the value from the `WidgetVisual` which seems like the right thing to do. Maybe there's a reason not to but it seems to fix my problem with no apparent downsides.

# Check.sh Issues

Note that I tried running `check.sh` but it fails to compile 'speech-dispatcher'. Most likely because the version on libspeechd I installed on my machine (latest on Arch linux) is too new and doesn't work with the existing crate.
