### PR TITLE
Plot boxed zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * Added `CollapsingHeader::icon` to override the default open/close icon using a custom function. ([1147](https://github.com/emilk/egui/pull/1147)).
 * Added `Plot::x_axis_formatter` and `Plot::y_axis_formatter` for custom axis labels ([#1130](https://github.com/emilk/egui/pull/1130)).
 * Added `ui.data()`, `ctx.data()`, `ctx.options()` and `ctx.tessellation_options()` ([#1175](https://github.com/emilk/egui/pull/1175)).
+* Added `Plot::allow_boxed_zoom()`, `Plot::boxed_zoom_pointer()` for boxed zooming on plots.
+
 
 ### Changed 🔧
 * ⚠️ `Context::input` and `Ui::input` now locks a mutex. This can lead to a dead-lock is used in an `if let` binding!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * Added `CollapsingHeader::icon` to override the default open/close icon using a custom function. ([1147](https://github.com/emilk/egui/pull/1147)).
 * Added `Plot::x_axis_formatter` and `Plot::y_axis_formatter` for custom axis labels ([#1130](https://github.com/emilk/egui/pull/1130)).
 * Added `ui.data()`, `ctx.data()`, `ctx.options()` and `ctx.tessellation_options()` ([#1175](https://github.com/emilk/egui/pull/1175)).
-* Added `Plot::allow_boxed_zoom()`, `Plot::boxed_zoom_pointer()` for boxed zooming on plots.
+* Added `Plot::allow_boxed_zoom()`, `Plot::boxed_zoom_pointer()` for boxed zooming on plots ([#1188](https://github.com/emilk/egui/pull/1188)).
 
 
 ### Changed 🔧

--- a/egui/src/widgets/plot/mod.rs
+++ b/egui/src/widgets/plot/mod.rs
@@ -76,7 +76,7 @@ pub struct Plot {
     min_auto_bounds: PlotBounds,
     margin_fraction: Vec2,
     allow_boxed_zoom: bool,
-    boxed_zoom_pointer: PointerButton,
+    boxed_zoom_pointer_button: PointerButton,
 
     min_size: Vec2,
     width: Option<f32>,
@@ -106,7 +106,7 @@ impl Plot {
             min_auto_bounds: PlotBounds::NOTHING,
             margin_fraction: Vec2::splat(0.05),
             allow_boxed_zoom: true,
-            boxed_zoom_pointer:  PointerButton::Secondary,
+            boxed_zoom_pointer_button: PointerButton::Secondary,
 
             min_size: Vec2::splat(64.0),
             width: None,
@@ -201,8 +201,8 @@ impl Plot {
     }
 
     /// Config the pointer to use for boxed_zoom. Default: `Secondary`
-    pub fn boxed_zoom_pointer(mut self, boxed_zoom_pointer: PointerButton) -> Self {
-        self.boxed_zoom_pointer = boxed_zoom_pointer;
+    pub fn boxed_zoom_pointer_button(mut self, boxed_zoom_pointer_button: PointerButton) -> Self {
+        self.boxed_zoom_pointer_button = boxed_zoom_pointer_button;
         self
     }
 
@@ -310,7 +310,7 @@ impl Plot {
             allow_zoom,
             allow_drag,
             allow_boxed_zoom,
-            boxed_zoom_pointer,
+            boxed_zoom_pointer_button: boxed_zoom_pointer,
             min_auto_bounds,
             margin_fraction,
             width,
@@ -367,7 +367,7 @@ impl Plot {
                 center_x_axis,
                 center_y_axis,
             ),
-            last_click_pos_for_zoom: None
+            last_click_pos_for_zoom: None,
         });
 
         // If the min bounds changed, recalculate everything.
@@ -472,7 +472,7 @@ impl Plot {
             if response.drag_started() && response.dragged_by(boxed_zoom_pointer) {
                 // it would be best for egui that input has a memory of the last click pos because it's a common pattern
                 last_click_pos_for_zoom = response.hover_pos()
-            } 
+            }
             let box_start_pos = last_click_pos_for_zoom;
             let box_end_pos = response.hover_pos();
             if let (Some(box_start_pos), Some(box_end_pos)) = (box_start_pos, box_end_pos) {
@@ -481,17 +481,25 @@ impl Plot {
                     response = response.on_hover_cursor(CursorIcon::ZoomIn);
                     let rect = epaint::Rect::from_two_pos(box_start_pos, box_end_pos);
                     boxed_zoom_rect = Some((
-                            epaint::RectShape::stroke(rect, 0.0, epaint::Stroke::new(4., Color32::DARK_BLUE)), // Outer stroke
-                            epaint::RectShape::stroke(rect, 0.0, epaint::Stroke::new(2., Color32::WHITE)) // Inner stroke
+                        epaint::RectShape::stroke(
+                            rect,
+                            0.0,
+                            epaint::Stroke::new(4., Color32::DARK_BLUE),
+                        ), // Outer stroke
+                        epaint::RectShape::stroke(
+                            rect,
+                            0.0,
+                            epaint::Stroke::new(2., Color32::WHITE),
+                        ), // Inner stroke
                     ));
                 }
                 // when the click is release perform the zoom
                 if response.drag_released() {
                     let box_start_pos = transform.value_from_position(box_start_pos);
                     let box_end_pos = transform.value_from_position(box_end_pos);
-                    let new_bounds = PlotBounds{
+                    let new_bounds = PlotBounds {
                         min: [box_start_pos.x, box_end_pos.y],
-                        max: [box_end_pos.x, box_start_pos.y]
+                        max: [box_end_pos.x, box_start_pos.y],
                     };
                     if new_bounds.is_valid() {
                         *transform.bounds_mut() = new_bounds;
@@ -558,7 +566,7 @@ impl Plot {
             hidden_items,
             min_auto_bounds,
             last_screen_transform: transform,
-            last_click_pos_for_zoom
+            last_click_pos_for_zoom,
         };
         memory.store(ui.ctx(), plot_id);
 

--- a/egui/src/widgets/plot/mod.rs
+++ b/egui/src/widgets/plot/mod.rs
@@ -192,7 +192,9 @@ impl Plot {
         self
     }
 
-    /// Whether to allow zooming in the plot. Default: `true`.
+    /// Whether to allow zooming in the plot by dragging out a box with the secondary mouse button.
+    ///
+    /// Default: `true`.
     pub fn allow_boxed_zoom(mut self, on: bool) -> Self {
         self.allow_boxed_zoom = on;
         self

--- a/egui/src/widgets/plot/mod.rs
+++ b/egui/src/widgets/plot/mod.rs
@@ -200,7 +200,7 @@ impl Plot {
         self
     }
 
-    /// Config the pointer to use for boxed_zoom. Default: `Secondary`
+    /// Config the button pointer to use for boxed zooming. Default: `Secondary`
     pub fn boxed_zoom_pointer_button(mut self, boxed_zoom_pointer_button: PointerButton) -> Self {
         self.boxed_zoom_pointer_button = boxed_zoom_pointer_button;
         self
@@ -471,7 +471,7 @@ impl Plot {
             // Save last click to allow boxed zooming
             if response.drag_started() && response.dragged_by(boxed_zoom_pointer) {
                 // it would be best for egui that input has a memory of the last click pos because it's a common pattern
-                last_click_pos_for_zoom = response.hover_pos()
+                last_click_pos_for_zoom = response.hover_pos();
             }
             let box_start_pos = last_click_pos_for_zoom;
             let box_end_pos = response.hover_pos();

--- a/egui/src/widgets/plot/transform.rs
+++ b/egui/src/widgets/plot/transform.rs
@@ -178,6 +178,10 @@ impl ScreenTransform {
         &self.bounds
     }
 
+    pub fn bounds_mut(&mut self) -> &mut PlotBounds {
+        &mut self.bounds
+    }
+
     pub fn translate_bounds(&mut self, mut delta_pos: Vec2) {
         if self.x_centered {
             delta_pos.x = 0.;

--- a/egui_demo_lib/src/apps/demo/plot_demo.rs
+++ b/egui_demo_lib/src/apps/demo/plot_demo.rs
@@ -679,6 +679,7 @@ impl super::View for PlotDemo {
             egui::reset_button(ui, self);
             ui.collapsing("Instructions", |ui| {
                 ui.label("Pan by dragging, or scroll (+ shift = horizontal).");
+                ui.label("Box zooming: Right click to zoom in and zoom out using a selection.");
                 if cfg!(target_arch = "wasm32") {
                     ui.label("Zoom with ctrl / ⌘ + pointer wheel, or with pinch gesture.");
                 } else if cfg!(target_os = "macos") {


### PR DESCRIPTION
Hello,

Very happy to make my first contribution here!

This adds boxed zooming feature on plots.
demo: https://www.youtube.com/watch?v=oUSWUgdFBCs 

To allow the feature to work I added:
* `Plot::allow_boxed_zoom(bool)`. Default `true`
* `Plot::boxed_zoom_pointer(PointerButton)`. Default: `Secondary`
* `PlotMemory::last_click_pos_for_zoom: Option<Pos2>`, Default `None`
* `ScreenTransform::bounds_mut(&mut self) -> &mut PlotBounds`

Also changelog has been updated, check.sh is passing. And next time I will make sure to create an issue first.

I had a little non related issue in check.sh so double check for me please.

Regards,
