### PR TITLE
eframe app creation refactor

### DIFF
--- a/eframe/examples/confirm_exit.rs
+++ b/eframe/examples/confirm_exit.rs
@@ -9,10 +9,6 @@ struct MyApp {
 }
 
 impl epi::App for MyApp {
-    fn name(&self) -> &str {
-        "Confirm exit"
-    }
-
     fn on_exit_event(&mut self) -> bool {
         self.is_exiting = true;
         self.can_exit
@@ -45,5 +41,7 @@ impl epi::App for MyApp {
 
 fn main() {
     let options = eframe::NativeOptions::default();
-    eframe::run_native(Box::new(MyApp::default()), options);
+    eframe::run_native("Confirm exit", options, |_, _, _, _| {
+        Box::new(MyApp::default())
+    });
 }

--- a/eframe/examples/confirm_exit.rs
+++ b/eframe/examples/confirm_exit.rs
@@ -41,7 +41,5 @@ impl epi::App for MyApp {
 
 fn main() {
     let options = eframe::NativeOptions::default();
-    eframe::run_native("Confirm exit", options, |_, _, _, _| {
-        Box::new(MyApp::default())
-    });
+    eframe::run_native("Confirm exit", options, |_cc| Box::new(MyApp::default()));
 }

--- a/eframe/examples/confirm_exit.rs
+++ b/eframe/examples/confirm_exit.rs
@@ -2,6 +2,11 @@
 
 use eframe::{egui, epi};
 
+fn main() {
+    let options = eframe::NativeOptions::default();
+    eframe::run_native("Confirm exit", options, |_cc| Box::new(MyApp::default()));
+}
+
 #[derive(Default)]
 struct MyApp {
     can_exit: bool,
@@ -37,9 +42,4 @@ impl epi::App for MyApp {
                 });
         }
     }
-}
-
-fn main() {
-    let options = eframe::NativeOptions::default();
-    eframe::run_native("Confirm exit", options, |_cc| Box::new(MyApp::default()));
 }

--- a/eframe/examples/confirm_exit.rs
+++ b/eframe/examples/confirm_exit.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use eframe::{egui, epi};
+use eframe::egui;
 
 fn main() {
     let options = eframe::NativeOptions::default();
@@ -13,13 +13,13 @@ struct MyApp {
     is_exiting: bool,
 }
 
-impl epi::App for MyApp {
+impl eframe::App for MyApp {
     fn on_exit_event(&mut self) -> bool {
         self.is_exiting = true;
         self.can_exit
     }
 
-    fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
+    fn update(&mut self, ctx: &egui::Context, frame: &eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("Try to close the window");
         });

--- a/eframe/examples/custom_3d.rs
+++ b/eframe/examples/custom_3d.rs
@@ -26,7 +26,7 @@ struct MyApp {
 }
 
 impl MyApp {
-    fn new(cc: epi::CreationContext<'_>) -> Self {
+    fn new(cc: &epi::CreationContext<'_>) -> Self {
         Self {
             rotating_triangle: Arc::new(Mutex::new(RotatingTriangle::new(&cc.gl))),
             angle: 0.0,

--- a/eframe/examples/custom_3d.rs
+++ b/eframe/examples/custom_3d.rs
@@ -8,7 +8,7 @@
 
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use eframe::{egui, epi};
+use eframe::egui;
 
 use parking_lot::Mutex;
 use std::sync::Arc;
@@ -27,7 +27,7 @@ struct MyApp {
 }
 
 impl MyApp {
-    fn new(cc: &epi::CreationContext<'_>) -> Self {
+    fn new(cc: &eframe::CreationContext<'_>) -> Self {
         Self {
             rotating_triangle: Arc::new(Mutex::new(RotatingTriangle::new(&cc.gl))),
             angle: 0.0,
@@ -35,8 +35,8 @@ impl MyApp {
     }
 }
 
-impl epi::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.horizontal(|ui| {
                 ui.spacing_mut().item_spacing.x = 0.0;

--- a/eframe/examples/custom_3d.rs
+++ b/eframe/examples/custom_3d.rs
@@ -21,6 +21,7 @@ fn main() {
 }
 
 struct MyApp {
+    /// Behind an `Arc<Mutex<…>>` so we can pass it to [`egui::PaintCallback`] and paint later.
     rotating_triangle: Arc<Mutex<RotatingTriangle>>,
     angle: f32,
 }
@@ -73,8 +74,7 @@ impl MyApp {
             rect,
             callback: std::sync::Arc::new(move |render_ctx| {
                 if let Some(painter) = render_ctx.downcast_ref::<egui_glow::Painter>() {
-                    let rotating_triangle = rotating_triangle.lock();
-                    rotating_triangle.paint(painter.gl(), angle);
+                    rotating_triangle.lock().paint(painter.gl(), angle);
                 } else {
                     eprintln!("Can't do custom painting because we are not using a glow context");
                 }

--- a/eframe/examples/custom_font.rs
+++ b/eframe/examples/custom_font.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use eframe::{egui, epi};
+use eframe::egui;
 
 fn main() {
     let options = eframe::NativeOptions::default();
@@ -43,7 +43,7 @@ struct MyApp {
 }
 
 impl MyApp {
-    fn new(cc: &epi::CreationContext<'_>) -> Self {
+    fn new(cc: &eframe::CreationContext<'_>) -> Self {
         setup_custom_fonts(&cc.egui_ctx);
         Self {
             text: "Edit this text field if you want".to_owned(),
@@ -51,8 +51,8 @@ impl MyApp {
     }
 }
 
-impl epi::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("egui using custom fonts");
             ui.text_edit_multiline(&mut self.text);

--- a/eframe/examples/custom_font.rs
+++ b/eframe/examples/custom_font.rs
@@ -34,7 +34,7 @@ struct MyApp {
 }
 
 impl MyApp {
-    fn new(cc: epi::CreationContext<'_>) -> Self {
+    fn new(cc: &epi::CreationContext<'_>) -> Self {
         setup_custom_fonts(&cc.egui_ctx);
         Self {
             text: "Edit this text field if you want".to_owned(),

--- a/eframe/examples/custom_font.rs
+++ b/eframe/examples/custom_font.rs
@@ -1,4 +1,13 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
+
 use eframe::{egui, epi};
+
+fn main() {
+    let options = eframe::NativeOptions::default();
+    eframe::run_native("egui example: custom font", options, |cc| {
+        Box::new(MyApp::new(cc))
+    });
+}
 
 fn setup_custom_fonts(ctx: &egui::Context) {
     // Start with the default fonts (we will be adding to them rather than replacing them).
@@ -49,11 +58,4 @@ impl epi::App for MyApp {
             ui.text_edit_multiline(&mut self.text);
         });
     }
-}
-
-fn main() {
-    let options = eframe::NativeOptions::default();
-    eframe::run_native("egui example: custom font", options, |cc| {
-        Box::new(MyApp::new(cc))
-    });
 }

--- a/eframe/examples/custom_font.rs
+++ b/eframe/examples/custom_font.rs
@@ -34,17 +34,11 @@ struct MyApp {
 }
 
 impl MyApp {
-    fn new(
-        ctx: &egui::Context,
-        _frame: &epi::Frame,
-        _storage: Option<&dyn epi::Storage>,
-        _gl: &std::rc::Rc<epi::glow::Context>,
-    ) -> Box<dyn epi::App> {
-        setup_custom_fonts(ctx);
-
-        Box::new(MyApp {
+    fn new(cc: epi::CreationContext<'_>) -> Self {
+        setup_custom_fonts(&cc.egui_ctx);
+        Self {
             text: "Edit this text field if you want".to_owned(),
-        })
+        }
     }
 }
 
@@ -59,5 +53,7 @@ impl epi::App for MyApp {
 
 fn main() {
     let options = eframe::NativeOptions::default();
-    eframe::run_native("egui example: custom font", options, MyApp::new);
+    eframe::run_native("egui example: custom font", options, |cc| {
+        Box::new(MyApp::new(cc))
+    });
 }

--- a/eframe/examples/custom_font.rs
+++ b/eframe/examples/custom_font.rs
@@ -1,57 +1,54 @@
 use eframe::{egui, epi};
 
+fn setup_custom_fonts(ctx: &egui::Context) {
+    // Start with the default fonts (we will be adding to them rather than replacing them).
+    let mut fonts = egui::FontDefinitions::default();
+
+    // Install my own font (maybe supporting non-latin characters).
+    // .ttf and .otf files supported.
+    fonts.font_data.insert(
+        "my_font".to_owned(),
+        egui::FontData::from_static(include_bytes!("../../epaint/fonts/Hack-Regular.ttf")),
+    );
+
+    // Put my font first (highest priority) for proportional text:
+    fonts
+        .families
+        .entry(egui::FontFamily::Proportional)
+        .or_default()
+        .insert(0, "my_font".to_owned());
+
+    // Put my font as last fallback for monospace:
+    fonts
+        .families
+        .entry(egui::FontFamily::Monospace)
+        .or_default()
+        .push("my_font".to_owned());
+
+    // Tell egui to use these fonts:
+    ctx.set_fonts(fonts);
+}
+
 struct MyApp {
     text: String,
 }
 
-impl Default for MyApp {
-    fn default() -> Self {
-        Self {
-            text: "Edit this text field if you want".to_owned(),
-        }
-    }
-}
-
-impl epi::App for MyApp {
-    fn name(&self) -> &str {
-        "egui example: custom font"
-    }
-
-    fn setup(
-        &mut self,
+impl MyApp {
+    fn new(
         ctx: &egui::Context,
         _frame: &epi::Frame,
         _storage: Option<&dyn epi::Storage>,
         _gl: &std::rc::Rc<epi::glow::Context>,
-    ) {
-        // Start with the default fonts (we will be adding to them rather than replacing them).
-        let mut fonts = egui::FontDefinitions::default();
+    ) -> Box<dyn epi::App> {
+        setup_custom_fonts(ctx);
 
-        // Install my own font (maybe supporting non-latin characters).
-        // .ttf and .otf files supported.
-        fonts.font_data.insert(
-            "my_font".to_owned(),
-            egui::FontData::from_static(include_bytes!("../../epaint/fonts/Hack-Regular.ttf")),
-        );
-
-        // Put my font first (highest priority) for proportional text:
-        fonts
-            .families
-            .entry(egui::FontFamily::Proportional)
-            .or_default()
-            .insert(0, "my_font".to_owned());
-
-        // Put my font as last fallback for monospace:
-        fonts
-            .families
-            .entry(egui::FontFamily::Monospace)
-            .or_default()
-            .push("my_font".to_owned());
-
-        // Tell egui to use these fonts:
-        ctx.set_fonts(fonts);
+        Box::new(MyApp {
+            text: "Edit this text field if you want".to_owned(),
+        })
     }
+}
 
+impl epi::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("egui using custom fonts");
@@ -62,5 +59,5 @@ impl epi::App for MyApp {
 
 fn main() {
     let options = eframe::NativeOptions::default();
-    eframe::run_native(Box::new(MyApp::default()), options);
+    eframe::run_native("egui example: custom font", options, MyApp::new);
 }

--- a/eframe/examples/download_image.rs
+++ b/eframe/examples/download_image.rs
@@ -9,7 +9,7 @@ fn main() {
     eframe::run_native(
         "Download and show an image with eframe/egui",
         options,
-        |_, _, _, _| Box::new(MyApp::default()),
+        |_cc| Box::new(MyApp::default()),
     );
 }
 

--- a/eframe/examples/download_image.rs
+++ b/eframe/examples/download_image.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use eframe::{egui, epi};
+use eframe::egui;
 use egui_extras::RetainedImage;
 use poll_promise::Promise;
 
@@ -19,8 +19,8 @@ struct MyApp {
     promise: Option<Promise<ehttp::Result<RetainedImage>>>,
 }
 
-impl epi::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &eframe::Frame) {
         let promise = self.promise.get_or_insert_with(|| {
             // Begin download.
             // We download the image using `ehttp`, a library that works both in WASM and on native.

--- a/eframe/examples/download_image.rs
+++ b/eframe/examples/download_image.rs
@@ -6,7 +6,11 @@ use poll_promise::Promise;
 
 fn main() {
     let options = eframe::NativeOptions::default();
-    eframe::run_native(Box::new(MyApp::default()), options);
+    eframe::run_native(
+        "Download and show an image with eframe/egui",
+        options,
+        |_, _, _, _| Box::new(MyApp::default()),
+    );
 }
 
 #[derive(Default)]
@@ -16,10 +20,6 @@ struct MyApp {
 }
 
 impl epi::App for MyApp {
-    fn name(&self) -> &str {
-        "Download and show an image with eframe/egui"
-    }
-
     fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
         let promise = self.promise.get_or_insert_with(|| {
             // Begin download.

--- a/eframe/examples/file_dialog.rs
+++ b/eframe/examples/file_dialog.rs
@@ -2,6 +2,18 @@
 
 use eframe::{egui, epi};
 
+fn main() {
+    let options = eframe::NativeOptions {
+        drag_and_drop_support: true,
+        ..Default::default()
+    };
+    eframe::run_native(
+        "Native file dialogs and drag-and-drop files",
+        options,
+        |_cc| Box::new(MyApp::default()),
+    );
+}
+
 #[derive(Default)]
 struct MyApp {
     dropped_files: Vec<egui::DroppedFile>,
@@ -88,16 +100,4 @@ impl MyApp {
             self.dropped_files = ctx.input().raw.dropped_files.clone();
         }
     }
-}
-
-fn main() {
-    let options = eframe::NativeOptions {
-        drag_and_drop_support: true,
-        ..Default::default()
-    };
-    eframe::run_native(
-        "Native file dialogs and drag-and-drop files",
-        options,
-        |_cc| Box::new(MyApp::default()),
-    );
 }

--- a/eframe/examples/file_dialog.rs
+++ b/eframe/examples/file_dialog.rs
@@ -98,6 +98,6 @@ fn main() {
     eframe::run_native(
         "Native file dialogs and drag-and-drop files",
         options,
-        |_, _, _, _| Box::new(MyApp::default()),
+        |_cc| Box::new(MyApp::default()),
     );
 }

--- a/eframe/examples/file_dialog.rs
+++ b/eframe/examples/file_dialog.rs
@@ -9,10 +9,6 @@ struct MyApp {
 }
 
 impl epi::App for MyApp {
-    fn name(&self) -> &str {
-        "Native file dialogs and drag-and-drop files"
-    }
-
     fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.label("Drag-and-drop files onto the window!");
@@ -99,5 +95,9 @@ fn main() {
         drag_and_drop_support: true,
         ..Default::default()
     };
-    eframe::run_native(Box::new(MyApp::default()), options);
+    eframe::run_native(
+        "Native file dialogs and drag-and-drop files",
+        options,
+        |_, _, _, _| Box::new(MyApp::default()),
+    );
 }

--- a/eframe/examples/file_dialog.rs
+++ b/eframe/examples/file_dialog.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use eframe::{egui, epi};
+use eframe::egui;
 
 fn main() {
     let options = eframe::NativeOptions {
@@ -20,8 +20,8 @@ struct MyApp {
     picked_path: Option<String>,
 }
 
-impl epi::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.label("Drag-and-drop files onto the window!");
 

--- a/eframe/examples/hello_world.rs
+++ b/eframe/examples/hello_world.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use eframe::{egui, epi};
+use eframe::egui;
 
 fn main() {
     let options = eframe::NativeOptions::default();
@@ -21,8 +21,8 @@ impl Default for MyApp {
     }
 }
 
-impl epi::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, frame: &eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("My egui Application");
             ui.horizontal(|ui| {

--- a/eframe/examples/hello_world.rs
+++ b/eframe/examples/hello_world.rs
@@ -38,7 +38,5 @@ impl epi::App for MyApp {
 
 fn main() {
     let options = eframe::NativeOptions::default();
-    eframe::run_native("My egui App", options, |_, _, _, _| {
-        Box::new(MyApp::default())
-    });
+    eframe::run_native("My egui App", options, |_cc| Box::new(MyApp::default()));
 }

--- a/eframe/examples/hello_world.rs
+++ b/eframe/examples/hello_world.rs
@@ -17,10 +17,6 @@ impl Default for MyApp {
 }
 
 impl epi::App for MyApp {
-    fn name(&self) -> &str {
-        "My egui App"
-    }
-
     fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("My egui Application");
@@ -42,5 +38,7 @@ impl epi::App for MyApp {
 
 fn main() {
     let options = eframe::NativeOptions::default();
-    eframe::run_native(Box::new(MyApp::default()), options);
+    eframe::run_native("My egui App", options, |_, _, _, _| {
+        Box::new(MyApp::default())
+    });
 }

--- a/eframe/examples/hello_world.rs
+++ b/eframe/examples/hello_world.rs
@@ -2,6 +2,11 @@
 
 use eframe::{egui, epi};
 
+fn main() {
+    let options = eframe::NativeOptions::default();
+    eframe::run_native("My egui App", options, |_cc| Box::new(MyApp::default()));
+}
+
 struct MyApp {
     name: String,
     age: u32,
@@ -34,9 +39,4 @@ impl epi::App for MyApp {
         // Resize the native window to be just the size we need it to be:
         frame.set_window_size(ctx.used_size());
     }
-}
-
-fn main() {
-    let options = eframe::NativeOptions::default();
-    eframe::run_native("My egui App", options, |_cc| Box::new(MyApp::default()));
 }

--- a/eframe/examples/image.rs
+++ b/eframe/examples/image.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use eframe::{egui, epi};
+use eframe::egui;
 use egui_extras::RetainedImage;
 
 fn main() {
@@ -26,8 +26,8 @@ impl Default for MyApp {
     }
 }
 
-impl epi::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("This is an image:");
             self.image.show(ui);

--- a/eframe/examples/image.rs
+++ b/eframe/examples/image.rs
@@ -20,10 +20,6 @@ impl Default for MyApp {
 }
 
 impl epi::App for MyApp {
-    fn name(&self) -> &str {
-        "Show an image with eframe/egui"
-    }
-
     fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("This is an image:");
@@ -40,5 +36,7 @@ impl epi::App for MyApp {
 
 fn main() {
     let options = eframe::NativeOptions::default();
-    eframe::run_native(Box::new(MyApp::default()), options);
+    eframe::run_native("Show an image with eframe/egui", options, |_, _, _, _| {
+        Box::new(MyApp::default())
+    });
 }

--- a/eframe/examples/image.rs
+++ b/eframe/examples/image.rs
@@ -36,7 +36,7 @@ impl epi::App for MyApp {
 
 fn main() {
     let options = eframe::NativeOptions::default();
-    eframe::run_native("Show an image with eframe/egui", options, |_, _, _, _| {
+    eframe::run_native("Show an image with eframe/egui", options, |_cc| {
         Box::new(MyApp::default())
     });
 }

--- a/eframe/examples/image.rs
+++ b/eframe/examples/image.rs
@@ -3,6 +3,13 @@
 use eframe::{egui, epi};
 use egui_extras::RetainedImage;
 
+fn main() {
+    let options = eframe::NativeOptions::default();
+    eframe::run_native("Show an image with eframe/egui", options, |_cc| {
+        Box::new(MyApp::default())
+    });
+}
+
 struct MyApp {
     image: RetainedImage,
 }
@@ -32,11 +39,4 @@ impl epi::App for MyApp {
             ));
         });
     }
-}
-
-fn main() {
-    let options = eframe::NativeOptions::default();
-    eframe::run_native("Show an image with eframe/egui", options, |_cc| {
-        Box::new(MyApp::default())
-    });
 }

--- a/eframe/examples/svg.rs
+++ b/eframe/examples/svg.rs
@@ -4,7 +4,7 @@
 
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use eframe::{egui, epi};
+use eframe::egui;
 
 fn main() {
     let options = eframe::NativeOptions {
@@ -30,8 +30,8 @@ impl Default for MyApp {
     }
 }
 
-impl epi::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("SVG example");
             ui.label("The SVG is rasterized and displayed as a texture.");

--- a/eframe/examples/svg.rs
+++ b/eframe/examples/svg.rs
@@ -6,6 +6,14 @@
 
 use eframe::{egui, epi};
 
+fn main() {
+    let options = eframe::NativeOptions {
+        initial_window_size: Some(egui::vec2(1000.0, 700.0)),
+        ..Default::default()
+    };
+    eframe::run_native("svg example", options, |_cc| Box::new(MyApp::default()));
+}
+
 struct MyApp {
     svg_image: egui_extras::RetainedImage,
 }
@@ -34,12 +42,4 @@ impl epi::App for MyApp {
             self.svg_image.show_max_size(ui, max_size);
         });
     }
-}
-
-fn main() {
-    let options = eframe::NativeOptions {
-        initial_window_size: Some(egui::vec2(1000.0, 700.0)),
-        ..Default::default()
-    };
-    eframe::run_native("svg example", options, |_cc| Box::new(MyApp::default()));
 }

--- a/eframe/examples/svg.rs
+++ b/eframe/examples/svg.rs
@@ -23,10 +23,6 @@ impl Default for MyApp {
 }
 
 impl epi::App for MyApp {
-    fn name(&self) -> &str {
-        "svg example"
-    }
-
     fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("SVG example");
@@ -45,5 +41,7 @@ fn main() {
         initial_window_size: Some(egui::vec2(1000.0, 700.0)),
         ..Default::default()
     };
-    eframe::run_native(Box::new(MyApp::default()), options);
+    eframe::run_native("svg example", options, |_, _, _, _| {
+        Box::new(MyApp::default())
+    });
 }

--- a/eframe/examples/svg.rs
+++ b/eframe/examples/svg.rs
@@ -41,7 +41,5 @@ fn main() {
         initial_window_size: Some(egui::vec2(1000.0, 700.0)),
         ..Default::default()
     };
-    eframe::run_native("svg example", options, |_, _, _, _| {
-        Box::new(MyApp::default())
-    });
+    eframe::run_native("svg example", options, |_cc| Box::new(MyApp::default()));
 }

--- a/eframe/src/lib.rs
+++ b/eframe/src/lib.rs
@@ -18,6 +18,11 @@
 //! ``` no_run
 //! use eframe::{epi, egui};
 //!
+//! fn main() {
+//!     let native_options = eframe::NativeOptions::default();
+//!     eframe::run_native("My egui App", native_options, |cc| Box::new(MyEguiApp::new(cc)));
+//! }
+//!
 //! #[derive(Default)]
 //! struct MyEguiApp {}
 //!
@@ -38,12 +43,6 @@
 //!        });
 //!    }
 //! }
-//!
-//! fn main() {
-//!     let app = MyEguiApp::default();
-//!     let native_options = eframe::NativeOptions::default();
-//!     eframe::run_native("My egui App", native_options, |cc| Box::new(MyEguiApp::new(cc)));
-//! }
 //! ```
 //!
 //! ## Usage, web:
@@ -55,7 +54,6 @@
 //! #[cfg(target_arch = "wasm32")]
 //! #[wasm_bindgen]
 //! pub fn start(canvas_id: &str) -> Result<(), eframe::wasm_bindgen::JsValue> {
-//!     let app = MyEguiApp::default();
 //!     eframe::start_web(canvas_id, |cc| Box::new(MyApp::new(cc)))
 //! }
 //! ```
@@ -124,6 +122,11 @@ pub fn start_web(
 /// ``` no_run
 /// use eframe::{epi, egui};
 ///
+/// fn main() {
+///     let native_options = eframe::NativeOptions::default();
+///     eframe::run_native("MyApp", native_options, |cc| Box::new(MyEguiApp::new(cc)));
+/// }
+///
 /// #[derive(Default)]
 /// struct MyEguiApp {}
 ///
@@ -143,12 +146,6 @@ pub fn start_web(
 ///            ui.heading("Hello World!");
 ///        });
 ///    }
-/// }
-///
-/// fn main() {
-///     let app = MyEguiApp::default();
-///     let native_options = eframe::NativeOptions::default();
-///     eframe::run_native("MyApp", native_options, |cc| Box::new(MyEguiApp::new(cc)));
 /// }
 /// ```
 #[cfg(not(target_arch = "wasm32"))]

--- a/eframe/src/lib.rs
+++ b/eframe/src/lib.rs
@@ -22,7 +22,7 @@
 //! struct MyEguiApp {}
 //!
 //! impl MyEguiApp {
-//!     fn new(cc: epi::CreationContext<'_>) -> Self {
+//!     fn new(cc: &epi::CreationContext<'_>) -> Self {
 //!         // Customize egui here with cc.egui_ctx.set_fonts and cc.egui_ctx.set_visuals.
 //!         // Restore app state using cc.storage (requires the "persistence" feature).
 //!         // Use the cc.gl (a glow::Context) to create graphics shaders and buffers that you can use
@@ -128,7 +128,7 @@ pub fn start_web(
 /// struct MyEguiApp {}
 ///
 /// impl MyEguiApp {
-///     fn new(cc: epi::CreationContext<'_>) -> Self {
+///     fn new(cc: &epi::CreationContext<'_>) -> Self {
 ///         // Customize egui here with cc.egui_ctx.set_fonts and cc.egui_ctx.set_visuals.
 ///         // Restore app state using cc.storage (requires the "persistence" feature).
 ///         // Use the cc.gl (a glow::Context) to create graphics shaders and buffers that you can use

--- a/eframe/src/lib.rs
+++ b/eframe/src/lib.rs
@@ -21,22 +21,28 @@
 //! #[derive(Default)]
 //! struct MyEguiApp {}
 //!
-//! impl epi::App for MyEguiApp {
-//!    fn name(&self) -> &str {
-//!        "My egui App"
-//!    }
+//! impl MyEguiApp {
+//!     fn new(cc: epi::CreationContext<'_>) -> Self {
+//!         // Customize egui here with cc.egui_ctx.set_fonts and cc.egui_ctx.set_visuals.
+//!         // Restore app state using cc.storage (requires the "persistence" feature).
+//!         // Use the cc.gl (a glow::Context) to create graphics shaders and buffers that you can use
+//!         // for e.g. egui::PaintCallback.
+//!         Self::default()
+//!     }
+//! }
 //!
+//! impl epi::App for MyEguiApp {
 //!    fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
 //!        egui::CentralPanel::default().show(ctx, |ui| {
 //!            ui.heading("Hello World!");
 //!        });
 //!    }
-//!}
+//! }
 //!
 //! fn main() {
 //!     let app = MyEguiApp::default();
 //!     let native_options = eframe::NativeOptions::default();
-//!     eframe::run_native(Box::new(app), native_options);
+//!     eframe::run_native("My egui App", native_options, |cc| Box::new(MyEguiApp::new(cc)));
 //! }
 //! ```
 //!
@@ -50,7 +56,7 @@
 //! #[wasm_bindgen]
 //! pub fn start(canvas_id: &str) -> Result<(), eframe::wasm_bindgen::JsValue> {
 //!     let app = MyEguiApp::default();
-//!     eframe::start_web(canvas_id, Box::new(app))
+//!     eframe::start_web(canvas_id, |cc| Box::new(MyApp::new(cc)))
 //! }
 //! ```
 
@@ -83,16 +89,6 @@ pub use egui_web::wasm_bindgen;
 /// fill the whole width of the browser.
 /// This can be changed by overriding [`epi::Frame::max_size_points`].
 ///
-/// ### Usage, native:
-/// ``` no_run
-/// fn main() {
-///     let app = MyEguiApp::default();
-///     let native_options = eframe::NativeOptions::default();
-///     eframe::run_native(Box::new(app), native_options);
-/// }
-/// ```
-///
-/// ### Web
 /// ``` no_run
 /// #[cfg(target_arch = "wasm32")]
 /// use wasm_bindgen::prelude::*;
@@ -104,8 +100,7 @@ pub use egui_web::wasm_bindgen;
 /// #[cfg(target_arch = "wasm32")]
 /// #[wasm_bindgen]
 /// pub fn start(canvas_id: &str) -> Result<(), eframe::wasm_bindgen::JsValue> {
-///     let app = MyEguiApp::default();
-///     eframe::start_web(canvas_id, Box::new(app))
+///     eframe::start_web(canvas_id, |cc| Box::new(MyEguiApp::new(cc)))
 /// }
 /// ```
 #[cfg(target_arch = "wasm32")]
@@ -133,17 +128,12 @@ pub fn start_web(
 /// struct MyEguiApp {}
 ///
 /// impl MyEguiApp {
-///     fn new(
-///         _ctx: &egui::Context,
-///         _frame: &epi::Frame,
-///         _storage: Option<&dyn epi::Storage>,
-///         _gl: &std::rc::Rc<glow::Context>
-///     ) -> Box<dyn epi::App> {
-///         // Customize egui here with ctx.set_fonts and ctx.set_visuals.
-///         // Restore app state using the storage (requires the "persistence" feature).
-///         // Use the glow::Context to create graphics shaders and buffers that you can use
-///         // for e.g. egui::PaintCallback
-///         Box::new(MyEguiApp::default())
+///     fn new(cc: epi::CreationContext<'_>) -> Self {
+///         // Customize egui here with cc.egui_ctx.set_fonts and cc.egui_ctx.set_visuals.
+///         // Restore app state using cc.storage (requires the "persistence" feature).
+///         // Use the cc.gl (a glow::Context) to create graphics shaders and buffers that you can use
+///         // for e.g. egui::PaintCallback.
+///         Self::default()
 ///     }
 /// }
 ///
@@ -153,12 +143,12 @@ pub fn start_web(
 ///            ui.heading("Hello World!");
 ///        });
 ///    }
-///}
+/// }
 ///
 /// fn main() {
 ///     let app = MyEguiApp::default();
 ///     let native_options = eframe::NativeOptions::default();
-///     eframe::run_native("MyApp", native_options, MyEguiApp::new);
+///     eframe::run_native("MyApp", native_options, |cc| Box::new(MyEguiApp::new(cc)));
 /// }
 /// ```
 #[cfg(not(target_arch = "wasm32"))]

--- a/eframe/src/lib.rs
+++ b/eframe/src/lib.rs
@@ -109,8 +109,11 @@ pub use egui_web::wasm_bindgen;
 /// }
 /// ```
 #[cfg(target_arch = "wasm32")]
-pub fn start_web(canvas_id: &str, app: Box<dyn epi::App>) -> Result<(), wasm_bindgen::JsValue> {
-    egui_web::start(canvas_id, app)?;
+pub fn start_web(
+    canvas_id: &str,
+    app_creator: epi::AppCreator,
+) -> Result<(), wasm_bindgen::JsValue> {
+    egui_web::start(canvas_id, app_creator)?;
     Ok(())
 }
 

--- a/eframe/src/lib.rs
+++ b/eframe/src/lib.rs
@@ -117,6 +117,11 @@ pub fn start_web(canvas_id: &str, app: Box<dyn epi::App>) -> Result<(), wasm_bin
 // ----------------------------------------------------------------------------
 // When compiling natively
 
+/// This is how you start a native (desktop) app.
+///
+/// The first argument is name of your app, used for the title bar of the native window
+/// and the save location of persistence (see [`epi::App::save`]).
+///
 /// Call from `fn main` like this:
 /// ``` no_run
 /// use eframe::{epi, egui};
@@ -124,11 +129,22 @@ pub fn start_web(canvas_id: &str, app: Box<dyn epi::App>) -> Result<(), wasm_bin
 /// #[derive(Default)]
 /// struct MyEguiApp {}
 ///
-/// impl epi::App for MyEguiApp {
-///    fn name(&self) -> &str {
-///        "My egui App"
-///    }
+/// impl MyEguiApp {
+///     fn new(
+///         _ctx: &egui::Context,
+///         _frame: &epi::Frame,
+///         _storage: Option<&dyn epi::Storage>,
+///         _gl: &std::rc::Rc<glow::Context>
+///     ) -> Box<dyn epi::App> {
+///         // Customize egui here with ctx.set_fonts and ctx.set_visuals.
+///         // Restore app state using the storage (requires the "persistence" feature).
+///         // Use the glow::Context to create graphics shaders and buffers that you can use
+///         // for e.g. egui::PaintCallback
+///         Box::new(MyEguiApp::default())
+///     }
+/// }
 ///
+/// impl epi::App for MyEguiApp {
 ///    fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
 ///        egui::CentralPanel::default().show(ctx, |ui| {
 ///            ui.heading("Hello World!");
@@ -139,10 +155,14 @@ pub fn start_web(canvas_id: &str, app: Box<dyn epi::App>) -> Result<(), wasm_bin
 /// fn main() {
 ///     let app = MyEguiApp::default();
 ///     let native_options = eframe::NativeOptions::default();
-///     eframe::run_native(Box::new(app), native_options);
+///     eframe::run_native("MyApp", native_options, MyEguiApp::new);
 /// }
 /// ```
 #[cfg(not(target_arch = "wasm32"))]
-pub fn run_native(app: Box<dyn epi::App>, native_options: epi::NativeOptions) -> ! {
-    egui_glow::run(app, &native_options)
+pub fn run_native(
+    app_name: &str,
+    native_options: epi::NativeOptions,
+    app_creator: epi::AppCreator,
+) -> ! {
+    egui_glow::run(app_name, &native_options, app_creator)
 }

--- a/eframe/src/lib.rs
+++ b/eframe/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ## Usage, native:
 //! ``` no_run
-//! use eframe::{epi, egui};
+//! use eframe::egui;
 //!
 //! fn main() {
 //!     let native_options = eframe::NativeOptions::default();
@@ -27,7 +27,7 @@
 //! struct MyEguiApp {}
 //!
 //! impl MyEguiApp {
-//!     fn new(cc: &epi::CreationContext<'_>) -> Self {
+//!     fn new(cc: &eframe::CreationContext<'_>) -> Self {
 //!         // Customize egui here with cc.egui_ctx.set_fonts and cc.egui_ctx.set_visuals.
 //!         // Restore app state using cc.storage (requires the "persistence" feature).
 //!         // Use the cc.gl (a glow::Context) to create graphics shaders and buffers that you can use
@@ -36,8 +36,8 @@
 //!     }
 //! }
 //!
-//! impl epi::App for MyEguiApp {
-//!    fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
+//! impl eframe::App for MyEguiApp {
+//!    fn update(&mut self, ctx: &egui::Context, frame: &eframe::Frame) {
 //!        egui::CentralPanel::default().show(ctx, |ui| {
 //!            ui.heading("Hello World!");
 //!        });
@@ -69,10 +69,11 @@
 )]
 #![allow(clippy::needless_doctest_main)]
 
+// Re-export all useful libraries:
 pub use {egui, egui::emath, egui::epaint, epi};
 
-#[cfg(not(target_arch = "wasm32"))]
-pub use epi::NativeOptions;
+// Re-export everything in `epi` so `eframe` users don't have to care about what `epi` is:
+pub use epi::*;
 
 // ----------------------------------------------------------------------------
 // When compiling for web
@@ -102,10 +103,7 @@ pub use egui_web::wasm_bindgen;
 /// }
 /// ```
 #[cfg(target_arch = "wasm32")]
-pub fn start_web(
-    canvas_id: &str,
-    app_creator: epi::AppCreator,
-) -> Result<(), wasm_bindgen::JsValue> {
+pub fn start_web(canvas_id: &str, app_creator: AppCreator) -> Result<(), wasm_bindgen::JsValue> {
     egui_web::start(canvas_id, app_creator)?;
     Ok(())
 }
@@ -120,7 +118,7 @@ pub fn start_web(
 ///
 /// Call from `fn main` like this:
 /// ``` no_run
-/// use eframe::{epi, egui};
+/// use eframe::egui;
 ///
 /// fn main() {
 ///     let native_options = eframe::NativeOptions::default();
@@ -131,7 +129,7 @@ pub fn start_web(
 /// struct MyEguiApp {}
 ///
 /// impl MyEguiApp {
-///     fn new(cc: &epi::CreationContext<'_>) -> Self {
+///     fn new(cc: &eframe::CreationContext<'_>) -> Self {
 ///         // Customize egui here with cc.egui_ctx.set_fonts and cc.egui_ctx.set_visuals.
 ///         // Restore app state using cc.storage (requires the "persistence" feature).
 ///         // Use the cc.gl (a glow::Context) to create graphics shaders and buffers that you can use
@@ -140,8 +138,8 @@ pub fn start_web(
 ///     }
 /// }
 ///
-/// impl epi::App for MyEguiApp {
-///    fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
+/// impl eframe::App for MyEguiApp {
+///    fn update(&mut self, ctx: &egui::Context, frame: &eframe::Frame) {
 ///        egui::CentralPanel::default().show(ctx, |ui| {
 ///            ui.heading("Hello World!");
 ///        });
@@ -149,10 +147,6 @@ pub fn start_web(
 /// }
 /// ```
 #[cfg(not(target_arch = "wasm32"))]
-pub fn run_native(
-    app_name: &str,
-    native_options: epi::NativeOptions,
-    app_creator: epi::AppCreator,
-) -> ! {
+pub fn run_native(app_name: &str, native_options: NativeOptions, app_creator: AppCreator) -> ! {
     egui_glow::run(app_name, &native_options, app_creator)
 }

--- a/egui-winit/src/epi.rs
+++ b/egui-winit/src/epi.rs
@@ -222,7 +222,7 @@ pub struct EpiIntegration {
     pending_full_output: egui::FullOutput,
     egui_winit: crate::State,
     /// When set, it is time to quit
-    pub quit: bool,
+    quit: bool,
     can_drag_window: bool,
 }
 

--- a/egui-winit/src/epi.rs
+++ b/egui-winit/src/epi.rs
@@ -231,7 +231,6 @@ impl EpiIntegration {
         integration_name: &'static str,
         max_texture_side: usize,
         window: &winit::window::Window,
-        gl: &std::rc::Rc<glow::Context>,
         persistence: crate::epi::Persistence,
     ) -> Self {
         let egui_ctx = egui::Context::default();

--- a/egui/src/lib.rs
+++ b/egui/src/lib.rs
@@ -386,8 +386,8 @@ pub use epaint::{
     color, mutex,
     text::{FontData, FontDefinitions, FontFamily, FontId, FontTweak},
     textures::TexturesDelta,
-    AlphaImage, ClippedPrimitive, Color32, ColorImage, ImageData, Mesh, Rgba, Rounding, Shape,
-    Stroke, TextureHandle, TextureId,
+    AlphaImage, ClippedPrimitive, Color32, ColorImage, ImageData, Mesh, PaintCallback, Rgba,
+    Rounding, Shape, Stroke, TextureHandle, TextureId,
 };
 
 pub mod text {

--- a/egui_demo_app/src/lib.rs
+++ b/egui_demo_app/src/lib.rs
@@ -19,6 +19,5 @@ pub fn start(canvas_id: &str) -> Result<(), wasm_bindgen::JsValue> {
     // Redirect tracing to console.log and friends:
     tracing_wasm::set_as_global_default();
 
-    let app = egui_demo_lib::WrapApp::default();
-    eframe::start_web(canvas_id, Box::new(app))
+    eframe::start_web(canvas_id, egui_demo_lib::WrapApp::new)
 }

--- a/egui_demo_app/src/lib.rs
+++ b/egui_demo_app/src/lib.rs
@@ -19,5 +19,5 @@ pub fn start(canvas_id: &str) -> Result<(), wasm_bindgen::JsValue> {
     // Redirect tracing to console.log and friends:
     tracing_wasm::set_as_global_default();
 
-    eframe::start_web(canvas_id, egui_demo_lib::WrapApp::new)
+    eframe::start_web(canvas_id, |cc| Box::new(egui_demo_lib::WrapApp::new(cc)))
 }

--- a/egui_demo_app/src/main.rs
+++ b/egui_demo_app/src/main.rs
@@ -10,12 +10,11 @@ fn main() {
     // Log to stdout (if you run with `RUST_LOG=debug`).
     tracing_subscriber::fmt::init();
 
-    let app = egui_demo_lib::WrapApp::default();
     let options = eframe::NativeOptions {
         // Let's show off that we support transparent windows
         transparent: true,
         drag_and_drop_support: true,
         ..Default::default()
     };
-    eframe::run_native(Box::new(app), options);
+    eframe::run_native("egui demo app", options, egui_demo_lib::WrapApp::new);
 }

--- a/egui_demo_app/src/main.rs
+++ b/egui_demo_app/src/main.rs
@@ -16,5 +16,7 @@ fn main() {
         drag_and_drop_support: true,
         ..Default::default()
     };
-    eframe::run_native("egui demo app", options, egui_demo_lib::WrapApp::new);
+    eframe::run_native("egui demo app", options, |cc| {
+        Box::new(egui_demo_lib::WrapApp::new(cc))
+    });
 }

--- a/egui_demo_lib/src/apps/color_test.rs
+++ b/egui_demo_lib/src/apps/color_test.rs
@@ -30,10 +30,6 @@ impl Default for ColorTest {
 }
 
 impl epi::App for ColorTest {
-    fn name(&self) -> &str {
-        "🎨 Color test"
-    }
-
     fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             if frame.is_web() {

--- a/egui_demo_lib/src/apps/demo/app.rs
+++ b/egui_demo_lib/src/apps/demo/app.rs
@@ -1,4 +1,3 @@
-/// Demonstrates how to make an eframe app using egui.
 #[derive(Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]

--- a/egui_demo_lib/src/apps/demo/app.rs
+++ b/egui_demo_lib/src/apps/demo/app.rs
@@ -1,7 +1,4 @@
-/// Demonstrates how to make an app using egui.
-///
-/// Implements `epi::App` so it can be used with
-/// [`egui_glium`](https://github.com/emilk/egui/tree/master/egui_glium), [`egui_glow`](https://github.com/emilk/egui/tree/master/egui_glow) and [`egui_web`](https://github.com/emilk/egui/tree/master/egui_web).
+/// Demonstrates how to make an eframe app using egui.
 #[derive(Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
@@ -10,28 +7,6 @@ pub struct DemoApp {
 }
 
 impl epi::App for DemoApp {
-    fn name(&self) -> &str {
-        "✨ Demos"
-    }
-
-    fn setup(
-        &mut self,
-        _ctx: &egui::Context,
-        _frame: &epi::Frame,
-        _storage: Option<&dyn epi::Storage>,
-        _gl: &std::rc::Rc<epi::glow::Context>,
-    ) {
-        #[cfg(feature = "persistence")]
-        if let Some(storage) = _storage {
-            *self = epi::get_value(storage, epi::APP_KEY).unwrap_or_default();
-        }
-    }
-
-    #[cfg(feature = "persistence")]
-    fn save(&mut self, storage: &mut dyn epi::Storage) {
-        epi::set_value(storage, epi::APP_KEY, self);
-    }
-
     fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
         self.demo_windows.ui(ctx);
     }

--- a/egui_demo_lib/src/apps/fractal_clock.rs
+++ b/egui_demo_lib/src/apps/fractal_clock.rs
@@ -33,10 +33,6 @@ impl Default for FractalClock {
 }
 
 impl epi::App for FractalClock {
-    fn name(&self) -> &str {
-        "🕑 Fractal Clock"
-    }
-
     fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
         egui::CentralPanel::default()
             .frame(Frame::dark_canvas(&ctx.style()))

--- a/egui_demo_lib/src/apps/http_app.rs
+++ b/egui_demo_lib/src/apps/http_app.rs
@@ -54,10 +54,6 @@ impl Default for HttpApp {
 }
 
 impl epi::App for HttpApp {
-    fn name(&self) -> &str {
-        "⬇ HTTP"
-    }
-
     fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
         egui::TopBottomPanel::bottom("http_bottom").show(ctx, |ui| {
             let layout = egui::Layout::top_down(egui::Align::Center).with_main_justify(true);

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -30,10 +30,6 @@ impl Default for EasyMarkEditor {
 }
 
 impl epi::App for EasyMarkEditor {
-    fn name(&self) -> &str {
-        "🖹 EasyMark editor"
-    }
-
     fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
         egui::TopBottomPanel::bottom("easy_mark_bottom").show(ctx, |ui| {
             let layout = egui::Layout::top_down(egui::Align::Center).with_main_justify(true);

--- a/egui_demo_lib/src/wrap_app.rs
+++ b/egui_demo_lib/src/wrap_app.rs
@@ -50,9 +50,9 @@ pub struct WrapApp {
 }
 
 impl WrapApp {
-    pub fn new(cc: &epi::CreationContext<'_>) -> Self {
+    pub fn new(_cc: &epi::CreationContext<'_>) -> Self {
         #[cfg(feature = "persistence")]
-        if let Some(storage) = cc.storage {
+        if let Some(storage) = _cc.storage {
             return epi::get_value(storage, epi::APP_KEY).unwrap_or_default();
         }
         Self::default()

--- a/egui_demo_lib/src/wrap_app.rs
+++ b/egui_demo_lib/src/wrap_app.rs
@@ -12,14 +12,26 @@ pub struct Apps {
 }
 
 impl Apps {
-    fn iter_mut(&mut self) -> impl Iterator<Item = (&str, &mut dyn epi::App)> {
+    fn iter_mut(&mut self) -> impl Iterator<Item = (&str, &str, &mut dyn epi::App)> {
         vec![
-            ("demo", &mut self.demo as &mut dyn epi::App),
-            ("easymark", &mut self.easy_mark_editor as &mut dyn epi::App),
+            ("✨ Demos", "demo", &mut self.demo as &mut dyn epi::App),
+            (
+                "🖹 EasyMark editor",
+                "easymark",
+                &mut self.easy_mark_editor as &mut dyn epi::App,
+            ),
             #[cfg(feature = "http")]
-            ("http", &mut self.http as &mut dyn epi::App),
-            ("clock", &mut self.clock as &mut dyn epi::App),
-            ("colors", &mut self.color_test as &mut dyn epi::App),
+            ("⬇ HTTP", "http", &mut self.http as &mut dyn epi::App),
+            (
+                "🕑 Fractal Clock",
+                "clock",
+                &mut self.clock as &mut dyn epi::App,
+            ),
+            (
+                "🎨 Color test",
+                "colors",
+                &mut self.color_test as &mut dyn epi::App,
+            ),
         ]
         .into_iter()
     }
@@ -37,24 +49,24 @@ pub struct WrapApp {
     dropped_files: Vec<egui::DroppedFile>,
 }
 
-impl epi::App for WrapApp {
-    fn name(&self) -> &str {
-        "egui demo apps"
-    }
-
-    fn setup(
-        &mut self,
+impl WrapApp {
+    pub fn new(
         _ctx: &egui::Context,
         _frame: &epi::Frame,
         _storage: Option<&dyn epi::Storage>,
         _gl: &std::rc::Rc<epi::glow::Context>,
-    ) {
+    ) -> Box<dyn epi::App> {
         #[cfg(feature = "persistence")]
         if let Some(storage) = _storage {
-            *self = epi::get_value(storage, epi::APP_KEY).unwrap_or_default();
+            let app: Self = epi::get_value(storage, epi::APP_KEY).unwrap_or_default();
+            return Box::new(app);
         }
-    }
 
+        Box::new(WrapApp::default())
+    }
+}
+
+impl epi::App for WrapApp {
     #[cfg(feature = "persistence")]
     fn save(&mut self, storage: &mut dyn epi::Storage) {
         epi::set_value(storage, epi::APP_KEY, self);
@@ -111,7 +123,7 @@ impl epi::App for WrapApp {
 
         let mut found_anchor = false;
 
-        for (anchor, app) in self.apps.iter_mut() {
+        for (_name, anchor, app) in self.apps.iter_mut() {
             if anchor == self.selected_anchor || ctx.memory().everything_is_visible() {
                 app.update(ctx, frame);
                 found_anchor = true;
@@ -138,9 +150,9 @@ impl WrapApp {
             ui.checkbox(&mut self.backend_panel.open, "💻 Backend");
             ui.separator();
 
-            for (anchor, app) in self.apps.iter_mut() {
+            for (name, anchor, _app) in self.apps.iter_mut() {
                 if ui
-                    .selectable_label(self.selected_anchor == anchor, app.name())
+                    .selectable_label(self.selected_anchor == anchor, name)
                     .clicked()
                 {
                     self.selected_anchor = anchor.to_owned();

--- a/egui_demo_lib/src/wrap_app.rs
+++ b/egui_demo_lib/src/wrap_app.rs
@@ -50,7 +50,7 @@ pub struct WrapApp {
 }
 
 impl WrapApp {
-    pub fn new(cc: epi::CreationContext<'_>) -> Self {
+    pub fn new(cc: &epi::CreationContext<'_>) -> Self {
         #[cfg(feature = "persistence")]
         if let Some(storage) = cc.storage {
             return epi::get_value(storage, epi::APP_KEY).unwrap_or_default();

--- a/egui_demo_lib/src/wrap_app.rs
+++ b/egui_demo_lib/src/wrap_app.rs
@@ -50,19 +50,12 @@ pub struct WrapApp {
 }
 
 impl WrapApp {
-    pub fn new(
-        _ctx: &egui::Context,
-        _frame: &epi::Frame,
-        _storage: Option<&dyn epi::Storage>,
-        _gl: &std::rc::Rc<epi::glow::Context>,
-    ) -> Box<dyn epi::App> {
+    pub fn new(cc: epi::CreationContext<'_>) -> Self {
         #[cfg(feature = "persistence")]
-        if let Some(storage) = _storage {
-            let app: Self = epi::get_value(storage, epi::APP_KEY).unwrap_or_default();
-            return Box::new(app);
+        if let Some(storage) = cc.storage {
+            return epi::get_value(storage, epi::APP_KEY).unwrap_or_default();
         }
-
-        Box::new(WrapApp::default())
+        Self::default()
     }
 }
 

--- a/egui_glium/examples/native_texture.rs
+++ b/egui_glium/examples/native_texture.rs
@@ -4,41 +4,6 @@
 
 use glium::glutin;
 
-fn create_display(event_loop: &glutin::event_loop::EventLoop<()>) -> glium::Display {
-    let window_builder = glutin::window::WindowBuilder::new()
-        .with_resizable(true)
-        .with_inner_size(glutin::dpi::LogicalSize {
-            width: 800.0,
-            height: 600.0,
-        })
-        .with_title("egui_glium example");
-
-    let context_builder = glutin::ContextBuilder::new()
-        .with_depth_buffer(0)
-        .with_srgb(true)
-        .with_stencil_buffer(0)
-        .with_vsync(true);
-
-    glium::Display::new(window_builder, context_builder, event_loop).unwrap()
-}
-
-fn load_glium_image(png_data: &[u8]) -> glium::texture::RawImage2d<u8> {
-    // Load image using the image crate:
-    let image = image::load_from_memory(png_data).unwrap().to_rgba8();
-    let image_dimensions = image.dimensions();
-
-    // Premultiply alpha:
-    let pixels: Vec<_> = image
-        .into_vec()
-        .chunks_exact(4)
-        .map(|p| egui::Color32::from_rgba_unmultiplied(p[0], p[1], p[2], p[3]))
-        .flat_map(|color| color.to_array())
-        .collect();
-
-    // Convert to glium image:
-    glium::texture::RawImage2d::from_raw_rgba(pixels, image_dimensions)
-}
-
 fn main() {
     let event_loop = glutin::event_loop::EventLoop::with_user_event();
     let display = create_display(&event_loop);
@@ -126,4 +91,39 @@ fn main() {
             _ => (),
         }
     });
+}
+
+fn create_display(event_loop: &glutin::event_loop::EventLoop<()>) -> glium::Display {
+    let window_builder = glutin::window::WindowBuilder::new()
+        .with_resizable(true)
+        .with_inner_size(glutin::dpi::LogicalSize {
+            width: 800.0,
+            height: 600.0,
+        })
+        .with_title("egui_glium example");
+
+    let context_builder = glutin::ContextBuilder::new()
+        .with_depth_buffer(0)
+        .with_srgb(true)
+        .with_stencil_buffer(0)
+        .with_vsync(true);
+
+    glium::Display::new(window_builder, context_builder, event_loop).unwrap()
+}
+
+fn load_glium_image(png_data: &[u8]) -> glium::texture::RawImage2d<u8> {
+    // Load image using the image crate:
+    let image = image::load_from_memory(png_data).unwrap().to_rgba8();
+    let image_dimensions = image.dimensions();
+
+    // Premultiply alpha:
+    let pixels: Vec<_> = image
+        .into_vec()
+        .chunks_exact(4)
+        .map(|p| egui::Color32::from_rgba_unmultiplied(p[0], p[1], p[2], p[3]))
+        .flat_map(|color| color.to_array())
+        .collect();
+
+    // Convert to glium image:
+    glium::texture::RawImage2d::from_raw_rgba(pixels, image_dimensions)
 }

--- a/egui_glium/examples/pure_glium.rs
+++ b/egui_glium/examples/pure_glium.rs
@@ -4,24 +4,6 @@
 
 use glium::glutin;
 
-fn create_display(event_loop: &glutin::event_loop::EventLoop<()>) -> glium::Display {
-    let window_builder = glutin::window::WindowBuilder::new()
-        .with_resizable(true)
-        .with_inner_size(glutin::dpi::LogicalSize {
-            width: 800.0,
-            height: 600.0,
-        })
-        .with_title("egui_glium example");
-
-    let context_builder = glutin::ContextBuilder::new()
-        .with_depth_buffer(0)
-        .with_srgb(true)
-        .with_stencil_buffer(0)
-        .with_vsync(true);
-
-    glium::Display::new(window_builder, context_builder, event_loop).unwrap()
-}
-
 fn main() {
     let event_loop = glutin::event_loop::EventLoop::with_user_event();
     let display = create_display(&event_loop);
@@ -88,4 +70,22 @@ fn main() {
             _ => (),
         }
     });
+}
+
+fn create_display(event_loop: &glutin::event_loop::EventLoop<()>) -> glium::Display {
+    let window_builder = glutin::window::WindowBuilder::new()
+        .with_resizable(true)
+        .with_inner_size(glutin::dpi::LogicalSize {
+            width: 800.0,
+            height: 600.0,
+        })
+        .with_title("egui_glium example");
+
+    let context_builder = glutin::ContextBuilder::new()
+        .with_depth_buffer(0)
+        .with_srgb(true)
+        .with_stencil_buffer(0)
+        .with_vsync(true);
+
+    glium::Display::new(window_builder, context_builder, event_loop).unwrap()
 }

--- a/egui_glium/src/lib.rs
+++ b/egui_glium/src/lib.rs
@@ -2,7 +2,6 @@
 //!
 //! The main type you want to use is [`EguiGlium`].
 //!
-//! This library is an [`epi`] backend.
 //! If you are writing an app, you may want to look at [`eframe`](https://docs.rs/eframe) instead.
 
 // Forbid warnings in release builds:

--- a/egui_glow/examples/pure_glow.rs
+++ b/egui_glow/examples/pure_glow.rs
@@ -2,42 +2,6 @@
 
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-fn create_display(
-    event_loop: &glutin::event_loop::EventLoop<()>,
-) -> (
-    glutin::WindowedContext<glutin::PossiblyCurrent>,
-    glow::Context,
-) {
-    let window_builder = glutin::window::WindowBuilder::new()
-        .with_resizable(true)
-        .with_inner_size(glutin::dpi::LogicalSize {
-            width: 800.0,
-            height: 600.0,
-        })
-        .with_title("egui_glow example");
-
-    let gl_window = unsafe {
-        glutin::ContextBuilder::new()
-            .with_depth_buffer(0)
-            .with_srgb(true)
-            .with_stencil_buffer(0)
-            .with_vsync(true)
-            .build_windowed(window_builder, event_loop)
-            .unwrap()
-            .make_current()
-            .unwrap()
-    };
-
-    let gl = unsafe { glow::Context::from_loader_function(|s| gl_window.get_proc_address(s)) };
-
-    unsafe {
-        use glow::HasContext as _;
-        gl.enable(glow::FRAMEBUFFER_SRGB);
-    }
-
-    (gl_window, gl)
-}
-
 fn main() {
     let mut clear_color = [0.1, 0.1, 0.1];
 
@@ -115,4 +79,40 @@ fn main() {
             _ => (),
         }
     });
+}
+
+fn create_display(
+    event_loop: &glutin::event_loop::EventLoop<()>,
+) -> (
+    glutin::WindowedContext<glutin::PossiblyCurrent>,
+    glow::Context,
+) {
+    let window_builder = glutin::window::WindowBuilder::new()
+        .with_resizable(true)
+        .with_inner_size(glutin::dpi::LogicalSize {
+            width: 800.0,
+            height: 600.0,
+        })
+        .with_title("egui_glow example");
+
+    let gl_window = unsafe {
+        glutin::ContextBuilder::new()
+            .with_depth_buffer(0)
+            .with_srgb(true)
+            .with_stencil_buffer(0)
+            .with_vsync(true)
+            .build_windowed(window_builder, event_loop)
+            .unwrap()
+            .make_current()
+            .unwrap()
+    };
+
+    let gl = unsafe { glow::Context::from_loader_function(|s| gl_window.get_proc_address(s)) };
+
+    unsafe {
+        use glow::HasContext as _;
+        gl.enable(glow::FRAMEBUFFER_SRGB);
+    }
+
+    (gl_window, gl)
 }

--- a/egui_glow/src/epi_backend.rs
+++ b/egui_glow/src/epi_backend.rs
@@ -65,7 +65,7 @@ pub fn run(app_name: &str, native_options: &epi::NativeOptions, app_creator: epi
         });
     }
 
-    let mut app = app_creator(epi::CreationContext {
+    let mut app = app_creator(&epi::CreationContext {
         egui_ctx: integration.egui_ctx.clone(),
         integration_info: integration.frame.info(),
         #[cfg(feature = "persistence")]

--- a/egui_glow/src/epi_backend.rs
+++ b/egui_glow/src/epi_backend.rs
@@ -55,7 +55,6 @@ pub fn run(app_name: &str, native_options: &epi::NativeOptions, app_creator: epi
         "egui_glow",
         painter.max_texture_side(),
         gl_window.window(),
-        &gl,
         persistence,
     );
 
@@ -88,7 +87,6 @@ pub fn run(app_name: &str, native_options: &epi::NativeOptions, app_creator: epi
 
     if app.warm_up_enabled() {
         integration.warm_up(app.as_mut(), gl_window.window());
->>>>>>> d870c2f1 (Change how eframe apps are created)
     }
 
     let mut is_focused = true;

--- a/egui_glow/src/epi_backend.rs
+++ b/egui_glow/src/epi_backend.rs
@@ -65,12 +65,13 @@ pub fn run(app_name: &str, native_options: &epi::NativeOptions, app_creator: epi
         });
     }
 
-    let mut app = app_creator(
-        &integration.egui_ctx,
-        &integration.frame,
-        integration.persistence.storage(),
-        &gl,
-    );
+    let mut app = app_creator(epi::CreationContext {
+        egui_ctx: integration.egui_ctx.clone(),
+        integration_info: integration.frame.info(),
+        #[cfg(feature = "persistence")]
+        storage: integration.persistence.storage(),
+        gl: gl.clone(),
+    });
 
     {
         // things that happened during app creation:

--- a/egui_glow/src/epi_backend.rs
+++ b/egui_glow/src/epi_backend.rs
@@ -73,19 +73,6 @@ pub fn run(app_name: &str, native_options: &epi::NativeOptions, app_creator: epi
         gl: gl.clone(),
     });
 
-    {
-        // things that happened during app creation:
-        let app_output = integration.frame.take_app_output();
-        if app_output.quit {
-            integration.quit = app.on_exit_event();
-        }
-        egui_winit::epi::handle_app_output(
-            gl_window.window(),
-            integration.egui_ctx.pixels_per_point(),
-            app_output,
-        );
-    }
-
     if app.warm_up_enabled() {
         integration.warm_up(app.as_mut(), gl_window.window());
     }

--- a/egui_glow/src/epi_backend.rs
+++ b/egui_glow/src/epi_backend.rs
@@ -68,7 +68,6 @@ pub fn run(app_name: &str, native_options: &epi::NativeOptions, app_creator: epi
     let mut app = app_creator(&epi::CreationContext {
         egui_ctx: integration.egui_ctx.clone(),
         integration_info: integration.frame.info(),
-        #[cfg(feature = "persistence")]
         storage: integration.persistence.storage(),
         gl: gl.clone(),
     });

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -177,7 +177,7 @@ impl AppRunner {
 
         let storage = LocalStorage::default();
 
-        let app = app_creator(epi::CreationContext {
+        let app = app_creator(&epi::CreationContext {
             egui_ctx: egui_ctx.clone(),
             integration_info: frame.info(),
             storage: Some(&storage),

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -177,7 +177,12 @@ impl AppRunner {
 
         let storage = LocalStorage::default();
 
-        let app = app_creator(&egui_ctx, &frame, Some(&storage), painter.painter.gl());
+        let app = app_creator(epi::CreationContext {
+            egui_ctx: egui_ctx.clone(),
+            integration_info: frame.info(),
+            storage: Some(&storage),
+            gl: painter.painter.gl().clone(),
+        });
 
         let mut runner = Self {
             frame,

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -139,7 +139,7 @@ pub struct AppRunner {
 }
 
 impl AppRunner {
-    pub fn new(canvas_id: &str, app: Box<dyn epi::App>) -> Result<Self, JsValue> {
+    pub fn new(canvas_id: &str, app_creator: epi::AppCreator) -> Result<Self, JsValue> {
         let painter = WrappedGlowPainter::new(canvas_id).map_err(JsValue::from)?;
 
         let prefer_dark_mode = crate::prefer_dark_mode();
@@ -177,6 +177,8 @@ impl AppRunner {
 
         let storage = LocalStorage::default();
 
+        let app = app_creator(&egui_ctx, &frame, Some(&storage), painter.painter.gl());
+
         let mut runner = Self {
             frame,
             egui_ctx,
@@ -193,11 +195,6 @@ impl AppRunner {
         };
 
         runner.input.raw.max_texture_side = Some(runner.painter.max_texture_side());
-
-        let gl = runner.painter.painter.gl();
-        runner
-            .app
-            .setup(&runner.egui_ctx, &runner.frame, Some(&runner.storage), gl);
 
         Ok(runner)
     }
@@ -327,8 +324,8 @@ impl AppRunner {
 
 /// Install event listeners to register different input events
 /// and start running the given app.
-pub fn start(canvas_id: &str, app: Box<dyn epi::App>) -> Result<AppRunnerRef, JsValue> {
-    let mut runner = AppRunner::new(canvas_id, app)?;
+pub fn start(canvas_id: &str, app_creator: epi::AppCreator) -> Result<AppRunnerRef, JsValue> {
+    let mut runner = AppRunner::new(canvas_id, app_creator)?;
     runner.warm_up()?;
     start_runner(runner)
 }

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -133,8 +133,7 @@ pub trait App {
     ///
     /// The [`egui::Context`] and [`Frame`] can be cloned and saved if you like.
     ///
-    /// To force a repaint, call either [`egui::Context::request_repaint`] during the call to `update`,
-    /// or call [`Frame::request_repaint`] at any time (e.g. from another thread).
+    /// To force a repaint, call [`egui::Context::request_repaint`] at any time (e.g. from another thread).
     fn update(&mut self, ctx: &egui::Context, frame: &Frame);
 
     /// Called on shutdown, and perhaps at regular intervals. Allows you to save state.

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -109,8 +109,27 @@ use std::sync::{Arc, Mutex};
 ///
 /// The [`glow::Context`] allows you to initialize OpenGL resources (e.g. shaders) that
 /// you might want to use later from a [`egui::PaintCallback`].
-pub type AppCreator =
-    fn(&egui::Context, &Frame, Option<&dyn Storage>, &std::rc::Rc<glow::Context>) -> Box<dyn App>;
+pub type AppCreator = fn(CreationContext<'_>) -> Box<dyn App>;
+
+/// Data that is passed to [`AppCreator`] that can be used to setup and initialize your app.
+pub struct CreationContext<'s> {
+    /// The egui Context.
+    ///
+    /// You can use this to customize the look of egui, e.g to call [`egui::Context::set_fonts`],
+    /// [`egui::Context::set_visuals`] etc.
+    pub egui_ctx: egui::Context,
+
+    /// Information about the surrounding environment.
+    pub integration_info: IntegrationInfo,
+
+    /// You can use the storage to restore app state state (requires the "persistence" feature).
+    #[cfg(feature = "persistence")]
+    pub storage: Option<&'s dyn Storage>,
+
+    /// The [`glow::Context`] allows you to initialize OpenGL resources (e.g. shaders) that
+    /// you might want to use later from a [`egui::PaintCallback`].
+    pub gl: std::rc::Rc<glow::Context>,
+}
 
 // ----------------------------------------------------------------------------
 

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -109,7 +109,7 @@ use std::sync::{Arc, Mutex};
 ///
 /// The [`glow::Context`] allows you to initialize OpenGL resources (e.g. shaders) that
 /// you might want to use later from a [`egui::PaintCallback`].
-pub type AppCreator = fn(CreationContext<'_>) -> Box<dyn App>;
+pub type AppCreator = fn(&CreationContext<'_>) -> Box<dyn App>;
 
 /// Data that is passed to [`AppCreator`] that can be used to setup and initialize your app.
 pub struct CreationContext<'s> {

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -115,7 +115,6 @@ pub struct CreationContext<'s> {
     pub integration_info: IntegrationInfo,
 
     /// You can use the storage to restore app state(requires the "persistence" feature).
-    #[cfg(feature = "persistence")]
     pub storage: Option<&'s dyn Storage>,
 
     /// The [`glow::Context`] allows you to initialize OpenGL resources (e.g. shaders) that

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -100,15 +100,7 @@ use std::sync::{Arc, Mutex};
 
 /// The is is how your app is created.
 ///
-/// You need to define a function with this signature.
-///
-/// You can use this to customize the look of egui, e.g to call [`egui::Context::set_fonts`],
-/// [`egui::Context::set_visuals`] etc.
-///
-/// You can use the storage to restore app state state (requires the "persistence" feature).
-///
-/// The [`glow::Context`] allows you to initialize OpenGL resources (e.g. shaders) that
-/// you might want to use later from a [`egui::PaintCallback`].
+/// You can use the [`CreationContext`] to setup egui, restore state, setup OpenGL things, etc.
 pub type AppCreator = fn(&CreationContext<'_>) -> Box<dyn App>;
 
 /// Data that is passed to [`AppCreator`] that can be used to setup and initialize your app.
@@ -122,7 +114,7 @@ pub struct CreationContext<'s> {
     /// Information about the surrounding environment.
     pub integration_info: IntegrationInfo,
 
-    /// You can use the storage to restore app state state (requires the "persistence" feature).
+    /// You can use the storage to restore app state(requires the "persistence" feature).
     #[cfg(feature = "persistence")]
     pub storage: Option<&'s dyn Storage>,
 


### PR DESCRIPTION
This refactors how eframe creates an app, removing the need for `App::setup`.

The purpose of this is to be able to access the following state before/during creation of ones app:
* `egui::Context`: alllow users to set fonts, style and maybe create textures.
* `epi::Storage`: for reading app state from storage.
* `epi::Frame`: can be cloned and stored so we can run [`request_repaint`](https://docs.rs/epi/latest/epi/struct.Frame.html#method.request_repaint).
* `glow::Context`: for creating rendering resources.

Previously eframe was designed so that these were passed into `App::setup`, but that meant one would have to create an app before running the setup of it, making `App::setup` a weird "second constructor". This PR solves that problem.

`App::name` is now also removed, and is instead passed in by argument to `eframe::run_native`.

Additionally, `eframe` now re-exports everything in `epi`, so `eframe` users can ignore `epi` completely.

---

This now changes the `eframe` use to look like so:


``` rust
use eframe::egui;

#[cfg(not(target_arch = "wasm32"))]
fn main() {
    let native_options = eframe::NativeOptions::default();
    eframe::run_native("MyApp", native_options, |cc| Box::new(MyEguiApp::new(cc)));
}

#[cfg(target_arch = "wasm32")]
#[wasm_bindgen]
pub fn start(canvas_id: &str) -> Result<(), eframe::wasm_bindgen::JsValue> {
    eframe::start_web(canvas_id, |cc| Box::new(MyApp::new(cc)))
}

#[derive(Default)]
struct MyEguiApp {}

impl MyEguiApp {
    fn new(cc: &eframe::CreationContext<'_>) -> Self {
        // Customize egui here with cc.egui_ctx.set_fonts and cc.egui_ctx.set_visuals.
        // Restore app state using cc.storage (requires the "persistence" feature).
        // Use the cc.gl (a glow::Context) to create graphics shaders and buffers that you can use
        // for e.g. egui::PaintCallback.
        Self::default()
    }
}

impl eframe::App for MyEguiApp {
   fn update(&mut self, ctx: &egui::Context, frame: &eframe::Frame) {
       egui::CentralPanel::default().show(ctx, |ui| {
           ui.heading("Hello World!");
       });
   }
}
```