### PR TITLE
Use tracing crate for logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
   * Added `TextStyle::resolve`.
 * `Context::load_texture` to convert an image into a texture which can be displayed using e.g. `ui.image(texture, size)` ([#1110](https://github.com/emilk/egui/pull/1110)).
 * Added `Ui::add_visible` and `Ui::add_visible_ui`.
+* Opt-in dependency on `tracing` crate for logging warnings.
 * Added `CollapsingHeader::icon` to override the default open/close icon using a custom function. ([1147](https://github.com/emilk/egui/pull/1147)).
 * Added `Plot::x_axis_formatter` and `Plot::y_axis_formatter` for custom axis labels ([#1130](https://github.com/emilk/egui/pull/1130)).
 * Added `ui.data()`, `ctx.data()`, `ctx.options()` and `ctx.tessellation_options()` ([#1175](https://github.com/emilk/egui/pull/1175)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
   * Added `TextStyle::resolve`.
 * `Context::load_texture` to convert an image into a texture which can be displayed using e.g. `ui.image(texture, size)` ([#1110](https://github.com/emilk/egui/pull/1110)).
 * Added `Ui::add_visible` and `Ui::add_visible_ui`.
-* Opt-in dependency on `tracing` crate for logging warnings.
+* Opt-in dependency on `tracing` crate for logging warnings ([#1192](https://github.com/emilk/egui/pull/1192)).
 * Added `CollapsingHeader::icon` to override the default open/close icon using a custom function. ([1147](https://github.com/emilk/egui/pull/1147)).
 * Added `Plot::x_axis_formatter` and `Plot::y_axis_formatter` for custom axis labels ([#1130](https://github.com/emilk/egui/pull/1130)).
 * Added `ui.data()`, `ctx.data()`, `ctx.options()` and `ctx.tessellation_options()` ([#1175](https://github.com/emilk/egui/pull/1175)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ dependencies = [
  "nohash-hasher",
  "ron",
  "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -977,6 +978,7 @@ dependencies = [
  "egui",
  "ron",
  "serde",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,6 @@ version = "0.16.0"
 dependencies = [
  "eframe",
  "egui_demo_lib",
- "tracing",
  "tracing-subscriber",
 ]
 
@@ -2507,7 +2506,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,7 @@ dependencies = [
  "glutin",
  "image",
  "memoffset",
+ "tracing",
  "wasm-bindgen",
  "web-sys",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,6 +880,8 @@ dependencies = [
  "js-sys",
  "ron",
  "serde",
+ "tracing",
+ "tracing-wasm",
  "tts",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1846,6 +1848,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2200,6 +2208,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2417,6 +2434,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,6 +2494,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+dependencies = [
+ "cfg-if 1.0.0",
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,7 @@ dependencies = [
  "epi",
  "instant",
  "serde",
+ "tracing",
  "tts",
  "webbrowser",
  "winit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,8 @@ version = "0.16.0"
 dependencies = [
  "eframe",
  "egui_demo_lib",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2531,14 +2533,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
 dependencies = [
+ "ansi_term",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/docs/index.html
+++ b/docs/index.html
@@ -122,17 +122,18 @@
         // We'll defer our execution until the wasm is ready to go.
         // Here we tell bindgen the path to the wasm file so it can start
         // initialization and return to us a promise when it's done.
+        console.debug("loading wasm…");
         wasm_bindgen("./egui_demo_app_bg.wasm")
             .then(on_wasm_loaded)
             .catch(on_wasm_error);
 
         function on_wasm_loaded() {
-            console.log("loaded wasm, starting egui app…");
+            console.debug("wasm loaded. starting egui app…");
 
             // This call installs a bunch of callbacks and then returns:
             wasm_bindgen.start("the_canvas_id");
 
-            console.log("egui app started.");
+            console.debug("egui app started.");
             document.getElementById("center_text").remove();
         }
 

--- a/eframe/CHANGELOG.md
+++ b/eframe/CHANGELOG.md
@@ -11,7 +11,7 @@ NOTE: [`egui_web`](../egui_web/CHANGELOG.md), [`egui-winit`](../egui-winit/CHANG
 * Fix horizontal scrolling direction on Linux.
 * Added `App::on_exit_event` ([#1038](https://github.com/emilk/egui/pull/1038))
 * Shift-scroll will now result in horizontal scrolling on all platforms ([#1136](https://github.com/emilk/egui/pull/1136)).
-* Log using the `tracing` crate. Log to stdout by adding `tracing_subscriber::fmt::init();` to your `main`. And run with `RUST_LOG=debug`.
+* Log using the `tracing` crate. Log to stdout by adding `tracing_subscriber::fmt::init();` to your `main` ([#1192](https://github.com/emilk/egui/pull/1192)).
 
 
 ## 0.16.0 - 2021-12-29

--- a/eframe/CHANGELOG.md
+++ b/eframe/CHANGELOG.md
@@ -11,6 +11,7 @@ NOTE: [`egui_web`](../egui_web/CHANGELOG.md), [`egui-winit`](../egui-winit/CHANG
 * Fix horizontal scrolling direction on Linux.
 * Added `App::on_exit_event` ([#1038](https://github.com/emilk/egui/pull/1038))
 * Shift-scroll will now result in horizontal scrolling on all platforms ([#1136](https://github.com/emilk/egui/pull/1136)).
+* Log using the `tracing` crate. Log to stdout by adding `tracing_subscriber::fmt::init();` to your `main`. And run with `RUST_LOG=debug`.
 
 
 ## 0.16.0 - 2021-12-29

--- a/egui-winit/Cargo.toml
+++ b/egui-winit/Cargo.toml
@@ -24,7 +24,7 @@ all-features = true
 [dependencies]
 egui = { version = "0.16.0", path = "../egui", default-features = false, features = ["single_threaded"] }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
-tracing = { version = "0.1", features = ["log"] }
+tracing = "0.1"
 winit = "0.26.1"
 
 epi = { version = "0.16.0", path = "../epi", optional = true }

--- a/egui-winit/Cargo.toml
+++ b/egui-winit/Cargo.toml
@@ -22,7 +22,7 @@ include = [
 all-features = true
 
 [dependencies]
-egui = { version = "0.16.0", path = "../egui", default-features = false, features = ["single_threaded"] }
+egui = { version = "0.16.0", path = "../egui", default-features = false, features = ["single_threaded", "tracing"] }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 tracing = "0.1"
 winit = "0.26.1"

--- a/egui-winit/Cargo.toml
+++ b/egui-winit/Cargo.toml
@@ -24,6 +24,7 @@ all-features = true
 [dependencies]
 egui = { version = "0.16.0", path = "../egui", default-features = false, features = ["single_threaded"] }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
+tracing = { version = "0.1", features = ["log"] }
 winit = "0.26.1"
 
 epi = { version = "0.16.0", path = "../epi", optional = true }

--- a/egui-winit/src/clipboard.rs
+++ b/egui-winit/src/clipboard.rs
@@ -29,7 +29,7 @@ impl Clipboard {
             match clipboard.get_contents() {
                 Ok(contents) => Some(contents),
                 Err(err) => {
-                    eprintln!("Paste error: {}", err);
+                    tracing::error!("Paste error: {}", err);
                     None
                 }
             }
@@ -46,7 +46,7 @@ impl Clipboard {
         if let Some(clipboard) = &mut self.copypasta {
             use copypasta::ClipboardProvider as _;
             if let Err(err) = clipboard.set_contents(text) {
-                eprintln!("Copy/Cut error: {}", err);
+                tracing::error!("Copy/Cut error: {}", err);
             }
         }
 
@@ -62,7 +62,7 @@ fn init_copypasta() -> Option<copypasta::ClipboardContext> {
     match copypasta::ClipboardContext::new() {
         Ok(clipboard) => Some(clipboard),
         Err(err) => {
-            eprintln!("Failed to initialize clipboard: {}", err);
+            tracing::error!("Failed to initialize clipboard: {}", err);
             None
         }
     }

--- a/egui-winit/src/lib.rs
+++ b/egui-winit/src/lib.rs
@@ -577,12 +577,12 @@ impl State {
 fn open_url_in_browser(_url: &str) {
     #[cfg(feature = "webbrowser")]
     if let Err(err) = webbrowser::open(_url) {
-        eprintln!("Failed to open url: {}", err);
+        tracing::warn!("Failed to open url: {}", err);
     }
 
     #[cfg(not(feature = "webbrowser"))]
     {
-        eprintln!("Cannot open url - feature \"links\" not enabled.");
+        tracing::warn!("Cannot open url - feature \"links\" not enabled.");
     }
 }
 

--- a/egui-winit/src/screen_reader.rs
+++ b/egui-winit/src/screen_reader.rs
@@ -15,11 +15,11 @@ impl Default for ScreenReader {
     fn default() -> Self {
         let tts = match tts::Tts::default() {
             Ok(screen_reader) => {
-                eprintln!("Initialized screen reader.");
+                tracing::debug!("Initialized screen reader.");
                 Some(screen_reader)
             }
             Err(err) => {
-                eprintln!("Failed to load screen reader: {}", err);
+                tracing::warn!("Failed to load screen reader: {}", err);
                 None
             }
         };
@@ -38,10 +38,10 @@ impl ScreenReader {
             return;
         }
         if let Some(tts) = &mut self.tts {
-            eprintln!("Speaking: {:?}", text);
+            tracing::debug!("Speaking: {:?}", text);
             let interrupt = true;
             if let Err(err) = tts.speak(text, interrupt) {
-                eprintln!("Failed to read: {}", err);
+                tracing::warn!("Failed to read: {}", err);
             }
         }
     }

--- a/egui/Cargo.toml
+++ b/egui/Cargo.toml
@@ -28,14 +28,21 @@ epaint = { version = "0.16.0", path = "../epaint", default-features = false }
 
 ahash = "0.7"
 nohash-hasher = "0.2"
+
+# Optional:
 ron = { version = "0.7", optional = true }
 serde = { version = "1", features = ["derive", "rc"], optional = true }
+# egui doesn't log much, but when it does, it uses `tracing`
+tracing = { version = "0.1", optional = true }
 
 [features]
 default = ["default_fonts", "single_threaded"]
 
 # add compatibility with https://crates.io/crates/cint
 cint = ["epaint/cint"]
+
+# implement bytemuck on most types.
+convert_bytemuck = ["epaint/convert_bytemuck"]
 
 # If set, egui will use `include_bytes!` to bundle some fonts.
 # If you plan on specifying your own fonts you may disable this feature.
@@ -54,9 +61,6 @@ persistence = ["serde", "epaint/serialize", "ron"]
 
 # implement serde on most types.
 serialize = ["serde", "epaint/serialize"]
-
-# implement bytemuck on most types.
-convert_bytemuck = ["epaint/convert_bytemuck"]
 
 # multi_threaded is only needed if you plan to use the same egui::Context
 # from multiple threads. It comes with a minor performance impact.

--- a/egui/src/util/id_type_map.rs
+++ b/egui/src/util/id_type_map.rs
@@ -275,11 +275,12 @@ impl Element {
 fn from_ron_str<T: serde::de::DeserializeOwned>(ron: &str) -> Option<T> {
     match ron::from_str::<T>(ron) {
         Ok(value) => Some(value),
-        Err(err) => {
-            eprintln!(
+        Err(_err) => {
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
                 "egui: Failed to deserialize {} from memory: {}, ron error: {:?}",
                 std::any::type_name::<T>(),
-                err,
+                _err,
                 ron
             );
             None

--- a/egui_demo_app/Cargo.toml
+++ b/egui_demo_app/Cargo.toml
@@ -18,7 +18,6 @@ eframe = { version = "0.16.0", path = "../eframe" }
 
 egui_demo_lib = { version = "0.16.0", path = "../egui_demo_lib", features = ["extra_debug_asserts"] }
 tracing-subscriber = "0.3"
-tracing = { version = "0.1", features = ["log"] }
 
 [features]
 default = ["persistence"]

--- a/egui_demo_app/Cargo.toml
+++ b/egui_demo_app/Cargo.toml
@@ -17,6 +17,8 @@ eframe = { version = "0.16.0", path = "../eframe" }
 # eframe = { version = "0.16.0", path = "../eframe", default-features = false, features = ["default_fonts", "egui_glium"] }
 
 egui_demo_lib = { version = "0.16.0", path = "../egui_demo_lib", features = ["extra_debug_asserts"] }
+tracing-subscriber = "0.3"
+tracing = { version = "0.1", features = ["log"] }
 
 [features]
 default = ["persistence"]

--- a/egui_demo_app/src/main.rs
+++ b/egui_demo_app/src/main.rs
@@ -7,6 +7,9 @@
 
 // When compiling natively:
 fn main() {
+    // Log to stdout (if you run with `RUST_LOG=debug`).
+    tracing_subscriber::fmt::init();
+
     let app = egui_demo_lib::WrapApp::default();
     let options = eframe::NativeOptions {
         // Let's show off that we support transparent windows

--- a/egui_glow/Cargo.toml
+++ b/egui_glow/Cargo.toml
@@ -32,6 +32,7 @@ epi = { version = "0.16.0", path = "../epi", optional = true }
 bytemuck = "1.7"
 glow = "0.11"
 memoffset = "0.6"
+tracing = { version = "0.1", features = ["log"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 egui-winit = { version = "0.16.0", path = "../egui-winit", default-features = false, features = ["epi"], optional = true }

--- a/egui_glow/Cargo.toml
+++ b/egui_glow/Cargo.toml
@@ -32,7 +32,7 @@ epi = { version = "0.16.0", path = "../epi", optional = true }
 bytemuck = "1.7"
 glow = "0.11"
 memoffset = "0.6"
-tracing = { version = "0.1", features = ["log"] }
+tracing = "0.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 egui-winit = { version = "0.16.0", path = "../egui-winit", default-features = false, features = ["epi"], optional = true }

--- a/egui_glow/src/epi_backend.rs
+++ b/egui_glow/src/epi_backend.rs
@@ -60,8 +60,7 @@ pub fn run(app: Box<dyn epi::App>, native_options: &epi::NativeOptions) -> ! {
     )));
 
     let mut painter = crate::Painter::new(&gl, None, "")
-        .map_err(|error| eprintln!("some OpenGL error occurred {}\n", error))
-        .unwrap();
+        .unwrap_or_else(|error| panic!("some OpenGL error occurred {}\n", error));
     let mut integration = egui_winit::epi::EpiIntegration::new(
         "egui_glow",
         painter.max_texture_side(),

--- a/egui_glow/src/lib.rs
+++ b/egui_glow/src/lib.rs
@@ -124,10 +124,7 @@ impl EguiGlow {
     pub fn new(window: &winit::window::Window, gl: &glow::Context) -> Self {
         let painter = crate::Painter::new(gl, None, "")
             .map_err(|error| {
-                crate::misc_util::glow_print_error(format!(
-                    "error occurred in initializing painter:\n{}",
-                    error
-                ));
+                tracing::error!("error occurred in initializing painter:\n{}", error);
             })
             .unwrap();
 

--- a/egui_glow/src/misc_util.rs
+++ b/egui_glow/src/misc_util.rs
@@ -5,27 +5,13 @@ use std::option::Option::Some;
 pub fn check_for_gl_error(gl: &glow::Context, context: &str) {
     let error_code = unsafe { gl.get_error() };
     if error_code != glow::NO_ERROR {
-        glow_print_error(format!(
+        tracing::error!(
             "GL error, at: '{}', code: {} (0x{:X})",
-            context, error_code, error_code
-        ));
+            context,
+            error_code,
+            error_code
+        );
     }
-}
-
-pub(crate) fn glow_print(s: impl std::fmt::Display) {
-    #[cfg(target_arch = "wasm32")]
-    web_sys::console::log_1(&format!("egui_glow: {}", s).into());
-
-    #[cfg(not(target_arch = "wasm32"))]
-    eprintln!("egui_glow: {}", s);
-}
-
-pub(crate) fn glow_print_error(s: impl std::fmt::Display) {
-    #[cfg(target_arch = "wasm32")]
-    web_sys::console::error_1(&format!("egui_glow: {}", s).into());
-
-    #[cfg(not(target_arch = "wasm32"))]
-    eprintln!("egui_glow ERROR: {}", s);
 }
 
 pub(crate) unsafe fn compile_shader(
@@ -130,7 +116,7 @@ pub(crate) fn supports_vao(gl: &glow::Context) -> bool {
     const OPENGL_ES_PREFIX: &str = "OpenGL ES ";
 
     let version_string = unsafe { gl.get_parameter_string(glow::VERSION) };
-    glow_print(format!("GL version: {:?}.", version_string));
+    tracing::info!("GL version: {:?}.", version_string);
 
     // Examples:
     // * "WebGL 2.0 (OpenGL ES 3.0 Chromium)"

--- a/egui_glow/src/misc_util.rs
+++ b/egui_glow/src/misc_util.rs
@@ -116,7 +116,7 @@ pub(crate) fn supports_vao(gl: &glow::Context) -> bool {
     const OPENGL_ES_PREFIX: &str = "OpenGL ES ";
 
     let version_string = unsafe { gl.get_parameter_string(glow::VERSION) };
-    tracing::info!("GL version: {:?}.", version_string);
+    tracing::debug!("GL version: {:?}.", version_string);
 
     // Examples:
     // * "WebGL 2.0 (OpenGL ES 3.0 Chromium)"

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -98,7 +98,7 @@ impl Painter {
         let shader_version = ShaderVersion::get(gl);
         let is_webgl_1 = shader_version == ShaderVersion::Es100;
         let header = shader_version.version();
-        tracing::info!("Shader header: {:?}.", header);
+        tracing::debug!("Shader header: {:?}.", header);
         let srgb_support = gl.supported_extensions().contains("EXT_sRGB");
 
         let (post_process, srgb_support_define) = match (shader_version, srgb_support) {
@@ -106,7 +106,7 @@ impl Painter {
             (ShaderVersion::Es300, _) | (ShaderVersion::Es100, true) => unsafe {
                 // Add sRGB support marker for fragment shader
                 if let Some([width, height]) = pp_fb_extent {
-                    tracing::info!("WebGL with sRGB enabled. Turning on post processing for linear framebuffer blending.");
+                    tracing::debug!("WebGL with sRGB enabled. Turning on post processing for linear framebuffer blending.");
                     // install post process to correct sRGB color:
                     (
                         Some(PostProcess::new(
@@ -120,7 +120,7 @@ impl Painter {
                         "#define SRGB_SUPPORTED",
                     )
                 } else {
-                    tracing::info!("WebGL or OpenGL ES detected but PostProcess disabled because dimension is None");
+                    tracing::debug!("WebGL or OpenGL ES detected but PostProcess disabled because dimension is None");
                     (None, "")
                 }
             },

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -9,7 +9,7 @@ use egui::{
 use glow::HasContext;
 use memoffset::offset_of;
 
-use crate::misc_util::{check_for_gl_error, compile_shader, glow_print, link_program};
+use crate::misc_util::{check_for_gl_error, compile_shader, link_program};
 use crate::post_process::PostProcess;
 use crate::shader_version::ShaderVersion;
 use crate::vao_emulate;
@@ -98,7 +98,7 @@ impl Painter {
         let shader_version = ShaderVersion::get(gl);
         let is_webgl_1 = shader_version == ShaderVersion::Es100;
         let header = shader_version.version();
-        glow_print(format!("Shader header: {:?}.", header));
+        tracing::info!("Shader header: {:?}.", header);
         let srgb_support = gl.supported_extensions().contains("EXT_sRGB");
 
         let (post_process, srgb_support_define) = match (shader_version, srgb_support) {
@@ -106,7 +106,7 @@ impl Painter {
             (ShaderVersion::Es300, _) | (ShaderVersion::Es100, true) => unsafe {
                 // Add sRGB support marker for fragment shader
                 if let Some([width, height]) = pp_fb_extent {
-                    glow_print("WebGL with sRGB enabled. Turning on post processing for linear framebuffer blending.");
+                    tracing::info!("WebGL with sRGB enabled. Turning on post processing for linear framebuffer blending.");
                     // install post process to correct sRGB color:
                     (
                         Some(PostProcess::new(
@@ -120,7 +120,7 @@ impl Painter {
                         "#define SRGB_SUPPORTED",
                     )
                 } else {
-                    glow_print("WebGL or OpenGL ES detected but PostProcess disabled because dimension is None");
+                    tracing::info!("WebGL or OpenGL ES detected but PostProcess disabled because dimension is None");
                     (None, "")
                 }
             },

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -582,7 +582,7 @@ pub fn clear(gl: &glow::Context, dimension: [u32; 2], clear_color: egui::Rgba) {
 impl Drop for Painter {
     fn drop(&mut self) {
         if !self.destroyed {
-            eprintln!(
+            tracing::warn!(
                 "You forgot to call destroy() on the egui glow painter. Resources will leak!"
             );
         }

--- a/egui_glow/src/shader_version.rs
+++ b/egui_glow/src/shader_version.rs
@@ -1,5 +1,5 @@
 #![allow(unsafe_code)]
-use crate::misc_util::glow_print;
+
 use glow::HasContext;
 use std::convert::TryInto;
 
@@ -17,10 +17,11 @@ impl ShaderVersion {
         let shading_lang_string =
             unsafe { gl.get_parameter_string(glow::SHADING_LANGUAGE_VERSION) };
         let shader_version = Self::parse(&shading_lang_string);
-        glow_print(format!(
+        tracing::info!(
             "Shader version: {:?} ({:?}).",
-            shader_version, shading_lang_string
-        ));
+            shader_version,
+            shading_lang_string
+        );
         shader_version
     }
 

--- a/egui_glow/src/shader_version.rs
+++ b/egui_glow/src/shader_version.rs
@@ -17,7 +17,7 @@ impl ShaderVersion {
         let shading_lang_string =
             unsafe { gl.get_parameter_string(glow::SHADING_LANGUAGE_VERSION) };
         let shader_version = Self::parse(&shading_lang_string);
-        tracing::info!(
+        tracing::debug!(
             "Shader version: {:?} ({:?}).",
             shader_version,
             shading_lang_string

--- a/egui_web/Cargo.toml
+++ b/egui_web/Cargo.toml
@@ -36,7 +36,7 @@ epi = { version = "0.16.0", path = "../epi" }
 bytemuck = "1.7"
 console_error_panic_hook = "0.1.6"
 js-sys = "0.3"
-tracing = { version = "0.1", features = ["log"] }
+tracing = "0.1"
 tracing-wasm = "0.2"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"

--- a/egui_web/Cargo.toml
+++ b/egui_web/Cargo.toml
@@ -29,6 +29,7 @@ crate-type = ["cdylib", "rlib"]
 egui = { version = "0.16.0", path = "../egui", default-features = false, features = [
   "convert_bytemuck",
   "single_threaded",
+  "tracing",
 ] }
 egui_glow = { version = "0.16.0",path = "../egui_glow", default-features = false, optional = true }
 epi = { version = "0.16.0", path = "../epi" }

--- a/egui_web/Cargo.toml
+++ b/egui_web/Cargo.toml
@@ -36,11 +36,15 @@ epi = { version = "0.16.0", path = "../epi" }
 bytemuck = "1.7"
 console_error_panic_hook = "0.1.6"
 js-sys = "0.3"
+tracing = { version = "0.1", features = ["log"] }
+tracing-wasm = "0.2"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+
+# Optional:
 ron = { version = "0.7", optional = true }
 serde = { version = "1", optional = true }
 tts = { version = "0.19", optional = true } # feature screen_reader
-wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4"
 
 [features]
 default = ["default_fonts", "glow"]

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -284,7 +284,7 @@ pub fn start(canvas_id: &str, app: Box<dyn epi::App>) -> Result<AppRunnerRef, Js
     // Make sure panics are logged using `console.error`.
     console_error_panic_hook::set_once();
 
-    // Redirect tracing to console.log and friends
+    // Redirect tracing to console.log and friends:
     tracing_wasm::set_as_global_default();
 
     let mut runner = AppRunner::new(canvas_id, app)?;

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -14,10 +14,10 @@ fn create_painter(canvas_id: &str) -> Result<Box<dyn Painter>, JsValue> {
 
     #[cfg(all(feature = "webgl", not(feature = "glow")))]
     if let Ok(webgl2_painter) = webgl2::WebGl2Painter::new(canvas_id) {
-        tracing::info!("Using WebGL2 backend");
+        tracing::debug!("Using WebGL2 backend");
         Ok(Box::new(webgl2_painter))
     } else {
-        tracing::info!("Falling back to WebGL1 backend");
+        tracing::debug!("Falling back to WebGL1 backend");
         let webgl1_painter = webgl1::WebGlPainter::new(canvas_id)?;
         Ok(Box::new(webgl1_painter))
     }

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -14,10 +14,10 @@ fn create_painter(canvas_id: &str) -> Result<Box<dyn Painter>, JsValue> {
 
     #[cfg(all(feature = "webgl", not(feature = "glow")))]
     if let Ok(webgl2_painter) = webgl2::WebGl2Painter::new(canvas_id) {
-        console_log!("Using WebGL2 backend");
+        tracing::info!("Using WebGL2 backend");
         Ok(Box::new(webgl2_painter))
     } else {
-        console_log!("Falling back to WebGL1 backend");
+        tracing::info!("Falling back to WebGL1 backend");
         let webgl1_painter = webgl1::WebGlPainter::new(canvas_id)?;
         Ok(Box::new(webgl1_painter))
     }
@@ -283,6 +283,9 @@ impl AppRunner {
 pub fn start(canvas_id: &str, app: Box<dyn epi::App>) -> Result<AppRunnerRef, JsValue> {
     // Make sure panics are logged using `console.error`.
     console_error_panic_hook::set_once();
+
+    // Redirect tracing to console.log and friends
+    tracing_wasm::set_as_global_default();
 
     let mut runner = AppRunner::new(canvas_id, app)?;
     runner.warm_up()?;

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -14,10 +14,10 @@ fn create_painter(canvas_id: &str) -> Result<Box<dyn Painter>, JsValue> {
 
     #[cfg(all(feature = "webgl", not(feature = "glow")))]
     if let Ok(webgl2_painter) = webgl2::WebGl2Painter::new(canvas_id) {
-        console_log("Using WebGL2 backend");
+        console_log!("Using WebGL2 backend");
         Ok(Box::new(webgl2_painter))
     } else {
-        console_log("Falling back to WebGL1 backend");
+        console_log!("Falling back to WebGL1 backend");
         let webgl1_painter = webgl1::WebGlPainter::new(canvas_id)?;
         Ok(Box::new(webgl1_painter))
     }

--- a/egui_web/src/glow_wrapping.rs
+++ b/egui_web/src/glow_wrapping.rs
@@ -93,7 +93,7 @@ fn init_glow_context_from_canvas(
         init_webgl2(canvas).or_else(|| init_webgl1(canvas))
     } else {
         // Trying WebGl1 first (useful for testing).
-        crate::console_warn!("Looking for WebGL1 first");
+        tracing::warn!("Looking for WebGL1 first");
         init_webgl1(canvas).or_else(|| init_webgl2(canvas))
     };
 
@@ -110,14 +110,14 @@ fn init_webgl1(canvas: &HtmlCanvasElement) -> Option<(glow::Context, &'static st
         .expect("Failed to query about WebGL2 context");
 
     let gl1_ctx = gl1_ctx?;
-    crate::console_log!("WebGL1 selected.");
+    tracing::info!("WebGL1 selected.");
 
     let gl1_ctx = gl1_ctx
         .dyn_into::<web_sys::WebGlRenderingContext>()
         .unwrap();
 
     let shader_prefix = if crate::webgl1_requires_brightening(&gl1_ctx) {
-        crate::console_log!("Enabling webkitGTK brightening workaround.");
+        tracing::info!("Enabling webkitGTK brightening workaround.");
         "#define APPLY_BRIGHTENING_GAMMA"
     } else {
         ""
@@ -134,7 +134,7 @@ fn init_webgl2(canvas: &HtmlCanvasElement) -> Option<(glow::Context, &'static st
         .expect("Failed to query about WebGL2 context");
 
     let gl2_ctx = gl2_ctx?;
-    crate::console_log!("WebGL2 selected.");
+    tracing::info!("WebGL2 selected.");
 
     let gl2_ctx = gl2_ctx
         .dyn_into::<web_sys::WebGl2RenderingContext>()

--- a/egui_web/src/glow_wrapping.rs
+++ b/egui_web/src/glow_wrapping.rs
@@ -93,7 +93,7 @@ fn init_glow_context_from_canvas(
         init_webgl2(canvas).or_else(|| init_webgl1(canvas))
     } else {
         // Trying WebGl1 first (useful for testing).
-        crate::console_warn("Looking for WebGL1 first");
+        crate::console_warn!("Looking for WebGL1 first");
         init_webgl1(canvas).or_else(|| init_webgl2(canvas))
     };
 
@@ -110,14 +110,14 @@ fn init_webgl1(canvas: &HtmlCanvasElement) -> Option<(glow::Context, &'static st
         .expect("Failed to query about WebGL2 context");
 
     let gl1_ctx = gl1_ctx?;
-    crate::console_log("WebGL1 selected.");
+    crate::console_log!("WebGL1 selected.");
 
     let gl1_ctx = gl1_ctx
         .dyn_into::<web_sys::WebGlRenderingContext>()
         .unwrap();
 
     let shader_prefix = if crate::webgl1_requires_brightening(&gl1_ctx) {
-        crate::console_log("Enabling webkitGTK brightening workaround.");
+        crate::console_log!("Enabling webkitGTK brightening workaround.");
         "#define APPLY_BRIGHTENING_GAMMA"
     } else {
         ""
@@ -134,7 +134,7 @@ fn init_webgl2(canvas: &HtmlCanvasElement) -> Option<(glow::Context, &'static st
         .expect("Failed to query about WebGL2 context");
 
     let gl2_ctx = gl2_ctx?;
-    crate::console_log("WebGL2 selected.");
+    crate::console_log!("WebGL2 selected.");
 
     let gl2_ctx = gl2_ctx
         .dyn_into::<web_sys::WebGl2RenderingContext>()

--- a/egui_web/src/glow_wrapping.rs
+++ b/egui_web/src/glow_wrapping.rs
@@ -110,14 +110,14 @@ fn init_webgl1(canvas: &HtmlCanvasElement) -> Option<(glow::Context, &'static st
         .expect("Failed to query about WebGL2 context");
 
     let gl1_ctx = gl1_ctx?;
-    tracing::info!("WebGL1 selected.");
+    tracing::debug!("WebGL1 selected.");
 
     let gl1_ctx = gl1_ctx
         .dyn_into::<web_sys::WebGlRenderingContext>()
         .unwrap();
 
     let shader_prefix = if crate::webgl1_requires_brightening(&gl1_ctx) {
-        tracing::info!("Enabling webkitGTK brightening workaround.");
+        tracing::debug!("Enabling webkitGTK brightening workaround.");
         "#define APPLY_BRIGHTENING_GAMMA"
     } else {
         ""
@@ -134,7 +134,7 @@ fn init_webgl2(canvas: &HtmlCanvasElement) -> Option<(glow::Context, &'static st
         .expect("Failed to query about WebGL2 context");
 
     let gl2_ctx = gl2_ctx?;
-    tracing::info!("WebGL2 selected.");
+    tracing::debug!("WebGL2 selected.");
 
     let gl2_ctx = gl2_ctx
         .dyn_into::<web_sys::WebGl2RenderingContext>()

--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -569,7 +569,7 @@ fn install_document_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
                 false
             };
 
-            // tracing::info!(
+            // tracing::debug!(
             //     "On key-down {:?}, egui_wants_keyboard: {}, prevent_default: {}",
             //     event.key().as_str(),
             //     egui_wants_keyboard,
@@ -1122,7 +1122,7 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
                             let last_modified = std::time::UNIX_EPOCH
                                 + std::time::Duration::from_millis(file.last_modified() as u64);
 
-                            tracing::info!("Loading {:?} ({} bytes)…", name, file.size());
+                            tracing::debug!("Loading {:?} ({} bytes)…", name, file.size());
 
                             let future = wasm_bindgen_futures::JsFuture::from(file.array_buffer());
 
@@ -1131,7 +1131,7 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
                                 match future.await {
                                     Ok(array_buffer) => {
                                         let bytes = js_sys::Uint8Array::new(&array_buffer).to_vec();
-                                        tracing::info!(
+                                        tracing::debug!(
                                             "Loaded {:?} ({} bytes).",
                                             name,
                                             bytes.len()

--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -41,16 +41,6 @@ static AGENT_ID: &str = "egui_text_agent";
 
 // ----------------------------------------------------------------------------
 
-pub fn string_from_js_value(s: wasm_bindgen::JsValue) -> String {
-    s.as_string().unwrap_or(format!("{:#?}", s))
-}
-
-pub fn string_from_js_string(s: js_sys::JsString) -> String {
-    s.as_string().unwrap_or(format!("{:#?}", s))
-}
-
-// ----------------------------------------------------------------------------
-
 /// Current time in seconds (since undefined point in time)
 pub fn now_sec() -> f64 {
     web_sys::window()

--- a/egui_web/src/screen_reader.rs
+++ b/egui_web/src/screen_reader.rs
@@ -15,11 +15,11 @@ impl Default for ScreenReader {
     fn default() -> Self {
         let tts = match tts::Tts::default() {
             Ok(screen_reader) => {
-                crate::console_log("Initialized screen reader.");
+                crate::console_log!("Initialized screen reader.");
                 Some(screen_reader)
             }
             Err(err) => {
-                crate::console_warn(format!("Failed to load screen reader: {}", err));
+                crate::console_warn!("Failed to load screen reader: {}", err);
                 None
             }
         };
@@ -37,10 +37,10 @@ impl ScreenReader {
             return;
         }
         if let Some(tts) = &mut self.tts {
-            crate::console_log(format!("Speaking: {:?}", text));
+            crate::console_log!("Speaking: {:?}", text);
             let interrupt = true;
             if let Err(err) = tts.speak(text, interrupt) {
-                crate::console_warn(format!("Failed to read: {}", err));
+                crate::console_warn!("Failed to read: {}", err);
             }
         }
     }

--- a/egui_web/src/screen_reader.rs
+++ b/egui_web/src/screen_reader.rs
@@ -15,11 +15,11 @@ impl Default for ScreenReader {
     fn default() -> Self {
         let tts = match tts::Tts::default() {
             Ok(screen_reader) => {
-                crate::console_log!("Initialized screen reader.");
+                tracing::info!("Initialized screen reader.");
                 Some(screen_reader)
             }
             Err(err) => {
-                crate::console_warn!("Failed to load screen reader: {}", err);
+                tracing::warn!("Failed to load screen reader: {}", err);
                 None
             }
         };
@@ -37,10 +37,10 @@ impl ScreenReader {
             return;
         }
         if let Some(tts) = &mut self.tts {
-            crate::console_log!("Speaking: {:?}", text);
+            tracing::info!("Speaking: {:?}", text);
             let interrupt = true;
             if let Err(err) = tts.speak(text, interrupt) {
-                crate::console_warn!("Failed to read: {}", err);
+                tracing::warn!("Failed to read: {}", err);
             }
         }
     }

--- a/egui_web/src/screen_reader.rs
+++ b/egui_web/src/screen_reader.rs
@@ -15,7 +15,7 @@ impl Default for ScreenReader {
     fn default() -> Self {
         let tts = match tts::Tts::default() {
             Ok(screen_reader) => {
-                tracing::info!("Initialized screen reader.");
+                tracing::debug!("Initialized screen reader.");
                 Some(screen_reader)
             }
             Err(err) => {
@@ -37,7 +37,7 @@ impl ScreenReader {
             return;
         }
         if let Some(tts) = &mut self.tts {
-            tracing::info!("Speaking: {:?}", text);
+            tracing::debug!("Speaking: {:?}", text);
             let interrupt = true;
             if let Err(err) = tts.speak(text, interrupt) {
                 tracing::warn!("Failed to read: {}", err);

--- a/egui_web/src/webgl1.rs
+++ b/egui_web/src/webgl1.rs
@@ -431,10 +431,7 @@ impl crate::Painter for WebGlPainter {
                     self.paint_mesh(&mesh)?;
                 }
             } else {
-                crate::console_warn(format!(
-                    "WebGL: Failed to find texture {:?}",
-                    mesh.texture_id
-                ));
+                tracing::warn!("WebGL: Failed to find texture {:?}", mesh.texture_id);
             }
         }
 
@@ -499,7 +496,7 @@ impl PostProcess {
         gl.bind_framebuffer(Gl::FRAMEBUFFER, None);
 
         let shader_prefix = if crate::webgl1_requires_brightening(&gl) {
-            crate::console_log!("Enabling webkitGTK brightening workaround");
+            tracing::info!("Enabling webkitGTK brightening workaround");
             "#define APPLY_BRIGHTENING_GAMMA"
         } else {
             ""

--- a/egui_web/src/webgl1.rs
+++ b/egui_web/src/webgl1.rs
@@ -299,7 +299,7 @@ impl crate::Painter for WebGlPainter {
             }
         }
 
-        crate::console_error("Failed to query max texture size");
+        tracing::error!("Failed to query max texture size");
 
         2048
     }

--- a/egui_web/src/webgl1.rs
+++ b/egui_web/src/webgl1.rs
@@ -499,7 +499,7 @@ impl PostProcess {
         gl.bind_framebuffer(Gl::FRAMEBUFFER, None);
 
         let shader_prefix = if crate::webgl1_requires_brightening(&gl) {
-            crate::console_log("Enabling webkitGTK brightening workaround");
+            crate::console_log!("Enabling webkitGTK brightening workaround");
             "#define APPLY_BRIGHTENING_GAMMA"
         } else {
             ""

--- a/egui_web/src/webgl1.rs
+++ b/egui_web/src/webgl1.rs
@@ -496,7 +496,7 @@ impl PostProcess {
         gl.bind_framebuffer(Gl::FRAMEBUFFER, None);
 
         let shader_prefix = if crate::webgl1_requires_brightening(&gl) {
-            tracing::info!("Enabling webkitGTK brightening workaround");
+            tracing::debug!("Enabling webkitGTK brightening workaround");
             "#define APPLY_BRIGHTENING_GAMMA"
         } else {
             ""

--- a/egui_web/src/webgl2.rs
+++ b/egui_web/src/webgl2.rs
@@ -283,7 +283,7 @@ impl crate::Painter for WebGl2Painter {
             }
         }
 
-        crate::console_error("Failed to query max texture size");
+        tracing::error!("Failed to query max texture size");
 
         2048
     }

--- a/egui_web/src/webgl2.rs
+++ b/egui_web/src/webgl2.rs
@@ -410,10 +410,7 @@ impl crate::Painter for WebGl2Painter {
                     self.paint_mesh(&mesh)?;
                 }
             } else {
-                crate::console_warn(format!(
-                    "WebGL: Failed to find texture {:?}",
-                    mesh.texture_id
-                ));
+                tracing::warn!("WebGL: Failed to find texture {:?}", mesh.texture_id);
             }
         }
 

--- a/epaint/src/texture_atlas.rs
+++ b/epaint/src/texture_atlas.rs
@@ -116,7 +116,10 @@ impl TextureAtlas {
 
         if required_height > self.max_height() {
             // This is a bad place to be - we need to start reusing space :/
-            eprintln!("epaint texture atlas overflowed!");
+
+            #[cfg(feature = "tracing")]
+            tracing::wan!("epaint texture atlas overflowed!");
+
             self.cursor = (0, self.image.height() / 3); // Restart a bit down - the top of the atlas has too many important things in it
             self.overflowed = true; // this will signal the user that we need to recreate the texture atlas next frame.
         } else if resize_to_min_height(&mut self.image, required_height) {

--- a/epi/Cargo.toml
+++ b/epi/Cargo.toml
@@ -25,6 +25,7 @@ all-features = true
 
 [dependencies]
 egui = { version = "0.16.0", path = "../egui", default-features = false, features = ["single_threaded"] }
+tracing = "0.1"
 
 directories-next = { version = "2", optional = true }
 ron = { version = "0.7", optional = true }

--- a/epi/src/file_storage.rs
+++ b/epi/src/file_storage.rs
@@ -29,16 +29,17 @@ impl FileStorage {
         if let Some(proj_dirs) = directories_next::ProjectDirs::from("", "", app_name) {
             let data_dir = proj_dirs.data_dir().to_path_buf();
             if let Err(err) = std::fs::create_dir_all(&data_dir) {
-                eprintln!(
+                tracing::warn!(
                     "Saving disabled: Failed to create app path at {:?}: {}",
-                    data_dir, err
+                    data_dir,
+                    err
                 );
                 None
             } else {
                 Some(Self::from_ron_filepath(data_dir.join("app.ron")))
             }
         } else {
-            eprintln!("Saving disabled: Failed to find path to data_dir.");
+            tracing::warn!("Saving disabled: Failed to find path to data_dir.");
             None
         }
     }
@@ -79,7 +80,7 @@ where
             match ron::de::from_reader(reader) {
                 Ok(value) => Some(value),
                 Err(err) => {
-                    eprintln!("ERROR: Failed to parse RON: {}", err);
+                    tracing::warn!("Failed to parse RON: {}", err);
                     None
                 }
             }


### PR DESCRIPTION
This adds the `tracing` crate to `egui_web`, `egui_glow` and `egui-winit`. `egui` gets it as an opt-in dependency. It is used for logging.

In `egui_web` the logs will automatically end up in the dev console. For native, app developers must add `tracing-subscriber = "0.3"` to their `Cargo.toml` and then add `tracing_subscriber::fmt::init();` to their `fn main` in order to get logs to `stdout`. Even then, the egui crates log very little, so you may not see anything logged unless you run with `RUST_LOG=debug`.