### PR TITLE
egui_extras README grammar fixes

### DIFF
--- a/egui_extras/README.md
+++ b/egui_extras/README.md
@@ -5,4 +5,4 @@
 ![MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Apache](https://img.shields.io/badge/license-Apache-blue.svg)
 
-This is a crate that adds some features on top top of [`egui`](https://github.com/emilk/egui). This crate are for experimental features, and features that require big dependencies that does not belong in `egui`.
+This is a crate that adds some features on top top of [`egui`](https://github.com/emilk/egui). This crate is for experimental features, and features that require big dependencies that do not belong in `egui`.


### PR DESCRIPTION
Change "are" to "is", "does" to "do" to fix the subject-verb agreement on the egui_extras README.md. A trivial change but it makes a nicer first impression for anyone following the link straight there from the 0.17 highlights.
