### PR TITLE
Run wasm-bindgen in CI and update parking_lot

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -155,7 +155,7 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@v1
 
   wasm_bindgen:
-    name: cargo doc web
+    name: wasm-bindgen
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -166,4 +166,4 @@ jobs:
           override: true
       - run: rustup target add wasm32-unknown-unknown
       - run: cargo install wasm-bindgen-cli
-      - run: ./sh/build_demo_web.sh --fast
+      - run: ./sh/wasm_bindgen_check.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -153,3 +153,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
+
+  wasm_bindgen:
+    name: cargo doc web
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.56.0
+          override: true
+      - run: rustup target add wasm32-unknown-unknown
+      - run: cargo install wasm-bindgen-cli
+      - run: ./sh/build_demo_web.sh --fast

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,7 +1060,7 @@ version = "0.16.0"
 dependencies = [
  "egui",
  "image",
- "parking_lot",
+ "parking_lot 0.12.0",
  "resvg",
  "tiny-skia",
  "usvg",
@@ -1209,7 +1209,7 @@ dependencies = [
  "criterion",
  "emath",
  "nohash-hasher",
- "parking_lot",
+ "parking_lot 0.12.0",
  "serde",
 ]
 
@@ -1517,7 +1517,7 @@ dependencies = [
  "log",
  "objc",
  "osmesa-sys",
- "parking_lot",
+ "parking_lot 0.11.2",
  "wayland-client",
  "wayland-egl",
  "winapi",
@@ -2287,7 +2287,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -2302,6 +2312,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3714,6 +3737,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3764,7 +3800,7 @@ dependencies = [
  "ndk-glue 0.5.1",
  "ndk-sys 0.2.2",
  "objc",
- "parking_lot",
+ "parking_lot 0.11.2",
  "percent-encoding",
  "raw-window-handle",
  "smithay-client-toolkit",

--- a/egui_extras/Cargo.toml
+++ b/egui_extras/Cargo.toml
@@ -33,7 +33,7 @@ svg = ["resvg", "tiny-skia", "usvg"]
 
 [dependencies]
 egui = { version = "0.16.1", path = "../egui", default-features = false, features = ["single_threaded"] }
-parking_lot = "0.11"
+parking_lot = "0.12"
 
 # Optional dependencies:
 

--- a/epaint/Cargo.toml
+++ b/epaint/Cargo.toml
@@ -63,7 +63,7 @@ atomic_refcell = { version = "0.1", optional = true } # Used instead of parking_
 bytemuck = { version = "1.7.2", features = ["derive"], optional = true }
 cint = { version = "^0.2.2", optional = true }
 nohash-hasher = "0.2"
-parking_lot = { version = "0.11", optional = true } # Using parking_lot over std::sync::Mutex gives 50% speedups in some real-world scenarios.
+parking_lot = { version = "0.12", optional = true } # Using parking_lot over std::sync::Mutex gives 50% speedups in some real-world scenarios.
 serde = { version = "1", features = ["derive", "rc"], optional = true }
 
 [dev-dependencies]

--- a/sh/build_demo_web.sh
+++ b/sh/build_demo_web.sh
@@ -56,8 +56,12 @@ TARGET=`cargo metadata --format-version=1 | jq --raw-output .target_directory`
 
 echo "Generating JS bindings for wasm…"
 TARGET_NAME="${CRATE_NAME}.wasm"
-wasm-bindgen "${TARGET}/wasm32-unknown-unknown/$BUILD/$TARGET_NAME" \
-  --out-dir docs --no-modules --no-typescript
+WASM_PATH="${TARGET}/wasm32-unknown-unknown/$BUILD/$TARGET_NAME"
+wasm-bindgen ${WASM_PATH} --out-dir docs --no-modules --no-typescript
+
+# if this fails with "error: cannot import from modules (`env`) with `--no-modules`", you can use:
+# wasm2wat target/wasm32-unknown-unknown/release/egui_demo_app.wasm | rg env
+# wasm2wat target/wasm32-unknown-unknown/release/egui_demo_app.wasm | rg "call .now\b" -B 20 # What calls `$now` (often a culprit)
 
 # to get wasm-strip:  apt/brew/dnf install wabt
 # wasm-strip docs/${CRATE_NAME}_bg.wasm

--- a/sh/check.sh
+++ b/sh/check.sh
@@ -46,8 +46,10 @@ cargo doc --document-private-items --no-deps --all-features
 (cd epaint && cargo check --all-features)
 (cd epi && cargo check --all-features)
 
+./sh/wasm_bindgen_check.sh --fast
+
 # cargo install cargo-deny
-# cargo deny check
+cargo deny check
 
 # ------------------------------------------------------------
 #

--- a/sh/wasm_bindgen_check.sh
+++ b/sh/wasm_bindgen_check.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -eu
+script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+cd "$script_path/.."
+
+CRATE_NAME="egui_demo_app"
+FEATURES="http,persistence,screen_reader"
+
+# This is required to enable the web_sys clipboard API which egui_web uses
+# https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Clipboard.html
+# https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html
+export RUSTFLAGS=--cfg=web_sys_unstable_apis
+
+echo "Building rust…"
+BUILD=debug # debug builds are faster
+
+(cd $CRATE_NAME &&
+  cargo build \
+    --lib \
+    --target wasm32-unknown-unknown \
+    --no-default-features \
+    --features ${FEATURES}
+)
+
+TARGET="target"
+
+echo "Generating JS bindings for wasm…"
+
+TARGET_PATH="${CRATE_NAME}_bg.wasm"
+rm -f ${TARGET_PATH} # Remove old output (if any)
+
+TARGET_NAME="${CRATE_NAME}.wasm"
+wasm-bindgen "${TARGET}/wasm32-unknown-unknown/$BUILD/$TARGET_NAME" \
+  --out-dir . --no-modules --no-typescript
+
+rm -f ${TARGET_PATH} # Remove output

--- a/sh/wasm_bindgen_check.sh
+++ b/sh/wasm_bindgen_check.sh
@@ -26,11 +26,12 @@ TARGET="target"
 
 echo "Generating JS bindings for wasm…"
 
-TARGET_PATH="${CRATE_NAME}_bg.wasm"
-rm -f ${TARGET_PATH} # Remove old output (if any)
+rm -f "${CRATE_NAME}_bg.wasm" # Remove old output (if any)
 
 TARGET_NAME="${CRATE_NAME}.wasm"
 wasm-bindgen "${TARGET}/wasm32-unknown-unknown/$BUILD/$TARGET_NAME" \
   --out-dir . --no-modules --no-typescript
 
-rm -f ${TARGET_PATH} # Remove output
+# Remove output:
+rm -f "${CRATE_NAME}_bg.wasm"
+rm -f "${CRATE_NAME}.js"


### PR DESCRIPTION
On current `master`, `wasm-bindgen` fails with:

> error: cannot import from modules (`env`) with `--no-modules`

`git bisect` lead me to https://github.com/emilk/egui/pull/1282 and a lot of `wasm2wat | rg` lead me to figure out it was because of https://github.com/Amanieu/parking_lot/issues/269

The fix is easy (update to `parking_lot 0.12`) but I would like the CI to find these problems earlier next time. Hence this PR.

