### PR TITLE
Added interaction control fields to PlotUi

### DIFF
--- a/egui/src/widgets/plot/mod.rs
+++ b/egui/src/widgets/plot/mod.rs
@@ -343,12 +343,14 @@ impl Plot {
             last_screen_transform,
             response,
             ctx: ui.ctx().clone(),
+            allow_drag,
         };
         let inner = build_fn(&mut plot_ui);
         let PlotUi {
             mut items,
             mut response,
             last_screen_transform,
+            allow_drag,
             ..
         } = plot_ui;
 
@@ -480,6 +482,7 @@ pub struct PlotUi {
     last_screen_transform: ScreenTransform,
     response: Response,
     ctx: Context,
+    allow_drag: bool,
 }
 
 impl PlotUi {
@@ -493,6 +496,12 @@ impl PlotUi {
 
     pub fn ctx(&self) -> &Context {
         &self.ctx
+    }
+
+    /// Whether to allow dragging in the plot to move the bounds. Default set by `allow_drag` value
+    /// of [Plot] widget (setting this value will override any value set previously on [Plot]).
+    pub fn allow_drag(&mut self, on: bool) {
+        self.allow_drag = on;
     }
 
     /// The plot bounds as they were in the last frame. If called on the first frame and the bounds were not


### PR DESCRIPTION
This is a WIP for closing <https://github.com/emilk/egui/issues/1122>. I changed the code to demonstrate what I describe in the issue regarding `allow_drag` and drag editing points. I'm creating this draft before continuing my work to get feedback regarding:

1. Should I move the fields to `PlotUi` (breaking API change) or duplicate them to be on both `Plot` and `PlotUi` (non-breaking API change)? Or perhaps take a different approach entirely?
2. I added a demo just to show editing (by dragging) points. This demo could be merged with the plot interactive demo already in place (since that interactive demo plot is currently left empty), left as its own demo, or removed entirely if deemed not useful.