### PR TITLE
Make non interactable layers not interact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,12 +44,15 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * Replaced Frame's `margin: Vec2` with `margin: Margin`, allowing for different margins on opposing sides ([#1219](https://github.com/emilk/egui/pull/1219)).
 * `Plot::highlight` now takes a `bool` argument ([#1159](https://github.com/emilk/egui/pull/1159)).
 * `ScrollArea::show` now returns a `ScrollAreaOutput`, so you might need to add `.inner` after the call to it ([#1166](https://github.com/emilk/egui/pull/1166)).
+* Tooltips that don't fit the window don't flicker anymore ([#1240](https://github.com/emilk/egui/pull/1240)).
+* `Areas::layer_id_at` ignores non interatable layers (i.e. Tooltips) ([#1240](https://github.com/emilk/egui/pull/1240)).
 
 ### Fixed 🐛
 * Context menus now respects the theme ([#1043](https://github.com/emilk/egui/pull/1043)).
 * Plot `Orientation` was not public, although fields using this type were ([#1130](https://github.com/emilk/egui/pull/1130)).
 * Fixed `enable_drag` for Windows ([#1108](https://github.com/emilk/egui/pull/1108)).
 * Calling `Context::set_pixels_per_point` before the first frame will now work.
+* Tooltips that don't fit the window don't flicker anymore ([#1240](https://github.com/emilk/egui/pull/1240)).
 
 ### Contributors 🙏
 * [AlexxxRu](https://github.com/alexxxru): [#1108](https://github.com/emilk/egui/pull/1108).

--- a/egui/src/containers/area.rs
+++ b/egui/src/containers/area.rs
@@ -204,7 +204,7 @@ impl Area {
         let state = ctx.memory().areas.get(id).cloned();
         let is_new = state.is_none();
         if is_new {
-            ctx.request_repaint(); // if we don't know the previous size we are likely drawing the area in the wrong place}
+            ctx.request_repaint(); // if we don't know the previous size we are likely drawing the area in the wrong place
         }
         let mut state = state.unwrap_or_else(|| State {
             pos: default_pos.unwrap_or_else(|| automatic_area_position(ctx)),
@@ -212,6 +212,7 @@ impl Area {
             interactable,
         });
         state.pos = new_pos.unwrap_or(state.pos);
+        state.interactable = interactable;
 
         if let Some((anchor, offset)) = anchor {
             if is_new {

--- a/egui/src/memory.rs
+++ b/egui/src/memory.rs
@@ -516,9 +516,9 @@ impl Areas {
                     if state.interactable {
                         // Allow us to resize by dragging just outside the window:
                         rect = rect.expand(resize_interact_radius_side);
-                    }
-                    if rect.contains(pos) {
-                        return Some(*layer);
+                        if rect.contains(pos) {
+                            return Some(*layer);
+                        }
                     }
                 }
             }

--- a/egui/src/menu.rs
+++ b/egui/src/menu.rs
@@ -126,7 +126,7 @@ pub(crate) fn menu_ui<'c, R>(
     let area = Area::new(menu_id)
         .order(Order::Foreground)
         .fixed_pos(pos)
-        .interactable(false)
+        .interactable(true)
         .drag_bounds(Rect::EVERYTHING);
     let inner_response = area.show(ctx, |ui| {
         ui.scope(|ui| {


### PR DESCRIPTION
Areas in the Tooltip layer shouldn't block interactions to layers below them. Currently, layers under a tooltip won't get hovered if there's a tooltip covering it. Causing the flickering seen in #1239 

Closes #1239 - Tooltips flicker when they can't fit on the screen