### PR TITLE
Add Ui.input_mut & InputState.ignore_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 
 
 ## Unreleased
-
+*  `Ui::input_mut` to modify how subsequent widgets see the `InputState` and a convenience `InputState::ignore_key` for shortcuts or hotkeys. 
 ### Added ⭐
 * Much improved font selection ([#1154](https://github.com/emilk/egui/pull/1154)):
   * You can now select any font size and family using `RichText::size` amd `RichText::family` and the new `FontId`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 ## Unreleased
 
 ### Added ⭐
-*  `Ui::input_mut` to modify how subsequent widgets see the `InputState` and a convenience method `InputState::ignore_key` for shortcuts or hotkeys ([#1212](https://github.com/emilk/egui/pull/1212)). 
+*  `Ui::input_mut` to modify how subsequent widgets see the `InputState` and a convenience method `InputState::consume_key` for shortcuts or hotkeys ([#1212](https://github.com/emilk/egui/pull/1212)). 
 * Much improved font selection ([#1154](https://github.com/emilk/egui/pull/1154)):
   * You can now select any font size and family using `RichText::size` amd `RichText::family` and the new `FontId`.
   * Easily change text styles with `Style::text_styles`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 ## Unreleased
 
 ### Added ⭐
-*  `Ui::input_mut` to modify how subsequent widgets see the `InputState` and a convenience `InputState::ignore_key` for shortcuts or hotkeys ([#1212](https://github.com/emilk/egui/pull/1212)). 
+*  `Ui::input_mut` to modify how subsequent widgets see the `InputState` and a convenience nethod `InputState::ignore_key` for shortcuts or hotkeys ([#1212](https://github.com/emilk/egui/pull/1212)). 
 * Much improved font selection ([#1154](https://github.com/emilk/egui/pull/1154)):
   * You can now select any font size and family using `RichText::size` amd `RichText::family` and the new `FontId`.
   * Easily change text styles with `Style::text_styles`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 
 
 ## Unreleased
-*  `Ui::input_mut` to modify how subsequent widgets see the `InputState` and a convenience `InputState::ignore_key` for shortcuts or hotkeys. 
+
 ### Added ⭐
+*  `Ui::input_mut` to modify how subsequent widgets see the `InputState` and a convenience `InputState::ignore_key` for shortcuts or hotkeys ([#1212](https://github.com/emilk/egui/pull/1212)). 
 * Much improved font selection ([#1154](https://github.com/emilk/egui/pull/1154)):
   * You can now select any font size and family using `RichText::size` amd `RichText::family` and the new `FontId`.
   * Easily change text styles with `Style::text_styles`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 ## Unreleased
 
 ### Added ⭐
-*  `Ui::input_mut` to modify how subsequent widgets see the `InputState` and a convenience nethod `InputState::ignore_key` for shortcuts or hotkeys ([#1212](https://github.com/emilk/egui/pull/1212)). 
+*  `Ui::input_mut` to modify how subsequent widgets see the `InputState` and a convenience method `InputState::ignore_key` for shortcuts or hotkeys ([#1212](https://github.com/emilk/egui/pull/1212)). 
 * Much improved font selection ([#1154](https://github.com/emilk/egui/pull/1154)):
   * You can now select any font size and family using `RichText::size` amd `RichText::family` and the new `FontId`.
   * Easily change text styles with `Style::text_styles`.

--- a/egui/src/data/input.rs
+++ b/egui/src/data/input.rs
@@ -264,6 +264,46 @@ pub struct Modifiers {
 }
 
 impl Modifiers {
+
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn alt(self, value: bool) -> Self {
+        Self {
+            alt: value,
+            ..self
+        }
+    }
+
+    pub fn ctrl(self, value: bool) -> Self {
+        Self {
+            ctrl: value,
+            ..self
+        }
+    }
+
+    pub fn shift(self, value: bool) -> Self {
+        Self {
+            shift: value,
+            ..self
+        }
+    }
+
+    pub fn mac_cmd(self, value: bool) -> Self {
+        Self {
+            mac_cmd: value,
+            ..self
+        }
+    }
+
+    pub fn command(self, value: bool) -> Self {
+        Self {
+            command: value,
+            ..self
+        }
+    }
+
     #[inline(always)]
     pub fn is_none(&self) -> bool {
         self == &Self::default()

--- a/egui/src/data/input.rs
+++ b/egui/src/data/input.rs
@@ -264,16 +264,12 @@ pub struct Modifiers {
 }
 
 impl Modifiers {
-
     pub fn new() -> Self {
         Default::default()
     }
 
     pub fn alt(self, value: bool) -> Self {
-        Self {
-            alt: value,
-            ..self
-        }
+        Self { alt: value, ..self }
     }
 
     pub fn ctrl(self, value: bool) -> Self {

--- a/egui/src/input_state.rs
+++ b/egui/src/input_state.rs
@@ -193,7 +193,8 @@ impl InputState {
     }
 
     /// Ignore a key if it was pressed or released this frame. Useful for hotkeys.
-    /// Returns if the key was pressed this frame
+    /// Matches on both key press and key release, consuming them and removing them from `self.events`.
+    /// Returns true if the key was pressed this frame (even if the key release was consumed).
     pub fn consume_key(&mut self, modifiers: Modifiers, key: Key) -> bool {
         self.events.retain(|event| {
             !matches!(

--- a/egui/src/input_state.rs
+++ b/egui/src/input_state.rs
@@ -192,8 +192,8 @@ impl InputState {
         self.pointer.wants_repaint() || self.scroll_delta != Vec2::ZERO || !self.events.is_empty()
     }
 
-    // Ignore a key if it was pressed or released this frame. Useful for hotkeys.
-    // Returns if the key was pressed this frame
+    /// Ignore a key if it was pressed or released this frame. Useful for hotkeys.
+    /// Returns if the key was pressed this frame
     pub fn consume_key(&mut self, modifiers: Modifiers, key: Key) -> bool {
         self.events.retain(|event| {
             !matches!(

--- a/egui/src/input_state.rs
+++ b/egui/src/input_state.rs
@@ -192,6 +192,23 @@ impl InputState {
         self.pointer.wants_repaint() || self.scroll_delta != Vec2::ZERO || !self.events.is_empty()
     }
 
+    // Ignore a key if it was pressed or released this frame. Useful for hotkeys.
+    // Returns if the key was pressed this frame
+    pub fn ignore_key(&mut self, ignore_key: Key, modifiers: Modifiers) -> bool {
+        self.events = std::mem::take(&mut self.events).into_iter().filter(|event| {
+            !matches!(
+                event,
+                Event::Key {
+                    key,
+                    modifiers: _mods,
+                    ..
+                } if *key == ignore_key && *_mods == modifiers
+            )
+        }).collect();
+
+        self.keys_down.remove(&ignore_key)
+    }
+
     /// Was the given key pressed this frame?
     pub fn key_pressed(&self, desired_key: Key) -> bool {
         self.num_presses(desired_key) > 0

--- a/egui/src/input_state.rs
+++ b/egui/src/input_state.rs
@@ -194,19 +194,19 @@ impl InputState {
 
     // Ignore a key if it was pressed or released this frame. Useful for hotkeys.
     // Returns if the key was pressed this frame
-    pub fn ignore_key(&mut self, ignore_key: Key, modifiers: Modifiers) -> bool {
-        self.events = std::mem::take(&mut self.events).into_iter().filter(|event| {
+    pub fn consume_key(&mut self, key: Key, modifiers: Modifiers) -> bool {
+        self.events.retain(|event| {
             !matches!(
                 event,
                 Event::Key {
-                    key,
-                    modifiers: mods,
+                    key: ev_key,
+                    modifiers: ev_mods,
                     ..
-                } if *key == ignore_key && *mods == modifiers
+                } if *ev_key == key && *ev_mods == modifiers
             )
-        }).collect();
+        });
 
-        self.keys_down.remove(&ignore_key)
+        self.keys_down.remove(&key)
     }
 
     /// Was the given key pressed this frame?

--- a/egui/src/input_state.rs
+++ b/egui/src/input_state.rs
@@ -194,7 +194,7 @@ impl InputState {
 
     // Ignore a key if it was pressed or released this frame. Useful for hotkeys.
     // Returns if the key was pressed this frame
-    pub fn consume_key(&mut self, key: Key, modifiers: Modifiers) -> bool {
+    pub fn consume_key(&mut self, modifiers: Modifiers, key: Key) -> bool {
         self.events.retain(|event| {
             !matches!(
                 event,

--- a/egui/src/input_state.rs
+++ b/egui/src/input_state.rs
@@ -200,9 +200,9 @@ impl InputState {
                 event,
                 Event::Key {
                     key,
-                    modifiers: _mods,
+                    modifiers: mods,
                     ..
-                } if *key == ignore_key && *_mods == modifiers
+                } if *key == ignore_key && *mods == modifiers
             )
         }).collect();
 

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -338,7 +338,6 @@ impl Ui {
         self.ctx().input()
     }
 
-
     /// The [`InputState`] of the [`Context`] associated with this [`Ui`].
     /// Equivalent to `.ctx().input_mut()`.
     ///
@@ -346,14 +345,13 @@ impl Ui {
     /// like for [`Self::input()`].
     /// ```
     /// # egui::__run_test_ui(|ui| {
-    /// ui.input_mut().consume_key(egui::Key::Enter, egui::Modifiers::default());
+    /// ui.input_mut().consume_key(egui::Modifiers::default(), egui::Key::Enter);
     /// # });
     /// ```
     #[inline]
     pub fn input_mut(&self) -> RwLockWriteGuard<'_, InputState> {
         self.ctx().input_mut()
     }
-
 
     /// The [`Memory`] of the [`Context`] associated with this ui.
     /// Equivalent to `.ctx().memory()`.

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -338,6 +338,23 @@ impl Ui {
         self.ctx().input()
     }
 
+
+    /// The [`InputState`] of the [`Context`] associated with this [`Ui`].
+    /// Equivalent to `.ctx().input_mut()`.
+    ///
+    /// Note that this locks the [`Context`], so be careful with if-let bindings
+    /// like for [`Self::input()`].
+    /// ```
+    /// # egui::__run_test_ui(|ui| {
+    /// ui.input_mut().time = 0.0;
+    /// # });
+    /// ```
+    #[inline]
+    pub fn input_mut(&self) -> RwLockWriteGuard<'_, InputState> {
+        self.ctx().input_mut()
+    }
+
+
     /// The [`Memory`] of the [`Context`] associated with this ui.
     /// Equivalent to `.ctx().memory()`.
     #[inline]

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -346,7 +346,7 @@ impl Ui {
     /// like for [`Self::input()`].
     /// ```
     /// # egui::__run_test_ui(|ui| {
-    /// ui.input_mut().time = 0.0;
+    /// ui.input_mut().consume_key(egui::Key::Enter, egui::Modifiers::default());
     /// # });
     /// ```
     #[inline]

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -118,11 +118,12 @@ impl EasyMarkEditor {
 fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRange) -> bool {
     let mut any_change = false;
     for (key, surrounding) in [
-        (Key::B, "*"),
-        (Key::C, "`"),
-        (Key::I, "/"),
-        (Key::R, "~"),
-        (Key::U, "_"),
+        (Key::B, "*"), // *bold*
+        (Key::C, "`"), // `code`
+        (Key::I, "/"), // /italics/
+        (Key::R, "^"), // ^superscript^
+        (Key::S, "~"), // ~strikethrough~
+        (Key::U, "_"), // _underline_
     ] {
         if ui.input_mut().consume_key(
             key,

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -121,6 +121,7 @@ fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRang
         (Key::B, "*"), // *bold*
         (Key::C, "`"), // `code`
         (Key::I, "/"), // /italics/
+        (Key::L, "$"), // $subscript$
         (Key::R, "^"), // ^superscript^
         (Key::S, "~"), // ~strikethrough~
         (Key::U, "_"), // _underline_

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -117,59 +117,28 @@ impl EasyMarkEditor {
 
 fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRange) -> bool {
     let mut any_change = false;
-    for event in &ui.input().events {
-        if let Event::Key {
+    for (key, surrounding) in [
+        (Key::B, "*"),
+        (Key::C, "`"),
+        (Key::I, "/"),
+        (Key::R, "~"),
+        (Key::U, "_"),
+    ] {
+        if ui.input_mut().consume_key(
             key,
-            pressed: true,
-            modifiers,
-        } = event
-        {
-            if modifiers.command_only() {
-                match &key {
-                    // toggle *bold*
-                    Key::B => {
-                        toggle_surrounding(code, ccursor_range, "*");
-                        any_change = true;
-                    }
-                    // toggle `code`
-                    Key::C => {
-                        toggle_surrounding(code, ccursor_range, "`");
-                        any_change = true;
-                    }
-                    // toggle /italics/
-                    Key::I => {
-                        toggle_surrounding(code, ccursor_range, "/");
-                        any_change = true;
-                    }
-                    // toggle $lowered$
-                    Key::L => {
-                        toggle_surrounding(code, ccursor_range, "$");
-                        any_change = true;
-                    }
-                    // toggle ^raised^
-                    Key::R => {
-                        toggle_surrounding(code, ccursor_range, "^");
-                        any_change = true;
-                    }
-                    // toggle ~strikethrough~
-                    Key::S => {
-                        toggle_surrounding(code, ccursor_range, "~");
-                        any_change = true;
-                    }
-                    // toggle _underline_
-                    Key::U => {
-                        toggle_surrounding(code, ccursor_range, "_");
-                        any_change = true;
-                    }
-                    _ => {}
-                }
-            }
-        }
+            egui::Modifiers {
+                command: true,
+                ..Default::default()
+            },
+        ) {
+            toggle_surrounding(code, ccursor_range, surrounding);
+            any_change = true;
+        };
     }
     any_change
 }
 
-/// E.g. toggle *strong* with `toggle(&mut text, &mut cursor, "*")`
+/// E.g. toggle *strong* with `toggle_surrounding(&mut text, &mut cursor, "*")`
 fn toggle_surrounding(
     code: &mut dyn TextBuffer,
     ccursor_range: &mut CCursorRange,

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -126,10 +126,10 @@ fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRang
         (Key::S, "~"), // ~strikethrough~
         (Key::U, "_"), // _underline_
     ] {
-        if ui.input_mut().consume_key(
-            egui::Modifiers::new().command(true),
-            key
-        ) {
+        if ui
+            .input_mut()
+            .consume_key(egui::Modifiers::new().command(true), key)
+        {
             toggle_surrounding(code, ccursor_range, surrounding);
             any_change = true;
         };

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -127,11 +127,8 @@ fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRang
         (Key::U, "_"), // _underline_
     ] {
         if ui.input_mut().consume_key(
-            key,
-            egui::Modifiers {
-                command: true,
-                ..Default::default()
-            },
+            egui::Modifiers::new().command(true),
+            key
         ) {
             toggle_surrounding(code, ccursor_range, surrounding);
             any_change = true;


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and it is green.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

This PR pipes through `ctx.input_mut()` through to the Uis, allowing control of what events subsequent widgets see, and adds a utility function to the InputState to do hotkeys/shortcuts.

Helps with https://github.com/emilk/egui/discussions/1124

