### PR TITLE
Remove unnecessary to_string in docs

### DIFF
--- a/egui/src/widgets/plot/mod.rs
+++ b/egui/src/widgets/plot/mod.rs
@@ -328,7 +328,7 @@ impl Plot {
     /// Plot::new("my_plot").view_aspect(2.0)
     /// .label_formatter(|name, value| {
     ///     if !name.is_empty() {
-    ///         format!("{}: {:.*}%", name, 1, value.y).to_string()
+    ///         format!("{}: {:.*}%", name, 1, value.y)
     ///     } else {
     ///         "".to_string()
     ///     }


### PR DESCRIPTION
In the docs for `label_formatter`, there's an unnecessary `to_string` after a `format!`. This PR removes that.