### PR TITLE
Fix combo box misalignment on rtl layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 
 
 ## Unreleased
-
+* Fixed ComboBoxes always being rendered left-aligned ([1304](https://github.com/emilk/egui/pull/1304))
 
 ## 0.17.0 - 2022-02-22 - Improved font selection and image handling
 

--- a/egui/src/containers/combo_box.rs
+++ b/egui/src/containers/combo_box.rs
@@ -95,22 +95,19 @@ impl ComboBox {
 
         let button_id = ui.make_persistent_id(id_source);
 
-        ui.horizontal(|ui| {
-            if let Some(width) = width {
-                ui.spacing_mut().slider_width = width; // yes, this is ugly. Will remove later.
-            }
-            let mut ir = combo_box_dyn(ui, button_id, selected_text, menu_contents);
-            if let Some(label) = label {
-                ir.response
-                    .widget_info(|| WidgetInfo::labeled(WidgetType::ComboBox, label.text()));
-                ir.response |= ui.label(label);
-            } else {
-                ir.response
-                    .widget_info(|| WidgetInfo::labeled(WidgetType::ComboBox, ""));
-            }
-            ir
-        })
-        .inner
+        if let Some(width) = width {
+            ui.spacing_mut().slider_width = width; // yes, this is ugly. Will remove later.
+        }
+        let mut ir = combo_box_dyn(ui, button_id, selected_text, menu_contents);
+        if let Some(label) = label {
+            ir.response
+                .widget_info(|| WidgetInfo::labeled(WidgetType::ComboBox, label.text()));
+            ir.response |= ui.label(label);
+        } else {
+            ir.response
+                .widget_info(|| WidgetInfo::labeled(WidgetType::ComboBox, ""));
+        }
+        ir
     }
 
     /// Show a list of items with the given selected index.
@@ -231,7 +228,7 @@ fn button_frame(
     outer_rect.set_height(outer_rect.height().at_least(interact_size.y));
 
     let inner_rect = outer_rect.shrink2(margin);
-    let mut content_ui = ui.child_ui(inner_rect, Layout::left_to_right());
+    let mut content_ui = ui.child_ui(inner_rect, *ui.layout());
     add_contents(&mut content_ui);
 
     let mut outer_rect = content_ui.min_rect().expand2(margin);

--- a/egui/src/containers/combo_box.rs
+++ b/egui/src/containers/combo_box.rs
@@ -95,19 +95,22 @@ impl ComboBox {
 
         let button_id = ui.make_persistent_id(id_source);
 
-        if let Some(width) = width {
-            ui.spacing_mut().slider_width = width; // yes, this is ugly. Will remove later.
-        }
-        let mut ir = combo_box_dyn(ui, button_id, selected_text, menu_contents);
-        if let Some(label) = label {
-            ir.response
-                .widget_info(|| WidgetInfo::labeled(WidgetType::ComboBox, label.text()));
-            ir.response |= ui.label(label);
-        } else {
-            ir.response
-                .widget_info(|| WidgetInfo::labeled(WidgetType::ComboBox, ""));
-        }
-        ir
+        ui.horizontal(|ui| {
+            if let Some(width) = width {
+                ui.spacing_mut().slider_width = width; // yes, this is ugly. Will remove later.
+            }
+            let mut ir = combo_box_dyn(ui, button_id, selected_text, menu_contents);
+            if let Some(label) = label {
+                ir.response
+                    .widget_info(|| WidgetInfo::labeled(WidgetType::ComboBox, label.text()));
+                ir.response |= ui.label(label);
+            } else {
+                ir.response
+                    .widget_info(|| WidgetInfo::labeled(WidgetType::ComboBox, ""));
+            }
+            ir
+        })
+        .inner
     }
 
     /// Show a list of items with the given selected index.


### PR DESCRIPTION
Combo boxes were hard-coded to be left aligned. Causing them to render in the wrong position within a RTL layout.

Before:
![image](https://user-images.githubusercontent.com/1410520/155769005-e6c3fdd9-564a-4321-ac82-3e4809b36bdc.png)


After:
![image](https://user-images.githubusercontent.com/1410520/155768771-07a69014-5a77-493f-acd6-ac5a34832c73.png)
