### PR TITLE
Add Tessellator::set_clip_rect

### DIFF
--- a/epaint/src/tessellator.rs
+++ b/epaint/src/tessellator.rs
@@ -695,6 +695,11 @@ impl Tessellator {
         }
     }
 
+    /// Set the `Rect` to use for culling.
+    pub fn set_clip_rect(&mut self, clip_rect: Rect) {
+        self.clip_rect = clip_rect;
+    }
+
     /// Tessellate a single [`Shape`] into a [`Mesh`].
     ///
     /// * `tex_size`: size of the font texture (required to normalize glyph uv rectangles).


### PR DESCRIPTION
This allows the user to set the outer rectangle used for culling, which is required to be able to implement something akin to tessellate_shapes entirely in user space. Alternatively, a `clip_rect_mut` method would also work.

I didn't feel this required opening an issue because of the simplicity of the PR.