### PR TITLE
Box the app creator

### DIFF
--- a/eframe/examples/confirm_exit.rs
+++ b/eframe/examples/confirm_exit.rs
@@ -4,7 +4,11 @@ use eframe::egui;
 
 fn main() {
     let options = eframe::NativeOptions::default();
-    eframe::run_native("Confirm exit", options, |_cc| Box::new(MyApp::default()));
+    eframe::run_native(
+        "Confirm exit",
+        options,
+        Box::new(|_cc| Box::new(MyApp::default())),
+    );
 }
 
 #[derive(Default)]

--- a/eframe/examples/custom_3d.rs
+++ b/eframe/examples/custom_3d.rs
@@ -15,9 +15,11 @@ use std::sync::Arc;
 
 fn main() {
     let options = eframe::NativeOptions::default();
-    eframe::run_native("Custom 3D painting in eframe", options, |cc| {
-        Box::new(MyApp::new(cc))
-    });
+    eframe::run_native(
+        "Custom 3D painting in eframe",
+        options,
+        Box::new(|cc| Box::new(MyApp::new(cc))),
+    );
 }
 
 struct MyApp {

--- a/eframe/examples/custom_font.rs
+++ b/eframe/examples/custom_font.rs
@@ -4,9 +4,11 @@ use eframe::egui;
 
 fn main() {
     let options = eframe::NativeOptions::default();
-    eframe::run_native("egui example: custom font", options, |cc| {
-        Box::new(MyApp::new(cc))
-    });
+    eframe::run_native(
+        "egui example: custom font",
+        options,
+        Box::new(|cc| Box::new(MyApp::new(cc))),
+    );
 }
 
 fn setup_custom_fonts(ctx: &egui::Context) {

--- a/eframe/examples/download_image.rs
+++ b/eframe/examples/download_image.rs
@@ -9,7 +9,7 @@ fn main() {
     eframe::run_native(
         "Download and show an image with eframe/egui",
         options,
-        |_cc| Box::new(MyApp::default()),
+        Box::new(|_cc| Box::new(MyApp::default())),
     );
 }
 

--- a/eframe/examples/file_dialog.rs
+++ b/eframe/examples/file_dialog.rs
@@ -10,7 +10,7 @@ fn main() {
     eframe::run_native(
         "Native file dialogs and drag-and-drop files",
         options,
-        |_cc| Box::new(MyApp::default()),
+        Box::new(|_cc| Box::new(MyApp::default())),
     );
 }
 

--- a/eframe/examples/hello_world.rs
+++ b/eframe/examples/hello_world.rs
@@ -4,7 +4,11 @@ use eframe::egui;
 
 fn main() {
     let options = eframe::NativeOptions::default();
-    eframe::run_native("My egui App", options, |_cc| Box::new(MyApp::default()));
+    eframe::run_native(
+        "My egui App",
+        options,
+        Box::new(|_cc| Box::new(MyApp::default())),
+    );
 }
 
 struct MyApp {

--- a/eframe/examples/image.rs
+++ b/eframe/examples/image.rs
@@ -5,9 +5,11 @@ use egui_extras::RetainedImage;
 
 fn main() {
     let options = eframe::NativeOptions::default();
-    eframe::run_native("Show an image with eframe/egui", options, |_cc| {
-        Box::new(MyApp::default())
-    });
+    eframe::run_native(
+        "Show an image with eframe/egui",
+        options,
+        Box::new(|_cc| Box::new(MyApp::default())),
+    );
 }
 
 struct MyApp {

--- a/eframe/examples/svg.rs
+++ b/eframe/examples/svg.rs
@@ -11,7 +11,11 @@ fn main() {
         initial_window_size: Some(egui::vec2(1000.0, 700.0)),
         ..Default::default()
     };
-    eframe::run_native("svg example", options, |_cc| Box::new(MyApp::default()));
+    eframe::run_native(
+        "svg example",
+        options,
+        Box::new(|_cc| Box::new(MyApp::default())),
+    );
 }
 
 struct MyApp {

--- a/eframe/src/lib.rs
+++ b/eframe/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! fn main() {
 //!     let native_options = eframe::NativeOptions::default();
-//!     eframe::run_native("My egui App", native_options, |cc| Box::new(MyEguiApp::new(cc)));
+//!     eframe::run_native("My egui App", native_options, Box::new(|cc| Box::new(MyEguiApp::new(cc))));
 //! }
 //!
 //! #[derive(Default)]
@@ -54,7 +54,7 @@
 //! #[cfg(target_arch = "wasm32")]
 //! #[wasm_bindgen]
 //! pub fn start(canvas_id: &str) -> Result<(), eframe::wasm_bindgen::JsValue> {
-//!     eframe::start_web(canvas_id, |cc| Box::new(MyApp::new(cc)))
+//!     eframe::start_web(canvas_id, Box::new(|cc| Box::new(MyApp::new(cc))))
 //! }
 //! ```
 
@@ -99,7 +99,7 @@ pub use egui_web::wasm_bindgen;
 /// #[cfg(target_arch = "wasm32")]
 /// #[wasm_bindgen]
 /// pub fn start(canvas_id: &str) -> Result<(), eframe::wasm_bindgen::JsValue> {
-///     eframe::start_web(canvas_id, |cc| Box::new(MyEguiApp::new(cc)))
+///     eframe::start_web(canvas_id, Box::new(|cc| Box::new(MyEguiApp::new(cc))))
 /// }
 /// ```
 #[cfg(target_arch = "wasm32")]
@@ -122,7 +122,7 @@ pub fn start_web(canvas_id: &str, app_creator: AppCreator) -> Result<(), wasm_bi
 ///
 /// fn main() {
 ///     let native_options = eframe::NativeOptions::default();
-///     eframe::run_native("MyApp", native_options, |cc| Box::new(MyEguiApp::new(cc)));
+///     eframe::run_native("MyApp", native_options, Box::new(|cc| Box::new(MyEguiApp::new(cc))));
 /// }
 ///
 /// #[derive(Default)]

--- a/egui_demo_app/src/lib.rs
+++ b/egui_demo_app/src/lib.rs
@@ -19,5 +19,8 @@ pub fn start(canvas_id: &str) -> Result<(), wasm_bindgen::JsValue> {
     // Redirect tracing to console.log and friends:
     tracing_wasm::set_as_global_default();
 
-    eframe::start_web(canvas_id, |cc| Box::new(egui_demo_lib::WrapApp::new(cc)))
+    eframe::start_web(
+        canvas_id,
+        Box::new(|cc| Box::new(egui_demo_lib::WrapApp::new(cc))),
+    )
 }

--- a/egui_demo_app/src/main.rs
+++ b/egui_demo_app/src/main.rs
@@ -16,7 +16,9 @@ fn main() {
         drag_and_drop_support: true,
         ..Default::default()
     };
-    eframe::run_native("egui demo app", options, |cc| {
-        Box::new(egui_demo_lib::WrapApp::new(cc))
-    });
+    eframe::run_native(
+        "egui demo app",
+        options,
+        Box::new(|cc| Box::new(egui_demo_lib::WrapApp::new(cc))),
+    );
 }

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -101,7 +101,7 @@ use std::sync::{Arc, Mutex};
 /// The is is how your app is created.
 ///
 /// You can use the [`CreationContext`] to setup egui, restore state, setup OpenGL things, etc.
-pub type AppCreator = fn(&CreationContext<'_>) -> Box<dyn App>;
+pub type AppCreator = Box<dyn FnOnce(&CreationContext<'_>) -> Box<dyn App>>;
 
 /// Data that is passed to [`AppCreator`] that can be used to setup and initialize your app.
 pub struct CreationContext<'s> {


### PR DESCRIPTION
Follow-up to https://github.com/emilk/egui/pull/1363

We need to add another boxing so that the `AppCreator` can be a closure, capturing parts of its environment.

This is a bit ugly "injection" style code. In the future I would prefer something similar to this:

```rust
let eframe = eframe::EFrame::create("My App", native_options);
let app = MyApp::new(eframe.egui_ctx(), eframe.glow());
eframe.run(app);
```

Still, that's a lot of work for a minor aesthetic gain.