### PR TITLE
Lower default font atlas size

### DIFF
--- a/epaint/src/text/fonts.rs
+++ b/epaint/src/text/fonts.rs
@@ -478,8 +478,8 @@ impl FontsImpl {
             pixels_per_point
         );
 
-        let texture_width = max_texture_side.at_most(16 * 1024);
-        let initial_height = 512;
+        let texture_width = max_texture_side.at_most(8 * 1024);
+        let initial_height = 64;
         let mut atlas = TextureAtlas::new([texture_width, initial_height]);
 
         {


### PR DESCRIPTION
In https://github.com/emilk/egui/pull/1154 the default was set to 16k x 512, which is way excessive, as most of it will be blank.

This PR changes it to 8k x 64, which will make egui use less RAM and VRAM, and load quicker again.

This also decreases the max size from 16k² to 8k². That should be enough.
