### PR TITLE
Allow scroll into view without specifying an alignment

### DIFF
--- a/egui/src/frame_state.rs
+++ b/egui/src/frame_state.rs
@@ -1,3 +1,5 @@
+use std::ops::RangeInclusive;
+
 use crate::*;
 
 /// State that is collected during a frame and then cleared.
@@ -28,7 +30,7 @@ pub(crate) struct FrameState {
     /// Cleared by the first `ScrollArea` that makes use of it.
     pub(crate) scroll_delta: Vec2, // TODO: move to a Mutex inside of `InputState` ?
     /// horizontal, vertical
-    pub(crate) scroll_target: [Option<(f32, Align)>; 2],
+    pub(crate) scroll_target: [Option<(RangeInclusive<f32>, Option<Align>)>; 2],
 }
 
 impl Default for FrameState {
@@ -40,7 +42,7 @@ impl Default for FrameState {
             used_by_panels: Rect::NAN,
             tooltip_rect: None,
             scroll_delta: Vec2::ZERO,
-            scroll_target: [None; 2],
+            scroll_target: [None, None],
         }
     }
 }
@@ -63,7 +65,7 @@ impl FrameState {
         *used_by_panels = Rect::NOTHING;
         *tooltip_rect = None;
         *scroll_delta = input.scroll_delta;
-        *scroll_target = [None; 2];
+        *scroll_target = [None, None];
     }
 
     /// How much space is still available after panels has been added.

--- a/egui/src/response.rs
+++ b/egui/src/response.rs
@@ -443,7 +443,8 @@ impl Response {
         )
     }
 
-    /// Move the scroll to this UI with the specified alignment.
+    /// Adjust the scroll position until this UI becomes visible. If `align` is not provided, it'll scroll enough to
+    /// bring the UI into view.
     ///
     /// ```
     /// # egui::__run_test_ui(|ui| {
@@ -451,18 +452,15 @@ impl Response {
     ///     for i in 0..1000 {
     ///         let response = ui.button("Scroll to me");
     ///         if response.clicked() {
-    ///             response.scroll_to_me(egui::Align::Center);
+    ///             response.scroll_to_me(Some(egui::Align::Center));
     ///         }
     ///     }
     /// });
     /// # });
     /// ```
-    pub fn scroll_to_me(&self, align: Align) {
-        let scroll_target = lerp(self.rect.x_range(), align.to_factor());
-        self.ctx.frame_state().scroll_target[0] = Some((scroll_target, align));
-
-        let scroll_target = lerp(self.rect.y_range(), align.to_factor());
-        self.ctx.frame_state().scroll_target[1] = Some((scroll_target, align));
+    pub fn scroll_to_me(&self, align: Option<Align>) {
+        self.ctx.frame_state().scroll_target[0] = Some((self.rect.x_range(), align));
+        self.ctx.frame_state().scroll_target[1] = Some((self.rect.y_range(), align));
     }
 
     /// For accessibility.

--- a/egui/src/response.rs
+++ b/egui/src/response.rs
@@ -1,5 +1,5 @@
 use crate::{
-    emath::{lerp, Align, Pos2, Rect, Vec2},
+    emath::{Align, Pos2, Rect, Vec2},
     menu, Context, CursorIcon, Id, LayerId, PointerButton, Sense, Ui, WidgetText,
     NUM_POINTER_BUTTONS,
 };

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -906,10 +906,11 @@ impl Ui {
     /// });
     /// # });
     /// ```
-    pub fn scroll_to_cursor(&mut self, align: Align) {
+    pub fn scroll_to_cursor(&mut self, align: Option<Align>) {
         let target = self.next_widget_position();
         for d in 0..2 {
-            self.ctx().frame_state().scroll_target[d] = Some((target[d], align));
+            let target = target[d];
+            self.ctx().frame_state().scroll_target[d] = Some((target..=target, align));
         }
     }
 }

--- a/egui_demo_lib/src/apps/demo/scrolling.rs
+++ b/egui_demo_lib/src/apps/demo/scrolling.rs
@@ -147,7 +147,7 @@ fn huge_content_painter(ui: &mut egui::Ui) {
 #[derive(PartialEq)]
 struct ScrollTo {
     track_item: usize,
-    tack_item_align: Align,
+    tack_item_align: Option<Align>,
     offset: f32,
 }
 
@@ -155,7 +155,7 @@ impl Default for ScrollTo {
     fn default() -> Self {
         Self {
             track_item: 25,
-            tack_item_align: Align::Center,
+            tack_item_align: Some(Align::Center),
             offset: 0.0,
         }
     }
@@ -180,13 +180,16 @@ impl super::View for ScrollTo {
         ui.horizontal(|ui| {
             ui.label("Item align:");
             track_item |= ui
-                .radio_value(&mut self.tack_item_align, Align::Min, "Top")
+                .radio_value(&mut self.tack_item_align, Some(Align::Min), "Top")
                 .clicked();
             track_item |= ui
-                .radio_value(&mut self.tack_item_align, Align::Center, "Center")
+                .radio_value(&mut self.tack_item_align, Some(Align::Center), "Center")
                 .clicked();
             track_item |= ui
-                .radio_value(&mut self.tack_item_align, Align::Max, "Bottom")
+                .radio_value(&mut self.tack_item_align, Some(Align::Max), "Bottom")
+                .clicked();
+            track_item |= ui
+                .radio_value(&mut self.tack_item_align, None, "None (Bring into view)")
                 .clicked();
         });
 
@@ -213,7 +216,7 @@ impl super::View for ScrollTo {
         let (current_scroll, max_scroll) = scroll_area
             .show(ui, |ui| {
                 if scroll_top {
-                    ui.scroll_to_cursor(Align::TOP);
+                    ui.scroll_to_cursor(Some(Align::TOP));
                 }
                 ui.vertical(|ui| {
                     for item in 1..=50 {
@@ -228,7 +231,7 @@ impl super::View for ScrollTo {
                 });
 
                 if scroll_bottom {
-                    ui.scroll_to_cursor(Align::BOTTOM);
+                    ui.scroll_to_cursor(Some(Align::BOTTOM));
                 }
 
                 let margin = ui.visuals().clip_rect_margin;


### PR DESCRIPTION
# Problem

`response.scroll_to_me` works great but can be jarring if the UI is already in view.

# Solution

Accept an `Option<Align>` instead of just `Align`. If `None` is passed, the minimum scrolling necessary to bring the ui into view will be applied.

:movie_camera: 
https://user-images.githubusercontent.com/1410520/153758767-80630356-756e-49fd-8dd9-1b4743ac3149.mp4


