### PR TITLE
Replace `top_most_layer` with more flexible `layer_ids`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * Renamed `AlphaImage` to `FontImage` to discourage any other use for it ([#1412](https://github.com/emilk/egui/pull/1412)).
 * Warnings will pe painted on screen when there is an `Id` clash for `Grid`, `Plot` or `ScrollArea` ([#1452](https://github.com/emilk/egui/pull/1452)).
 * `Checkbox` and `RadioButton` with an empty label (`""`) will now take up much less space ([#1456](https://github.com/emilk/egui/pull/1456)).
+* Replaced `Memory::top_most_layer` with more flexible `Memory::layer_ids`.
 
 ### Fixed 🐛
 * Fixed ComboBoxes always being rendered left-aligned ([#1304](https://github.com/emilk/egui/pull/1304)).

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -943,13 +943,8 @@ impl Context {
         self.memory().layer_id_at(pos, resize_grab_radius_side)
     }
 
-    /// The overall top-most layer. When an area is clicked on or interacted
-    /// with, it is moved above all other areas.
-    pub fn top_most_layer(&self) -> Option<LayerId> {
-        self.memory().top_most_layer()
-    }
-
-    /// Moves the given area to the top.
+    /// Moves the given area to the top in its [`Order`].
+    /// [`Area`]:s and [`Window`]:s also do this automatically when being clicked on or interacted with.
     pub fn move_to_top(&self, layer_id: LayerId) {
         self.memory().areas.move_to_top(layer_id);
     }

--- a/egui/src/memory.rs
+++ b/egui/src/memory.rs
@@ -329,10 +329,9 @@ impl Memory {
         self.areas.layer_id_at(pos, resize_interact_radius_side)
     }
 
-    /// The overall top-most layer. When an area is clicked on or interacted
-    /// with, it is moved above all other areas.
-    pub fn top_most_layer(&self) -> Option<LayerId> {
-        self.areas.order().last().copied()
+    /// An iterator over all layers. Back-to-front. Top is last.
+    pub fn layer_ids(&self) -> impl Iterator<Item = LayerId> + '_ {
+        self.areas.order().iter().copied()
     }
 
     pub(crate) fn had_focus_last_frame(&self, id: Id) -> bool {

--- a/egui/src/memory.rs
+++ b/egui/src/memory.rs
@@ -330,7 +330,7 @@ impl Memory {
     }
 
     /// An iterator over all layers. Back-to-front. Top is last.
-    pub fn layer_ids(&self) -> impl Iterator<Item = LayerId> + '_ {
+    pub fn layer_ids(&self) -> impl ExactSizeIterator<Item = LayerId> + '_ {
         self.areas.order().iter().copied()
     }
 


### PR DESCRIPTION
Previous: #1242

After adding tooltips to my application, I noticed the area created for them consistently takes up the top-most layer position.

https://github.com/emilk/egui/blob/6abdde0334e9300ebe11f970a870a79cd3010835/egui/src/memory.rs#L579

This is confirmed in the code: layers can't move out of their `order`. Therefore we should add this filter to allow for access to the top-most layer in every `Order`.