### PR TITLE
Fix code that could lead to a possible deadlock.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 
 ### Fixed 🐛
 * Fixed ComboBoxes always being rendered left-aligned ([#1304](https://github.com/emilk/egui/pull/1304)).
-
+* Fixed ui code that could lead to a deadlock ([#1380](https://github.com/emilk/egui/pull/1380))
 
 ## 0.17.0 - 2022-02-22 - Improved font selection and image handling
 

--- a/egui/src/menu.rs
+++ b/egui/src/menu.rs
@@ -277,10 +277,10 @@ impl MenuRoot {
         root: &mut MenuRootManager,
         id: Id,
     ) -> MenuResponse {
-        let pointer = &response.ctx.input().pointer;
-        if (response.clicked() && root.is_menu_open(id))
-            || response.ctx.input().key_pressed(Key::Escape)
-        {
+        // Lock the input once for the whole function call
+        let input = response.ctx.input();
+
+        if (response.clicked() && root.is_menu_open(id)) || input.key_pressed(Key::Escape) {
             // menu open and button clicked or esc pressed
             return MenuResponse::Close;
         } else if (response.clicked() && !root.is_menu_open(id))
@@ -290,8 +290,8 @@ impl MenuRoot {
             // or button hovered while other menu is open
             let pos = response.rect.left_bottom();
             return MenuResponse::Create(pos, id);
-        } else if pointer.any_pressed() && pointer.primary_down() {
-            if let Some(pos) = pointer.interact_pos() {
+        } else if input.pointer.any_pressed() && input.pointer.primary_down() {
+            if let Some(pos) = input.pointer.interact_pos() {
                 if let Some(root) = root.inner.as_mut() {
                     if root.id == id {
                         // pressed somewhere while this menu is open

--- a/egui/src/menu.rs
+++ b/egui/src/menu.rs
@@ -277,7 +277,7 @@ impl MenuRoot {
         root: &mut MenuRootManager,
         id: Id,
     ) -> MenuResponse {
-        // Lock the input once for the whole function call (see #1380)
+        // Lock the input once for the whole function call (see https://github.com/emilk/egui/pull/1380).
         let input = response.ctx.input();
 
         if (response.clicked() && root.is_menu_open(id)) || input.key_pressed(Key::Escape) {

--- a/egui/src/menu.rs
+++ b/egui/src/menu.rs
@@ -277,7 +277,7 @@ impl MenuRoot {
         root: &mut MenuRootManager,
         id: Id,
     ) -> MenuResponse {
-        // Lock the input once for the whole function call
+        // Lock the input once for the whole function call (see #1380)
         let input = response.ctx.input();
 
         if (response.clicked() && root.is_menu_open(id)) || input.key_pressed(Key::Escape) {

--- a/egui/src/widgets/slider.rs
+++ b/egui/src/widgets/slider.rs
@@ -456,6 +456,7 @@ impl<'a> Slider<'a> {
     fn value_ui(&mut self, ui: &mut Ui, position_range: RangeInclusive<f32>) -> Response {
         // If `DragValue` is controlled from the keyboard and `step` is defined, set speed to `step`
         let change = {
+            // Hold one lock rather than 4 (see #1380)
             let input = ui.input();
 
             input.num_presses(Key::ArrowUp) as i32 + input.num_presses(Key::ArrowRight) as i32

--- a/egui/src/widgets/slider.rs
+++ b/egui/src/widgets/slider.rs
@@ -455,10 +455,13 @@ impl<'a> Slider<'a> {
 
     fn value_ui(&mut self, ui: &mut Ui, position_range: RangeInclusive<f32>) -> Response {
         // If `DragValue` is controlled from the keyboard and `step` is defined, set speed to `step`
-        let change = ui.input().num_presses(Key::ArrowUp) as i32
-            + ui.input().num_presses(Key::ArrowRight) as i32
-            - ui.input().num_presses(Key::ArrowDown) as i32
-            - ui.input().num_presses(Key::ArrowLeft) as i32;
+        let change = {
+            let input = ui.input();
+
+            input.num_presses(Key::ArrowUp) as i32 + input.num_presses(Key::ArrowRight) as i32
+                - input.num_presses(Key::ArrowDown) as i32
+                - input.num_presses(Key::ArrowLeft) as i32
+        };
         let speed = match self.step {
             Some(step) if change != 0 => step,
             _ => self.current_gradient(&position_range),

--- a/egui/src/widgets/slider.rs
+++ b/egui/src/widgets/slider.rs
@@ -456,7 +456,7 @@ impl<'a> Slider<'a> {
     fn value_ui(&mut self, ui: &mut Ui, position_range: RangeInclusive<f32>) -> Response {
         // If `DragValue` is controlled from the keyboard and `step` is defined, set speed to `step`
         let change = {
-            // Hold one lock rather than 4 (see #1380)
+            // Hold one lock rather than 4 (see https://github.com/emilk/egui/pull/1380).
             let input = ui.input();
 
             input.num_presses(Key::ArrowUp) as i32 + input.num_presses(Key::ArrowRight) as i32


### PR DESCRIPTION
This pull request aims to address some accidental double-read locks on `RwLock`s made by egui. When acquiring 2 read locks, if a thread in parallel happened to attempt to acquire a write lock between the two read locks, the second read lock will deadlock. This deadlock occurs due to `RwLock`s refusing any new read locks on a `RwLock` that has a pending Write lock which in most cases can lead to better fairness.

Each commit has a detailed description of the deadlock and how the changes prevent it.

Rather than taking one lock and reusing it, it could be possible to use something like `parking_lot`'s [`read_recursive`](https://docs.rs/lock_api/0.4.6/lock_api/struct.RwLock.html#method.read_recursive) which would bypass the aforementioned second read lock from blocking if a write lock is queued, but in my opinion it would be less clear and maintainers would need to understand the difference between `read()` and `read_recursive()`. Using the already commonly understood scoping/drop system of Rust seems like the better choice.

**Note:** Each of these deadlocks have been found by accident, I did not do an extensive comb through the egui code for these situations so others are bound to exist in the codebase that I have not encountered. These deadlocks were just encountered in my code where a second thread was calling `ctx.request_repaint` very frequently.

**Note 2:** There is no way that I know of to prove that the deadlocks are gone, but the deadlocks have gone away in my application after these changes.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and it is green.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->
