### PR TITLE
Fix `Margin` being inside a private module

### DIFF
--- a/egui/src/containers/frame.rs
+++ b/egui/src/containers/frame.rs
@@ -1,50 +1,7 @@
 //! Frame container
 
-use crate::{layers::ShapeIdx, *};
+use crate::{layers::ShapeIdx, style::Margin, *};
 use epaint::*;
-
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct Margin {
-    pub left: f32,
-    pub right: f32,
-    pub top: f32,
-    pub bottom: f32,
-}
-
-impl Margin {
-    #[inline]
-    pub fn same(margin: f32) -> Self {
-        Self {
-            left: margin,
-            right: margin,
-            top: margin,
-            bottom: margin,
-        }
-    }
-
-    /// Margins with the same size on opposing sides
-    #[inline]
-    pub fn symmetric(x: f32, y: f32) -> Self {
-        Self {
-            left: x,
-            right: x,
-            top: y,
-            bottom: y,
-        }
-    }
-
-    /// Total margins on both sides
-    pub fn sum(&self) -> Vec2 {
-        Vec2::new(self.left + self.right, self.top + self.bottom)
-    }
-}
-
-impl From<Vec2> for Margin {
-    fn from(v: Vec2) -> Self {
-        Self::symmetric(v.x, v.y)
-    }
-}
 
 /// Color and margin of a rectangular background of a [`Ui`].
 #[derive(Clone, Copy, Debug, Default, PartialEq)]

--- a/egui/src/containers/mod.rs
+++ b/egui/src/containers/mod.rs
@@ -16,7 +16,7 @@ pub use {
     area::Area,
     collapsing_header::{CollapsingHeader, CollapsingResponse},
     combo_box::*,
-    frame::{Frame, Margin},
+    frame::Frame,
     panel::{CentralPanel, SidePanel, TopBottomPanel},
     popup::*,
     resize::Resize,

--- a/egui/src/style.rs
+++ b/egui/src/style.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::if_same_then_else)]
 
-use crate::{color::*, emath::*, FontFamily, FontId, Margin, Response, RichText, WidgetText};
+use crate::{color::*, emath::*, FontFamily, FontId, Response, RichText, WidgetText};
 use epaint::{mutex::Arc, Rounding, Shadow, Stroke};
 use std::collections::BTreeMap;
 
@@ -274,6 +274,49 @@ impl Spacing {
             Rect::from_center_size(big_icon_rect.center(), Vec2::splat(small_rect_side));
 
         (small_icon_rect, big_icon_rect)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct Margin {
+    pub left: f32,
+    pub right: f32,
+    pub top: f32,
+    pub bottom: f32,
+}
+
+impl Margin {
+    #[inline]
+    pub fn same(margin: f32) -> Self {
+        Self {
+            left: margin,
+            right: margin,
+            top: margin,
+            bottom: margin,
+        }
+    }
+
+    /// Margins with the same size on opposing sides
+    #[inline]
+    pub fn symmetric(x: f32, y: f32) -> Self {
+        Self {
+            left: x,
+            right: x,
+            top: y,
+            bottom: y,
+        }
+    }
+
+    /// Total margins on both sides
+    pub fn sum(&self) -> Vec2 {
+        Vec2::new(self.left + self.right, self.top + self.bottom)
+    }
+}
+
+impl From<Vec2> for Margin {
+    fn from(v: Vec2) -> Self {
+        Self::symmetric(v.x, v.y)
     }
 }
 


### PR DESCRIPTION
Move `Margin` to `style.rs` so that it can be accessed publicly via `egui::style::Margin`.

Fixes https://github.com/emilk/egui/pull/1219.