### PR TITLE
Remove warning about cpal drag and drop

### DIFF
--- a/eframe/CHANGELOG.md
+++ b/eframe/CHANGELOG.md
@@ -5,6 +5,7 @@ NOTE: [`egui_web`](../egui_web/CHANGELOG.md), [`egui-winit`](../egui-winit/CHANG
 
 
 ## Unreleased
+* Change default for `NativeOptions::drag_and_drop_support` to `true` ([#1329](https://github.com/emilk/egui/pull/1329))
 
 
 ## 0.17.0 - 2022-02-22

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -260,7 +260,7 @@ impl Default for NativeOptions {
             always_on_top: false,
             maximized: false,
             decorated: true,
-            drag_and_drop_support: false,
+            drag_and_drop_support: true,
             icon_data: None,
             initial_window_pos: None,
             initial_window_size: None,

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -221,10 +221,13 @@ pub struct NativeOptions {
     /// If false it will be difficult to move and resize the app.
     pub decorated: bool,
 
-    /// On Windows: enable drag and drop support.
-    /// Default is `false` to avoid issues with crates such as [`cpal`](https://github.com/RustAudio/cpal) which
-    /// will hang when combined with drag-and-drop.
-    /// See <https://github.com/rust-windowing/winit/issues/1255>.
+    /// On Windows: enable drag and drop support. Drag and drop can
+    /// not be disabled on other platforms.
+    ///
+    /// See [winit's documentation][drag_and_drop] for information on why you
+    /// might want to disable this on windows.
+    ///
+    /// [drag_and_drop]: https://docs.rs/winit/latest/x86_64-pc-windows-msvc/winit/platform/windows/trait.WindowBuilderExtWindows.html#tymethod.with_drag_and_drop
     pub drag_and_drop_support: bool,
 
     /// The application icon, e.g. in the Windows task bar etc.


### PR DESCRIPTION
Given that the issue https://github.com/rust-windowing/winit/issues/1255 was closed by https://github.com/rust-windowing/winit/pull/1524, it would make sense to remove the warning about the issue from NativeOptions.

I also propose changing the default for `NativeOptions::drag_and_drop_support` to `true`, since the issue with winit has been resolved. Because this may be a breaking change, I have separated it into its own commit so it can be reverted if the default should stay the same.

