### PR TITLE
Remove egui_glium as a backend for eframe

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,7 +81,7 @@ jobs:
           override: true
       - run: rustup target add wasm32-unknown-unknown
       - name: check
-        run: cargo check -p eframe --lib --no-default-features --features egui_glow,persistence --target wasm32-unknown-unknown
+        run: cargo check -p eframe --lib --no-default-features --features persistence --target wasm32-unknown-unknown
 
   check_web_all_features:
     name: cargo check web --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,7 +987,6 @@ dependencies = [
  "egui",
  "egui-winit",
  "egui_extras",
- "egui_glium",
  "egui_glow",
  "egui_web",
  "ehttp",

--- a/README.md
+++ b/README.md
@@ -160,13 +160,13 @@ An integration needs to do the following each frame:
 
 ### Official integrations
 
-If you're making an app, your best bet is using [`eframe`](https://github.com/emilk/egui/tree/master/eframe), the official egui framework. It lets you write apps that work on both the web and native. `eframe` is just a thin wrapper over `egui_web` and `egui_glium` (see below).
+If you're making an app, your best bet is using [`eframe`](https://github.com/emilk/egui/tree/master/eframe), the official egui framework. It lets you write apps that work on both the web and native. `eframe` is just a thin wrapper over `egui_web` and `egui_glow` (see below).
 
 These are the official egui integrations:
 
 * [`egui_glium`](https://github.com/emilk/egui/tree/master/egui_glium) for compiling native apps with [Glium](https://github.com/glium/glium).
-* [`egui_glow`](https://github.com/emilk/egui/tree/master/egui_glow) for compiling native apps with [Glow](https://github.com/grovesNL/glow).
-* [`egui_web`](https://github.com/emilk/egui/tree/master/egui_web) for making a web app. Compiles to WASM, renders with WebGL. [Click to run the egui demo](https://www.egui.rs/#demo).
+* [`egui_glow`](https://github.com/emilk/egui/tree/master/egui_glow) for compiling native apps with [glow](https://github.com/grovesNL/glow).
+* [`egui_web`](https://github.com/emilk/egui/tree/master/egui_web) for making a web app. Compiles to WASM, renders with WebGL. [Click to run the egui demo](https://www.egui.rs/#demo). Uses `egui_glow`.
 * [`egui-winit`](https://github.com/emilk/egui/tree/master/egui-winit) for integrating with [winit](https://github.com/rust-windowing/winit). `egui-winit` is used by `egui_glium` and `egui_glow`.
 
 ### 3rd party integrations

--- a/eframe/CHANGELOG.md
+++ b/eframe/CHANGELOG.md
@@ -5,7 +5,8 @@ NOTE: [`egui_web`](../egui_web/CHANGELOG.md), [`egui-winit`](../egui-winit/CHANG
 
 
 ## Unreleased
-* Change default for `NativeOptions::drag_and_drop_support` to `true` ([#1329](https://github.com/emilk/egui/pull/1329))
+* Remove the `egui_glium` feature. `eframe` will now always use `egui_glow` as the native backend ([#1357](https://github.com/emilk/egui/pull/1357)).
+* Change default for `NativeOptions::drag_and_drop_support` to `true` ([#1329](https://github.com/emilk/egui/pull/1329)).
 
 
 ## 0.17.0 - 2022-02-22

--- a/eframe/Cargo.toml
+++ b/eframe/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 
 
 [features]
-default = ["default_fonts", "egui_glow"]
+default = ["default_fonts"]
 
 # If set, egui will use `include_bytes!` to bundle some fonts.
 # If you plan on specifying your own fonts you may disable this feature.
@@ -49,18 +49,13 @@ epi = { version = "0.17.0", path = "../epi" }
 
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-egui-winit = { version = "0.17.0", path = "../egui-winit", default-features = false }
-egui_glium = { version = "0.17.0", path = "../egui_glium", optional = true, default-features = false, features = [
-  "clipboard",
-  "epi",
-  "links",
-] }
-egui_glow = { version = "0.17.0", path = "../egui_glow", optional = true, default-features = false, features = [
+egui_glow = { version = "0.17.0", path = "../egui_glow", default-features = false, features = [
   "clipboard",
   "epi",
   "links",
   "winit",
 ] }
+egui-winit = { version = "0.17.0", path = "../egui-winit", default-features = false }
 
 # web:
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/eframe/README.md
+++ b/eframe/README.md
@@ -18,7 +18,7 @@ For how to use `egui`, see [the egui docs](https://docs.rs/egui).
 
 `eframe` is a very thin crate that re-exports [`egui`](https://github.com/emilk/egui) and[`epi`](https://github.com/emilk/egui/tree/master/epi) with thin wrappers over the backends.
 
-`eframe` uses [`egui_web`](https://github.com/emilk/egui/tree/master/egui_web) for web and [`egui_glium`](https://github.com/emilk/egui/tree/master/egui_glium) or [`egui_glow`](https://github.com/emilk/egui/tree/master/egui_glow) for native.
+`eframe` uses [`egui_web`](https://github.com/emilk/egui/tree/master/egui_web) for web and [`egui_glow`](https://github.com/emilk/egui/tree/master/egui_glow) for native.
 
 To use on Linux, first run:
 
@@ -28,13 +28,7 @@ sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev lib
 
 
 ## Alternatives
-The default native backend for `eframe` is currently [`egui_glow`](https://github.com/emilk/egui/tree/master/egui_glow), but you can switch to the previous [`egui_glium`](https://github.com/emilk/egui/tree/master/egui_glium) backend by putting this in your `Cargo.toml`:
-
-``` toml
-eframe = { version = "*", default-features = false, features = ["default_fonts", "egui_glium"] }
-```
-
-`eframe` is not the only way to write an app using `egui`! You can also try [`egui-miniquad`](https://github.com/not-fl3/egui-miniquad) and [`egui_sdl2_gl`](https://github.com/ArjunNair/egui_sdl2_gl).
+`eframe` is not the only way to write an app using `egui`! You can also try [`egui-miniquad`](https://github.com/not-fl3/egui-miniquad), [`bevy_egui`](https://github.com/mvlabat/bevy_egui), [`egui_sdl2_gl`](https://github.com/ArjunNair/egui_sdl2_gl), and others.
 
 
 ## Companion crates

--- a/eframe/src/lib.rs
+++ b/eframe/src/lib.rs
@@ -143,46 +143,6 @@ pub fn start_web(canvas_id: &str, app: Box<dyn epi::App>) -> Result<(), wasm_bin
 /// }
 /// ```
 #[cfg(not(target_arch = "wasm32"))]
-#[cfg(feature = "egui_glium")]
-pub fn run_native(app: Box<dyn epi::App>, native_options: epi::NativeOptions) -> ! {
-    egui_glium::run(app, &native_options)
-}
-
-/// Call from `fn main` like this:
-/// ``` no_run
-/// use eframe::{epi, egui};
-///
-/// #[derive(Default)]
-/// struct MyEguiApp {}
-///
-/// impl epi::App for MyEguiApp {
-///    fn name(&self) -> &str {
-///        "My egui App"
-///    }
-///
-///    fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
-///        egui::CentralPanel::default().show(ctx, |ui| {
-///            ui.heading("Hello World!");
-///        });
-///    }
-///}
-///
-/// fn main() {
-///     let app = MyEguiApp::default();
-///     let native_options = eframe::NativeOptions::default();
-///     eframe::run_native(Box::new(app), native_options);
-/// }
-/// ```
-#[cfg(not(target_arch = "wasm32"))]
-#[cfg(not(feature = "egui_glium"))] // make sure we still compile with `--all-features`
-#[cfg(feature = "egui_glow")]
 pub fn run_native(app: Box<dyn epi::App>, native_options: epi::NativeOptions) -> ! {
     egui_glow::run(app, &native_options)
 }
-
-// disabled since we want to be able to compile with `--all-features`
-// #[cfg(all(feature = "egui_glium", feature = "egui_glow"))]
-// compile_error!("Enable either egui_glium or egui_glow, not both");
-
-#[cfg(not(any(feature = "egui_glium", feature = "egui_glow")))]
-compile_error!("Enable either egui_glium or egui_glow");

--- a/sh/check.sh
+++ b/sh/check.sh
@@ -25,7 +25,7 @@ cargo doc --document-private-items --no-deps --all-features
 (cd epaint && cargo check --no-default-features --features "single_threaded" --release)
 (cd epaint && cargo check --no-default-features --features "multi_threaded" --release)
 (cd egui && cargo check --no-default-features --features "multi_threaded,serialize")
-(cd eframe && cargo check --no-default-features --features "egui_glow")
+(cd eframe && cargo check --no-default-features)
 (cd epi && cargo check --no-default-features)
 (cd egui_demo_lib && cargo check --no-default-features)
 (cd egui_extras && cargo check --no-default-features)


### PR DESCRIPTION
eframe will now always use egui_glow as a native backend.

Part of https://github.com/emilk/egui/issues/1198
