### PR TITLE
Don't move fixed windows

### DIFF
--- a/egui/src/containers/window.rs
+++ b/egui/src/containers/window.rs
@@ -29,6 +29,7 @@ pub struct Window<'open> {
     resize: Resize,
     scroll: ScrollArea,
     collapsible: bool,
+    fixed_pos: bool,
     with_title_bar: bool,
 }
 
@@ -50,6 +51,7 @@ impl<'open> Window<'open> {
                 .default_size([340.0, 420.0]), // Default inner size of a window
             scroll: ScrollArea::neither(),
             collapsible: true,
+            fixed_pos: false,
             with_title_bar: true,
         }
     }
@@ -117,6 +119,7 @@ impl<'open> Window<'open> {
     /// Set initial position of the window.
     pub fn default_pos(mut self, default_pos: impl Into<Pos2>) -> Self {
         self.area = self.area.default_pos(default_pos);
+        self.fixed_pos = false;
         self
     }
 
@@ -133,6 +136,7 @@ impl<'open> Window<'open> {
     /// It is an error to set both an anchor and a position.
     pub fn anchor(mut self, align: Align2, offset: impl Into<Vec2>) -> Self {
         self.area = self.area.anchor(align, offset);
+        self.fixed_pos = false;
         self
     }
 
@@ -161,6 +165,7 @@ impl<'open> Window<'open> {
     /// Sets the window position and prevents it from being dragged around.
     pub fn fixed_pos(mut self, pos: impl Into<Pos2>) -> Self {
         self.area = self.area.fixed_pos(pos);
+        self.fixed_pos = true;
         self
     }
 
@@ -254,6 +259,7 @@ impl<'open> Window<'open> {
             resize,
             scroll,
             collapsible,
+            fixed_pos,
             with_title_bar,
         } = self;
 
@@ -399,9 +405,11 @@ impl<'open> Window<'open> {
             content_inner
         };
 
-        area.state_mut().pos = ctx
-            .constrain_window_rect_to_area(area.state().rect(), area.drag_bounds())
-            .min;
+        if !fixed_pos {
+            area.state_mut().pos = ctx
+                .constrain_window_rect_to_area(area.state().rect(), area.drag_bounds())
+                .min;
+        }
 
         let full_response = area.end(ctx, area_content_ui);
 


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and it is green.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->
This is a more restricted version of https://github.com/emilk/egui/pull/1049

It only applies to windows that have `fixed_pos` set. The issue still remains for the anchored example provided in https://github.com/emilk/egui/issues/1048 sadly. But doing the same for anchored windows would not be correct as seen with `Align2::CENTER_CENTER`, where moving the window up is correct behaviour.

