### PR TITLE
Return more info from ScrollArea::show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * Replaced `Style::body_text_style` with more generic `Style::text_styles` ([#1154](https://github.com/emilk/egui/pull/1154)).
 * `TextStyle` is no longer `Copy` ([#1154](https://github.com/emilk/egui/pull/1154)).
 * Replaced `TextEdit::text_style` with `TextEdit::font` ([#1154](https://github.com/emilk/egui/pull/1154)).
-* `Plot::highlight` now takes a `bool` argument ([#1159](https://github.com/emilk/egui/pull/1159)),
+* `Plot::highlight` now takes a `bool` argument ([#1159](https://github.com/emilk/egui/pull/1159)).
+* `ScrollArea::show` now returns a `ScrollAreaOutput`, so you might need to add `.inner` after the call to it ([#1166](https://github.com/emilk/egui/pull/1166)).
 
 ### Fixed 🐛
 * Context menu now respects the theme ([#1043](https://github.com/emilk/egui/pull/1043))

--- a/egui/src/containers/combo_box.rs
+++ b/egui/src/containers/combo_box.rs
@@ -196,6 +196,7 @@ fn combo_box_dyn<'c, R>(
         ScrollArea::vertical()
             .max_height(ui.spacing().combo_height)
             .show(ui, menu_contents)
+            .inner
     });
 
     InnerResponse {

--- a/egui/src/containers/window.rs
+++ b/egui/src/containers/window.rs
@@ -354,7 +354,7 @@ impl<'open> Window<'open> {
                         }
 
                         if scroll.has_any_bar() {
-                            scroll.show(ui, add_contents)
+                            scroll.show(ui, add_contents).inner
                         } else {
                             add_contents(ui)
                         }

--- a/egui/src/response.rs
+++ b/egui/src/response.rs
@@ -586,7 +586,9 @@ impl std::ops::BitOrAssign for Response {
 /// ```
 #[derive(Debug)]
 pub struct InnerResponse<R> {
+    /// What the user closure returned.
     pub inner: R,
+    /// The response of the area.
     pub response: Response,
 }
 

--- a/egui_demo_lib/src/apps/demo/scrolling.rs
+++ b/egui_demo_lib/src/apps/demo/scrolling.rs
@@ -210,32 +210,34 @@ impl super::View for ScrollTo {
         }
 
         ui.separator();
-        let (current_scroll, max_scroll) = scroll_area.show(ui, |ui| {
-            if scroll_top {
-                ui.scroll_to_cursor(Align::TOP);
-            }
-            ui.vertical(|ui| {
-                for item in 1..=50 {
-                    if track_item && item == self.track_item {
-                        let response =
-                            ui.colored_label(Color32::YELLOW, format!("This is item {}", item));
-                        response.scroll_to_me(self.tack_item_align);
-                    } else {
-                        ui.label(format!("This is item {}", item));
-                    }
+        let (current_scroll, max_scroll) = scroll_area
+            .show(ui, |ui| {
+                if scroll_top {
+                    ui.scroll_to_cursor(Align::TOP);
                 }
-            });
+                ui.vertical(|ui| {
+                    for item in 1..=50 {
+                        if track_item && item == self.track_item {
+                            let response =
+                                ui.colored_label(Color32::YELLOW, format!("This is item {}", item));
+                            response.scroll_to_me(self.tack_item_align);
+                        } else {
+                            ui.label(format!("This is item {}", item));
+                        }
+                    }
+                });
 
-            if scroll_bottom {
-                ui.scroll_to_cursor(Align::BOTTOM);
-            }
+                if scroll_bottom {
+                    ui.scroll_to_cursor(Align::BOTTOM);
+                }
 
-            let margin = ui.visuals().clip_rect_margin;
+                let margin = ui.visuals().clip_rect_margin;
 
-            let current_scroll = ui.clip_rect().top() - ui.min_rect().top() + margin;
-            let max_scroll = ui.min_rect().height() - ui.clip_rect().height() + 2.0 * margin;
-            (current_scroll, max_scroll)
-        });
+                let current_scroll = ui.clip_rect().top() - ui.min_rect().top() + margin;
+                let max_scroll = ui.min_rect().height() - ui.clip_rect().height() + 2.0 * margin;
+                (current_scroll, max_scroll)
+            })
+            .inner;
         ui.separator();
 
         ui.label(format!(


### PR DESCRIPTION
This will let users know where on the screen the `ScrollArea` was shown and how far scrolled it was. This also adds a place to add more info in the future, like how much it scrolled this frame, if the user tried to "over-scroll" (which could be used to trigger loading more content).