### PR TITLE
[egui_web] Prevent event handlers from running if code has panicked

### DIFF
--- a/egui/src/widgets/plot/mod.rs
+++ b/egui/src/widgets/plot/mod.rs
@@ -1,6 +1,6 @@
 //! Simple plotting library.
 
-use std::{cell::RefCell, ops::RangeInclusive, rc::Rc};
+use std::{cell::Cell, ops::RangeInclusive, rc::Rc};
 
 use crate::*;
 use epaint::ahash::AHashSet;
@@ -92,7 +92,7 @@ impl PlotMemory {
 pub struct LinkedAxisGroup {
     pub(crate) link_x: bool,
     pub(crate) link_y: bool,
-    pub(crate) bounds: Rc<RefCell<Option<PlotBounds>>>,
+    pub(crate) bounds: Rc<Cell<Option<PlotBounds>>>,
 }
 
 impl LinkedAxisGroup {
@@ -100,7 +100,7 @@ impl LinkedAxisGroup {
         Self {
             link_x,
             link_y,
-            bounds: Rc::new(RefCell::new(None)),
+            bounds: Rc::new(Cell::new(None)),
         }
     }
 
@@ -132,11 +132,11 @@ impl LinkedAxisGroup {
     }
 
     fn get(&self) -> Option<PlotBounds> {
-        *self.bounds.borrow()
+        self.bounds.get()
     }
 
     fn set(&self, bounds: PlotBounds) {
-        *self.bounds.borrow_mut() = Some(bounds);
+        self.bounds.set(Some(bounds));
     }
 }
 

--- a/egui_web/CHANGELOG.md
+++ b/egui_web/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to the `egui_web` integration will be noted in this file.
 
 
 ## Unreleased
+* egui code will no longer be called after panic ([#1306](https://github.com/emilk/egui/pull/1306))
 
 
 ## 0.17.0 - 2022-02-22

--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -308,6 +308,8 @@ pub type AppRunnerRef = Arc<Mutex<AppRunner>>;
 
 pub struct AppRunnerContainer {
     runner: AppRunnerRef,
+    /// Set to `true` if there is a panic.
+    /// Used to ignore callbacks after a panic.
     panicked: Arc<AtomicBool>,
 }
 

--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -29,14 +29,16 @@ pub mod webgl2;
 
 pub use backend::*;
 
-use egui::mutex::Mutex;
+use egui::mutex::{Mutex, MutexGuard};
 pub use wasm_bindgen;
 pub use web_sys;
 
 use input::*;
 pub use painter::Painter;
+use web_sys::EventTarget;
 
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 
@@ -302,12 +304,56 @@ pub fn percent_decode(s: &str) -> String {
 
 // ----------------------------------------------------------------------------
 
-#[derive(Clone)]
-pub struct AppRunnerRef(Arc<Mutex<AppRunner>>);
+pub type AppRunnerRef = Arc<Mutex<AppRunner>>;
 
-fn paint_and_schedule(runner_ref: AppRunnerRef) -> Result<(), JsValue> {
+pub struct AppRunnerContainer {
+    runner: AppRunnerRef,
+    panicked: Arc<AtomicBool>,
+}
+
+impl AppRunnerContainer {
+    /// Convenience function to reduce boilerplate and ensure that all event handlers
+    /// are dealt with in the same way
+    pub fn add_event_listener<E: wasm_bindgen::JsCast>(
+        &self,
+        target: &EventTarget,
+        event_name: &'static str,
+        mut closure: impl FnMut(E, MutexGuard<'_, AppRunner>) + 'static,
+    ) -> Result<(), JsValue> {
+        use wasm_bindgen::JsCast;
+
+        // Create a JS closure based on the FnMut provided
+        let closure = Closure::wrap(Box::new({
+            // Clone atomics
+            let runner_ref = self.runner.clone();
+            let panicked = self.panicked.clone();
+
+            move |event: web_sys::Event| {
+                // Only call the wrapped closure if the egui code has not panicked
+                if !panicked.load(Ordering::SeqCst) {
+                    // Cast the event to the expected event type
+                    let event = event.unchecked_into::<E>();
+
+                    let lock = runner_ref.lock();
+
+                    closure(event, lock);
+                }
+            }
+        }) as Box<dyn FnMut(_)>);
+
+        // Add the event listener to the target
+        target.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
+
+        // Bypass closure drop so that event handler can call the closure
+        closure.forget();
+
+        Ok(())
+    }
+}
+
+fn paint_and_schedule(runner_ref: &AppRunnerRef, panicked: Arc<AtomicBool>) -> Result<(), JsValue> {
     fn paint_if_needed(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
-        let mut runner_lock = runner_ref.0.lock();
+        let mut runner_lock = runner_ref.lock();
         if runner_lock.needs_repaint.fetch_and_clear() {
             let (needs_repaint, clipped_meshes) = runner_lock.logic()?;
             runner_lock.paint(clipped_meshes)?;
@@ -320,34 +366,40 @@ fn paint_and_schedule(runner_ref: AppRunnerRef) -> Result<(), JsValue> {
         Ok(())
     }
 
-    fn request_animation_frame(runner_ref: AppRunnerRef) -> Result<(), JsValue> {
+    fn request_animation_frame(
+        runner_ref: AppRunnerRef,
+        panicked: Arc<AtomicBool>,
+    ) -> Result<(), JsValue> {
         use wasm_bindgen::JsCast;
         let window = web_sys::window().unwrap();
-        let closure = Closure::once(move || paint_and_schedule(runner_ref));
+        let closure = Closure::once(move || paint_and_schedule(&runner_ref, panicked));
         window.request_animation_frame(closure.as_ref().unchecked_ref())?;
         closure.forget(); // We must forget it, or else the callback is canceled on drop
         Ok(())
     }
 
-    paint_if_needed(&runner_ref)?;
-    request_animation_frame(runner_ref)
+    // Only paint and schedule if there has been no panic
+    if !panicked.load(Ordering::SeqCst) {
+        paint_if_needed(runner_ref)?;
+        request_animation_frame(runner_ref.clone(), panicked)?;
+    }
+
+    Ok(())
 }
 
-fn install_document_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
-    use wasm_bindgen::JsCast;
+fn install_document_events(runner_container: &AppRunnerContainer) -> Result<(), JsValue> {
     let window = web_sys::window().unwrap();
     let document = window.document().unwrap();
 
-    {
-        // keydown
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
+    runner_container.add_event_listener(
+        &document,
+        "keydown",
+        |event: web_sys::KeyboardEvent, mut runner_lock| {
             if event.is_composing() || event.key_code() == 229 {
                 // https://www.fxsitecompat.dev/en-CA/docs/2018/keydown-and-keyup-events-are-now-fired-during-ime-composition/
                 return;
             }
 
-            let mut runner_lock = runner_ref.0.lock();
             let modifiers = modifiers_from_event(&event);
             runner_lock.input.raw.modifiers = modifiers;
 
@@ -400,16 +452,13 @@ fn install_document_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
             if prevent_default {
                 event.prevent_default();
             }
-        }) as Box<dyn FnMut(_)>);
-        document.add_event_listener_with_callback("keydown", closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        },
+    )?;
 
-    {
-        // keyup
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
-            let mut runner_lock = runner_ref.0.lock();
+    runner_container.add_event_listener(
+        &document,
+        "keyup",
+        |event: web_sys::KeyboardEvent, mut runner_lock| {
             let modifiers = modifiers_from_event(&event);
             runner_lock.input.raw.modifiers = modifiers;
             if let Some(key) = translate_key(&event.key()) {
@@ -420,19 +469,16 @@ fn install_document_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
                 });
             }
             runner_lock.needs_repaint.set_true();
-        }) as Box<dyn FnMut(_)>);
-        document.add_event_listener_with_callback("keyup", closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        },
+    )?;
 
     #[cfg(web_sys_unstable_apis)]
-    {
-        // paste
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move |event: web_sys::ClipboardEvent| {
+    runner_container.add_event_listener(
+        &document,
+        "paste",
+        |event: web_sys::ClipboardEvent, mut runner_lock| {
             if let Some(data) = event.clipboard_data() {
                 if let Ok(text) = data.get_data("text") {
-                    let mut runner_lock = runner_ref.0.lock();
                     runner_lock
                         .input
                         .raw
@@ -443,85 +489,90 @@ fn install_document_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
                     event.prevent_default();
                 }
             }
-        }) as Box<dyn FnMut(_)>);
-        document.add_event_listener_with_callback("paste", closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        },
+    )?;
 
     #[cfg(web_sys_unstable_apis)]
-    {
-        // cut
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move |_: web_sys::ClipboardEvent| {
-            let mut runner_lock = runner_ref.0.lock();
+    runner_container.add_event_listener(
+        &document,
+        "cut",
+        |_: web_sys::ClipboardEvent, mut runner_lock| {
             runner_lock.input.raw.events.push(egui::Event::Cut);
             runner_lock.needs_repaint.set_true();
-        }) as Box<dyn FnMut(_)>);
-        document.add_event_listener_with_callback("cut", closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        },
+    )?;
 
     #[cfg(web_sys_unstable_apis)]
-    {
-        // copy
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move |_: web_sys::ClipboardEvent| {
-            let mut runner_lock = runner_ref.0.lock();
+    runner_container.add_event_listener(
+        &document,
+        "copy",
+        |_: web_sys::ClipboardEvent, mut runner_lock| {
             runner_lock.input.raw.events.push(egui::Event::Copy);
             runner_lock.needs_repaint.set_true();
-        }) as Box<dyn FnMut(_)>);
-        document.add_event_listener_with_callback("copy", closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        },
+    )?;
 
     for event_name in &["load", "pagehide", "pageshow", "resize"] {
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move || {
-            runner_ref.0.lock().needs_repaint.set_true();
-        }) as Box<dyn FnMut()>);
-        window.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
-        closure.forget();
+        runner_container.add_event_listener(
+            &document,
+            event_name,
+            |_: web_sys::Event, runner_lock| {
+                runner_lock.needs_repaint.set_true();
+            },
+        )?;
     }
 
-    {
-        // hashchange
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move || {
-            let runner_lock = runner_ref.0.lock();
+    runner_container.add_event_listener(
+        &document,
+        "hashchange",
+        |_: web_sys::Event, runner_lock| {
             let mut frame_lock = runner_lock.frame.lock();
 
             // `epi::Frame::info(&self)` clones `epi::IntegrationInfo`, but we need to modify the original here
             if let Some(web_info) = &mut frame_lock.info.web_info {
                 web_info.location.hash = location_hash();
             }
-        }) as Box<dyn FnMut()>);
-        window.add_event_listener_with_callback("hashchange", closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        },
+    )?;
 
     Ok(())
 }
 
 /// Repaint at least every `ms` milliseconds.
-fn repaint_every_ms(runner_ref: &AppRunnerRef, milliseconds: i32) -> Result<(), JsValue> {
+pub fn repaint_every_ms(
+    runner_container: &AppRunnerContainer,
+    milliseconds: i32,
+) -> Result<(), JsValue> {
     assert!(milliseconds >= 0);
+
     use wasm_bindgen::JsCast;
+
     let window = web_sys::window().unwrap();
-    let runner_ref = runner_ref.clone();
-    let closure = Closure::wrap(Box::new(move || {
-        runner_ref.0.lock().needs_repaint.set_true();
+
+    let closure = Closure::wrap(Box::new({
+        let runner = runner_container.runner.clone();
+        let panicked = runner_container.panicked.clone();
+
+        move || {
+            // Do not lock the runner if the code has panicked
+            if !panicked.load(Ordering::SeqCst) {
+                runner.lock().needs_repaint.set_true();
+            }
+        }
     }) as Box<dyn FnMut()>);
+
     window.set_interval_with_callback_and_timeout_and_arguments_0(
         closure.as_ref().unchecked_ref(),
         milliseconds,
     )?;
+
     closure.forget();
     Ok(())
 }
 
-fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
+fn install_canvas_events(runner_container: &AppRunnerContainer) -> Result<(), JsValue> {
     use wasm_bindgen::JsCast;
-    let canvas = canvas_element(runner_ref.0.lock().canvas_id()).unwrap();
+    let canvas = canvas_element(runner_container.runner.lock().canvas_id()).unwrap();
 
     {
         // By default, right-clicks open a context menu.
@@ -534,12 +585,11 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
         closure.forget();
     }
 
-    {
-        let event_name = "mousedown";
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
+    runner_container.add_event_listener(
+        &canvas,
+        "mousedown",
+        |event: web_sys::MouseEvent, mut runner_lock| {
             if let Some(button) = button_from_mouse_event(&event) {
-                let mut runner_lock = runner_ref.0.lock();
                 let pos = pos_from_mouse_event(runner_lock.canvas_id(), &event);
                 let modifiers = runner_lock.input.raw.modifiers;
                 runner_lock
@@ -556,16 +606,13 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
             }
             event.stop_propagation();
             // Note: prevent_default breaks VSCode tab focusing, hence why we don't call it here.
-        }) as Box<dyn FnMut(_)>);
-        canvas.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        },
+    )?;
 
-    {
-        let event_name = "mousemove";
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
-            let mut runner_lock = runner_ref.0.lock();
+    runner_container.add_event_listener(
+        &canvas,
+        "mousemove",
+        |event: web_sys::MouseEvent, mut runner_lock| {
             let pos = pos_from_mouse_event(runner_lock.canvas_id(), &event);
             runner_lock
                 .input
@@ -575,17 +622,14 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
             runner_lock.needs_repaint.set_true();
             event.stop_propagation();
             event.prevent_default();
-        }) as Box<dyn FnMut(_)>);
-        canvas.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        },
+    )?;
 
-    {
-        let event_name = "mouseup";
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
+    runner_container.add_event_listener(
+        &canvas,
+        "mouseup",
+        |event: web_sys::MouseEvent, mut runner_lock| {
             if let Some(button) = button_from_mouse_event(&event) {
-                let mut runner_lock = runner_ref.0.lock();
                 let pos = pos_from_mouse_event(runner_lock.canvas_id(), &event);
                 let modifiers = runner_lock.input.raw.modifiers;
                 runner_lock
@@ -604,30 +648,24 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
             }
             event.stop_propagation();
             event.prevent_default();
-        }) as Box<dyn FnMut(_)>);
-        canvas.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        },
+    )?;
 
-    {
-        let event_name = "mouseleave";
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
-            let mut runner_lock = runner_ref.0.lock();
+    runner_container.add_event_listener(
+        &canvas,
+        "mouseleave",
+        |event: web_sys::MouseEvent, mut runner_lock| {
             runner_lock.input.raw.events.push(egui::Event::PointerGone);
             runner_lock.needs_repaint.set_true();
             event.stop_propagation();
             event.prevent_default();
-        }) as Box<dyn FnMut(_)>);
-        canvas.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        },
+    )?;
 
-    {
-        let event_name = "touchstart";
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move |event: web_sys::TouchEvent| {
-            let mut runner_lock = runner_ref.0.lock();
+    runner_container.add_event_listener(
+        &canvas,
+        "touchstart",
+        |event: web_sys::TouchEvent, mut runner_lock| {
             let mut latest_touch_pos_id = runner_lock.input.latest_touch_pos_id;
             let pos =
                 pos_from_touch_event(runner_lock.canvas_id(), &event, &mut latest_touch_pos_id);
@@ -649,16 +687,13 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
             runner_lock.needs_repaint.set_true();
             event.stop_propagation();
             event.prevent_default();
-        }) as Box<dyn FnMut(_)>);
-        canvas.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        },
+    )?;
 
-    {
-        let event_name = "touchmove";
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move |event: web_sys::TouchEvent| {
-            let mut runner_lock = runner_ref.0.lock();
+    runner_container.add_event_listener(
+        &canvas,
+        "touchmove",
+        |event: web_sys::TouchEvent, mut runner_lock| {
             let mut latest_touch_pos_id = runner_lock.input.latest_touch_pos_id;
             let pos =
                 pos_from_touch_event(runner_lock.canvas_id(), &event, &mut latest_touch_pos_id);
@@ -674,17 +709,13 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
             runner_lock.needs_repaint.set_true();
             event.stop_propagation();
             event.prevent_default();
-        }) as Box<dyn FnMut(_)>);
-        canvas.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        },
+    )?;
 
-    {
-        let event_name = "touchend";
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move |event: web_sys::TouchEvent| {
-            let mut runner_lock = runner_ref.0.lock();
-
+    runner_container.add_event_listener(
+        &canvas,
+        "touchend",
+        |event: web_sys::TouchEvent, mut runner_lock| {
             if let Some(pos) = runner_lock.input.latest_touch_pos {
                 let modifiers = runner_lock.input.raw.modifiers;
                 // First release mouse to click:
@@ -709,33 +740,26 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
 
             // Finally, focus or blur text agent to toggle mobile keyboard:
             text_agent::update_text_agent(&runner_lock);
-        }) as Box<dyn FnMut(_)>);
-        canvas.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        },
+    )?;
 
-    {
-        let event_name = "touchcancel";
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move |event: web_sys::TouchEvent| {
-            let mut runner_lock = runner_ref.0.lock();
+    runner_container.add_event_listener(
+        &canvas,
+        "touchcancel",
+        |event: web_sys::TouchEvent, mut runner_lock| {
             push_touches(&mut *runner_lock, egui::TouchPhase::Cancel, &event);
             event.stop_propagation();
             event.prevent_default();
-        }) as Box<dyn FnMut(_)>);
-        canvas.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        },
+    )?;
 
-    {
-        let event_name = "wheel";
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move |event: web_sys::WheelEvent| {
-            let mut runner_lock = runner_ref.0.lock();
-
+    runner_container.add_event_listener(
+        &canvas,
+        "wheel",
+        |event: web_sys::WheelEvent, mut runner_lock| {
             let scroll_multiplier = match event.delta_mode() {
                 web_sys::WheelEvent::DOM_DELTA_PAGE => {
-                    canvas_size_in_points(runner_ref.0.lock().canvas_id()).y
+                    canvas_size_in_points(runner_lock.canvas_id()).y
                 }
                 web_sys::WheelEvent::DOM_DELTA_LINE => {
                     #[allow(clippy::let_and_return)]
@@ -771,17 +795,14 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
             runner_lock.needs_repaint.set_true();
             event.stop_propagation();
             event.prevent_default();
-        }) as Box<dyn FnMut(_)>);
-        canvas.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        },
+    )?;
 
-    {
-        let event_name = "dragover";
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move |event: web_sys::DragEvent| {
+    runner_container.add_event_listener(
+        &canvas,
+        "dragover",
+        |event: web_sys::DragEvent, mut runner_lock| {
             if let Some(data_transfer) = event.data_transfer() {
-                let mut runner_lock = runner_ref.0.lock();
                 runner_lock.input.raw.hovered_files.clear();
                 for i in 0..data_transfer.items().length() {
                     if let Some(item) = data_transfer.items().get(i) {
@@ -795,35 +816,28 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
                 event.stop_propagation();
                 event.prevent_default();
             }
-        }) as Box<dyn FnMut(_)>);
-        canvas.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        },
+    )?;
 
-    {
-        let event_name = "dragleave";
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move |event: web_sys::DragEvent| {
-            let mut runner_lock = runner_ref.0.lock();
+    runner_container.add_event_listener(
+        &canvas,
+        "dragleave",
+        |event: web_sys::DragEvent, mut runner_lock| {
             runner_lock.input.raw.hovered_files.clear();
             runner_lock.needs_repaint.set_true();
             event.stop_propagation();
             event.prevent_default();
-        }) as Box<dyn FnMut(_)>);
-        canvas.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        },
+    )?;
 
-    {
-        let event_name = "drop";
-        let runner_ref = runner_ref.clone();
-        let closure = Closure::wrap(Box::new(move |event: web_sys::DragEvent| {
+    runner_container.add_event_listener(&canvas, "drop", {
+        let runner_ref = runner_container.runner.clone();
+
+        move |event: web_sys::DragEvent, mut runner_lock| {
             if let Some(data_transfer) = event.data_transfer() {
-                {
-                    let mut runner_lock = runner_ref.0.lock();
-                    runner_lock.input.raw.hovered_files.clear();
-                    runner_lock.needs_repaint.set_true();
-                }
+                runner_lock.input.raw.hovered_files.clear();
+                runner_lock.needs_repaint.set_true();
+                drop(runner_lock);
 
                 if let Some(files) = data_transfer.files() {
                     for i in 0..files.length() {
@@ -847,7 +861,7 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
                                             bytes.len()
                                         );
 
-                                        let mut runner_lock = runner_ref.0.lock();
+                                        let mut runner_lock = runner_ref.lock();
                                         runner_lock.input.raw.dropped_files.push(
                                             egui::DroppedFile {
                                                 name,
@@ -870,10 +884,8 @@ fn install_canvas_events(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
                 event.stop_propagation();
                 event.prevent_default();
             }
-        }) as Box<dyn FnMut(_)>);
-        canvas.add_event_listener_with_callback(event_name, closure.as_ref().unchecked_ref())?;
-        closure.forget();
-    }
+        }
+    })?;
 
     Ok(())
 }

--- a/egui_web/src/text_agent.rs
+++ b/egui_web/src/text_agent.rs
@@ -174,8 +174,8 @@ pub fn update_text_agent(runner: MutexGuard<'_, AppRunner>) -> Option<()> {
 
         // Holding the runner lock while calling input.blur() causes a panic.
         // This is most probably caused by the browser running the event handler
-        // synchronously, meaning that the runner does not get dropped when another
-        // event handler is called.
+        // for the triggered blur event synchronously, meaning that the mutex
+        // lock does not get dropped by the time another event handler is called.
         //
         // Why this didn't exist before #1290 is a mystery to me, but it exists now
         // and this apparently is the fix for it

--- a/egui_web/src/text_agent.rs
+++ b/egui_web/src/text_agent.rs
@@ -1,7 +1,8 @@
 //! The text agent is an `<input>` element used to trigger
 //! mobile keyboard and IME input.
 
-use crate::{canvas_element, AppRunner, AppRunnerRef};
+use crate::{canvas_element, AppRunner, AppRunnerContainer};
+use egui::mutex::MutexGuard;
 use std::cell::Cell;
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
@@ -21,7 +22,7 @@ pub fn text_agent() -> web_sys::HtmlInputElement {
 }
 
 /// Text event handler,
-pub fn install_text_agent(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
+pub fn install_text_agent(runner_container: &AppRunnerContainer) -> Result<(), JsValue> {
     use wasm_bindgen::JsCast;
     let window = web_sys::window().unwrap();
     let document = window.document().unwrap();
@@ -43,61 +44,73 @@ pub fn install_text_agent(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
     input.set_size(1);
     input.set_autofocus(true);
     input.set_hidden(true);
-    {
-        // When IME is off
+
+    // When IME is off
+    runner_container.add_event_listener(&input, "input", {
         let input_clone = input.clone();
-        let runner_ref = runner_ref.clone();
         let is_composing = is_composing.clone();
-        let on_input = Closure::wrap(Box::new(move |_event: web_sys::InputEvent| {
+
+        move |_event: web_sys::InputEvent, mut runner_lock| {
             let text = input_clone.value();
             if !text.is_empty() && !is_composing.get() {
                 input_clone.set_value("");
-                let mut runner_lock = runner_ref.0.lock();
                 runner_lock.input.raw.events.push(egui::Event::Text(text));
                 runner_lock.needs_repaint.set_true();
             }
-        }) as Box<dyn FnMut(_)>);
-        input.add_event_listener_with_callback("input", on_input.as_ref().unchecked_ref())?;
-        on_input.forget();
-    }
+        }
+    })?;
+
     {
         // When IME is on, handle composition event
-        let input_clone = input.clone();
-        let runner_ref = runner_ref.clone();
-        let on_compositionend = Closure::wrap(Box::new(move |event: web_sys::CompositionEvent| {
-            let mut runner_lock = runner_ref.0.lock();
-            let opt_event = match event.type_().as_ref() {
-                "compositionstart" => {
-                    is_composing.set(true);
-                    input_clone.set_value("");
-                    Some(egui::Event::CompositionStart)
-                }
-                "compositionend" => {
-                    is_composing.set(false);
-                    input_clone.set_value("");
-                    event.data().map(egui::Event::CompositionEnd)
-                }
-                "compositionupdate" => event.data().map(egui::Event::CompositionUpdate),
-                s => {
-                    tracing::error!("Unknown composition event type: {:?}", s);
-                    None
-                }
-            };
-            if let Some(event) = opt_event {
-                runner_lock.input.raw.events.push(event);
+        runner_container.add_event_listener(&input, "compositionstart", {
+            let input_clone = input.clone();
+            let is_composing = is_composing.clone();
+
+            move |_event: web_sys::CompositionEvent, mut runner_lock: MutexGuard<'_, AppRunner>| {
+                is_composing.set(true);
+                input_clone.set_value("");
+
+                runner_lock
+                    .input
+                    .raw
+                    .events
+                    .push(egui::Event::CompositionStart);
                 runner_lock.needs_repaint.set_true();
             }
-        }) as Box<dyn FnMut(_)>);
-        let f = on_compositionend.as_ref().unchecked_ref();
-        input.add_event_listener_with_callback("compositionstart", f)?;
-        input.add_event_listener_with_callback("compositionupdate", f)?;
-        input.add_event_listener_with_callback("compositionend", f)?;
-        on_compositionend.forget();
+        })?;
+
+        runner_container.add_event_listener(
+            &input,
+            "compositionupdate",
+            move |event: web_sys::CompositionEvent, mut runner_lock: MutexGuard<'_, AppRunner>| {
+                if let Some(event) = event.data().map(egui::Event::CompositionUpdate) {
+                    runner_lock.input.raw.events.push(event);
+                    runner_lock.needs_repaint.set_true();
+                }
+            },
+        )?;
+
+        runner_container.add_event_listener(&input, "compositionend", {
+            let input_clone = input.clone();
+
+            move |event: web_sys::CompositionEvent, mut runner_lock: MutexGuard<'_, AppRunner>| {
+                is_composing.set(false);
+                input_clone.set_value("");
+
+                if let Some(event) = event.data().map(egui::Event::CompositionEnd) {
+                    runner_lock.input.raw.events.push(event);
+                    runner_lock.needs_repaint.set_true();
+                }
+            }
+        })?;
     }
-    {
-        // When input lost focus, focus on it again.
-        // It is useful when user click somewhere outside canvas.
-        let on_focusout = Closure::wrap(Box::new(move |_event: web_sys::MouseEvent| {
+
+    // When input lost focus, focus on it again.
+    // It is useful when user click somewhere outside canvas.
+    runner_container.add_event_listener(
+        &input,
+        "focusout",
+        move |_event: web_sys::MouseEvent, _| {
             // Delay 10 ms, and focus again.
             let func = js_sys::Function::new_no_args(&format!(
                 "document.getElementById('{}').focus()",
@@ -106,11 +119,11 @@ pub fn install_text_agent(runner_ref: &AppRunnerRef) -> Result<(), JsValue> {
             window
                 .set_timeout_with_callback_and_timeout_and_arguments_0(&func, 10)
                 .unwrap();
-        }) as Box<dyn FnMut(_)>);
-        input.add_event_listener_with_callback("focusout", on_focusout.as_ref().unchecked_ref())?;
-        on_focusout.forget();
-    }
+        },
+    )?;
+
     body.append_child(&input)?;
+
     Ok(())
 }
 


### PR DESCRIPTION
The way egui_web works involves adding event handlers to a `<canvas>` element, the `<body>`, and a helper `<input>` element. By setting up such callbacks, it creates a position where the JavaScript/WASM runtime will call rust code across a FFI boundary, but that rust code could be in an invalid state, due to a previous panic. More information on the issue can be seen in #1209.

There are 2 ways to prevent this problem from occuring:
1. Provide a way to de-register all of the callbacks that were setup which the user could call in a panic handler, or `std::panic::catch_unwind`
2. Leave callbacks registered, but return early from all of them if the code has encountered a panic.

The first option would be preferable since it would allow for the user to have more control over the de-registering of the callbacks. This was my first attempt but it became hard to near impossible.
1. Lots of the types used in `egui` and `egui_web` are not [`UnwindSafe`](https://doc.rust-lang.org/stable/std/panic/trait.UnwindSafe.html) or [`RefUnwindSafe`](https://doc.rust-lang.org/stable/std/panic/trait.RefUnwindSafe.html) which make using `std::panic::catch_unwind` impossible.
2. None of the types from `wasm_bindgen`, `web_sys`, or `js_sys` are `Send`. This means that there would be no way for a panic handler (`std::panic::set_hook`) to be passed the `js_sys::Function` or even the `web_sys::EventTarget`. both of which are needed to call `remove_event_listener`.

Both of the above limitations mean that the event listeners can not be de-registered from inside of a panic handler. This leaves only option 2.

The way I have implemented this is using a shared `Arc<AtomicBool>` between all of the event handlers and the panic handler. Every time the event handlers are called, they perform a `AtomicBool::load(SeqCst)` and check that the bool is false. If it is, they continue calling the normal rust code. If the bool was true, the event handler returns early. The `AtomicBool` is set to true by the panic handler as soon as it is hit, so all callbacks after will be skipped.

In making this change, I created a [convenience method](https://github.com/emilk/egui/compare/master...DusterTheFirst:web-panic#diff-08ecc98d40fc709c6db305a8848c79dd3018a23007b6dfc3558257c3bab55d84R317-R351) that will wrap the callbacks in a check against the atomic bool as well as reduce boilerplate with closure creation, event listener adding, and closure forgetting.

There is only one event listener I did not touch, and that is the [contextmenu](https://github.com/emilk/egui/compare/master...DusterTheFirst:web-panic#diff-08ecc98d40fc709c6db305a8848c79dd3018a23007b6dfc3558257c3bab55d84R577-R586) event handler. Since this handler does not call into any egui code, it does not contribute to the problem and can be left alone.

The main culprit of the errors is the locking of the mutex guarding the `AppRunner`.

Here is a link to a few important changes:
- [The panic handler](https://github.com/emilk/egui/compare/master...DusterTheFirst:web-panic#diff-df803feb9e2073afc33fd76e71604ec5e6044094886b4b456bd49d05c01fe632R374-R392)
- [Add event listener convenience method](https://github.com/emilk/egui/compare/master...DusterTheFirst:web-panic#diff-08ecc98d40fc709c6db305a8848c79dd3018a23007b6dfc3558257c3bab55d84R317-R351)
- [A check against the atomic bool in `paint_and_schedule`](https://github.com/emilk/egui/compare/master...DusterTheFirst:web-panic#diff-08ecc98d40fc709c6db305a8848c79dd3018a23007b6dfc3558257c3bab55d84R381-R385)

And a before/after comparison:

## Before:

https://user-images.githubusercontent.com/14093962/155794187-cee13e4a-e0b8-4b50-9ee0-780c5852f168.mp4

## After:

https://user-images.githubusercontent.com/14093962/155794214-b8411fba-2fd1-45ec-9a46-a243c33649b4.mp4

As can be seen in the after demo, there is still one `unreachable executed` error, but this is caused by the builtin rust panic handler calling unsupported code so there is nothing I can do about it.

<!--

Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and it is green.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Closes <https://github.com/emilk/egui/issues/1290>.

