### PR TITLE
Add example using `three-d`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +452,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cgmath"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a98d30140e3296250832bbaaff83b27dcd6fa3cc70fb6f1f3e5c9c0023b5317"
+dependencies = [
+ "approx",
+ "num-traits",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,7 +814,7 @@ dependencies = [
  "dirs",
  "objc",
  "rust-ini",
- "winreg",
+ "winreg 0.8.0",
  "zbus",
  "zvariant",
 ]
@@ -995,6 +1014,7 @@ dependencies = [
  "image",
  "poll-promise",
  "rfd",
+ "three-d",
 ]
 
 [[package]]
@@ -1140,6 +1160,15 @@ dependencies = [
  "bytemuck",
  "mint",
  "serde",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1321,6 +1350,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1525,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "gloo-timers"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d12a7f4e95cfe710f1d624fb1210b7d961a5fb05c4fd942f4feab06e61f590e"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "glow"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,10 +1648,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+dependencies = [
+ "num-traits",
+ "serde",
+ "zerocopy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1642,10 +1714,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa 1.0.1",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa 1.0.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
 
 [[package]]
 name = "ident_case"
@@ -1701,6 +1844,12 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
 name = "itertools"
@@ -1808,6 +1957,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
+
+[[package]]
 name = "line-wrap"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,6 +2044,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,6 +2100,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2122,6 +2301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2223,6 +2403,39 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "openssl"
+version = "0.10.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-multimap"
@@ -2596,6 +2809,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "resvg"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2771,6 +3029,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2790,6 +3058,29 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.3",
+ "core-foundation-sys 0.8.3",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys 0.8.3",
+ "libc",
 ]
 
 [[package]]
@@ -2848,6 +3139,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa 1.0.1",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3039,6 +3342,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "syntect"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3078,6 +3393,20 @@ name = "takeable-option"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36ae8932fcfea38b7d3883ae2ab357b0d57a02caaa18ebb4f5ece08beaec4aa0"
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
 
 [[package]]
 name = "termcolor"
@@ -3124,6 +3453,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "three-d"
+version = "0.11.0"
+source = "git+https://github.com/asny/three-d?rev=d9e613d209e45b214fdb96e06ea9907e7a03d4dc#d9e613d209e45b214fdb96e06ea9907e7a03d4dc"
+dependencies = [
+ "cgmath",
+ "gl_generator",
+ "gloo-timers",
+ "glow",
+ "half",
+ "js-sys",
+ "log",
+ "reqwest",
+ "serde",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3187,6 +3536,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "tokio"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+dependencies = [
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3194,6 +3582,12 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
@@ -3263,6 +3657,12 @@ dependencies = [
  "tracing-subscriber",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "ttf-parser"
@@ -3429,6 +3829,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3464,6 +3870,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3476,6 +3892,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if 1.0.0",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -3823,6 +4241,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "x11-clipboard"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3948,6 +4375,27 @@ dependencies = [
  "serde",
  "static_assertions",
  "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0fbc82b82efe24da867ee52e015e58178684bd9dd64c34e66bdf21da2582a9f"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "three-d"
 version = "0.11.0"
-source = "git+https://github.com/asny/three-d?rev=d9e613d209e45b214fdb96e06ea9907e7a03d4dc#d9e613d209e45b214fdb96e06ea9907e7a03d4dc"
+source = "git+https://github.com/asny/three-d?rev=07bbf3b6e3336b758d7dbdfcc14c72f95f361376#07bbf3b6e3336b758d7dbdfcc14c72f95f361376"
 dependencies = [
  "cgmath",
  "gl_generator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
  "dirs",
  "objc",
  "rust-ini",
- "winreg 0.8.0",
+ "winreg",
  "zbus",
  "zvariant",
 ]
@@ -1163,15 +1163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "enum-map"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,15 +1338,6 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
-dependencies = [
- "futures-core",
 ]
 
 [[package]]
@@ -1648,25 +1630,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,81 +1677,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "http"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
-dependencies = [
- "bytes",
- "fnv",
- "itoa 1.0.1",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
-dependencies = [
- "bytes",
- "http",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
-
-[[package]]
-name = "httpdate"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "hyper"
-version = "0.14.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa 1.0.1",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
 
 [[package]]
 name = "ident_case"
@@ -1844,12 +1736,6 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
-
-[[package]]
-name = "ipnet"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
 name = "itertools"
@@ -2044,12 +1930,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,24 +1980,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -2403,39 +2265,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "openssl"
-version = "0.10.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-multimap"
@@ -2809,51 +2638,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-tls",
- "ipnet",
- "js-sys",
- "lazy_static",
- "log",
- "mime",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-native-tls",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg 0.10.1",
-]
-
-[[package]]
 name = "resvg"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3029,16 +2813,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
-dependencies = [
- "lazy_static",
- "winapi",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,29 +2832,6 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.3",
- "core-foundation-sys 0.8.3",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
-dependencies = [
- "core-foundation-sys 0.8.3",
- "libc",
 ]
 
 [[package]]
@@ -3139,18 +2890,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa 1.0.1",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -3395,20 +3134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36ae8932fcfea38b7d3883ae2ab357b0d57a02caaa18ebb4f5ece08beaec4aa0"
 
 [[package]]
-name = "tempfile"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
-dependencies = [
- "cfg-if 1.0.0",
- "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3458,7 +3183,7 @@ dependencies = [
 [[package]]
 name = "three-d"
 version = "0.11.0"
-source = "git+https://github.com/asny/three-d?rev=07bbf3b6e3336b758d7dbdfcc14c72f95f361376#07bbf3b6e3336b758d7dbdfcc14c72f95f361376"
+source = "git+https://github.com/asny/three-d?rev=fa475673e284e05b2f4e068769dce3ec5bcabc8d#fa475673e284e05b2f4e068769dce3ec5bcabc8d"
 dependencies = [
  "cgmath",
  "gl_generator",
@@ -3467,7 +3192,6 @@ dependencies = [
  "half",
  "js-sys",
  "log",
- "reqwest",
  "serde",
  "thiserror",
  "wasm-bindgen",
@@ -3536,45 +3260,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
-name = "tokio"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
-dependencies = [
- "bytes",
- "libc",
- "memchr",
- "mio",
- "pin-project-lite",
- "socket2",
- "winapi",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3582,12 +3267,6 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "tower-service"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
@@ -3657,12 +3336,6 @@ dependencies = [
  "tracing-subscriber",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "try-lock"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "ttf-parser"
@@ -3829,12 +3502,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3867,16 +3534,6 @@ dependencies = [
  "same-file",
  "winapi",
  "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
-dependencies = [
- "log",
- "try-lock",
 ]
 
 [[package]]
@@ -4236,15 +3893,6 @@ name = "winreg"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d107f8c6e916235c4c01cabb3e8acf7bea8ef6a63ca2e7fa0527c049badfc48c"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winreg"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]

--- a/eframe/Cargo.toml
+++ b/eframe/Cargo.toml
@@ -73,4 +73,4 @@ image = { version = "0.24", default-features = false, features = [
 ] }
 poll-promise = "0.1"
 rfd = "0.8"
-three-d = { git = "https://github.com/asny/three-d", rev = "d9e613d209e45b214fdb96e06ea9907e7a03d4dc", default-features = false } # 2022-03-22
+three-d = { git = "https://github.com/asny/three-d", rev = "07bbf3b6e3336b758d7dbdfcc14c72f95f361376", default-features = false } # 2022-03-22

--- a/eframe/Cargo.toml
+++ b/eframe/Cargo.toml
@@ -73,3 +73,4 @@ image = { version = "0.24", default-features = false, features = [
 ] }
 poll-promise = "0.1"
 rfd = "0.8"
+three-d = { git = "https://github.com/asny/three-d", rev = "d9e613d209e45b214fdb96e06ea9907e7a03d4dc", default-features = false } # 2022-03-22

--- a/eframe/Cargo.toml
+++ b/eframe/Cargo.toml
@@ -73,4 +73,4 @@ image = { version = "0.24", default-features = false, features = [
 ] }
 poll-promise = "0.1"
 rfd = "0.8"
-three-d = { git = "https://github.com/asny/three-d", rev = "07bbf3b6e3336b758d7dbdfcc14c72f95f361376", default-features = false } # 2022-03-22
+three-d = { git = "https://github.com/asny/three-d", rev = "fa475673e284e05b2f4e068769dce3ec5bcabc8d", default-features = false } # 2022-03-22

--- a/eframe/examples/custom_3d.rs
+++ b/eframe/examples/custom_3d.rs
@@ -49,7 +49,7 @@ impl eframe::App for MyApp {
             });
 
             egui::ScrollArea::both().show(ui, |ui| {
-                egui::Frame::dark_canvas(ui.style()).show(ui, |ui| {
+                egui::Frame::canvas(ui.style()).show(ui, |ui| {
                     self.custom_painting(ui);
                 });
                 ui.label("Drag to rotate!");
@@ -75,7 +75,7 @@ impl MyApp {
 
         let callback = egui::PaintCallback {
             rect,
-            callback: std::sync::Arc::new(move |render_ctx| {
+            callback: std::sync::Arc::new(move |_info, render_ctx| {
                 if let Some(painter) = render_ctx.downcast_ref::<egui_glow::Painter>() {
                     rotating_triangle.lock().paint(painter.gl(), angle);
                 } else {

--- a/eframe/examples/custom_3d_three-d.rs
+++ b/eframe/examples/custom_3d_three-d.rs
@@ -1,0 +1,160 @@
+//! This demo shows how to embed 3D rendering using [`three-d`](https://github.com/asny/three-d) in `eframe`.
+
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
+#![allow(unsafe_code)]
+
+use eframe::egui;
+
+fn main() {
+    let options = eframe::NativeOptions::default();
+    eframe::run_native(
+        "Custom 3D painting in eframe",
+        options,
+        Box::new(|cc| Box::new(MyApp::new(cc))),
+    );
+}
+
+struct MyApp {
+    // three_d: three_d::Context,
+    angle: f32,
+    reuse_three_d: bool,
+}
+
+impl MyApp {
+    fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+        Self {
+            // three_d: three_d::Context::from_gl_context(cc.gl.clone()).unwrap(),
+            angle: 0.0,
+            reuse_three_d: false,
+        }
+    }
+}
+
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &eframe::Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                ui.spacing_mut().item_spacing.x = 0.0;
+                ui.label("The triangle is being painted using ");
+                ui.hyperlink_to("three-d", "https://github.com/asny/three-d");
+                ui.label(".");
+            });
+
+            ui.checkbox(&mut self.reuse_three_d, "Reuse three-d context");
+
+            egui::ScrollArea::both().show(ui, |ui| {
+                egui::Frame::dark_canvas(ui.style()).show(ui, |ui| {
+                    self.custom_painting(ui);
+                });
+                ui.label("Drag to rotate!");
+            });
+        });
+    }
+}
+
+impl MyApp {
+    fn custom_painting(&mut self, ui: &mut egui::Ui) {
+        let (rect, response) =
+            ui.allocate_exact_size(egui::Vec2::splat(256.0), egui::Sense::drag());
+
+        self.angle += response.drag_delta().x * 0.01;
+
+        // Clone locals so we can move them into the paint callback:
+        let angle = self.angle;
+        let reuse_three_d = self.reuse_three_d;
+        // let three_d = self.three_d.clone();
+
+        let callback = egui::PaintCallback {
+            rect,
+            callback: std::sync::Arc::new(move |render_ctx| {
+                if let Some(painter) = render_ctx.downcast_ref::<egui_glow::Painter>() {
+                    if reuse_three_d {
+                        with_three_d_context(painter.gl(), |three_d| {
+                            paint_with_three_d(three_d, rect, angle);
+                        });
+                    } else {
+                        let three_d =
+                            three_d::Context::from_gl_context(painter.gl().clone()).unwrap();
+                        paint_with_three_d(&three_d, rect, angle);
+                    }
+                } else {
+                    eprintln!("Can't do custom painting because we are not using a glow context");
+                }
+            }),
+        };
+        ui.painter().add(callback);
+    }
+}
+
+// TODO: make `three_d::Context` a member of `MyApp` instead.
+// Requires making `Shape`, and thus `Context`, `!Send + !Sync`.
+fn with_three_d_context<R>(
+    gl: &std::rc::Rc<glow::Context>,
+    f: impl FnOnce(&three_d::Context) -> R,
+) -> R {
+    use std::cell::RefCell;
+    thread_local! {
+        pub static THREE_D: RefCell<Option<three_d::Context>> = RefCell::new(None);
+    }
+
+    THREE_D.with(|three_d| {
+        let mut three_d = three_d.borrow_mut();
+        let three_d =
+            three_d.get_or_insert_with(|| three_d::Context::from_gl_context(gl.clone()).unwrap());
+        f(three_d)
+    })
+}
+
+fn paint_with_three_d(three_d: &three_d::Context, rect: egui::Rect, angle: f32) {
+    // Based on https://github.com/asny/three-d/blob/master/examples/triangle/src/main.rs
+    use three_d::*;
+
+    let viewport = Viewport {
+        x: rect.left() as _,
+        y: rect.top() as _,
+        width: rect.width() as _,
+        height: rect.height() as _,
+    };
+
+    // Create a camera
+    let mut camera = Camera::new_perspective(
+        &three_d,
+        viewport,
+        vec3(0.0, 0.0, 2.0),
+        vec3(0.0, 0.0, 0.0),
+        vec3(0.0, 1.0, 0.0),
+        degrees(45.0),
+        0.1,
+        10.0,
+    )
+    .unwrap();
+
+    // Create a CPU-side mesh consisting of a single colored triangle
+    let positions = vec![
+        vec3(0.5, -0.5, 0.0),  // bottom right
+        vec3(-0.5, -0.5, 0.0), // bottom left
+        vec3(0.0, 0.5, 0.0),   // top
+    ];
+    let colors = vec![
+        Color::new(255, 0, 0, 255), // bottom right
+        Color::new(0, 255, 0, 255), // bottom left
+        Color::new(0, 0, 255, 255), // top
+    ];
+    let cpu_mesh = CpuMesh {
+        positions: Positions::F32(positions),
+        colors: Some(colors),
+        ..Default::default()
+    };
+
+    // Construct a model, with a default color material, thereby transferring the mesh data to the GPU
+    let mut model = Model::new(&three_d, &cpu_mesh).unwrap();
+
+    // Ensure the viewport matches the current window viewport which changes if the window is resized
+    camera.set_viewport(viewport).unwrap();
+
+    // Set the current transformation of the triangle
+    model.set_transformation(Mat4::from_angle_y(radians(angle)));
+
+    // Render the triangle with the color material which uses the per vertex colors defined at construction
+    model.render(&camera, &[]).unwrap();
+}

--- a/eframe/examples/custom_3d_three-d.rs
+++ b/eframe/examples/custom_3d_three-d.rs
@@ -25,12 +25,16 @@ impl MyApp {
         Self {
             // three_d: three_d::Context::from_gl_context(cc.gl.clone()).unwrap(),
             angle: 0.0,
-            reuse_three_d: false,
+            reuse_three_d: true,
         }
     }
 }
 
 impl eframe::App for MyApp {
+    fn clear_color(&self) -> egui::Rgba {
+        egui::Color32::from_rgba_unmultiplied(200, 12, 200, 180).into()
+    }
+
     fn update(&mut self, ctx: &egui::Context, _frame: &eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.horizontal(|ui| {
@@ -43,7 +47,7 @@ impl eframe::App for MyApp {
             ui.checkbox(&mut self.reuse_three_d, "Reuse three-d context");
 
             egui::ScrollArea::both().show(ui, |ui| {
-                egui::Frame::dark_canvas(ui.style()).show(ui, |ui| {
+                egui::Frame::canvas(ui.style()).show(ui, |ui| {
                     self.custom_painting(ui);
                 });
                 ui.label("Drag to rotate!");
@@ -117,7 +121,7 @@ fn paint_with_three_d(three_d: &three_d::Context, info: &egui::PaintCallbackInfo
     };
 
     // Create a camera
-    let mut camera = Camera::new_perspective(
+    let camera = Camera::new_perspective(
         three_d,
         viewport,
         vec3(0.0, 0.0, 2.0),
@@ -148,9 +152,6 @@ fn paint_with_three_d(three_d: &three_d::Context, info: &egui::PaintCallbackInfo
 
     // Construct a model, with a default color material, thereby transferring the mesh data to the GPU
     let mut model = Model::new(three_d, &cpu_mesh).unwrap();
-
-    // Ensure the viewport matches the current window viewport which changes if the window is resized
-    camera.set_viewport(viewport).unwrap();
 
     // Set the current transformation of the triangle
     model.set_transformation(Mat4::from_angle_y(radians(angle)));

--- a/eframe/examples/custom_3d_three-d.rs
+++ b/eframe/examples/custom_3d_three-d.rs
@@ -1,7 +1,6 @@
 //! This demo shows how to embed 3D rendering using [`three-d`](https://github.com/asny/three-d) in `eframe`.
 
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
-#![allow(unsafe_code)]
 
 use eframe::egui;
 

--- a/egui/src/lib.rs
+++ b/egui/src/lib.rs
@@ -307,8 +307,8 @@ pub use epaint::{
     color, mutex,
     text::{FontData, FontDefinitions, FontFamily, FontId, FontTweak},
     textures::TexturesDelta,
-    AlphaImage, ClippedPrimitive, Color32, ColorImage, ImageData, Mesh, PaintCallback, Rgba,
-    Rounding, Shape, Stroke, TextureHandle, TextureId,
+    AlphaImage, ClippedPrimitive, Color32, ColorImage, ImageData, Mesh, PaintCallback,
+    PaintCallbackInfo, Rgba, Rounding, Shape, Stroke, TextureHandle, TextureId,
 };
 
 pub mod text {

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -37,7 +37,7 @@ pub struct Painter {
     u_sampler: glow::UniformLocation,
     is_webgl_1: bool,
     is_embedded: bool,
-    vao: crate::vao::VAO,
+    vao: crate::vao::VertexArrayObject,
     srgb_support: bool,
     /// The filter used for subsequent textures.
     texture_filter: TextureFilter,
@@ -201,7 +201,7 @@ impl Painter {
                     offset: offset_of!(Vertex, color) as i32,
                 },
             ];
-            let vao = crate::vao::VAO::new(&gl, vbo, buffer_infos);
+            let vao = crate::vao::VertexArrayObject::new(&gl, vbo, buffer_infos);
 
             let element_array_buffer = gl.create_buffer()?;
 

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -256,9 +256,13 @@ impl Painter {
         self.gl.enable(glow::SCISSOR_TEST);
         // egui outputs mesh in both winding orders
         self.gl.disable(glow::CULL_FACE);
+        self.gl.disable(glow::DEPTH_TEST);
+
+        self.gl.color_mask(true, true, true, true);
 
         self.gl.enable(glow::BLEND);
-        self.gl.blend_equation(glow::FUNC_ADD);
+        self.gl
+            .blend_equation_separate(glow::FUNC_ADD, glow::FUNC_ADD);
         self.gl.blend_func_separate(
             // egui outputs colors with premultiplied alpha:
             glow::ONE,

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -384,7 +384,13 @@ impl Painter {
                             );
                         }
 
-                        callback.call(self);
+                        let info = egui::PaintCallbackInfo {
+                            rect: callback.rect,
+                            pixels_per_point,
+                            screen_size_px: inner_size,
+                        };
+
+                        callback.call(&info, self);
 
                         check_for_gl_error!(&self.gl, "callback");
 

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -37,12 +37,12 @@ pub struct Painter {
     u_sampler: glow::UniformLocation,
     is_webgl_1: bool,
     is_embedded: bool,
-    vertex_array: crate::vao::VAO,
+    vao: crate::vao::VAO,
     srgb_support: bool,
     /// The filter used for subsequent textures.
     texture_filter: TextureFilter,
     post_process: Option<PostProcess>,
-    vertex_buffer: glow::Buffer,
+    vbo: glow::Buffer,
     element_array_buffer: glow::Buffer,
 
     textures: HashMap<egui::TextureId, glow::Texture>,
@@ -100,11 +100,6 @@ impl Painter {
 
         let max_texture_side = unsafe { gl.get_parameter_i32(glow::MAX_TEXTURE_SIZE) } as usize;
 
-        let support_vao = crate::vao::supports_vao(&gl);
-        if !support_vao {
-            tracing::debug!("VAO not supported");
-        }
-
         let shader_version = ShaderVersion::get(&gl);
         let is_webgl_1 = shader_version == ShaderVersion::Es100;
         let header = shader_version.version();
@@ -122,7 +117,6 @@ impl Painter {
                         Some(PostProcess::new(
                             gl.clone(),
                             shader_prefix,
-                            support_vao,
                             is_webgl_1,
                             width,
                             height,
@@ -173,47 +167,44 @@ impl Painter {
             gl.delete_shader(frag);
             let u_screen_size = gl.get_uniform_location(program, "u_screen_size").unwrap();
             let u_sampler = gl.get_uniform_location(program, "u_sampler").unwrap();
-            let vertex_buffer = gl.create_buffer()?;
-            let element_array_buffer = gl.create_buffer()?;
-            gl.bind_buffer(glow::ARRAY_BUFFER, Some(vertex_buffer));
+
+            let vbo = gl.create_buffer()?;
+
             let a_pos_loc = gl.get_attrib_location(program, "a_pos").unwrap();
             let a_tc_loc = gl.get_attrib_location(program, "a_tc").unwrap();
             let a_srgba_loc = gl.get_attrib_location(program, "a_srgba").unwrap();
-            let mut vertex_array = if support_vao {
-                crate::vao::VAO::native(&gl)
-            } else {
-                crate::vao::VAO::emulated()
-            };
-            vertex_array.bind_vertex_array(&gl);
-            vertex_array.bind_buffer(&gl, &vertex_buffer);
+
             let stride = std::mem::size_of::<Vertex>() as i32;
-            let position_buffer_info = vao::BufferInfo {
-                location: a_pos_loc,
-                vector_size: 2,
-                data_type: glow::FLOAT,
-                normalized: false,
-                stride,
-                offset: offset_of!(Vertex, pos) as i32,
-            };
-            let tex_coord_buffer_info = vao::BufferInfo {
-                location: a_tc_loc,
-                vector_size: 2,
-                data_type: glow::FLOAT,
-                normalized: false,
-                stride,
-                offset: offset_of!(Vertex, uv) as i32,
-            };
-            let color_buffer_info = vao::BufferInfo {
-                location: a_srgba_loc,
-                vector_size: 4,
-                data_type: glow::UNSIGNED_BYTE,
-                normalized: false,
-                stride,
-                offset: offset_of!(Vertex, color) as i32,
-            };
-            vertex_array.add_new_attribute(&gl, position_buffer_info);
-            vertex_array.add_new_attribute(&gl, tex_coord_buffer_info);
-            vertex_array.add_new_attribute(&gl, color_buffer_info);
+            let buffer_infos = vec![
+                vao::BufferInfo {
+                    location: a_pos_loc,
+                    vector_size: 2,
+                    data_type: glow::FLOAT,
+                    normalized: false,
+                    stride,
+                    offset: offset_of!(Vertex, pos) as i32,
+                },
+                vao::BufferInfo {
+                    location: a_tc_loc,
+                    vector_size: 2,
+                    data_type: glow::FLOAT,
+                    normalized: false,
+                    stride,
+                    offset: offset_of!(Vertex, uv) as i32,
+                },
+                vao::BufferInfo {
+                    location: a_srgba_loc,
+                    vector_size: 4,
+                    data_type: glow::UNSIGNED_BYTE,
+                    normalized: false,
+                    stride,
+                    offset: offset_of!(Vertex, color) as i32,
+                },
+            ];
+            let vao = crate::vao::VAO::new(&gl, vbo, buffer_infos);
+
+            let element_array_buffer = gl.create_buffer()?;
+
             check_for_gl_error!(&gl, "after Painter::new");
 
             Ok(Painter {
@@ -224,11 +215,11 @@ impl Painter {
                 u_sampler,
                 is_webgl_1,
                 is_embedded: matches!(shader_version, ShaderVersion::Es100 | ShaderVersion::Es300),
-                vertex_array,
+                vao,
                 srgb_support,
                 texture_filter: Default::default(),
                 post_process,
-                vertex_buffer,
+                vbo,
                 element_array_buffer,
                 textures: Default::default(),
                 #[cfg(feature = "epi")]
@@ -289,8 +280,8 @@ impl Painter {
             .uniform_2_f32(Some(&self.u_screen_size), width_in_points, height_in_points);
         self.gl.uniform_1_i32(Some(&self.u_sampler), 0);
         self.gl.active_texture(glow::TEXTURE0);
-        self.vertex_array.bind_vertex_array(&self.gl);
 
+        self.vao.bind(&self.gl);
         self.gl
             .bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(self.element_array_buffer));
 
@@ -405,8 +396,9 @@ impl Painter {
                 }
             }
         }
+
         unsafe {
-            self.vertex_array.unbind_vertex_array(&self.gl);
+            self.vao.unbind(&self.gl);
             self.gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, None);
 
             if let Some(ref post_process) = self.post_process {
@@ -424,8 +416,7 @@ impl Painter {
         debug_assert!(mesh.is_valid());
         if let Some(texture) = self.get_texture(mesh.texture_id) {
             unsafe {
-                self.gl
-                    .bind_buffer(glow::ARRAY_BUFFER, Some(self.vertex_buffer));
+                self.gl.bind_buffer(glow::ARRAY_BUFFER, Some(self.vbo));
                 self.gl.buffer_data_u8_slice(
                     glow::ARRAY_BUFFER,
                     bytemuck::cast_slice(&mesh.vertices),
@@ -610,7 +601,7 @@ impl Painter {
         for tex in self.textures.values() {
             self.gl.delete_texture(*tex);
         }
-        self.gl.delete_buffer(self.vertex_buffer);
+        self.gl.delete_buffer(self.vbo);
         self.gl.delete_buffer(self.element_array_buffer);
         for t in &self.textures_to_destroy {
             self.gl.delete_texture(*t);

--- a/egui_glow/src/post_process.rs
+++ b/egui_glow/src/post_process.rs
@@ -10,7 +10,7 @@ pub(crate) struct PostProcess {
     gl: std::rc::Rc<glow::Context>,
     pos_buffer: glow::Buffer,
     index_buffer: glow::Buffer,
-    vao: crate::vao::VAO,
+    vao: crate::vao::VertexArrayObject,
     is_webgl_1: bool,
     texture: glow::Texture,
     texture_size: (i32, i32),
@@ -124,7 +124,7 @@ impl PostProcess {
         let a_pos_loc = gl
             .get_attrib_location(program, "a_pos")
             .ok_or_else(|| "failed to get location of a_pos".to_string())?;
-        let vao = crate::vao::VAO::new(
+        let vao = crate::vao::VertexArrayObject::new(
             &gl,
             pos_buffer,
             vec![BufferInfo {

--- a/egui_glow/src/post_process.rs
+++ b/egui_glow/src/post_process.rs
@@ -10,7 +10,7 @@ pub(crate) struct PostProcess {
     gl: std::rc::Rc<glow::Context>,
     pos_buffer: glow::Buffer,
     index_buffer: glow::Buffer,
-    vertex_array: crate::vao::VAO,
+    vao: crate::vao::VAO,
     is_webgl_1: bool,
     texture: glow::Texture,
     texture_size: (i32, i32),
@@ -22,7 +22,6 @@ impl PostProcess {
     pub(crate) unsafe fn new(
         gl: std::rc::Rc<glow::Context>,
         shader_prefix: &str,
-        need_to_emulate_vao: bool,
         is_webgl_1: bool,
         width: i32,
         height: i32,
@@ -125,22 +124,18 @@ impl PostProcess {
         let a_pos_loc = gl
             .get_attrib_location(program, "a_pos")
             .ok_or_else(|| "failed to get location of a_pos".to_string())?;
-        let mut vertex_array = if need_to_emulate_vao {
-            crate::vao::VAO::emulated()
-        } else {
-            crate::vao::VAO::native(&gl)
-        };
-        vertex_array.bind_vertex_array(&gl);
-        vertex_array.bind_buffer(&gl, &pos_buffer);
-        let buffer_info_a_pos = BufferInfo {
-            location: a_pos_loc,
-            vector_size: 2,
-            data_type: glow::FLOAT,
-            normalized: false,
-            stride: 0,
-            offset: 0,
-        };
-        vertex_array.add_new_attribute(&gl, buffer_info_a_pos);
+        let vao = crate::vao::VAO::new(
+            &gl,
+            pos_buffer,
+            vec![BufferInfo {
+                location: a_pos_loc,
+                vector_size: 2,
+                data_type: glow::FLOAT,
+                normalized: false,
+                stride: 0,
+                offset: 0,
+            }],
+        );
 
         let index_buffer = gl.create_buffer()?;
         gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(index_buffer));
@@ -153,7 +148,7 @@ impl PostProcess {
             gl,
             pos_buffer,
             index_buffer,
-            vertex_array,
+            vao,
             is_webgl_1,
             texture,
             texture_size: (width, height),
@@ -212,13 +207,13 @@ impl PostProcess {
             .get_uniform_location(self.program, "u_sampler")
             .unwrap();
         self.gl.uniform_1_i32(Some(&u_sampler_loc), 0);
-        self.vertex_array.bind_vertex_array(&self.gl);
+        self.vao.bind(&self.gl);
 
         self.gl
             .bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(self.index_buffer));
         self.gl
             .draw_elements(glow::TRIANGLES, 6, glow::UNSIGNED_BYTE, 0);
-        self.vertex_array.unbind_vertex_array(&self.gl);
+        self.vao.unbind(&self.gl);
         self.gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, None);
         self.gl.bind_texture(glow::TEXTURE_2D, None);
         self.gl.use_program(None);

--- a/egui_glow/src/vao.rs
+++ b/egui_glow/src/vao.rs
@@ -19,14 +19,14 @@ pub(crate) struct BufferInfo {
 // ----------------------------------------------------------------------------
 
 /// Wrapper around either Emulated VAO and GL's VAO
-pub(crate) struct VAO {
+pub(crate) struct VertexArrayObject {
     // If `None`, we emulate VAO:s.
     vao: Option<crate::glow::VertexArray>,
     vbo: glow::Buffer,
     buffer_infos: Vec<BufferInfo>,
 }
 
-impl VAO {
+impl VertexArrayObject {
     pub(crate) unsafe fn new(
         gl: &glow::Context,
         vbo: glow::Buffer,

--- a/egui_glow/src/vao.rs
+++ b/egui_glow/src/vao.rs
@@ -18,35 +18,66 @@ pub(crate) struct BufferInfo {
 
 // ----------------------------------------------------------------------------
 
-pub struct EmulatedVao {
-    buffer: Option<glow::Buffer>,
+/// Wrapper around either Emulated VAO and GL's VAO
+pub(crate) struct VAO {
+    // If `None`, we emulate VAO:s.
+    vao: Option<crate::glow::VertexArray>,
+    vbo: glow::Buffer,
     buffer_infos: Vec<BufferInfo>,
 }
 
-impl EmulatedVao {
-    pub(crate) fn new() -> Self {
+impl VAO {
+    pub(crate) unsafe fn new(
+        gl: &glow::Context,
+        vbo: glow::Buffer,
+        buffer_infos: Vec<BufferInfo>,
+    ) -> Self {
+        let vao = if supports_vao(gl) {
+            let vao = gl.create_vertex_array().unwrap();
+            check_for_gl_error!(gl, "create_vertex_array");
+
+            // Store state in the VAO:
+            gl.bind_vertex_array(Some(vao));
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(vbo));
+
+            for attribute in &buffer_infos {
+                gl.vertex_attrib_pointer_f32(
+                    attribute.location,
+                    attribute.vector_size,
+                    attribute.data_type,
+                    attribute.normalized,
+                    attribute.stride,
+                    attribute.offset,
+                );
+                check_for_gl_error!(gl, "vertex_attrib_pointer_f32");
+                gl.enable_vertex_attrib_array(attribute.location);
+                check_for_gl_error!(gl, "enable_vertex_attrib_array");
+            }
+
+            gl.bind_vertex_array(None);
+
+            Some(vao)
+        } else {
+            tracing::debug!("VAO not supported");
+            None
+        };
+
         Self {
-            buffer: None,
-            buffer_infos: vec![],
+            vao,
+            vbo,
+            buffer_infos,
         }
     }
 
-    pub(crate) fn bind_buffer(&mut self, buffer: &glow::Buffer) {
-        let _old = self.buffer.replace(*buffer);
-    }
-
-    pub(crate) fn add_new_attribute(&mut self, buffer_info: BufferInfo) {
-        self.buffer_infos.push(buffer_info);
-    }
-
-    pub(crate) fn bind_vertex_array(&self, gl: &glow::Context) {
-        unsafe {
-            gl.bind_buffer(glow::ARRAY_BUFFER, self.buffer);
+    pub(crate) unsafe fn bind(&self, gl: &glow::Context) {
+        if let Some(vao) = self.vao {
+            gl.bind_vertex_array(Some(vao));
+            check_for_gl_error!(gl, "bind_vertex_array");
+        } else {
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(self.vbo));
             check_for_gl_error!(gl, "bind_buffer");
-        }
-        for attribute in &self.buffer_infos {
-            dbg!(attribute);
-            unsafe {
+
+            for attribute in &self.buffer_infos {
                 gl.vertex_attrib_pointer_f32(
                     attribute.location,
                     attribute.vector_size,
@@ -62,87 +93,21 @@ impl EmulatedVao {
         }
     }
 
-    pub(crate) fn unbind_vertex_array(&self, gl: &glow::Context) {
-        for attribute in &self.buffer_infos {
-            unsafe {
+    pub(crate) unsafe fn unbind(&self, gl: &glow::Context) {
+        if self.vao.is_some() {
+            gl.bind_vertex_array(None);
+        } else {
+            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+            for attribute in &self.buffer_infos {
                 gl.disable_vertex_attrib_array(attribute.location);
             }
         }
-        unsafe {
-            gl.bind_buffer(glow::ARRAY_BUFFER, None);
-        }
     }
 }
 
 // ----------------------------------------------------------------------------
 
-/// Wrapper around either Emulated VAO and GL's VAO
-pub(crate) enum VAO {
-    Emulated(crate::vao::EmulatedVao),
-    Native(crate::glow::VertexArray),
-}
-
-impl VAO {
-    pub(crate) unsafe fn native(gl: &glow::Context) -> Self {
-        Self::Native(gl.create_vertex_array().unwrap())
-    }
-
-    pub(crate) unsafe fn emulated() -> Self {
-        Self::Emulated(crate::vao::EmulatedVao::new())
-    }
-
-    pub(crate) unsafe fn bind_vertex_array(&self, gl: &glow::Context) {
-        match self {
-            VAO::Emulated(emulated_vao) => emulated_vao.bind_vertex_array(gl),
-            VAO::Native(vao) => {
-                gl.bind_vertex_array(Some(*vao));
-                check_for_gl_error!(gl, "bind_vertex_array");
-            }
-        }
-    }
-
-    pub(crate) unsafe fn bind_buffer(&mut self, gl: &glow::Context, buffer: &glow::Buffer) {
-        match self {
-            VAO::Emulated(emulated_vao) => emulated_vao.bind_buffer(buffer),
-            VAO::Native(_) => gl.bind_buffer(glow::ARRAY_BUFFER, Some(*buffer)),
-        }
-    }
-
-    pub(crate) unsafe fn add_new_attribute(
-        &mut self,
-        gl: &glow::Context,
-        buffer_info: crate::vao::BufferInfo,
-    ) {
-        match self {
-            VAO::Emulated(emulated_vao) => emulated_vao.add_new_attribute(buffer_info),
-            VAO::Native(_) => {
-                gl.vertex_attrib_pointer_f32(
-                    buffer_info.location,
-                    buffer_info.vector_size,
-                    buffer_info.data_type,
-                    buffer_info.normalized,
-                    buffer_info.stride,
-                    buffer_info.offset,
-                );
-                gl.enable_vertex_attrib_array(buffer_info.location);
-            }
-        }
-    }
-
-    pub(crate) unsafe fn unbind_vertex_array(&self, gl: &glow::Context) {
-        match self {
-            VAO::Emulated(emulated_vao) => emulated_vao.unbind_vertex_array(gl),
-            VAO::Native(_) => {
-                gl.bind_vertex_array(None);
-            }
-        }
-    }
-}
-
-// ----------------------------------------------------------------------------
-
-/// If returned true no need to emulate vao
-pub(crate) fn supports_vao(gl: &glow::Context) -> bool {
+fn supports_vao(gl: &glow::Context) -> bool {
     const WEBGL_PREFIX: &str = "WebGL ";
     const OPENGL_ES_PREFIX: &str = "OpenGL ES ";
 

--- a/egui_glow/src/vao.rs
+++ b/egui_glow/src/vao.rs
@@ -18,7 +18,7 @@ pub(crate) struct BufferInfo {
 
 // ----------------------------------------------------------------------------
 
-/// Wrapper around either Emulated VAO and GL's VAO
+/// Wrapper around either Emulated VAO or GL's VAO.
 pub(crate) struct VertexArrayObject {
     // If `None`, we emulate VAO:s.
     vao: Option<crate::glow::VertexArray>,

--- a/egui_glow/src/vao.rs
+++ b/egui_glow/src/vao.rs
@@ -27,6 +27,7 @@ pub(crate) struct VertexArrayObject {
 }
 
 impl VertexArrayObject {
+    #[allow(clippy::needless_pass_by_value)] // false positive
     pub(crate) unsafe fn new(
         gl: &glow::Context,
         vbo: glow::Buffer,

--- a/epaint/src/lib.rs
+++ b/epaint/src/lib.rs
@@ -31,7 +31,10 @@ pub use {
     image::{AlphaImage, ColorImage, ImageData, ImageDelta},
     mesh::{Mesh, Mesh16, Vertex},
     shadow::Shadow,
-    shape::{CircleShape, PaintCallback, PathShape, RectShape, Rounding, Shape, TextShape},
+    shape::{
+        CircleShape, PaintCallback, PaintCallbackInfo, PathShape, RectShape, Rounding, Shape,
+        TextShape,
+    },
     stats::PaintStats,
     stroke::Stroke,
     tessellator::{tessellate_shapes, TessellationOptions, Tessellator},

--- a/epaint/src/shape.rs
+++ b/epaint/src/shape.rs
@@ -642,6 +642,7 @@ fn dashes_from_line(
 
 // ----------------------------------------------------------------------------
 
+/// Information passed along with [`PaintCallback`] ([`Shape::Callback`]).
 pub struct PaintCallbackInfo {
     /// Viewport in points.
     pub rect: Rect,
@@ -654,27 +655,33 @@ pub struct PaintCallbackInfo {
 }
 
 impl PaintCallbackInfo {
+    /// Physical pixel offset for left side of the viewport.
     #[inline]
     pub fn viewport_left_px(&self) -> f32 {
         self.rect.min.x * self.pixels_per_point
     }
 
+    /// Physical pixel offset for top side of the viewport.
     #[inline]
     pub fn viewport_top_px(&self) -> f32 {
         self.rect.min.y * self.pixels_per_point
     }
 
-    // This is what `glViewport` etc expects.
+    /// Physical pixel offset for bottom side of the viewport.
+    ///
+    /// This is what `glViewport` etc expects for the y axis.
     #[inline]
     pub fn viewport_from_bottom_px(&self) -> f32 {
         self.screen_size_px[1] as f32 - self.rect.max.y * self.pixels_per_point
     }
 
+    /// Viewport width in physical pixels.
     #[inline]
     pub fn viewport_width_px(&self) -> f32 {
         self.rect.width() * self.pixels_per_point
     }
 
+    /// Viewport width in physical pixels.
     #[inline]
     pub fn viewport_height_px(&self) -> f32 {
         self.rect.height() * self.pixels_per_point

--- a/epaint/src/shape.rs
+++ b/epaint/src/shape.rs
@@ -642,6 +642,45 @@ fn dashes_from_line(
 
 // ----------------------------------------------------------------------------
 
+pub struct PaintCallbackInfo {
+    /// Viewport in points.
+    pub rect: Rect,
+
+    /// Pixels per point.
+    pub pixels_per_point: f32,
+
+    /// Full size of the screen, in pixels.
+    pub screen_size_px: [u32; 2],
+}
+
+impl PaintCallbackInfo {
+    #[inline]
+    pub fn viewport_left_px(&self) -> f32 {
+        self.rect.min.x * self.pixels_per_point
+    }
+
+    #[inline]
+    pub fn viewport_top_px(&self) -> f32 {
+        self.rect.min.y * self.pixels_per_point
+    }
+
+    // This is what `glViewport` etc expects.
+    #[inline]
+    pub fn viewport_from_bottom_px(&self) -> f32 {
+        self.screen_size_px[1] as f32 - self.rect.max.y * self.pixels_per_point
+    }
+
+    #[inline]
+    pub fn viewport_width_px(&self) -> f32 {
+        self.rect.width() * self.pixels_per_point
+    }
+
+    #[inline]
+    pub fn viewport_height_px(&self) -> f32 {
+        self.rect.height() * self.pixels_per_point
+    }
+}
+
 /// If you want to paint some 3D shapes inside an egui region, you can use this.
 ///
 /// This is advanced usage, and is backend specific.
@@ -650,21 +689,22 @@ pub struct PaintCallback {
     /// Where to paint.
     pub rect: Rect,
 
-    /// Paint something custom using.
+    /// Paint something custom (e.g. 3D stuff).
     ///
     /// The argument is the render context, and what it contains depends on the backend.
     /// In `eframe` it will be `egui_glow::Painter`.
     ///
     /// The rendering backend is responsible for first setting the active viewport to [`Self::rect`].
-    /// The rendering backend is also responsible for restoring any state it needs,
+    ///
+    /// The rendering backend is also responsible for restoring any state,
     /// such as the bound shader program and vertex array.
-    pub callback: std::sync::Arc<dyn Fn(&dyn std::any::Any) + Send + Sync>,
+    pub callback: std::sync::Arc<dyn Fn(&PaintCallbackInfo, &dyn std::any::Any) + Send + Sync>,
 }
 
 impl PaintCallback {
     #[inline]
-    pub fn call(&self, render_ctx: &dyn std::any::Any) {
-        (self.callback)(render_ctx);
+    pub fn call(&self, info: &PaintCallbackInfo, render_ctx: &dyn std::any::Any) {
+        (self.callback)(info, render_ctx);
     }
 }
 


### PR DESCRIPTION
https://github.com/asny/three-d recently merged a PR adding `glow` support: https://github.com/asny/three-d/pull/210.
This means it is a prime candidate for embedding 3D painting inside an eframe app.

![Screen Shot 2022-03-22 at 10 27 24](https://user-images.githubusercontent.com/1148717/159449118-08bac832-181f-424c-9a6c-82df719389dc.png)

There are currently a few kinks that need to be figured out:

* [x] sudden egui paint failure
* [x] viewport
* [ ] anti-aliasing
* [ ] `Send+Sync`

## Sudden egui paint failure
When reusing the same `three_d` context over time (as one should), we get two(!) good frames of `egui+three_d`, but frame three and onwards the `egui` painting breaks (nothing is painted), but the `three_d` still works. Very weird!

**EDIT**: fixed by https://github.com/asny/three-d/commit/07bbf3b6e3336b758d7dbdfcc14c72f95f361376

## Viewport
The `thee-d` camera requires a viewport (in pixels). This need to be passed in to the `PaintCallback` function, or there needs to be some way of telling `three-d` to use the currently set viewport (less likely).

**EDIT**: fixed by https://github.com/emilk/egui/pull/1398/commits/9181dc7a0e52c48fbdc2648d4b328d95dcaac051

## Anti-aliasing
It would be nice to enable MSAA to smooth out the edges.

## `Shape: Send + Sync`
`Shape` is `Send + Sync` and `three_d::Context` is not. This means we cannot store a three_d context and send it to the `Shape::Callback`.

So we either need to recreate the three_d context each frame (obviously a bad idea), or access it through a `thread_local` hack. This PR adds both as examples, with a checkbox to switch.

We could consider making `Shape: !Send + !Sync`, but that has a lot of downstream implications, as discussed in https://github.com/emilk/egui/issues/1399
