### PR TITLE
Put repaint callback and tex manager behind separate mutexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 ### Added ⭐
 * Added `Shape::Callback` for backend-specific painting ([#1351](https://github.com/emilk/egui/pull/1351)).
 * Added `Frame::canvas` ([#1362](https://github.com/emilk/egui/pull/1362)).
-* `Context::request_repaint` will wake up UI thread, if integrations has called `Context::set_request_repaint_callback` ([#1366](https://github.com/emilk/egui/pull/1366)).
+* `Context::request_repaint` will wake up UI thread, if integrations has called `Context::with_repaint_callback` ([#1366](https://github.com/emilk/egui/pull/1366)).
 * Added `Ui::push_id` ([#1374](https://github.com/emilk/egui/pull/1374)).
 
 ### Changed 🔧

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,7 @@ dependencies = [
  "ahash 0.7.6",
  "epaint",
  "nohash-hasher",
+ "parking_lot 0.12.0",
  "ron",
  "serde",
  "tracing",

--- a/egui-winit/src/epi.rs
+++ b/egui-winit/src/epi.rs
@@ -229,12 +229,11 @@ pub struct EpiIntegration {
 impl EpiIntegration {
     pub fn new(
         integration_name: &'static str,
+        egui_ctx: egui::Context,
         max_texture_side: usize,
         window: &winit::window::Window,
         persistence: crate::epi::Persistence,
     ) -> Self {
-        let egui_ctx = egui::Context::default();
-
         *egui_ctx.memory() = persistence.load_memory().unwrap_or_default();
 
         let prefer_dark_mode = prefer_dark_mode();

--- a/egui/Cargo.toml
+++ b/egui/Cargo.toml
@@ -57,6 +57,7 @@ epaint = { version = "0.17.0", path = "../epaint", default-features = false }
 
 ahash = "0.7"
 nohash-hasher = "0.2"
+parking_lot = "0.12"
 
 # Optional:
 ron = { version = "0.7", optional = true }

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -159,14 +159,12 @@ impl AppRunner {
 
         let needs_repaint: std::sync::Arc<NeedRepaint> = Default::default();
 
-        let egui_ctx = egui::Context::default();
-
-        {
+        let egui_ctx = egui::Context::with_repaint_callback({
             let needs_repaint = needs_repaint.clone();
-            egui_ctx.set_request_repaint_callback(move || {
+            move || {
                 needs_repaint.0.store(true, SeqCst);
-            });
-        }
+            }
+        });
 
         load_memory(&egui_ctx);
         if prefer_dark_mode == Some(true) {

--- a/epaint/Cargo.toml
+++ b/epaint/Cargo.toml
@@ -51,7 +51,7 @@ single_threaded = ["atomic_refcell"]
 
 # Only needed if you plan to use the same fonts from multiple threads.
 # It comes with a minor performance impact.
-multi_threaded = ["parking_lot"]
+multi_threaded = []
 
 
 [dependencies]
@@ -63,7 +63,7 @@ atomic_refcell = { version = "0.1", optional = true }                     # Used
 bytemuck = { version = "1.7.2", optional = true, features = ["derive"] }
 cint = { version = "^0.2.2", optional = true }
 nohash-hasher = "0.2"
-parking_lot = { version = "0.12", optional = true }                       # Using parking_lot over std::sync::Mutex gives 50% speedups in some real-world scenarios.
+parking_lot = "0.12"
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
 
 [dev-dependencies]

--- a/epaint/src/texture_handle.rs
+++ b/epaint/src/texture_handle.rs
@@ -1,8 +1,6 @@
-use crate::{
-    emath::NumExt,
-    mutex::{Arc, RwLock},
-    ImageData, ImageDelta, TextureId, TextureManager,
-};
+use crate::{emath::NumExt, mutex::Arc, ImageData, ImageDelta, TextureId, TextureManager};
+
+use parking_lot::RwLock;
 
 /// Used to paint images.
 ///


### PR DESCRIPTION
Closes https://github.com/emilk/egui/issues/1379

Please take a look @DusterTheFirst 

This fattens up `Context` so that the repaint callback and texture manager can be used from any thread, even when you are _not_ compiling with the `multi_threaded` feature flag:

``` rust
pub struct Context {
    ctx: Arc<RwLock<ContextImpl>>,
    repaint_info: Arc<RepaintInfo>,
    tex_manager: WrappedTextureManager,
}
```

This is one solution, but I'm not sure it is the best one.

The solution in this PR has the added advantage of mitigating https://github.com/emilk/egui/pull/1380

---
Performance: the e2e tests shows very little change, but some specific tests (`Painter::rect` and `label format!`) shows 10% slowdowns.

---

I think the simpler solution is to remove the `single_threaded/multi_threaded` features and to always use proper mutexes, as proposed in:

* https://github.com/emilk/egui/pull/1390