### PR TITLE
Add method to enable generation of a ComboBox with both id and label

### DIFF
--- a/egui/src/containers/combo_box.rs
+++ b/egui/src/containers/combo_box.rs
@@ -27,6 +27,16 @@ pub struct ComboBox {
 }
 
 impl ComboBox {
+    /// Create new `ComboBox` with id and label
+    pub fn new(id_source: impl std::hash::Hash, label: impl Into<WidgetText>) -> Self {
+        Self {
+            id_source: Id::new(id_source),
+            label: Some(label.into()),
+            selected_text: Default::default(),
+            width: None,
+        }
+    }
+
     /// Label shown next to the combo box
     pub fn from_label(label: impl Into<WidgetText>) -> Self {
         let label = label.into();


### PR DESCRIPTION
Fixes issue #1203. Now possible to generate `ComboBox` when specifying an id and a label, enabling multiple `ComboBox` instances with the same label.

