### PR TITLE
Make the background in `SidePanel` fill the available space

### DIFF
--- a/egui/src/containers/panel.rs
+++ b/egui/src/containers/panel.rs
@@ -241,10 +241,19 @@ impl SidePanel {
         let inner_response = frame.show(&mut panel_ui, |ui| {
             ui.set_min_height(ui.max_rect().height()); // Make sure the frame fills the full height
             ui.set_min_width(*width_range.start());
-            add_contents(ui)
+            let res = add_contents(ui);
+
+            // This is a hack to force the `Frame` to expand its background to fill the available
+            // space.
+            let mut rect = ui.min_rect();
+            rect.min -= Vec2::new(frame.margin.left, frame.margin.top);
+            rect.max += Vec2::new(frame.margin.right, frame.margin.bottom);
+            ui.allocate_space(ui.available_size());
+
+            (rect, res)
         });
 
-        let rect = inner_response.response.rect;
+        let rect = inner_response.inner.0;
 
         {
             let mut cursor = ui.cursor();
@@ -278,7 +287,10 @@ impl SidePanel {
                 .line_segment([top, bottom], stroke);
         }
 
-        inner_response
+        InnerResponse {
+            inner: inner_response.inner.1,
+            response: inner_response.response,
+        }
     }
 
     /// Show the panel at the top level.


### PR DESCRIPTION
This is a small hack to fix #1262. It works by measuring the the size of the content in the panel with `ui.min_rect()`, before finally using `ui.allocate_space(ui.available_size())` to force the frame to fill all the available space. Since be measured the size of the content before the space allocation this should not affect how much space the panel occupies in subsequent frames.