### PR TITLE
Prevent ScrollArea:s from becoming tiny

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * Renamed `Plot::custom_label_func` to `Plot::label_formatter` ([#1235](https://github.com/emilk/egui/pull/1235)).
 * Tooltips that don't fit the window don't flicker anymore ([#1240](https://github.com/emilk/egui/pull/1240)).
 * `Areas::layer_id_at` ignores non interatable layers (i.e. Tooltips) ([#1240](https://github.com/emilk/egui/pull/1240)).
+* `ScrollArea`:s will not shrink below a certain minimum size, set by `min_scrolled_width/min_scrolled_height` ([1255](https://github.com/emilk/egui/pull/1255)).
 
 ### Fixed 🐛
 * Context menus now respects the theme ([#1043](https://github.com/emilk/egui/pull/1043)).
@@ -62,7 +63,6 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * Calling `Context::set_pixels_per_point` before the first frame will now work.
 * Tooltips that don't fit the window don't flicker anymore ([#1240](https://github.com/emilk/egui/pull/1240)).
 * Scroll areas now follow text cursor ([1252](https://github.com/emilk/egui/pull/1252)).
-* Prevent ScrollArea:s from becoming tiny ([1255](https://github.com/emilk/egui/pull/1255)).
 
 ### Contributors 🙏
 * [AlexxxRu](https://github.com/alexxxru): [#1108](https://github.com/emilk/egui/pull/1108).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,10 +59,10 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 ### Fixed 🐛
 * Context menus now respects the theme ([#1043](https://github.com/emilk/egui/pull/1043)).
 * Plot `Orientation` was not public, although fields using this type were ([#1130](https://github.com/emilk/egui/pull/1130)).
-* Fixed `enable_drag` for Windows ([#1108](https://github.com/emilk/egui/pull/1108)).
 * Calling `Context::set_pixels_per_point` before the first frame will now work.
 * Tooltips that don't fit the window don't flicker anymore ([#1240](https://github.com/emilk/egui/pull/1240)).
 * Scroll areas now follow text cursor ([1252](https://github.com/emilk/egui/pull/1252)).
+* Prevent ScrollArea:s from becoming tiny ([1255](https://github.com/emilk/egui/pull/1255)).
 
 ### Contributors 🙏
 * [AlexxxRu](https://github.com/alexxxru): [#1108](https://github.com/emilk/egui/pull/1108).

--- a/eframe/CHANGELOG.md
+++ b/eframe/CHANGELOG.md
@@ -12,6 +12,7 @@ NOTE: [`egui_web`](../egui_web/CHANGELOG.md), [`egui-winit`](../egui-winit/CHANG
 * Fix horizontal scrolling direction on Linux.
 * Added `App::on_exit_event` ([#1038](https://github.com/emilk/egui/pull/1038))
 * Added `NativeOptions::initial_window_pos`.
+* Fixed `enable_drag` for Windows ([#1108](https://github.com/emilk/egui/pull/1108)).
 * Shift-scroll will now result in horizontal scrolling on all platforms ([#1136](https://github.com/emilk/egui/pull/1136)).
 * Log using the `tracing` crate. Log to stdout by adding `tracing_subscriber::fmt::init();` to your `main` ([#1192](https://github.com/emilk/egui/pull/1192)).
 

--- a/egui/src/containers/scroll_area.rs
+++ b/egui/src/containers/scroll_area.rs
@@ -124,7 +124,7 @@ impl ScrollArea {
             has_bar,
             auto_shrink: [true; 2],
             max_size: Vec2::INFINITY,
-            min_scrolled_size: Vec2::splat(100.0),
+            min_scrolled_size: Vec2::splat(64.0),
             always_show_scroll: false,
             id_source: None,
             offset_x: None,
@@ -159,7 +159,7 @@ impl ScrollArea {
     /// The `ScrollArea` will only become smaller than this if the content is smaller than this
     /// (and so we don't require scroll bars).
     ///
-    /// Default: `100.0`.
+    /// Default: `64.0`.
     pub fn min_scrolled_width(mut self, min_scrolled_width: f32) -> Self {
         self.min_scrolled_size.x = min_scrolled_width;
         self
@@ -170,7 +170,7 @@ impl ScrollArea {
     /// The `ScrollArea` will only become smaller than this if the content is smaller than this
     /// (and so we don't require scroll bars).
     ///
-    /// Default: `100.0`.
+    /// Default: `64.0`.
     pub fn min_scrolled_height(mut self, min_scrolled_height: f32) -> Self {
         self.min_scrolled_size.y = min_scrolled_height;
         self


### PR DESCRIPTION
Closes https://github.com/emilk/egui/issues/1097

`ScrollArea`:s will not shrink below a certain minimum size, set by `min_scrolled_width/min_scrolled_height`. Default: 64.0 points. This is to prevent tiny `ScrollArea`:s.
