### PR TITLE
Partial font texture update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * `Context` can now be cloned and stored between frames ([#1050](https://github.com/emilk/egui/pull/1050)).
 * Renamed `Ui::visible` to `Ui::is_visible`.
 * Split `Event::Text` into `Event::Text` and `Event::Paste` ([#1058](https://github.com/emilk/egui/pull/1058)).
-* For integrations: `FontImage` has been replaced by `TexturesDelta` (found in `Output`), describing what textures were loaded and freed each frame ([#1110](https://github.com/emilk/egui/pull/1110)).
+* For integrations:
+  * `FontImage` has been replaced by `TexturesDelta` (found in `Output`), describing what textures were loaded and freed each frame ([#1110](https://github.com/emilk/egui/pull/1110)).
+  * The painter must support partial texture updates ([#1149](https://github.com/emilk/egui/pull/1149)).
 
 ### Fixed 🐛
 * Context menu now respects the theme ([#1043](https://github.com/emilk/egui/pull/1043))

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -713,11 +713,10 @@ impl Context {
             let font_image_version = font_image.version;
 
             if Some(font_image_version) != ctx_impl.latest_font_image_version {
-                ctx_impl
-                    .tex_manager
-                    .0
-                    .write()
-                    .set(TextureId::default(), font_image.image.clone().into());
+                ctx_impl.tex_manager.0.write().set(
+                    TextureId::default(),
+                    epaint::textures::ImageDelta::whole(font_image.image.clone()),
+                );
                 ctx_impl.latest_font_image_version = Some(font_image_version);
             }
             ctx_impl

--- a/egui/src/introspection.rs
+++ b/egui/src/introspection.rs
@@ -1,60 +1,58 @@
 //! uis for egui types.
 use crate::*;
 
-impl Widget for &epaint::FontImage {
-    fn ui(self, ui: &mut Ui) -> Response {
-        use epaint::Mesh;
+// Show font texture in demo Ui
+pub(crate) fn font_texture_ui(ui: &mut Ui, [width, height]: [usize; 2]) -> Response {
+    use epaint::Mesh;
 
-        ui.vertical(|ui| {
-            // Show font texture in demo Ui
-            let [width, height] = self.size();
+    ui.vertical(|ui| {
+        let color = if ui.visuals().dark_mode {
+            Color32::WHITE
+        } else {
+            Color32::BLACK
+        };
 
-            ui.label(format!(
-                "Texture size: {} x {} (hover to zoom)",
-                width, height
-            ));
-            if width <= 1 || height <= 1 {
-                return;
-            }
-            let mut size = vec2(width as f32, height as f32);
-            if size.x > ui.available_width() {
-                size *= ui.available_width() / size.x;
-            }
-            let (rect, response) = ui.allocate_at_least(size, Sense::hover());
-            let mut mesh = Mesh::default();
-            mesh.add_rect_with_uv(
-                rect,
-                [pos2(0.0, 0.0), pos2(1.0, 1.0)].into(),
-                Color32::WHITE,
-            );
-            ui.painter().add(Shape::mesh(mesh));
+        ui.label(format!(
+            "Texture size: {} x {} (hover to zoom)",
+            width, height
+        ));
+        if width <= 1 || height <= 1 {
+            return;
+        }
+        let mut size = vec2(width as f32, height as f32);
+        if size.x > ui.available_width() {
+            size *= ui.available_width() / size.x;
+        }
+        let (rect, response) = ui.allocate_at_least(size, Sense::hover());
+        let mut mesh = Mesh::default();
+        mesh.add_rect_with_uv(rect, [pos2(0.0, 0.0), pos2(1.0, 1.0)].into(), color);
+        ui.painter().add(Shape::mesh(mesh));
 
-            let (tex_w, tex_h) = (width as f32, height as f32);
+        let (tex_w, tex_h) = (width as f32, height as f32);
 
-            response
-                .on_hover_cursor(CursorIcon::ZoomIn)
-                .on_hover_ui_at_pointer(|ui| {
-                    if let Some(pos) = ui.ctx().latest_pointer_pos() {
-                        let (_id, zoom_rect) = ui.allocate_space(vec2(128.0, 128.0));
-                        let u = remap_clamp(pos.x, rect.x_range(), 0.0..=tex_w);
-                        let v = remap_clamp(pos.y, rect.y_range(), 0.0..=tex_h);
+        response
+            .on_hover_cursor(CursorIcon::ZoomIn)
+            .on_hover_ui_at_pointer(|ui| {
+                if let Some(pos) = ui.ctx().latest_pointer_pos() {
+                    let (_id, zoom_rect) = ui.allocate_space(vec2(128.0, 128.0));
+                    let u = remap_clamp(pos.x, rect.x_range(), 0.0..=tex_w);
+                    let v = remap_clamp(pos.y, rect.y_range(), 0.0..=tex_h);
 
-                        let texel_radius = 32.0;
-                        let u = u.at_least(texel_radius).at_most(tex_w - texel_radius);
-                        let v = v.at_least(texel_radius).at_most(tex_h - texel_radius);
+                    let texel_radius = 32.0;
+                    let u = u.at_least(texel_radius).at_most(tex_w - texel_radius);
+                    let v = v.at_least(texel_radius).at_most(tex_h - texel_radius);
 
-                        let uv_rect = Rect::from_min_max(
-                            pos2((u - texel_radius) / tex_w, (v - texel_radius) / tex_h),
-                            pos2((u + texel_radius) / tex_w, (v + texel_radius) / tex_h),
-                        );
-                        let mut mesh = Mesh::default();
-                        mesh.add_rect_with_uv(zoom_rect, uv_rect, Color32::WHITE);
-                        ui.painter().add(Shape::mesh(mesh));
-                    }
-                });
-        })
-        .response
-    }
+                    let uv_rect = Rect::from_min_max(
+                        pos2((u - texel_radius) / tex_w, (v - texel_radius) / tex_h),
+                        pos2((u + texel_radius) / tex_w, (v + texel_radius) / tex_h),
+                    );
+                    let mut mesh = Mesh::default();
+                    mesh.add_rect_with_uv(zoom_rect, uv_rect, color);
+                    ui.painter().add(Shape::mesh(mesh));
+                }
+            });
+    })
+    .response
 }
 
 impl Widget for &mut epaint::text::FontDefinitions {

--- a/egui/src/widgets/plot/items/mod.rs
+++ b/egui/src/widgets/plot/items/mod.rs
@@ -1087,9 +1087,13 @@ pub struct PlotImage {
 
 impl PlotImage {
     /// Create a new image with position and size in plot coordinates.
-    pub fn new(texture_id: impl Into<TextureId>, position: Value, size: impl Into<Vec2>) -> Self {
+    pub fn new(
+        texture_id: impl Into<TextureId>,
+        center_position: Value,
+        size: impl Into<Vec2>,
+    ) -> Self {
         Self {
-            position,
+            position: center_position,
             name: Default::default(),
             highlight: false,
             texture_id: texture_id.into(),

--- a/egui_demo_lib/benches/benchmark.rs
+++ b/egui_demo_lib/benches/benchmark.rs
@@ -114,11 +114,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let text_shape = TextShape::new(egui::Pos2::ZERO, galley);
         c.bench_function("tessellate_text", |b| {
             b.iter(|| {
-                tessellator.tessellate_text(
-                    fonts.font_image().size(),
-                    text_shape.clone(),
-                    &mut mesh,
-                );
+                tessellator.tessellate_text(fonts.font_image_size(), text_shape.clone(), &mut mesh);
                 mesh.clear();
             })
         });

--- a/egui_demo_lib/src/apps/demo/plot_demo.rs
+++ b/egui_demo_lib/src/apps/demo/plot_demo.rs
@@ -343,10 +343,7 @@ impl Widget for &mut ItemsDemo {
         let image = PlotImage::new(
             texture,
             Value::new(0.0, 10.0),
-            [
-                ui.fonts().font_image().width() as f32 / 100.0,
-                ui.fonts().font_image().height() as f32 / 100.0,
-            ],
+            5.0 * vec2(texture.aspect_ratio(), 1.0),
         );
 
         let plot = Plot::new("items_demo")

--- a/egui_glium/src/epi_backend.rs
+++ b/egui_glium/src/epi_backend.rs
@@ -70,8 +70,8 @@ pub fn run(app: Box<dyn epi::App>, native_options: &epi::NativeOptions) -> ! {
                 integration.update(display.gl_window().window());
             let clipped_meshes = integration.egui_ctx.tessellate(shapes);
 
-            for (id, image) in textures_delta.set {
-                painter.set_texture(&display, id, &image);
+            for (id, image_delta) in textures_delta.set {
+                painter.set_texture(&display, id, &image_delta);
             }
 
             // paint:

--- a/egui_glium/src/lib.rs
+++ b/egui_glium/src/lib.rs
@@ -155,8 +155,8 @@ impl EguiGlium {
         let shapes = std::mem::take(&mut self.shapes);
         let mut textures_delta = std::mem::take(&mut self.textures_delta);
 
-        for (id, image) in textures_delta.set {
-            self.painter.set_texture(display, id, &image);
+        for (id, image_delta) in textures_delta.set {
+            self.painter.set_texture(display, id, &image_delta);
         }
 
         let clipped_meshes = self.egui_ctx.tessellate(shapes);

--- a/egui_glium/src/painter.rs
+++ b/egui_glium/src/painter.rs
@@ -185,9 +185,9 @@ impl Painter {
         &mut self,
         facade: &dyn glium::backend::Facade,
         tex_id: egui::TextureId,
-        image: &egui::ImageData,
+        delta: &egui::epaint::ImageDelta,
     ) {
-        let pixels: Vec<(u8, u8, u8, u8)> = match image {
+        let pixels: Vec<(u8, u8, u8, u8)> = match &delta.image {
             egui::ImageData::Color(image) => {
                 assert_eq!(
                     image.width() * image.height(),
@@ -206,15 +206,29 @@ impl Painter {
         };
         let glium_image = glium::texture::RawImage2d {
             data: std::borrow::Cow::Owned(pixels),
-            width: image.width() as _,
-            height: image.height() as _,
+            width: delta.image.width() as _,
+            height: delta.image.height() as _,
             format: glium::texture::ClientFormat::U8U8U8U8,
         };
         let format = texture::SrgbFormat::U8U8U8U8;
         let mipmaps = texture::MipmapsOption::NoMipmap;
-        let gl_texture = SrgbTexture2d::with_format(facade, glium_image, format, mipmaps).unwrap();
 
-        self.textures.insert(tex_id, gl_texture.into());
+        if let Some(pos) = delta.pos {
+            // update a sub-region
+            if let Some(gl_texture) = self.textures.get(&tex_id) {
+                let rect = glium::Rect {
+                    left: pos[0] as _,
+                    bottom: pos[1] as _,
+                    width: glium_image.width,
+                    height: glium_image.height,
+                };
+                gl_texture.main_level().write(rect, glium_image)
+            }
+        } else {
+            let gl_texture =
+                SrgbTexture2d::with_format(facade, glium_image, format, mipmaps).unwrap();
+            self.textures.insert(tex_id, gl_texture.into());
+        }
     }
 
     pub fn free_texture(&mut self, tex_id: egui::TextureId) {

--- a/egui_glium/src/painter.rs
+++ b/egui_glium/src/painter.rs
@@ -222,7 +222,7 @@ impl Painter {
                     width: glium_image.width,
                     height: glium_image.height,
                 };
-                gl_texture.main_level().write(rect, glium_image)
+                gl_texture.main_level().write(rect, glium_image);
             }
         } else {
             let gl_texture =

--- a/egui_glow/src/epi_backend.rs
+++ b/egui_glow/src/epi_backend.rs
@@ -86,8 +86,8 @@ pub fn run(app: Box<dyn epi::App>, native_options: &epi::NativeOptions) -> ! {
                 integration.update(gl_window.window());
             let clipped_meshes = integration.egui_ctx.tessellate(shapes);
 
-            for (id, image) in textures_delta.set {
-                painter.set_texture(&gl, id, &image);
+            for (id, image_delta) in textures_delta.set {
+                painter.set_texture(&gl, id, &image_delta);
             }
 
             // paint:

--- a/egui_glow/src/lib.rs
+++ b/egui_glow/src/lib.rs
@@ -175,8 +175,8 @@ impl EguiGlow {
         let shapes = std::mem::take(&mut self.shapes);
         let mut textures_delta = std::mem::take(&mut self.textures_delta);
 
-        for (id, image) in textures_delta.set {
-            self.painter.set_texture(gl, id, &image);
+        for (id, image_delta) in textures_delta.set {
+            self.painter.set_texture(gl, id, &image_delta);
         }
 
         let clipped_meshes = self.egui_ctx.tessellate(shapes);

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -386,7 +386,7 @@ impl Painter {
         &mut self,
         gl: &glow::Context,
         tex_id: egui::TextureId,
-        delta: &egui::epaint::textures::ImageDelta,
+        delta: &egui::epaint::ImageDelta,
     ) {
         self.assert_not_destroyed();
 
@@ -463,6 +463,7 @@ impl Painter {
                 glow::TEXTURE_WRAP_T,
                 glow::CLAMP_TO_EDGE as i32,
             );
+            check_for_gl_error(gl, "tex_parameter");
 
             let (internal_format, format) = if self.is_webgl_1 {
                 let format = if self.srgb_support {
@@ -477,7 +478,6 @@ impl Painter {
 
             let level = 0;
             if let Some([x, y]) = pos {
-                gl.tex_storage_2d(glow::TEXTURE_2D, 1, internal_format, w as i32, h as i32);
                 gl.tex_sub_image_2d(
                     glow::TEXTURE_2D,
                     level,
@@ -489,6 +489,7 @@ impl Painter {
                     glow::UNSIGNED_BYTE,
                     glow::PixelUnpackData::Slice(data),
                 );
+                check_for_gl_error(gl, "tex_sub_image_2d");
             } else {
                 let border = 0;
                 gl.tex_image_2d(
@@ -502,9 +503,8 @@ impl Painter {
                     glow::UNSIGNED_BYTE,
                     Some(data),
                 );
+                check_for_gl_error(gl, "tex_image_2d");
             }
-
-            check_for_gl_error(gl, "upload_texture_srgb");
         }
     }
 

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -465,7 +465,7 @@ impl Painter {
             );
             check_for_gl_error(gl, "tex_parameter");
 
-            let (internal_format, format) = if self.is_webgl_1 {
+            let (internal_format, src_format) = if self.is_webgl_1 {
                 let format = if self.srgb_support {
                     glow::SRGB_ALPHA
                 } else {
@@ -476,6 +476,8 @@ impl Painter {
                 (glow::SRGB8_ALPHA8, glow::RGBA)
             };
 
+            gl.pixel_store_i32(glow::UNPACK_ALIGNMENT, 1);
+
             let level = 0;
             if let Some([x, y]) = pos {
                 gl.tex_sub_image_2d(
@@ -485,7 +487,7 @@ impl Painter {
                     y as _,
                     w as _,
                     h as _,
-                    format,
+                    src_format,
                     glow::UNSIGNED_BYTE,
                     glow::PixelUnpackData::Slice(data),
                 );
@@ -499,7 +501,7 @@ impl Painter {
                     w as _,
                     h as _,
                     border,
-                    format,
+                    src_format,
                     glow::UNSIGNED_BYTE,
                     Some(data),
                 );

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -340,6 +340,7 @@ impl Painter {
 
                 gl.bind_texture(glow::TEXTURE_2D, Some(texture));
             }
+
             // Transform clip rect to physical pixels:
             let clip_min_x = pixels_per_point * clip_rect.min.x;
             let clip_min_y = pixels_per_point * clip_rect.min.y;

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -221,8 +221,8 @@ impl AppRunner {
     /// Paint the results of the last call to [`Self::logic`].
     pub fn paint(&mut self, clipped_meshes: Vec<egui::ClippedMesh>) -> Result<(), JsValue> {
         let textures_delta = std::mem::take(&mut self.textures_delta);
-        for (id, image) in textures_delta.set {
-            self.painter.set_texture(id, image);
+        for (id, image_delta) in textures_delta.set {
+            self.painter.set_texture(id, image_delta);
         }
 
         self.painter.clear(self.app.clear_color());

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -222,7 +222,7 @@ impl AppRunner {
     pub fn paint(&mut self, clipped_meshes: Vec<egui::ClippedMesh>) -> Result<(), JsValue> {
         let textures_delta = std::mem::take(&mut self.textures_delta);
         for (id, image_delta) in textures_delta.set {
-            self.painter.set_texture(id, image_delta);
+            self.painter.set_texture(id, &image_delta);
         }
 
         self.painter.clear(self.app.clear_color());

--- a/egui_web/src/glow_wrapping.rs
+++ b/egui_web/src/glow_wrapping.rs
@@ -41,7 +41,7 @@ impl WrappedGlowPainter {
 
 impl crate::Painter for WrappedGlowPainter {
     fn set_texture(&mut self, tex_id: egui::TextureId, delta: &egui::epaint::ImageDelta) {
-        self.painter.set_texture(&self.glow_ctx, tex_id, &delta);
+        self.painter.set_texture(&self.glow_ctx, tex_id, delta);
     }
 
     fn free_texture(&mut self, tex_id: egui::TextureId) {

--- a/egui_web/src/glow_wrapping.rs
+++ b/egui_web/src/glow_wrapping.rs
@@ -40,8 +40,8 @@ impl WrappedGlowPainter {
 }
 
 impl crate::Painter for WrappedGlowPainter {
-    fn set_texture(&mut self, tex_id: egui::TextureId, image: egui::ImageData) {
-        self.painter.set_texture(&self.glow_ctx, tex_id, &image);
+    fn set_texture(&mut self, tex_id: egui::TextureId, delta: &egui::epaint::ImageDelta) {
+        self.painter.set_texture(&self.glow_ctx, tex_id, &delta);
     }
 
     fn free_texture(&mut self, tex_id: egui::TextureId) {

--- a/egui_web/src/painter.rs
+++ b/egui_web/src/painter.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::JsValue;
 
 pub trait Painter {
-    fn set_texture(&mut self, tex_id: egui::TextureId, image: egui::ImageData);
+    fn set_texture(&mut self, tex_id: egui::TextureId, delta: &egui::epaint::ImageDelta);
 
     fn free_texture(&mut self, tex_id: egui::TextureId);
 

--- a/egui_web/src/webgl1.rs
+++ b/egui_web/src/webgl1.rs
@@ -222,9 +222,20 @@ impl WebGlPainter {
         Ok(())
     }
 
-    fn set_texture_rgba(&mut self, tex_id: egui::TextureId, size: [usize; 2], pixels: &[u8]) {
+    fn set_texture_rgba(
+        &mut self,
+        tex_id: egui::TextureId,
+        pos: Option<[usize; 2]>,
+        [w, h]: [usize; 2],
+        pixels: &[u8],
+    ) {
         let gl = &self.gl;
-        let gl_texture = gl.create_texture().unwrap();
+
+        let gl_texture = self
+            .textures
+            .entry(tex_id)
+            .or_insert_with(|| gl.create_texture().unwrap());
+
         gl.bind_texture(Gl::TEXTURE_2D, Some(&gl_texture));
         gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_S, Gl::CLAMP_TO_EDGE as _);
         gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_T, Gl::CLAMP_TO_EDGE as _);
@@ -238,20 +249,36 @@ impl WebGlPainter {
         let border = 0;
         let src_format = self.texture_format;
         let src_type = Gl::UNSIGNED_BYTE;
-        gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
-            Gl::TEXTURE_2D,
-            level,
-            internal_format as _,
-            size[0] as _,
-            size[1] as _,
-            border,
-            src_format,
-            src_type,
-            Some(pixels),
-        )
-        .unwrap();
 
-        self.textures.insert(tex_id, gl_texture);
+        gl.pixel_storei(Gl::UNPACK_ALIGNMENT, 1);
+
+        if let Some([x, y]) = pos {
+            gl.tex_sub_image_2d_with_i32_and_i32_and_u32_and_type_and_opt_u8_array(
+                Gl::TEXTURE_2D,
+                level,
+                x as _,
+                y as _,
+                w as _,
+                h as _,
+                src_format,
+                src_type,
+                Some(pixels),
+            )
+            .unwrap();
+        } else {
+            gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
+                Gl::TEXTURE_2D,
+                level,
+                internal_format as _,
+                w as _,
+                h as _,
+                border,
+                src_format,
+                src_type,
+                Some(pixels),
+            )
+            .unwrap();
+        }
     }
 }
 
@@ -271,8 +298,8 @@ impl epi::NativeTexture for WebGlPainter {
 }
 
 impl crate::Painter for WebGlPainter {
-    fn set_texture(&mut self, tex_id: egui::TextureId, image: egui::ImageData) {
-        match image {
+    fn set_texture(&mut self, tex_id: egui::TextureId, delta: &egui::epaint::ImageDelta) {
+        match &delta.image {
             egui::ImageData::Color(image) => {
                 assert_eq!(
                     image.width() * image.height(),
@@ -281,7 +308,7 @@ impl crate::Painter for WebGlPainter {
                 );
 
                 let data: &[u8] = bytemuck::cast_slice(image.pixels.as_ref());
-                self.set_texture_rgba(tex_id, image.size, data);
+                self.set_texture_rgba(tex_id, delta.pos, image.size, data);
             }
             egui::ImageData::Alpha(image) => {
                 let gamma = if self.post_process.is_none() {
@@ -293,7 +320,7 @@ impl crate::Painter for WebGlPainter {
                     .srgba_pixels(gamma)
                     .flat_map(|a| a.to_array())
                     .collect();
-                self.set_texture_rgba(tex_id, image.size, &data);
+                self.set_texture_rgba(tex_id, delta.pos, image.size, &data);
             }
         };
     }

--- a/egui_web/src/webgl1.rs
+++ b/egui_web/src/webgl1.rs
@@ -40,13 +40,6 @@ impl WebGlPainter {
 
         // --------------------------------------------------------------------
 
-        let egui_texture = gl.create_texture().unwrap();
-        gl.bind_texture(Gl::TEXTURE_2D, Some(&egui_texture));
-        gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_S, Gl::CLAMP_TO_EDGE as i32);
-        gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_T, Gl::CLAMP_TO_EDGE as i32);
-        gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MIN_FILTER, Gl::LINEAR as i32);
-        gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MAG_FILTER, Gl::LINEAR as i32);
-
         let srgb_supported = matches!(gl.get_extension("EXT_sRGB"), Ok(Some(_)));
 
         let vert_shader = compile_shader(
@@ -236,13 +229,11 @@ impl WebGlPainter {
             .entry(tex_id)
             .or_insert_with(|| gl.create_texture().unwrap());
 
-        gl.bind_texture(Gl::TEXTURE_2D, Some(&gl_texture));
+        gl.bind_texture(Gl::TEXTURE_2D, Some(gl_texture));
         gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_S, Gl::CLAMP_TO_EDGE as _);
         gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_T, Gl::CLAMP_TO_EDGE as _);
         gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MIN_FILTER, Gl::LINEAR as _);
         gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MAG_FILTER, Gl::LINEAR as _);
-
-        gl.bind_texture(Gl::TEXTURE_2D, Some(&gl_texture));
 
         let level = 0;
         let internal_format = self.texture_format;

--- a/egui_web/src/webgl2.rs
+++ b/egui_web/src/webgl2.rs
@@ -206,9 +206,20 @@ impl WebGl2Painter {
         Ok(())
     }
 
-    fn set_texture_rgba(&mut self, tex_id: egui::TextureId, size: [usize; 2], pixels: &[u8]) {
+    fn set_texture_rgba(
+        &mut self,
+        tex_id: egui::TextureId,
+        pos: Option<[usize; 2]>,
+        [w, h]: [usize; 2],
+        pixels: &[u8],
+    ) {
         let gl = &self.gl;
-        let gl_texture = gl.create_texture().unwrap();
+
+        let gl_texture = self
+            .textures
+            .entry(tex_id)
+            .or_insert_with(|| gl.create_texture().unwrap());
+
         gl.bind_texture(Gl::TEXTURE_2D, Some(&gl_texture));
         gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_S, Gl::CLAMP_TO_EDGE as _);
         gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_T, Gl::CLAMP_TO_EDGE as _);
@@ -222,21 +233,36 @@ impl WebGl2Painter {
         let border = 0;
         let src_format = Gl::RGBA;
         let src_type = Gl::UNSIGNED_BYTE;
-        gl.pixel_storei(Gl::UNPACK_ALIGNMENT, 1);
-        gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
-            Gl::TEXTURE_2D,
-            level,
-            internal_format as i32,
-            size[0] as i32,
-            size[1] as i32,
-            border,
-            src_format,
-            src_type,
-            Some(pixels),
-        )
-        .unwrap();
 
-        self.textures.insert(tex_id, gl_texture);
+        gl.pixel_storei(Gl::UNPACK_ALIGNMENT, 1);
+
+        if let Some([x, y]) = pos {
+            gl.tex_sub_image_2d_with_i32_and_i32_and_u32_and_type_and_opt_u8_array(
+                Gl::TEXTURE_2D,
+                level,
+                x as _,
+                y as _,
+                w as _,
+                h as _,
+                src_format,
+                src_type,
+                Some(pixels),
+            )
+            .unwrap();
+        } else {
+            gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
+                Gl::TEXTURE_2D,
+                level,
+                internal_format as _,
+                w as _,
+                h as _,
+                border,
+                src_format,
+                src_type,
+                Some(pixels),
+            )
+            .unwrap();
+        }
     }
 }
 
@@ -256,8 +282,8 @@ impl epi::NativeTexture for WebGl2Painter {
 }
 
 impl crate::Painter for WebGl2Painter {
-    fn set_texture(&mut self, tex_id: egui::TextureId, image: egui::ImageData) {
-        match image {
+    fn set_texture(&mut self, tex_id: egui::TextureId, delta: &egui::epaint::ImageDelta) {
+        match &delta.image {
             egui::ImageData::Color(image) => {
                 assert_eq!(
                     image.width() * image.height(),
@@ -266,7 +292,7 @@ impl crate::Painter for WebGl2Painter {
                 );
 
                 let data: &[u8] = bytemuck::cast_slice(image.pixels.as_ref());
-                self.set_texture_rgba(tex_id, image.size, data);
+                self.set_texture_rgba(tex_id, delta.pos, image.size, data);
             }
             egui::ImageData::Alpha(image) => {
                 let gamma = 1.0;
@@ -274,7 +300,7 @@ impl crate::Painter for WebGl2Painter {
                     .srgba_pixels(gamma)
                     .flat_map(|a| a.to_array())
                     .collect();
-                self.set_texture_rgba(tex_id, image.size, &data);
+                self.set_texture_rgba(tex_id, delta.pos, image.size, &data);
             }
         };
     }

--- a/egui_web/src/webgl2.rs
+++ b/egui_web/src/webgl2.rs
@@ -40,13 +40,6 @@ impl WebGl2Painter {
 
         // --------------------------------------------------------------------
 
-        let egui_texture = gl.create_texture().unwrap();
-        gl.bind_texture(Gl::TEXTURE_2D, Some(&egui_texture));
-        gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_S, Gl::CLAMP_TO_EDGE as i32);
-        gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_T, Gl::CLAMP_TO_EDGE as i32);
-        gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MIN_FILTER, Gl::LINEAR as i32);
-        gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MAG_FILTER, Gl::LINEAR as i32);
-
         let vert_shader = compile_shader(
             &gl,
             Gl::VERTEX_SHADER,
@@ -220,13 +213,11 @@ impl WebGl2Painter {
             .entry(tex_id)
             .or_insert_with(|| gl.create_texture().unwrap());
 
-        gl.bind_texture(Gl::TEXTURE_2D, Some(&gl_texture));
+        gl.bind_texture(Gl::TEXTURE_2D, Some(gl_texture));
         gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_S, Gl::CLAMP_TO_EDGE as _);
         gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_T, Gl::CLAMP_TO_EDGE as _);
         gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MIN_FILTER, Gl::LINEAR as _);
         gl.tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MAG_FILTER, Gl::LINEAR as _);
-
-        gl.bind_texture(Gl::TEXTURE_2D, Some(&gl_texture));
 
         let level = 0;
         let internal_format = Gl::SRGB8_ALPHA8;

--- a/epaint/src/lib.rs
+++ b/epaint/src/lib.rs
@@ -105,7 +105,7 @@ pub mod util;
 
 pub use {
     color::{Color32, Rgba},
-    image::{AlphaImage, ColorImage, ImageData},
+    image::{AlphaImage, ColorImage, ImageData, ImageDelta},
     mesh::{Mesh, Mesh16, Vertex},
     shadow::Shadow,
     shape::{CircleShape, PathShape, RectShape, Shape, TextShape},
@@ -113,7 +113,7 @@ pub use {
     stroke::Stroke,
     tessellator::{tessellate_shapes, TessellationOptions, Tessellator},
     text::{Fonts, Galley, TextStyle},
-    texture_atlas::{FontImage, TextureAtlas},
+    texture_atlas::TextureAtlas,
     texture_handle::TextureHandle,
     textures::TextureManager,
 };

--- a/epaint/src/text/font.rs
+++ b/epaint/src/text/font.rs
@@ -374,14 +374,12 @@ fn allocate_glyph(
         if glyph_width == 0 || glyph_height == 0 {
             UvRect::default()
         } else {
-            let glyph_pos = atlas.allocate((glyph_width, glyph_height));
-
-            let image = atlas.image_mut();
+            let (glyph_pos, image) = atlas.allocate((glyph_width, glyph_height));
             glyph.draw(|x, y, v| {
                 if v > 0.0 {
                     let px = glyph_pos.0 + x as usize;
                     let py = glyph_pos.1 + y as usize;
-                    image.image[(px, py)] = (v * 255.0).round() as u8;
+                    image[(px, py)] = (v * 255.0).round() as u8;
                 }
             });
 

--- a/epaint/src/texture_atlas.rs
+++ b/epaint/src/texture_atlas.rs
@@ -1,39 +1,40 @@
-use crate::image::AlphaImage;
+use crate::{AlphaImage, ImageDelta};
 
-/// An 8-bit texture containing font data.
-#[derive(Clone, Default)]
-pub struct FontImage {
-    /// e.g. a hash of the data. Use this to detect changes!
-    /// If the texture changes, this too will change.
-    pub version: u64,
-
-    /// The actual image data.
-    pub image: AlphaImage,
+#[derive(Clone, Copy, Eq, PartialEq)]
+struct Rectu {
+    /// inclusive
+    min_x: usize,
+    /// inclusive
+    min_y: usize,
+    /// exclusive
+    max_x: usize,
+    /// exclusive
+    max_y: usize,
 }
 
-impl FontImage {
-    #[inline]
-    pub fn size(&self) -> [usize; 2] {
-        self.image.size
-    }
-
-    #[inline]
-    pub fn width(&self) -> usize {
-        self.image.size[0]
-    }
-
-    #[inline]
-    pub fn height(&self) -> usize {
-        self.image.size[1]
-    }
+impl Rectu {
+    const NOTHING: Self = Self {
+        min_x: usize::MAX,
+        min_y: usize::MAX,
+        max_x: 0,
+        max_y: 0,
+    };
+    const EVERYTHING: Self = Self {
+        min_x: 0,
+        min_y: 0,
+        max_x: usize::MAX,
+        max_y: usize::MAX,
+    };
 }
 
 /// Contains font data in an atlas, where each character occupied a small rectangle.
 ///
 /// More characters can be added, possibly expanding the texture.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct TextureAtlas {
-    image: FontImage,
+    image: AlphaImage,
+    /// What part of the image that is dirty
+    dirty: Rectu,
 
     /// Used for when allocating new rectangles.
     cursor: (usize, usize),
@@ -43,25 +44,35 @@ pub struct TextureAtlas {
 impl TextureAtlas {
     pub fn new(size: [usize; 2]) -> Self {
         Self {
-            image: FontImage {
-                version: 0,
-                image: AlphaImage::new(size),
-            },
-            ..Default::default()
+            image: AlphaImage::new(size),
+            dirty: Rectu::EVERYTHING,
+            cursor: (0, 0),
+            row_height: 0,
         }
     }
 
-    pub fn image(&self) -> &FontImage {
-        &self.image
+    pub fn size(&self) -> [usize; 2] {
+        self.image.size
     }
 
-    pub fn image_mut(&mut self) -> &mut FontImage {
-        self.image.version += 1;
-        &mut self.image
+    /// Call to get the change to the image since last call.
+    pub fn take_delta(&mut self) -> Option<ImageDelta> {
+        let dirty = std::mem::replace(&mut self.dirty, Rectu::NOTHING);
+        if dirty == Rectu::NOTHING {
+            None
+        } else if dirty == Rectu::EVERYTHING {
+            Some(ImageDelta::full(self.image.clone()))
+        } else {
+            let pos = [dirty.min_x, dirty.min_y];
+            let size = [dirty.max_x - dirty.min_x, dirty.max_y - dirty.min_y];
+            let region = self.image.region(pos, size);
+            Some(ImageDelta::partial(pos, region))
+        }
     }
 
-    /// Returns the coordinates of where the rect ended up.
-    pub fn allocate(&mut self, (w, h): (usize, usize)) -> (usize, usize) {
+    /// Returns the coordinates of where the rect ended up,
+    /// and invalidates the region.
+    pub fn allocate(&mut self, (w, h): (usize, usize)) -> ((usize, usize), &mut AlphaImage) {
         /// On some low-precision GPUs (my old iPad) characters get muddled up
         /// if we don't add some empty pixels between the characters.
         /// On modern high-precision GPUs this is not needed.
@@ -81,21 +92,31 @@ impl TextureAtlas {
         }
 
         self.row_height = self.row_height.max(h);
-        resize_to_min_height(&mut self.image.image, self.cursor.1 + self.row_height);
+        if resize_to_min_height(&mut self.image, self.cursor.1 + self.row_height) {
+            self.dirty = Rectu::EVERYTHING;
+        }
 
         let pos = self.cursor;
         self.cursor.0 += w + PADDING;
-        self.image.version += 1;
-        (pos.0 as usize, pos.1 as usize)
+
+        self.dirty.min_x = self.dirty.min_x.min(pos.0);
+        self.dirty.min_y = self.dirty.min_y.min(pos.1);
+        self.dirty.max_x = self.dirty.max_x.max(pos.0 + w);
+        self.dirty.max_y = self.dirty.max_y.max(pos.1 + h);
+
+        (pos, &mut self.image)
     }
 }
 
-fn resize_to_min_height(image: &mut AlphaImage, min_height: usize) {
+fn resize_to_min_height(image: &mut AlphaImage, min_height: usize) -> bool {
     while min_height >= image.height() {
         image.size[1] *= 2; // double the height
     }
 
     if image.width() * image.height() > image.pixels.len() {
         image.pixels.resize(image.width() * image.height(), 0);
+        true
+    } else {
+        false
     }
 }

--- a/epaint/src/texture_handle.rs
+++ b/epaint/src/texture_handle.rs
@@ -1,8 +1,7 @@
 use crate::{
     emath::NumExt,
     mutex::{Arc, RwLock},
-    textures::ImageDelta,
-    ImageData, TextureId, TextureManager,
+    ImageData, ImageDelta, TextureId, TextureManager,
 };
 
 /// Used to paint images.
@@ -69,7 +68,7 @@ impl TextureHandle {
     pub fn set(&mut self, image: impl Into<ImageData>) {
         self.tex_mngr
             .write()
-            .set(self.id, ImageDelta::whole(image.into()));
+            .set(self.id, ImageDelta::full(image.into()));
     }
 
     /// Assign a new image to a subregion of the whole texture.

--- a/epaint/src/texture_handle.rs
+++ b/epaint/src/texture_handle.rs
@@ -1,6 +1,7 @@
 use crate::{
     emath::NumExt,
     mutex::{Arc, RwLock},
+    textures::ImageDelta,
     ImageData, TextureId, TextureManager,
 };
 
@@ -66,7 +67,16 @@ impl TextureHandle {
 
     /// Assign a new image to an existing texture.
     pub fn set(&mut self, image: impl Into<ImageData>) {
-        self.tex_mngr.write().set(self.id, image.into());
+        self.tex_mngr
+            .write()
+            .set(self.id, ImageDelta::whole(image.into()));
+    }
+
+    /// Assign a new image to a subregion of the whole texture.
+    pub fn set_partial(&mut self, pos: [usize; 2], image: impl Into<ImageData>) {
+        self.tex_mngr
+            .write()
+            .set(self.id, ImageDelta::partial(pos, image.into()));
     }
 
     /// width x height

--- a/epaint/src/textures.rs
+++ b/epaint/src/textures.rs
@@ -1,4 +1,4 @@
-use crate::{image::ImageData, TextureId};
+use crate::{ImageData, ImageDelta, TextureId};
 use ahash::AHashMap;
 
 // ----------------------------------------------------------------------------
@@ -38,7 +38,7 @@ impl TextureManager {
             retain_count: 1,
         });
 
-        self.delta.set.insert(id, ImageDelta::whole(image));
+        self.delta.set.insert(id, ImageDelta::full(image));
         id
     }
 
@@ -160,45 +160,5 @@ impl TexturesDelta {
     pub fn append(&mut self, mut newer: TexturesDelta) {
         self.set.extend(newer.set.into_iter());
         self.free.append(&mut newer.free);
-    }
-}
-
-/// A change to an image.
-///
-/// Either a whole new image,
-/// or an update to a rectangular region of it.
-#[derive(Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[must_use = "The painter must take care of this"]
-pub struct ImageDelta {
-    /// What to set the texture to.
-    pub image: ImageData,
-
-    /// If `None`, set the whole texture to [`Self::image`].
-    /// If `Some(pos)`, update a sub-region of an already allocated texture.
-    pub pos: Option<[usize; 2]>,
-}
-
-impl ImageDelta {
-    /// Update the whole texture.
-    pub fn whole(image: impl Into<ImageData>) -> Self {
-        Self {
-            image: image.into(),
-            pos: None,
-        }
-    }
-
-    /// Update a sub-region of an existing texture.
-    pub fn partial(pos: [usize; 2], image: impl Into<ImageData>) -> Self {
-        Self {
-            image: image.into(),
-            pos: Some(pos),
-        }
-    }
-
-    /// Is this affecting the whole texture?
-    /// If `false`, this is a partial (sub-region) update.
-    pub fn is_whole(&self) -> bool {
-        self.pos.is_none()
     }
 }


### PR DESCRIPTION
When a new character is rendered into the font atlas, only the changed region will now be uploaded to the GPU. This helps maintain a smoother framerate and better performance when entering uncached characters. It requires slightly more of the backend integrations, but not much (see the change to the glium/glow/webgl painters).