### PR TITLE
Add ability to override collapsing icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 ### Added ⭐
 * `Context::load_texture` to convert an image into a texture which can be displayed using e.g. `ui.image(texture, size)` ([#1110](https://github.com/emilk/egui/pull/1110)).
 * Added `Ui::add_visible` and `Ui::add_visible_ui`.
+* Added `CollapsingHeader::icon` to override the default open/close icon using a custom function. ([1147](https://github.com/emilk/egui/pull/1147))
 
 ### Changed 🔧
 * ⚠️ `Context::input` and `Ui::input` now locks a mutex. This can lead to a dead-lock is used in an `if let` binding!
@@ -26,6 +27,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 
 ### Contributors 🙏
 * [danielkeller](https://github.com/danielkeller): [#1050](https://github.com/emilk/egui/pull/1050).
+* [juancampa](https://github.com/juancampa): [#1147](https://github.com/emilk/egui/pull/1147).
 
 
 ## 0.16.1 - 2021-12-31 - Add back `CtxRef::begin_frame,end_frame`

--- a/egui/src/containers/collapsing_header.rs
+++ b/egui/src/containers/collapsing_header.rs
@@ -244,14 +244,17 @@ impl CollapsingHeader {
     ///
     /// For example:
     /// ```
-    /// fn circle_icon(ui: &mut Ui, openness: f32, response: &Response) {
+    /// 
+    /// # egui::__run_test_ui(|ui| {
+    /// fn circle_icon(ui: &mut egui::Ui, openness: f32, response: &egui::Response) {
     ///     let stroke = ui.style().interact(&response).fg_stroke;
     ///     ui.painter().circle_filled(response.rect.center(), 2.0 + openness, stroke.color);
     /// }
     ///
-    /// CollapsingHeader::new("Circles")
+    /// egui::CollapsingHeader::new("Circles")
     ///   .icon(circle_icon)
     ///   .show(ui, |ui| { ui.label("Hi!"); });
+    /// # });
     /// ```
     pub fn icon(mut self, icon_fn: impl FnOnce(&mut Ui, f32, &Response) + 'static) -> Self {
         self.icon = Some(Box::new(icon_fn));

--- a/egui/src/containers/collapsing_header.rs
+++ b/egui/src/containers/collapsing_header.rs
@@ -98,7 +98,7 @@ impl State {
 }
 
 /// Paint the arrow icon that indicated if the region is open or not
-pub(crate) fn paint_icon(ui: &mut Ui, openness: f32, response: &Response) {
+pub(crate) fn paint_default_icon(ui: &mut Ui, openness: f32, response: &Response) {
     let visuals = ui.style().interact(response);
     let stroke = visuals.fg_stroke;
 
@@ -116,6 +116,9 @@ pub(crate) fn paint_icon(ui: &mut Ui, openness: f32, response: &Response) {
 
     ui.painter().add(Shape::closed_line(points, stroke));
 }
+
+/// A function that paints an icon indicating if the region is open or not
+pub type IconPainter = Box<dyn FnOnce(&mut Ui, f32, &Response)>;
 
 /// A header which can be collapsed/expanded, revealing a contained [`Ui`] region.
 ///
@@ -141,7 +144,7 @@ pub struct CollapsingHeader {
     selectable: bool,
     selected: bool,
     show_background: bool,
-    icon: Option<Box<dyn FnOnce(&mut Ui, f32, &Response)>>,
+    icon: Option<IconPainter>,
 }
 
 impl CollapsingHeader {
@@ -244,11 +247,11 @@ impl CollapsingHeader {
     ///
     /// For example:
     /// ```
-    /// 
     /// # egui::__run_test_ui(|ui| {
     /// fn circle_icon(ui: &mut egui::Ui, openness: f32, response: &egui::Response) {
     ///     let stroke = ui.style().interact(&response).fg_stroke;
-    ///     ui.painter().circle_filled(response.rect.center(), 2.0 + openness, stroke.color);
+    ///     let radius = egui::lerp(2.0..=3.0, openness);
+    ///     ui.painter().circle_filled(response.rect.center(), radius, stroke.color);
     /// }
     ///
     /// egui::CollapsingHeader::new("Circles")
@@ -369,7 +372,7 @@ impl CollapsingHeader {
                 if let Some(icon) = icon {
                     icon(ui, openness, &icon_response);
                 } else {
-                    paint_icon(ui, openness, &icon_response);
+                    paint_default_icon(ui, openness, &icon_response);
                 }
             }
 

--- a/egui/src/containers/window.rs
+++ b/egui/src/containers/window.rs
@@ -782,7 +782,7 @@ fn show_title_bar(
                 collapsing.toggle(ui);
             }
             let openness = collapsing.openness(ui.ctx(), collapsing_id);
-            collapsing_header::paint_icon(ui, openness, &collapse_button_response);
+            collapsing_header::paint_default_icon(ui, openness, &collapse_button_response);
         }
 
         let title_galley = title.into_galley(ui, Some(false), f32::INFINITY, TextStyle::Heading);


### PR DESCRIPTION
I wanted custom icons for my tree so I added the ability to override's `CollapsingHeader`'s icon by passing a function that gets called instead of `paint_icon`.

I personally like the pointy triangles but not the fact that they get thicker on hover.

Let's discuss if this is the best approach or if there's something better (e.g. implementing an `Icon` trait or something). I can add a demo if we decide to move forward.

https://user-images.githubusercontent.com/1410520/150612047-357e837e-18f4-4c60-b29a-e5edc3034a61.mp4


