### PR TITLE
Add Image::rotate and Mesh::rotate

### DIFF
--- a/eframe/examples/image.rs
+++ b/eframe/examples/image.rs
@@ -4,11 +4,12 @@ use eframe::egui;
 use egui_extras::RetainedImage;
 
 fn main() {
-    let options = eframe::NativeOptions::default();
-    eframe::run_native(
-        "Show an image with eframe/egui",
-        options,
-        Box::new(|_cc| Box::new(MyApp::default())),
+    let options = eframe::NativeOptions {
+        initial_window_size: Some(egui::vec2(500.0, 900.0)),
+        ..Default::default()
+    };
+    eframe::run_native("Show an image with eframe/egui", options,
+        Box::new(|_cc| Box::new(MyApp::default()))
     );
 }
 
@@ -33,6 +34,12 @@ impl eframe::App for MyApp {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("This is an image:");
             self.image.show(ui);
+
+            ui.heading("This is a rotated image:");
+            ui.add(
+                egui::Image::new(self.image.texture_id(ctx), self.image.size_vec2())
+                    .rotate(45.0_f32.to_radians(), self.image.size_vec2() / 2.0),
+            );
 
             ui.heading("This is an image you can click:");
             ui.add(egui::ImageButton::new(

--- a/eframe/examples/image.rs
+++ b/eframe/examples/image.rs
@@ -38,7 +38,7 @@ impl eframe::App for MyApp {
             ui.heading("This is a rotated image:");
             ui.add(
                 egui::Image::new(self.image.texture_id(ctx), self.image.size_vec2())
-                    .rotate(45.0_f32.to_radians(), self.image.size_vec2() / 2.0),
+                    .rotate(45.0_f32.to_radians(), egui::Vec2::splat(0.5)),
             );
 
             ui.heading("This is an image you can click:");

--- a/eframe/examples/image.rs
+++ b/eframe/examples/image.rs
@@ -8,8 +8,10 @@ fn main() {
         initial_window_size: Some(egui::vec2(500.0, 900.0)),
         ..Default::default()
     };
-    eframe::run_native("Show an image with eframe/egui", options,
-        Box::new(|_cc| Box::new(MyApp::default()))
+    eframe::run_native(
+        "Show an image with eframe/egui",
+        options,
+        Box::new(|_cc| Box::new(MyApp::default())),
     );
 }
 

--- a/egui/src/widgets/image.rs
+++ b/egui/src/widgets/image.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use emath::Rot2;
 
 /// An widget to show an image of a given size.
 ///
@@ -36,6 +37,7 @@ pub struct Image {
     bg_fill: Color32,
     tint: Color32,
     sense: Sense,
+    rotation: Option<(Rot2, Vec2)>,
 }
 
 impl Image {
@@ -47,6 +49,7 @@ impl Image {
             bg_fill: Default::default(),
             tint: Color32::WHITE,
             sense: Sense::hover(),
+            rotation: None,
         }
     }
 
@@ -75,6 +78,15 @@ impl Image {
         self.sense = sense;
         self
     }
+
+    /// Rotate the image about an origin by some angle
+    ///
+    /// Positive angle is clockwise.
+    /// Origin is a vector relative to the top-left corner of the image.
+    pub fn rotate(mut self, angle: f32, origin: Vec2) -> Self {
+        self.rotation = Some((Rot2::from_angle(angle), origin));
+        self
+    }
 }
 
 impl Image {
@@ -92,6 +104,7 @@ impl Image {
                 bg_fill,
                 tint,
                 sense: _,
+                rotation,
             } = self;
 
             if *bg_fill != Default::default() {
@@ -104,6 +117,10 @@ impl Image {
                 // TODO: builder pattern for Mesh
                 let mut mesh = Mesh::with_texture(*texture_id);
                 mesh.add_rect_with_uv(rect, *uv, *tint);
+                if let Some((rot, origin)) = rotation {
+                    let origin_abs = rect.min.to_vec2() + *origin;
+                    mesh.rotate(*rot, origin_abs);
+                }
                 ui.painter().add(Shape::mesh(mesh));
             }
         }

--- a/egui/src/widgets/image.rs
+++ b/egui/src/widgets/image.rs
@@ -82,9 +82,11 @@ impl Image {
     /// Rotate the image about an origin by some angle
     ///
     /// Positive angle is clockwise.
-    /// Origin is a vector relative to the top-left corner of the image.
+    /// Origin is a vector in UV space (normalized space by default unless set by [`Image::uv`])
+    ///
+    /// To rotate about the center you can pass `Vec2::splat(0.5)` as the origin.
     pub fn rotate(mut self, angle: f32, origin: Vec2) -> Self {
-        self.rotation = Some((Rot2::from_angle(angle), origin));
+        self.rotation = Some((Rot2::from_angle(angle), origin / self.uv.size()));
         self
     }
 }
@@ -100,7 +102,7 @@ impl Image {
             let Self {
                 texture_id,
                 uv,
-                size: _,
+                size,
                 bg_fill,
                 tint,
                 sense: _,
@@ -118,7 +120,7 @@ impl Image {
                 let mut mesh = Mesh::with_texture(*texture_id);
                 mesh.add_rect_with_uv(rect, *uv, *tint);
                 if let Some((rot, origin)) = rotation {
-                    let origin_abs = rect.min.to_vec2() + *origin;
+                    let origin_abs = rect.min.to_vec2() + (*origin * *size);
                     mesh.rotate(*rot, origin_abs);
                 }
                 ui.painter().add(Shape::mesh(mesh));

--- a/egui/src/widgets/image.rs
+++ b/egui/src/widgets/image.rs
@@ -82,11 +82,11 @@ impl Image {
     /// Rotate the image about an origin by some angle
     ///
     /// Positive angle is clockwise.
-    /// Origin is a vector in UV space (normalized space by default unless set by [`Image::uv`])
+    /// Origin is a vector in normalized UV space ((0,0) in top-left, (1,1) bottom right).
     ///
     /// To rotate about the center you can pass `Vec2::splat(0.5)` as the origin.
     pub fn rotate(mut self, angle: f32, origin: Vec2) -> Self {
-        self.rotation = Some((Rot2::from_angle(angle), origin / self.uv.size()));
+        self.rotation = Some((Rot2::from_angle(angle), origin));
         self
     }
 }
@@ -120,8 +120,7 @@ impl Image {
                 let mut mesh = Mesh::with_texture(*texture_id);
                 mesh.add_rect_with_uv(rect, *uv, *tint);
                 if let Some((rot, origin)) = rotation {
-                    let origin_abs = rect.min.to_vec2() + (*origin * *size);
-                    mesh.rotate(*rot, origin_abs);
+                    mesh.rotate(*rot, rect.min + *origin * *size);
                 }
                 ui.painter().add(Shape::mesh(mesh));
             }

--- a/epaint/src/mesh.rs
+++ b/epaint/src/mesh.rs
@@ -245,10 +245,10 @@ impl Mesh {
 
     /// Rotate by some angle about an origin, in-place.
     ///
-    /// Origin is a vector in screen space.
-    pub fn rotate(&mut self, rot: Rot2, origin: Vec2) {
+    /// Origin is a position in screen space.
+    pub fn rotate(&mut self, rot: Rot2, origin: Pos2) {
         for v in &mut self.vertices {
-            v.pos = (rot * (v.pos - origin).to_vec2()).to_pos2() + origin;
+            v.pos = origin + rot * (v.pos - origin);
         }
     }
 }

--- a/epaint/src/mesh.rs
+++ b/epaint/src/mesh.rs
@@ -242,6 +242,17 @@ impl Mesh {
             v.pos += delta;
         }
     }
+
+    /// Rotate by some angle about an origin, in-place.
+    ///
+    /// Origin is relative to the top left corner of the screen.
+    pub fn rotate(&mut self, rot: Rot2, origin: Vec2) {
+        self.translate(-origin);
+        for v in &mut self.vertices {
+            v.pos = (rot * v.pos.to_vec2()).to_pos2();
+        }
+        self.translate(origin);
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/epaint/src/mesh.rs
+++ b/epaint/src/mesh.rs
@@ -245,13 +245,11 @@ impl Mesh {
 
     /// Rotate by some angle about an origin, in-place.
     ///
-    /// Origin is relative to the top left corner of the screen.
+    /// Origin is a vector in screen space.
     pub fn rotate(&mut self, rot: Rot2, origin: Vec2) {
-        self.translate(-origin);
         for v in &mut self.vertices {
-            v.pos = (rot * v.pos.to_vec2()).to_pos2();
+            v.pos = (rot * (v.pos - origin).to_vec2()).to_pos2() + origin;
         }
-        self.translate(origin);
     }
 }
 


### PR DESCRIPTION
Related to https://github.com/emilk/egui/issues/1279

This adds rotation capabilities to `Image` and `Mesh` (since `Image` uses it). You can specify an origin to rotate about too.

Updated the `eframe/examples/image.rs` example:

![image](https://user-images.githubusercontent.com/9222431/158882501-280bca4e-3d54-4b72-bf97-b35e08ee5302.png)