### PR TITLE
feat: don't install console panic hook and tracing wasm subscriber by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,16 +558,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if 1.0.0",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "copypasta"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,7 +1062,6 @@ name = "egui_web"
 version = "0.16.0"
 dependencies = [
  "bytemuck",
- "console_error_panic_hook",
  "egui",
  "egui_glow",
  "epi",
@@ -1080,7 +1069,6 @@ dependencies = [
  "ron",
  "serde",
  "tracing",
- "tracing-wasm",
  "tts",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3141,17 +3129,6 @@ dependencies = [
  "thread_local",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "tracing-wasm"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
-dependencies = [
- "tracing",
- "tracing-subscriber",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "copypasta"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,9 +1015,11 @@ dependencies = [
 name = "egui_demo_app"
 version = "0.16.0"
 dependencies = [
+ "console_error_panic_hook",
  "eframe",
  "egui_demo_lib",
  "tracing-subscriber",
+ "tracing-wasm",
 ]
 
 [[package]]
@@ -3129,6 +3141,17 @@ dependencies = [
  "thread_local",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/egui_demo_app/Cargo.toml
+++ b/egui_demo_app/Cargo.toml
@@ -30,3 +30,7 @@ eframe = { version = "0.16.0", path = "../eframe" }
 
 egui_demo_lib = { version = "0.16.0", path = "../egui_demo_lib", features = ["extra_debug_asserts"] }
 tracing-subscriber = "0.3"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+console_error_panic_hook = "0.1.6"
+tracing-wasm = "0.2"

--- a/egui_demo_app/src/lib.rs
+++ b/egui_demo_app/src/lib.rs
@@ -13,6 +13,12 @@ use eframe::wasm_bindgen::{self, prelude::*};
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn start(canvas_id: &str) -> Result<(), wasm_bindgen::JsValue> {
+    // Make sure panics are logged using `console.error`.
+    console_error_panic_hook::set_once();
+
+    // Redirect tracing to console.log and friends:
+    tracing_wasm::set_as_global_default();
+
     let app = egui_demo_lib::WrapApp::default();
     eframe::start_web(canvas_id, Box::new(app))
 }

--- a/egui_web/Cargo.toml
+++ b/egui_web/Cargo.toml
@@ -56,10 +56,8 @@ egui_glow = { version = "0.16.0",path = "../egui_glow", default-features = false
 epi = { version = "0.16.0", path = "../epi" }
 
 bytemuck = "1.7"
-console_error_panic_hook = "0.1.6"
 js-sys = "0.3"
 tracing = "0.1"
-tracing-wasm = "0.2"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -281,12 +281,6 @@ impl AppRunner {
 /// Install event listeners to register different input events
 /// and start running the given app.
 pub fn start(canvas_id: &str, app: Box<dyn epi::App>) -> Result<AppRunnerRef, JsValue> {
-    // Make sure panics are logged using `console.error`.
-    console_error_panic_hook::set_once();
-
-    // Redirect tracing to console.log and friends:
-    tracing_wasm::set_as_global_default();
-
     let mut runner = AppRunner::new(canvas_id, app)?;
     runner.warm_up()?;
     start_runner(runner)


### PR DESCRIPTION
This resolves #1229.

