### PR TITLE
Make v-align and scale of user fonts tweakable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
   * Easily change text styles with `Style::text_styles`.
   * Added `Ui::text_style_height`.
   * Added `TextStyle::resolve`.
+* Made v-align and scale of user fonts tweakable ([#1241](https://github.com/emilk/egui/pull/1027)).
 * `Context::load_texture` to convert an image into a texture which can be displayed using e.g. `ui.image(texture, size)` ([#1110](https://github.com/emilk/egui/pull/1110)).
 * Added `Ui::add_visible` and `Ui::add_visible_ui`.
 * Opt-in dependency on `tracing` crate for logging warnings ([#1192](https://github.com/emilk/egui/pull/1192)).

--- a/epaint/CHANGELOG.md
+++ b/epaint/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the epaint crate will be documented in this file.
 * Much improved font selection ([#1154](https://github.com/emilk/egui/pull/1154)):
   * Replaced `TextStyle` with `FontId` which lets you pick any font size and font family.
   * Replaced `Fonts::font_image` with `font_image_delta` for partial font atlas updates.
+* Made v-align and scale of user fonts tweakable ([#1241](https://github.com/emilk/egui/pull/1027)).
 * Added `ImageData` and `TextureManager` for loading images into textures ([#1110](https://github.com/emilk/egui/pull/1110)).
 * Added `Shape::dashed_line_many` ([#1027](https://github.com/emilk/egui/pull/1027)).
 * Replaced `corner_radius: f32` with `rounding: Rounding`, allowing per-corner rounding settings ([#1206](https://github.com/emilk/egui/pull/1206)).

--- a/epaint/src/text/font.rs
+++ b/epaint/src/text/font.rs
@@ -73,20 +73,22 @@ impl FontImpl {
         pixels_per_point: f32,
         ab_glyph_font: ab_glyph::FontArc,
         scale_in_pixels: u32,
-        y_offset: f32,
+        y_offset_points: f32,
     ) -> FontImpl {
         assert!(scale_in_pixels > 0);
         assert!(pixels_per_point > 0.0);
 
         let height_in_points = scale_in_pixels as f32 / pixels_per_point;
 
-        // TODO: use v_metrics for line spacing ?
-        // let v = rusttype_font.v_metrics(Scale::uniform(scale_in_pixels));
-        // let height_in_pixels = v.ascent - v.descent + v.line_gap;
-        // let height_in_points = height_in_pixels / pixels_per_point;
+        // TODO: use these font metrics?
+        // use ab_glyph::ScaleFont as _;
+        // let scaled = ab_glyph_font.as_scaled(scale_in_pixels as f32);
+        // dbg!(scaled.ascent());
+        // dbg!(scaled.descent());
+        // dbg!(scaled.line_gap());
 
         // Round to closest pixel:
-        let y_offset = (y_offset * pixels_per_point).round() / pixels_per_point;
+        let y_offset = (y_offset_points * pixels_per_point).round() / pixels_per_point;
 
         Self {
             ab_glyph_font,

--- a/epaint/src/text/fonts.rs
+++ b/epaint/src/text/fonts.rs
@@ -120,6 +120,9 @@ pub struct FontData {
     /// Which font face in the file to use.
     /// When in doubt, use `0`.
     pub index: u32,
+
+    /// Extra scale and vertical tweak to apply to all text of this font.
+    pub tweak: FontTweak,
 }
 
 impl FontData {
@@ -127,6 +130,7 @@ impl FontData {
         Self {
             font: std::borrow::Cow::Borrowed(font),
             index: 0,
+            tweak: Default::default(),
         }
     }
 
@@ -134,9 +138,47 @@ impl FontData {
         Self {
             font: std::borrow::Cow::Owned(font),
             index: 0,
+            tweak: Default::default(),
+        }
+    }
+
+    pub fn tweak(self, tweak: FontTweak) -> Self {
+        Self { tweak, ..self }
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+/// Extra scale and vertical tweak to apply to all text of a certain font.
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct FontTweak {
+    /// Scale the font by this much.
+    ///
+    /// Default: `1.0`
+    pub scale: f32,
+
+    /// Shift font downwards by this fraction of the font size.
+    ///
+    /// If you load a custom font and it looks like it is too high up,
+    /// set this to e.g. `0.3`.
+    pub y_offset_factor: f32,
+
+    /// Shift font downwards by this absolute amount.
+    pub y_offset: f32,
+}
+
+impl Default for FontTweak {
+    fn default() -> Self {
+        Self {
+            scale: 1.0,
+            y_offset_factor: 0.0,
+            y_offset: -3.0, // makes most fonts look more centered in buttons and such
         }
     }
 }
+
+// ----------------------------------------------------------------------------
 
 fn ab_glyph_font_from_font_data(name: &str, data: &FontData) -> ab_glyph::FontArc {
     match &data.font {
@@ -220,10 +262,17 @@ impl Default for FontDefinitions {
                 "NotoEmoji-Regular".to_owned(),
                 FontData::from_static(include_bytes!("../../fonts/NotoEmoji-Regular.ttf")),
             );
+
             // Bigger emojis, and more. <http://jslegers.github.io/emoji-icon-font/>:
             font_data.insert(
                 "emoji-icon-font".to_owned(),
-                FontData::from_static(include_bytes!("../../fonts/emoji-icon-font.ttf")),
+                FontData::from_static(include_bytes!("../../fonts/emoji-icon-font.ttf")).tweak(
+                    FontTweak {
+                        scale: 0.8,
+                        y_offset_factor: 0.29,
+                        y_offset: -3.0,
+                    },
+                ),
             );
 
             families.insert(
@@ -603,7 +652,7 @@ impl GalleyCache {
 struct FontImplCache {
     atlas: Arc<Mutex<TextureAtlas>>,
     pixels_per_point: f32,
-    ab_glyph_fonts: BTreeMap<String, ab_glyph::FontArc>,
+    ab_glyph_fonts: BTreeMap<String, (FontTweak, ab_glyph::FontArc)>,
 
     /// Map font pixel sizes and names to the cached `FontImpl`.
     cache: ahash::AHashMap<(u32, String), Arc<FontImpl>>,
@@ -617,7 +666,11 @@ impl FontImplCache {
     ) -> Self {
         let ab_glyph_fonts = font_data
             .iter()
-            .map(|(name, font_data)| (name.clone(), ab_glyph_font_from_font_data(name, font_data)))
+            .map(|(name, font_data)| {
+                let tweak = font_data.tweak;
+                let ab_glyph = ab_glyph_font_from_font_data(name, font_data);
+                (name.clone(), (tweak, ab_glyph))
+            })
             .collect();
 
         Self {
@@ -638,29 +691,22 @@ impl FontImplCache {
     }
 
     pub fn font_impl(&mut self, scale_in_pixels: u32, font_name: &str) -> Arc<FontImpl> {
-        let scale_in_pixels = if font_name == "emoji-icon-font" {
-            (scale_in_pixels as f32 * 0.8).round() as u32 // TODO: remove font scale HACK!
-        } else {
-            scale_in_pixels
-        };
+        let (tweak, ab_glyph_font) = self
+            .ab_glyph_fonts
+            .get(font_name)
+            .unwrap_or_else(|| panic!("No font data found for {:?}", font_name))
+            .clone();
 
-        let y_offset = if font_name == "emoji-icon-font" {
+        let scale_in_pixels = (scale_in_pixels as f32 * tweak.scale).round() as u32;
+
+        let y_offset = {
             let scale_in_points = scale_in_pixels as f32 / self.pixels_per_point;
-            scale_in_points * 0.29375 // TODO: remove font alignment hack
-        } else {
-            0.0
-        };
-        let y_offset = y_offset - 3.0; // Tweaked to make text look centered in buttons and text edit fields
+            scale_in_points * tweak.y_offset_factor
+        } + tweak.y_offset;
 
         self.cache
             .entry((scale_in_pixels, font_name.to_owned()))
             .or_insert_with(|| {
-                let ab_glyph_font = self
-                    .ab_glyph_fonts
-                    .get(font_name)
-                    .unwrap_or_else(|| panic!("No font data found for {:?}", font_name))
-                    .clone();
-
                 Arc::new(FontImpl::new(
                     self.atlas.clone(),
                     self.pixels_per_point,

--- a/epaint/src/text/fonts.rs
+++ b/epaint/src/text/fonts.rs
@@ -272,8 +272,8 @@ impl Default for FontDefinitions {
                 "emoji-icon-font".to_owned(),
                 FontData::from_static(include_bytes!("../../fonts/emoji-icon-font.ttf")).tweak(
                     FontTweak {
-                        scale: 0.8,           // make it smaller
-                        y_offset_factor: 0.1, // move it down slightly
+                        scale: 0.8,            // make it smaller
+                        y_offset_factor: 0.07, // move it down slightly
                         y_offset: 0.0,
                     },
                 ),

--- a/epaint/src/text/fonts.rs
+++ b/epaint/src/text/fonts.rs
@@ -166,7 +166,7 @@ pub struct FontTweak {
     /// Example value: `-0.2`.
     pub y_offset_factor: f32,
 
-    /// Shift font downwards by this absolute amount of logical points.
+    /// Shift font downwards by this amount of logical points.
     ///
     /// Example value: `-1.0`.
     pub y_offset: f32,
@@ -272,8 +272,8 @@ impl Default for FontDefinitions {
                 "emoji-icon-font".to_owned(),
                 FontData::from_static(include_bytes!("../../fonts/emoji-icon-font.ttf")).tweak(
                     FontTweak {
-                        scale: 0.8,
-                        y_offset_factor: 0.1,
+                        scale: 0.8,           // make it smaller
+                        y_offset_factor: 0.1, // move it down slightly
                         y_offset: 0.0,
                     },
                 ),

--- a/epaint/src/text/fonts.rs
+++ b/epaint/src/text/fonts.rs
@@ -155,16 +155,20 @@ impl FontData {
 pub struct FontTweak {
     /// Scale the font by this much.
     ///
-    /// Default: `1.0`
+    /// Default: `1.0` (no scaling).
     pub scale: f32,
 
-    /// Shift font downwards by this fraction of the font size.
+    /// Shift font downwards by this fraction of the font size (in points).
     ///
-    /// If you load a custom font and it looks like it is too high up,
-    /// set this to e.g. `0.3`.
+    /// A positive value shifts the text upwards.
+    /// A negative value shifts it downwards.
+    ///
+    /// Example value: `-0.2`.
     pub y_offset_factor: f32,
 
-    /// Shift font downwards by this absolute amount.
+    /// Shift font downwards by this absolute amount of logical points.
+    ///
+    /// Example value: `-1.0`.
     pub y_offset: f32,
 }
 
@@ -172,8 +176,8 @@ impl Default for FontTweak {
     fn default() -> Self {
         Self {
             scale: 1.0,
-            y_offset_factor: 0.0,
-            y_offset: -3.0, // makes most fonts look more centered in buttons and such
+            y_offset_factor: -0.2, // makes the default fonts look more centered in buttons and such
+            y_offset: 0.0,
         }
     }
 }
@@ -269,8 +273,8 @@ impl Default for FontDefinitions {
                 FontData::from_static(include_bytes!("../../fonts/emoji-icon-font.ttf")).tweak(
                     FontTweak {
                         scale: 0.8,
-                        y_offset_factor: 0.29,
-                        y_offset: -3.0,
+                        y_offset_factor: 0.1,
+                        y_offset: 0.0,
                     },
                 ),
             );
@@ -699,7 +703,7 @@ impl FontImplCache {
 
         let scale_in_pixels = (scale_in_pixels as f32 * tweak.scale).round() as u32;
 
-        let y_offset = {
+        let y_offset_points = {
             let scale_in_points = scale_in_pixels as f32 / self.pixels_per_point;
             scale_in_points * tweak.y_offset_factor
         } + tweak.y_offset;
@@ -712,7 +716,7 @@ impl FontImplCache {
                     self.pixels_per_point,
                     ab_glyph_font,
                     scale_in_pixels,
-                    y_offset,
+                    y_offset_points,
                 ))
             })
             .clone()


### PR DESCRIPTION
Some fonts sit higher on a line, and some lower.

This PR allows users to tweak the vertical alignment and scale of each font to match it better with other fonts and the rest of the UI, like so:

```rust
font_data.insert(
    "emoji-icon-font".to_owned(),
    FontData::from_static(include_bytes!("../../fonts/emoji-icon-font.ttf")).tweak(
        FontTweak {
            scale: 0.8, // make it smaller
            y_offset_factor: 0.1, // move it down slightly
            y_offset: 0.0,
        },
    ),
);
```

--- 

This PR also changes those values slightly for the default fonts.

This moves some text by a pixel or so, especially small and large text, but the difference i minimal:

### Before:
![fonts-master](https://user-images.githubusercontent.com/1148717/153718576-b8d422ac-42f6-41eb-9a8e-f67d778dd128.png)


### After:
![fonts-tweaked](https://user-images.githubusercontent.com/1148717/153718581-7d2e470a-6d15-43a9-8787-7cdb77aca564.png)

After plus text bounding boxes (text should be centered vertically in each green box):
![fonts-tweaked-bb](https://user-images.githubusercontent.com/1148717/153718602-9b39376b-b42e-451f-96c6-86a61f46e95a.png)

