### PR TITLE
Add step parameter to egui::Slider

### DIFF
--- a/egui_demo_lib/src/apps/demo/widget_gallery.rs
+++ b/egui_demo_lib/src/apps/demo/widget_gallery.rs
@@ -14,6 +14,7 @@ pub struct WidgetGallery {
     boolean: bool,
     radio: Enum,
     scalar: f32,
+    step: f64,
     string: String,
     color: egui::Color32,
     animate_progress_bar: bool,
@@ -29,6 +30,7 @@ impl Default for WidgetGallery {
             boolean: false,
             radio: Enum::First,
             scalar: 42.0,
+            step: 0.0,
             string: Default::default(),
             color: egui::Color32::LIGHT_BLUE.linear_multiply(0.5),
             animate_progress_bar: false,
@@ -99,6 +101,7 @@ impl WidgetGallery {
             boolean,
             radio,
             scalar,
+            step,
             string,
             color,
             animate_progress_bar,
@@ -166,8 +169,20 @@ impl WidgetGallery {
             });
         ui.end_row();
 
+        ui.add(doc_link_label("Slider step", "Slider"));
+        ui.add(egui::Slider::new(step, 0.0..=90.0));
+        ui.end_row();
+
         ui.add(doc_link_label("Slider", "Slider"));
-        ui.add(egui::Slider::new(scalar, 0.0..=360.0).suffix("°"));
+        if *step != 0.0 {
+            ui.add(
+                egui::Slider::new(scalar, 0.0..=360.0)
+                    .suffix("°")
+                    .step_by(*step),
+            );
+        } else {
+            ui.add(egui::Slider::new(scalar, 0.0..=360.0).suffix("°"));
+        }
         ui.end_row();
 
         ui.add(doc_link_label("DragValue", "DragValue"));


### PR DESCRIPTION
PR adds `step_by()` and `disable_step()` methods to egui::Slider.
It allows adjusting the value of the slider with discrete steps, which is useful when we want to control something like the number of bits in a buffer and similar.

The demo app is updated: added one more slider, which controls the step value of another.