### PR TITLE
Introduce egui::FullOutput, returned from Context::run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,8 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * Renamed `Ui::visible` to `Ui::is_visible`.
 * Split `Event::Text` into `Event::Text` and `Event::Paste` ([#1058](https://github.com/emilk/egui/pull/1058)).
 * For integrations:
-  * `FontImage` has been replaced by `TexturesDelta` (found in `Output`), describing what textures were loaded and freed each frame ([#1110](https://github.com/emilk/egui/pull/1110)).
+  * `Output` has now been renamed `PlatformOutput` and `Context::run` now returns the new `FullOutput` ([#1292](https://github.com/emilk/egui/pull/1292)).
+  * `FontImage` has been replaced by `TexturesDelta` (found in `FullOutput`), describing what textures were loaded and freed each frame ([#1110](https://github.com/emilk/egui/pull/1110)).
   * The painter must support partial texture updates ([#1149](https://github.com/emilk/egui/pull/1149)).
   * Added `RawInput::max_texture_side` which should be filled in with e.g. `GL_MAX_TEXTURE_SIZE` ([#1154](https://github.com/emilk/egui/pull/1154)).
 * Replaced `Style::body_text_style` with more generic `Style::text_styles` ([#1154](https://github.com/emilk/egui/pull/1154)).

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Missing an integration for the thing you're working on? Create one, it's easy!
 
 ### Writing your own egui integration
 
-You need to collect [`egui::RawInput`](https://docs.rs/egui/latest/egui/struct.RawInput.html), paint [`egui::ClippedMesh`](https://docs.rs/epaint/latest/epaint/struct.ClippedMesh.html):es and handle [`egui::Output`](https://docs.rs/egui/latest/egui/struct.Output.html). The basic structure is this:
+You need to collect [`egui::RawInput`](https://docs.rs/egui/latest/egui/struct.RawInput.html) and handle [`egui::FullOutput`](https://docs.rs/egui/latest/egui/struct.FullOutput.html). The basic structure is this:
 
 ``` rust
 let mut egui_ctx = egui::CtxRef::default();
@@ -201,20 +201,19 @@ let mut egui_ctx = egui::CtxRef::default();
 loop {
     // Gather input (mouse, touches, keyboard, screen size, etc):
     let raw_input: egui::RawInput = my_integration.gather_input();
-    let (output, shapes) = egui_ctx.run(raw_input, |egui_ctx| {
+    let full_output = egui_ctx.run(raw_input, |egui_ctx| {
         my_app.ui(egui_ctx); // add panels, windows and widgets to `egui_ctx` here
     });
-    let clipped_meshes = egui_ctx.tessellate(shapes); // creates triangles to paint
+    let clipped_meshes = egui_ctx.tessellate(full_output.shapes); // creates triangles to paint
 
-    my_integration.set_egui_textures(&output.textures_delta.set);
-    my_integration.paint(clipped_meshes);
-    my_integration.free_egui_textures(&output.textures_delta.free);
+    my_integration.paint(&full_output.textures_delta, clipped_meshes);
 
+    let output = full_output.output;
     my_integration.set_cursor_icon(output.cursor_icon);
     if !output.copied_text.is_empty() {
         my_integration.set_clipboard_text(output.copied_text);
     }
-    // See `egui::Output` for more
+    // See `egui::FullOutput` for more
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -208,12 +208,12 @@ loop {
 
     my_integration.paint(&full_output.textures_delta, clipped_meshes);
 
-    let output = full_output.output;
-    my_integration.set_cursor_icon(output.cursor_icon);
-    if !output.copied_text.is_empty() {
-        my_integration.set_clipboard_text(output.copied_text);
+    let platform_output = full_output.platform_output;
+    my_integration.set_cursor_icon(platform_output.cursor_icon);
+    if !platform_output.copied_text.is_empty() {
+        my_integration.set_clipboard_text(platform_output.copied_text);
     }
-    // See `egui::FullOutput` for more
+    // See `egui::FullOutput` and `egui::PlatformOutput` for more
 }
 ```
 

--- a/egui-winit/src/epi.rs
+++ b/egui-winit/src/epi.rs
@@ -348,13 +348,13 @@ impl EpiIntegration {
         full_output
     }
 
-    pub fn handle_egui_output(
+    pub fn handle_platform_output(
         &mut self,
         window: &winit::window::Window,
-        egui_output: egui::Output,
+        platform_output: egui::PlatformOutput,
     ) {
         self.egui_winit
-            .handle_egui_output(window, &self.egui_ctx, egui_output);
+            .handle_platform_output(window, &self.egui_ctx, platform_output);
     }
 
     pub fn maybe_autosave(&mut self, window: &winit::window::Window) {

--- a/egui-winit/src/lib.rs
+++ b/egui-winit/src/lib.rs
@@ -514,24 +514,25 @@ impl State {
     /// * open any clicked urls
     /// * update the IME
     /// *
-    pub fn handle_egui_output(
+    pub fn handle_platform_output(
         &mut self,
         window: &winit::window::Window,
         egui_ctx: &egui::Context,
-        output: egui::Output,
+        platform_output: egui::PlatformOutput,
     ) {
         if egui_ctx.options().screen_reader {
-            self.screen_reader.speak(&output.events_description());
+            self.screen_reader
+                .speak(&platform_output.events_description());
         }
 
-        let egui::Output {
+        let egui::PlatformOutput {
             cursor_icon,
             open_url,
             copied_text,
             events: _,                    // handled above
             mutable_text_under_cursor: _, // only used in egui_web
             text_cursor_pos,
-        } = output;
+        } = platform_output;
 
         self.current_pixels_per_point = egui_ctx.pixels_per_point(); // someone can have changed it to scale the UI
 

--- a/egui-winit/src/lib.rs
+++ b/egui-winit/src/lib.rs
@@ -514,12 +514,12 @@ impl State {
     /// * open any clicked urls
     /// * update the IME
     /// *
-    pub fn handle_output(
+    pub fn handle_egui_output(
         &mut self,
         window: &winit::window::Window,
         egui_ctx: &egui::Context,
         output: egui::Output,
-    ) -> egui::TexturesDelta {
+    ) {
         if egui_ctx.options().screen_reader {
             self.screen_reader.speak(&output.events_description());
         }
@@ -528,11 +528,9 @@ impl State {
             cursor_icon,
             open_url,
             copied_text,
-            needs_repaint: _,             // needs to be handled elsewhere
             events: _,                    // handled above
             mutable_text_under_cursor: _, // only used in egui_web
             text_cursor_pos,
-            textures_delta,
         } = output;
 
         self.current_pixels_per_point = egui_ctx.pixels_per_point(); // someone can have changed it to scale the UI
@@ -550,8 +548,6 @@ impl State {
         if let Some(egui::Pos2 { x, y }) = text_cursor_pos {
             window.set_ime_position(winit::dpi::LogicalPosition { x, y });
         }
-
-        textures_delta
     }
 
     fn set_cursor_icon(&mut self, window: &winit::window::Window, cursor_icon: egui::CursorIcon) {

--- a/egui/src/data/output.rs
+++ b/egui/src/data/output.rs
@@ -2,13 +2,13 @@
 
 use crate::WidgetType;
 
-/// What egui emits each frame.
+/// What egui emits each frame from [`crate::Context::run`].
 ///
 /// The backend should use this.
 #[derive(Clone, Default, PartialEq)]
 pub struct FullOutput {
     /// Non-rendering related output.
-    pub output: Output,
+    pub platform_output: PlatformOutput,
 
     /// If `true`, egui is requesting immediate repaint (i.e. on the next frame).
     ///
@@ -31,13 +31,13 @@ impl FullOutput {
     /// Add on new output.
     pub fn append(&mut self, newer: Self) {
         let Self {
-            output,
+            platform_output,
             needs_repaint,
             textures_delta,
             shapes,
         } = newer;
 
-        self.output.append(output);
+        self.platform_output.append(platform_output);
         self.needs_repaint = needs_repaint; // if the last frame doesn't need a repaint, then we don't need to repaint
         self.textures_delta.append(textures_delta);
         self.shapes = shapes; // Only paint the latest
@@ -46,10 +46,12 @@ impl FullOutput {
 
 /// The non-rendering part of what egui emits each frame.
 ///
+/// You can access (and modify) this with [`crate::Context::output`].
+///
 /// The backend should use this.
 #[derive(Clone, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct Output {
+pub struct PlatformOutput {
     /// Set the cursor to this icon.
     pub cursor_icon: CursorIcon,
 
@@ -72,7 +74,7 @@ pub struct Output {
     pub text_cursor_pos: Option<crate::Pos2>,
 }
 
-impl Output {
+impl PlatformOutput {
     /// Open the given url in a web browser.
     /// If egui is running in a browser, the same tab will be reused.
     pub fn open_url(&mut self, url: impl ToString) {
@@ -157,7 +159,7 @@ impl OpenUrl {
 
 /// A mouse cursor icon.
 ///
-/// egui emits a [`CursorIcon`] in [`Output`] each frame as a request to the integration.
+/// egui emits a [`CursorIcon`] in [`PlatformOutput`] each frame as a request to the integration.
 ///
 /// Loosely based on <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor>.
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/egui/src/lib.rs
+++ b/egui/src/lib.rs
@@ -110,7 +110,7 @@
 //! To write your own integration for egui you need to do this:
 //!
 //! ``` no_run
-//! # fn handle_output(_: egui::Output) {}
+//! # fn handle_platform_output(_: egui::PlatformOutput) {}
 //! # fn gather_input() -> egui::RawInput { egui::RawInput::default() }
 //! # fn paint(textures_detla: egui::TexturesDelta, _: Vec<egui::ClippedMesh>) {}
 //! let mut ctx = egui::Context::default();
@@ -127,7 +127,7 @@
 //!             }
 //!         });
 //!     });
-//!     handle_output(full_output.output);
+//!     handle_platform_output(full_output.platform_output);
 //!     let clipped_meshes = ctx.tessellate(full_output.shapes); // create triangles to paint
 //!     paint(full_output.textures_delta, clipped_meshes);
 //! }
@@ -402,7 +402,7 @@ pub use {
     context::Context,
     data::{
         input::*,
-        output::{self, CursorIcon, FullOutput, Output, WidgetInfo},
+        output::{self, CursorIcon, FullOutput, PlatformOutput, WidgetInfo},
     },
     grid::Grid,
     id::{Id, IdMap},

--- a/egui/src/lib.rs
+++ b/egui/src/lib.rs
@@ -111,15 +111,15 @@
 //!
 //! ``` no_run
 //! # fn handle_output(_: egui::Output) {}
-//! # fn paint(_: Vec<egui::ClippedMesh>) {}
 //! # fn gather_input() -> egui::RawInput { egui::RawInput::default() }
+//! # fn paint(textures_detla: egui::TexturesDelta, _: Vec<egui::ClippedMesh>) {}
 //! let mut ctx = egui::Context::default();
 //!
 //! // Game loop:
 //! loop {
 //!     let raw_input: egui::RawInput = gather_input();
 //!
-//!     let (output, shapes) = ctx.run(raw_input, |ctx| {
+//!     let full_output = ctx.run(raw_input, |ctx| {
 //!         egui::CentralPanel::default().show(&ctx, |ui| {
 //!             ui.label("Hello world!");
 //!             if ui.button("Click me").clicked() {
@@ -127,10 +127,9 @@
 //!             }
 //!         });
 //!     });
-//!
-//!     let clipped_meshes = ctx.tessellate(shapes); // create triangles to paint
-//!     handle_output(output);
-//!     paint(clipped_meshes);
+//!     handle_output(full_output.output);
+//!     let clipped_meshes = ctx.tessellate(full_output.shapes); // create triangles to paint
+//!     paint(full_output.textures_delta, clipped_meshes);
 //! }
 //! ```
 //!
@@ -403,7 +402,7 @@ pub use {
     context::Context,
     data::{
         input::*,
-        output::{self, CursorIcon, Output, WidgetInfo},
+        output::{self, CursorIcon, FullOutput, Output, WidgetInfo},
     },
     grid::Grid,
     id::{Id, IdMap},

--- a/egui/src/memory.rs
+++ b/egui/src/memory.rs
@@ -105,7 +105,7 @@ pub struct Options {
     pub tessellation_options: epaint::TessellationOptions,
 
     /// This does not at all change the behavior of egui,
-    /// but is a signal to any backend that we want the [`crate::Output::events`] read out loud.
+    /// but is a signal to any backend that we want the [`crate::PlatformOutput::events`] read out loud.
     /// Screen readers is an experimental feature of egui, and not supported on all platforms.
     pub screen_reader: bool,
 

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -366,10 +366,10 @@ impl Ui {
         self.ctx().data()
     }
 
-    /// The [`Output`] of the [`Context`] associated with this ui.
+    /// The [`PlatformOutput`] of the [`Context`] associated with this ui.
     /// Equivalent to `.ctx().output()`.
     #[inline]
-    pub fn output(&self) -> RwLockWriteGuard<'_, Output> {
+    pub fn output(&self) -> RwLockWriteGuard<'_, PlatformOutput> {
         self.ctx().output()
     }
 

--- a/egui_demo_lib/benches/benchmark.rs
+++ b/egui_demo_lib/benches/benchmark.rs
@@ -13,10 +13,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         // The most end-to-end benchmark.
         c.bench_function("demo_with_tessellate__realistic", |b| {
             b.iter(|| {
-                let (_output, shapes) = ctx.run(RawInput::default(), |ctx| {
+                let full_output = ctx.run(RawInput::default(), |ctx| {
                     demo_windows.ui(ctx);
                 });
-                ctx.tessellate(shapes)
+                ctx.tessellate(full_output.shapes)
             })
         });
 
@@ -28,11 +28,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             })
         });
 
-        let (_output, shapes) = ctx.run(RawInput::default(), |ctx| {
+        let full_output = ctx.run(RawInput::default(), |ctx| {
             demo_windows.ui(ctx);
         });
         c.bench_function("demo_only_tessellate", |b| {
-            b.iter(|| ctx.tessellate(shapes.clone()))
+            b.iter(|| ctx.tessellate(full_output.shapes.clone()))
         });
     }
 

--- a/egui_demo_lib/src/lib.rs
+++ b/egui_demo_lib/src/lib.rs
@@ -145,10 +145,10 @@ fn test_egui_e2e() {
 
     const NUM_FRAMES: usize = 5;
     for _ in 0..NUM_FRAMES {
-        let (_output, shapes) = ctx.run(raw_input.clone(), |ctx| {
+        let full_output = ctx.run(raw_input.clone(), |ctx| {
             demo_windows.ui(ctx);
         });
-        let clipped_meshes = ctx.tessellate(shapes);
+        let clipped_meshes = ctx.tessellate(full_output.shapes);
         assert!(!clipped_meshes.is_empty());
     }
 }
@@ -164,10 +164,10 @@ fn test_egui_zero_window_size() {
 
     const NUM_FRAMES: usize = 5;
     for _ in 0..NUM_FRAMES {
-        let (_output, shapes) = ctx.run(raw_input.clone(), |ctx| {
+        let full_output = ctx.run(raw_input.clone(), |ctx| {
             demo_windows.ui(ctx);
         });
-        let clipped_meshes = ctx.tessellate(shapes);
+        let clipped_meshes = ctx.tessellate(full_output.shapes);
         assert!(clipped_meshes.is_empty(), "There should be nothing to show");
     }
 }

--- a/egui_glium/src/epi_backend.rs
+++ b/egui_glium/src/epi_backend.rs
@@ -67,8 +67,15 @@ pub fn run(app: Box<dyn epi::App>, native_options: &epi::NativeOptions) -> ! {
                 std::thread::sleep(std::time::Duration::from_millis(10));
             }
 
-            let (needs_repaint, textures_delta, shapes) =
-                integration.update(display.gl_window().window());
+            let egui::FullOutput {
+                output,
+                needs_repaint,
+                textures_delta,
+                shapes,
+            } = integration.update(display.gl_window().window());
+
+            integration.handle_egui_output(display.gl_window().window(), output);
+
             let clipped_meshes = integration.egui_ctx.tessellate(shapes);
 
             // paint:

--- a/egui_glium/src/epi_backend.rs
+++ b/egui_glium/src/epi_backend.rs
@@ -68,13 +68,13 @@ pub fn run(app: Box<dyn epi::App>, native_options: &epi::NativeOptions) -> ! {
             }
 
             let egui::FullOutput {
-                output,
+                platform_output,
                 needs_repaint,
                 textures_delta,
                 shapes,
             } = integration.update(display.gl_window().window());
 
-            integration.handle_egui_output(display.gl_window().window(), output);
+            integration.handle_platform_output(display.gl_window().window(), platform_output);
 
             let clipped_meshes = integration.egui_ctx.tessellate(shapes);
 

--- a/egui_glium/src/lib.rs
+++ b/egui_glium/src/lib.rs
@@ -142,14 +142,17 @@ impl EguiGlium {
             .egui_winit
             .take_egui_input(display.gl_window().window());
         let egui::FullOutput {
-            output,
+            platform_output,
             needs_repaint,
             textures_delta,
             shapes,
         } = self.egui_ctx.run(raw_input, run_ui);
 
-        self.egui_winit
-            .handle_egui_output(display.gl_window().window(), &self.egui_ctx, output);
+        self.egui_winit.handle_platform_output(
+            display.gl_window().window(),
+            &self.egui_ctx,
+            platform_output,
+        );
 
         self.shapes = shapes;
         self.textures_delta.append(textures_delta);

--- a/egui_glium/src/lib.rs
+++ b/egui_glium/src/lib.rs
@@ -141,16 +141,19 @@ impl EguiGlium {
         let raw_input = self
             .egui_winit
             .take_egui_input(display.gl_window().window());
-        let (egui_output, shapes) = self.egui_ctx.run(raw_input, run_ui);
-        let needs_repaint = egui_output.needs_repaint;
-        let textures_delta = self.egui_winit.handle_output(
-            display.gl_window().window(),
-            &self.egui_ctx,
-            egui_output,
-        );
+        let egui::FullOutput {
+            output,
+            needs_repaint,
+            textures_delta,
+            shapes,
+        } = self.egui_ctx.run(raw_input, run_ui);
+
+        self.egui_winit
+            .handle_egui_output(display.gl_window().window(), &self.egui_ctx, output);
 
         self.shapes = shapes;
         self.textures_delta.append(textures_delta);
+
         needs_repaint
     }
 

--- a/egui_glow/src/epi_backend.rs
+++ b/egui_glow/src/epi_backend.rs
@@ -83,7 +83,15 @@ pub fn run(app: Box<dyn epi::App>, native_options: &epi::NativeOptions) -> ! {
                 std::thread::sleep(std::time::Duration::from_millis(10));
             }
 
-            let (needs_repaint, textures_delta, shapes) = integration.update(gl_window.window());
+            let egui::FullOutput {
+                output,
+                needs_repaint,
+                textures_delta,
+                shapes,
+            } = integration.update(gl_window.window());
+
+            integration.handle_egui_output(gl_window.window(), output);
+
             let clipped_meshes = integration.egui_ctx.tessellate(shapes);
 
             // paint:

--- a/egui_glow/src/epi_backend.rs
+++ b/egui_glow/src/epi_backend.rs
@@ -84,13 +84,13 @@ pub fn run(app: Box<dyn epi::App>, native_options: &epi::NativeOptions) -> ! {
             }
 
             let egui::FullOutput {
-                output,
+                platform_output,
                 needs_repaint,
                 textures_delta,
                 shapes,
             } = integration.update(gl_window.window());
 
-            integration.handle_egui_output(gl_window.window(), output);
+            integration.handle_platform_output(gl_window.window(), platform_output);
 
             let clipped_meshes = integration.egui_ctx.tessellate(shapes);
 

--- a/egui_glow/src/lib.rs
+++ b/egui_glow/src/lib.rs
@@ -157,14 +157,14 @@ impl EguiGlow {
     ) -> bool {
         let raw_input = self.egui_winit.take_egui_input(window);
         let egui::FullOutput {
-            output,
+            platform_output,
             needs_repaint,
             textures_delta,
             shapes,
         } = self.egui_ctx.run(raw_input, run_ui);
 
         self.egui_winit
-            .handle_egui_output(window, &self.egui_ctx, output);
+            .handle_platform_output(window, &self.egui_ctx, platform_output);
 
         self.shapes = shapes;
         self.textures_delta.append(textures_delta);

--- a/egui_glow/src/lib.rs
+++ b/egui_glow/src/lib.rs
@@ -156,11 +156,15 @@ impl EguiGlow {
         run_ui: impl FnMut(&egui::Context),
     ) -> bool {
         let raw_input = self.egui_winit.take_egui_input(window);
-        let (egui_output, shapes) = self.egui_ctx.run(raw_input, run_ui);
-        let needs_repaint = egui_output.needs_repaint;
-        let textures_delta = self
-            .egui_winit
-            .handle_output(window, &self.egui_ctx, egui_output);
+        let egui::FullOutput {
+            output,
+            needs_repaint,
+            textures_delta,
+            shapes,
+        } = self.egui_ctx.run(raw_input, run_ui);
+
+        self.egui_winit
+            .handle_egui_output(window, &self.egui_ctx, output);
 
         self.shapes = shapes;
         self.textures_delta.append(textures_delta);

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -271,13 +271,13 @@ impl AppRunner {
             self.app.update(egui_ctx, &self.frame);
         });
         let egui::FullOutput {
-            output,
+            platform_output,
             needs_repaint,
             textures_delta,
             shapes,
         } = full_output;
 
-        self.handle_egui_output(output);
+        self.handle_platform_output(platform_output);
         self.textures_delta.append(textures_delta);
         let clipped_meshes = self.egui_ctx.tessellate(shapes);
 
@@ -311,19 +311,20 @@ impl AppRunner {
         Ok(())
     }
 
-    fn handle_egui_output(&mut self, output: egui::Output) {
+    fn handle_platform_output(&mut self, platform_output: egui::PlatformOutput) {
         if self.egui_ctx.options().screen_reader {
-            self.screen_reader.speak(&output.events_description());
+            self.screen_reader
+                .speak(&platform_output.events_description());
         }
 
-        let egui::Output {
+        let egui::PlatformOutput {
             cursor_icon,
             open_url,
             copied_text,
             events: _, // already handled
             mutable_text_under_cursor,
             text_cursor_pos,
-        } = output;
+        } = platform_output;
 
         set_cursor_icon(cursor_icon);
         if let Some(open) = open_url {

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -267,14 +267,19 @@ impl AppRunner {
         let canvas_size = canvas_size_in_points(self.canvas_id());
         let raw_input = self.input.new_frame(canvas_size);
 
-        let (egui_output, shapes) = self.egui_ctx.run(raw_input, |egui_ctx| {
+        let full_output = self.egui_ctx.run(raw_input, |egui_ctx| {
             self.app.update(egui_ctx, &self.frame);
         });
-        let clipped_meshes = self.egui_ctx.tessellate(shapes);
+        let egui::FullOutput {
+            output,
+            needs_repaint,
+            textures_delta,
+            shapes,
+        } = full_output;
 
-        let needs_repaint = egui_output.needs_repaint;
-        let textures_delta = self.handle_egui_output(egui_output);
+        self.handle_egui_output(output);
         self.textures_delta.append(textures_delta);
+        let clipped_meshes = self.egui_ctx.tessellate(shapes);
 
         {
             let app_output = self.frame.take_app_output();
@@ -306,7 +311,7 @@ impl AppRunner {
         Ok(())
     }
 
-    fn handle_egui_output(&mut self, output: egui::Output) -> egui::TexturesDelta {
+    fn handle_egui_output(&mut self, output: egui::Output) {
         if self.egui_ctx.options().screen_reader {
             self.screen_reader.speak(&output.events_description());
         }
@@ -315,11 +320,9 @@ impl AppRunner {
             cursor_icon,
             open_url,
             copied_text,
-            needs_repaint: _, // handled elsewhere
-            events: _,        // already handled
+            events: _, // already handled
             mutable_text_under_cursor,
             text_cursor_pos,
-            textures_delta,
         } = output;
 
         set_cursor_icon(cursor_icon);
@@ -341,8 +344,6 @@ impl AppRunner {
             text_agent::move_text_cursor(text_cursor_pos, self.canvas_id());
             self.text_cursor_pos = text_cursor_pos;
         }
-
-        textures_delta
     }
 }
 

--- a/epaint/src/textures.rs
+++ b/epaint/src/textures.rs
@@ -152,7 +152,7 @@ pub struct TexturesDelta {
     /// New or changed textures. Apply before painting.
     pub set: AHashMap<TextureId, ImageDelta>,
 
-    /// Texture to free after painting.
+    /// Textures to free after painting.
     pub free: Vec<TextureId>,
 }
 


### PR DESCRIPTION
This adds a new struct:

```
pub struct FullOutput {
    pub output: Output,
    pub needs_repaint: bool,
    pub textures_delta: epaint::textures::TexturesDelta,
    pub shapes: Vec<epaint::ClippedShape>,
}
```

The name is not great, nor the name of the nested `Output`, but structurally it works rather well.

Closes https://github.com/emilk/egui/issues/1281