### PR TITLE
Expose more tessellator method

### DIFF
--- a/egui_demo_lib/benches/benchmark.rs
+++ b/egui_demo_lib/benches/benchmark.rs
@@ -129,7 +129,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let font_image_size = fonts.font_image_size();
         c.bench_function("tessellate_text", |b| {
             b.iter(|| {
-                tessellator.tessellate_text(font_image_size, text_shape.clone(), &mut mesh);
+                tessellator.tessellate_text(font_image_size, &text_shape, &mut mesh);
                 mesh.clear();
             })
         });

--- a/epaint/src/mesh.rs
+++ b/epaint/src/mesh.rs
@@ -91,16 +91,28 @@ impl Mesh {
         if self.is_empty() {
             *self = other;
         } else {
+            self.append_ref(&other);
+        }
+    }
+
+    /// Append all the indices and vertices of `other` to `self` without
+    /// taking ownership.
+    pub fn append_ref(&mut self, other: &Mesh) {
+        crate::epaint_assert!(other.is_valid());
+
+        if !self.is_empty() {
             assert_eq!(
                 self.texture_id, other.texture_id,
                 "Can't merge Mesh using different textures"
             );
-
-            let index_offset = self.vertices.len() as u32;
-            self.indices
-                .extend(other.indices.iter().map(|index| index + index_offset));
-            self.vertices.extend(other.vertices.iter());
+        } else {
+            self.texture_id = other.texture_id;
         }
+
+        let index_offset = self.vertices.len() as u32;
+        self.indices
+            .extend(other.indices.iter().map(|index| index + index_offset));
+        self.vertices.extend(other.vertices.iter());
     }
 
     #[inline(always)]

--- a/epaint/src/tessellator.rs
+++ b/epaint/src/tessellator.rs
@@ -744,7 +744,7 @@ impl Tessellator {
                         out,
                     );
                 }
-                self.tessellate_text(tex_size, text_shape, out);
+                self.tessellate_text(tex_size, &text_shape, out);
             }
             Shape::QuadraticBezier(quadratic_shape) => {
                 self.tessellate_quadratic_bezier(quadratic_shape, out);
@@ -913,7 +913,12 @@ impl Tessellator {
     /// * `tex_size`: size of the font texture (required to normalize glyph uv rectangles).
     /// * `text_shape`: the text to tessellate.
     /// * `out`: triangles are appended to this.
-    pub fn tessellate_text(&mut self, tex_size: [usize; 2], text_shape: TextShape, out: &mut Mesh) {
+    pub fn tessellate_text(
+        &mut self,
+        tex_size: [usize; 2],
+        text_shape: &TextShape,
+        out: &mut Mesh,
+    ) {
         let TextShape {
             pos: galley_pos,
             galley,
@@ -938,7 +943,7 @@ impl Tessellator {
 
         let uv_normalizer = vec2(1.0 / tex_size[0] as f32, 1.0 / tex_size[1] as f32);
 
-        let rotator = Rot2::from_angle(angle);
+        let rotator = Rot2::from_angle(*angle);
 
         for row in &galley.rows {
             if row.visuals.mesh.is_empty() {
@@ -946,7 +951,7 @@ impl Tessellator {
             }
 
             let mut row_rect = row.visuals.mesh_bounds;
-            if angle != 0.0 {
+            if *angle != 0.0 {
                 row_rect = row_rect.rotate_bb(rotator);
             }
             row_rect = row_rect.translate(galley_pos.to_vec2());
@@ -978,11 +983,11 @@ impl Tessellator {
 
                         if let Some(override_text_color) = override_text_color {
                             if row.visuals.glyph_vertex_range.contains(&i) {
-                                color = override_text_color;
+                                color = *override_text_color;
                             }
                         }
 
-                        let offset = if angle == 0.0 {
+                        let offset = if *angle == 0.0 {
                             pos.to_vec2()
                         } else {
                             rotator * pos.to_vec2()
@@ -996,12 +1001,12 @@ impl Tessellator {
                     }),
             );
 
-            if underline != Stroke::none() {
+            if *underline != Stroke::none() {
                 self.scratchpad_path.clear();
                 self.scratchpad_path
                     .add_line_segment([row_rect.left_bottom(), row_rect.right_bottom()]);
                 self.scratchpad_path
-                    .stroke_open(underline, &self.options, out);
+                    .stroke_open(*underline, &self.options, out);
             }
         }
     }


### PR DESCRIPTION
* Make public the Tessellator methods to tessellate a circle, a
    mesh, a rectangle, a line, a path, a quadratic and cubic
    bezier curve.
* Add doc to tessellate_text & make it take a reference.
* Add Mesh::append_ref method.

## Notes
* I'm not too happy with the `Mesh::append_ref` method name, but I couldn't think of anything else.
* I'm not exactly sure what should be the behavior of `Mesh::append_ref`
* This is a breaking change because tessellate_text now takes a reference. A non-breaking alternative would be to make it take a `AsRef<TextShape>`.

Closes #1383