### PR TITLE
Context::request_repaint will wake up the UI thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 ### Added ⭐
 * Add `Shape::Callback` for backend-specific painting ([#1351](https://github.com/emilk/egui/pull/1351)).
 * Added `Frame::canvas` ([#1362](https://github.com/emilk/egui/pull/1362)).
+* `Context::request_repaint` will wake up UI thread, if integrations has called `Context::set_request_repaint_callback` ([#1366](https://github.com/emilk/egui/pull/1366)).
 
 ### Changed 🔧
 * `ClippedMesh` has been replaced with `ClippedPrimitive` ([#1351](https://github.com/emilk/egui/pull/1351)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,6 +1053,7 @@ dependencies = [
  "poll-promise",
  "serde",
  "syntect",
+ "tracing",
  "unicode_names2",
 ]
 
@@ -1091,6 +1092,7 @@ dependencies = [
  "glow",
  "glutin",
  "memoffset",
+ "parking_lot 0.12.0",
  "tracing",
  "wasm-bindgen",
  "web-sys",

--- a/eframe/CHANGELOG.md
+++ b/eframe/CHANGELOG.md
@@ -7,6 +7,7 @@ NOTE: [`egui_web`](../egui_web/CHANGELOG.md), [`egui-winit`](../egui-winit/CHANG
 ## Unreleased
 * Remove the `egui_glium` feature. `eframe` will now always use `egui_glow` as the native backend ([#1357](https://github.com/emilk/egui/pull/1357)).
 * Change default for `NativeOptions::drag_and_drop_support` to `true` ([#1329](https://github.com/emilk/egui/pull/1329)).
+* Removed `Frame::request_repaint` - just call `egui::Context::request_repaint` for the same effect ([#1366](https://github.com/emilk/egui/pull/1366)).
 
 
 ## 0.17.0 - 2022-02-22

--- a/eframe/examples/download_image.rs
+++ b/eframe/examples/download_image.rs
@@ -20,18 +20,18 @@ impl epi::App for MyApp {
         "Download and show an image with eframe/egui"
     }
 
-    fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
         let promise = self.promise.get_or_insert_with(|| {
             // Begin download.
             // We download the image using `ehttp`, a library that works both in WASM and on native.
             // We use the `poll-promise` library to communicate with the UI thread.
-            let frame = frame.clone();
+            let ctx = ctx.clone();
             let (sender, promise) = Promise::new();
             let request = ehttp::Request::get("https://picsum.photos/seed/1.759706314/1024");
             ehttp::fetch(request, move |response| {
                 let image = response.and_then(parse_response);
                 sender.send(image); // send the results back to the UI thread.
-                frame.request_repaint(); // wake up UI thread
+                ctx.request_repaint(); // wake up UI thread
             });
             promise
         });

--- a/egui-winit/src/epi.rs
+++ b/egui-winit/src/epi.rs
@@ -233,7 +233,6 @@ impl EpiIntegration {
         max_texture_side: usize,
         window: &winit::window::Window,
         gl: &std::rc::Rc<glow::Context>,
-        repaint_signal: std::sync::Arc<dyn epi::backend::RepaintSignal>,
         persistence: crate::epi::Persistence,
         app: Box<dyn epi::App>,
     ) -> Self {
@@ -252,7 +251,6 @@ impl EpiIntegration {
                 native_pixels_per_point: Some(crate::native_pixels_per_point(window)),
             },
             output: Default::default(),
-            repaint_signal,
         });
 
         if prefer_dark_mode == Some(true) {

--- a/egui_demo_lib/Cargo.toml
+++ b/egui_demo_lib/Cargo.toml
@@ -39,6 +39,7 @@ epi = { version = "0.17.0", path = "../epi" }
 
 chrono = { version = "0.4", optional = true, features = ["js-sys", "wasmbind"] }
 enum-map = { version = "2", features = ["serde"] }
+tracing = "0.1"
 unicode_names2 = { version = "0.5.0", default-features = false }
 
 # feature "http":

--- a/egui_demo_lib/src/apps/http_app.rs
+++ b/egui_demo_lib/src/apps/http_app.rs
@@ -78,11 +78,10 @@ impl epi::App for HttpApp {
 
             if trigger_fetch {
                 let ctx = ctx.clone();
-                let frame = frame.clone();
                 let (sender, promise) = Promise::new();
                 let request = ehttp::Request::get(&self.url);
                 ehttp::fetch(request, move |response| {
-                    frame.request_repaint(); // wake up UI thread
+                    ctx.request_repaint(); // wake up UI thread
                     let resource = response.map(|response| Resource::from_response(&ctx, response));
                     sender.send(resource);
                 });

--- a/egui_glow/Cargo.toml
+++ b/egui_glow/Cargo.toml
@@ -64,6 +64,7 @@ epi = { version = "0.17.0", path = "../epi", optional = true }
 bytemuck = "1.7"
 glow = "0.11"
 memoffset = "0.6"
+parking_lot = "0.12"
 tracing = "0.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -359,13 +359,6 @@ impl Frame {
         self.lock().output.drag_window = true;
     }
 
-    /// This signals the [`egui`] integration that a repaint is required.
-    ///
-    /// Call this e.g. when a background process finishes in an async context and/or background thread.
-    pub fn request_repaint(&self) {
-        self.lock().repaint_signal.request_repaint();
-    }
-
     /// for integrations only: call once per frame
     pub fn take_app_output(&self) -> crate::backend::AppOutput {
         std::mem::take(&mut self.lock().output)
@@ -524,14 +517,6 @@ pub const APP_KEY: &str = "app";
 pub mod backend {
     use super::*;
 
-    /// How to signal the [`egui`] integration that a repaint is required.
-    pub trait RepaintSignal: Send + Sync {
-        /// This signals the [`egui`] integration that a repaint is required.
-        ///
-        /// Call this e.g. when a background process finishes in an async context and/or background thread.
-        fn request_repaint(&self);
-    }
-
     /// The data required by [`Frame`] each frame.
     pub struct FrameData {
         /// Information about the integration.
@@ -539,9 +524,6 @@ pub mod backend {
 
         /// Where the app can issue commands back to the integration.
         pub output: AppOutput,
-
-        /// If you need to request a repaint from another thread, clone this and send it to that other thread.
-        pub repaint_signal: std::sync::Arc<dyn RepaintSignal>,
     }
 
     /// Action that can be taken by the user app.


### PR DESCRIPTION
This adds a callback (set by `Context::set_request_repaint_callback`) which integration can use to wake up the UI thread.

eframe (egui_web and egui_glow) will use this, replacing `epi::Frame::request_repaint`.

Existing code calling `epi::Frame::request_repaint` should be changed to instead call `egui::Context::request_repaint`.

This is the first callback added to the egui API, which otherwise is completely driven by data.

The purpose of this is to remove the confusion between the two `request_repaint` methods (by removing one). Furthermore, it makes `epi::Frame` a lot simpler, allowing future simplifications to it (perhaps no longer having it be `Send+Sync+Clone`).

Closes https://github.com/emilk/egui/pull/1187