### PR TITLE
Add more source code links to demos

### DIFF
--- a/egui_demo_lib/src/apps/demo/code_example.rs
+++ b/egui_demo_lib/src/apps/demo/code_example.rs
@@ -83,6 +83,10 @@ impl super::View for CodeExample {
     fn ui(&mut self, ui: &mut egui::Ui) {
         use crate::syntax_highlighting::code_view_ui;
 
+        ui.vertical_centered(|ui| {
+            ui.add(crate::__egui_github_link_file!());
+        });
+
         code_view_ui(
             ui,
             r"

--- a/egui_demo_lib/src/apps/demo/context_menu.rs
+++ b/egui_demo_lib/src/apps/demo/context_menu.rs
@@ -105,6 +105,9 @@ impl super::View for ContextMenus {
                 });
             });
         });
+        ui.vertical_centered(|ui| {
+            ui.add(crate::__egui_github_link_file!());
+        });
     }
 }
 

--- a/egui_demo_lib/src/apps/demo/font_book.rs
+++ b/egui_demo_lib/src/apps/demo/font_book.rs
@@ -31,6 +31,10 @@ impl super::Demo for FontBook {
 
 impl super::View for FontBook {
     fn ui(&mut self, ui: &mut egui::Ui) {
+        ui.vertical_centered(|ui| {
+            ui.add(crate::__egui_github_link_file!());
+        });
+
         ui.label(format!(
             "The selected font supports {} characters.",
             self.named_chars

--- a/egui_demo_lib/src/apps/demo/paint_bezier.rs
+++ b/egui_demo_lib/src/apps/demo/paint_bezier.rs
@@ -242,9 +242,9 @@ impl super::Demo for PaintBezier {
 
 impl super::View for PaintBezier {
     fn ui(&mut self, ui: &mut Ui) {
-        // ui.vertical_centered(|ui| {
-        //     ui.add(crate::__egui_github_link_file!());
-        // });
+        ui.vertical_centered(|ui| {
+            ui.add(crate::__egui_github_link_file!());
+        });
         self.ui_control(ui);
 
         Frame::dark_canvas(ui.style()).show(ui, |ui| {


### PR DESCRIPTION
I was looking for an example on how to build context menus and noticed that some demos were missing the `(source code)` link.

Added the link to the following demos:
* Code Example
* Context Menus
* Font Book
* Bezier Curve