### PR TITLE
Expose cursor and next_widget_position

### DIFF
--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -783,6 +783,16 @@ impl Ui {
         &self.placer
     }
 
+    /// Where the next widget will be put.
+    ///
+    /// One side of this will always be infinite: the direction in which new widgets will be added.
+    /// The opposing side is what is incremented.
+    /// The crossing sides are initialized to `max_rect`.
+    ///
+    /// So one can think of `cursor` as a constraint on the available region.
+    ///
+    /// If something has already been added, this will point to `style.spacing.item_spacing` beyond the latest child.
+    /// The cursor can thus be `style.spacing.item_spacing` pixels outside of the min_rect.
     pub fn cursor(&self) -> Rect {
         self.placer.cursor()
     }

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -783,7 +783,7 @@ impl Ui {
         &self.placer
     }
 
-    pub(crate) fn cursor(&self) -> Rect {
+    pub fn cursor(&self) -> Rect {
         self.placer.cursor()
     }
 
@@ -792,7 +792,7 @@ impl Ui {
     }
 
     /// Where do we expect a zero-sized widget to be placed?
-    pub(crate) fn next_widget_position(&self) -> Pos2 {
+    pub fn next_widget_position(&self) -> Pos2 {
         self.placer.next_widget_position()
     }
 


### PR DESCRIPTION
Change `Ui::cursor` and `Ui::next_widget_position` from crate-visible to public. These are useful for layout code and scrolling.

Closes <https://github.com/emilk/egui/issues/1339>.

