### PR TITLE
glow painter improvements

### DIFF
--- a/eframe/examples/custom_3d.rs
+++ b/eframe/examples/custom_3d.rs
@@ -75,7 +75,7 @@ impl MyApp {
 
         let callback = egui::PaintCallback {
             rect,
-            callback: std::sync::Arc::new(move |render_ctx| {
+            callback: std::sync::Arc::new(move |_info, render_ctx| {
                 if let Some(painter) = render_ctx.downcast_ref::<egui_glow::Painter>() {
                     rotating_triangle.lock().paint(painter.gl(), angle);
                 } else {

--- a/egui/src/lib.rs
+++ b/egui/src/lib.rs
@@ -307,8 +307,8 @@ pub use epaint::{
     color, mutex,
     text::{FontData, FontDefinitions, FontFamily, FontId, FontTweak},
     textures::TexturesDelta,
-    AlphaImage, ClippedPrimitive, Color32, ColorImage, ImageData, Mesh, PaintCallback, Rgba,
-    Rounding, Shape, Stroke, TextureHandle, TextureId,
+    AlphaImage, ClippedPrimitive, Color32, ColorImage, ImageData, Mesh, PaintCallback,
+    PaintCallbackInfo, Rgba, Rounding, Shape, Stroke, TextureHandle, TextureId,
 };
 
 pub mod text {

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -256,9 +256,13 @@ impl Painter {
         self.gl.enable(glow::SCISSOR_TEST);
         // egui outputs mesh in both winding orders
         self.gl.disable(glow::CULL_FACE);
+        self.gl.disable(glow::DEPTH_TEST);
+
+        self.gl.color_mask(true, true, true, true);
 
         self.gl.enable(glow::BLEND);
-        self.gl.blend_equation(glow::FUNC_ADD);
+        self.gl
+            .blend_equation_separate(glow::FUNC_ADD, glow::FUNC_ADD);
         self.gl.blend_func_separate(
             // egui outputs colors with premultiplied alpha:
             glow::ONE,

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -380,7 +380,13 @@ impl Painter {
                             );
                         }
 
-                        callback.call(self);
+                        let info = egui::PaintCallbackInfo {
+                            rect: callback.rect,
+                            pixels_per_point,
+                            screen_size_px: inner_size,
+                        };
+
+                        callback.call(&info, self);
 
                         check_for_gl_error!(&self.gl, "callback");
 

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -37,12 +37,12 @@ pub struct Painter {
     u_sampler: glow::UniformLocation,
     is_webgl_1: bool,
     is_embedded: bool,
-    vertex_array: crate::vao::VAO,
+    vao: crate::vao::VertexArrayObject,
     srgb_support: bool,
     /// The filter used for subsequent textures.
     texture_filter: TextureFilter,
     post_process: Option<PostProcess>,
-    vertex_buffer: glow::Buffer,
+    vbo: glow::Buffer,
     element_array_buffer: glow::Buffer,
 
     textures: HashMap<egui::TextureId, glow::Texture>,
@@ -100,11 +100,6 @@ impl Painter {
 
         let max_texture_side = unsafe { gl.get_parameter_i32(glow::MAX_TEXTURE_SIZE) } as usize;
 
-        let support_vao = crate::vao::supports_vao(&gl);
-        if !support_vao {
-            tracing::debug!("VAO not supported");
-        }
-
         let shader_version = ShaderVersion::get(&gl);
         let is_webgl_1 = shader_version == ShaderVersion::Es100;
         let header = shader_version.version();
@@ -122,7 +117,6 @@ impl Painter {
                         Some(PostProcess::new(
                             gl.clone(),
                             shader_prefix,
-                            support_vao,
                             is_webgl_1,
                             width,
                             height,
@@ -173,47 +167,44 @@ impl Painter {
             gl.delete_shader(frag);
             let u_screen_size = gl.get_uniform_location(program, "u_screen_size").unwrap();
             let u_sampler = gl.get_uniform_location(program, "u_sampler").unwrap();
-            let vertex_buffer = gl.create_buffer()?;
-            let element_array_buffer = gl.create_buffer()?;
-            gl.bind_buffer(glow::ARRAY_BUFFER, Some(vertex_buffer));
+
+            let vbo = gl.create_buffer()?;
+
             let a_pos_loc = gl.get_attrib_location(program, "a_pos").unwrap();
             let a_tc_loc = gl.get_attrib_location(program, "a_tc").unwrap();
             let a_srgba_loc = gl.get_attrib_location(program, "a_srgba").unwrap();
-            let mut vertex_array = if support_vao {
-                crate::vao::VAO::native(&gl)
-            } else {
-                crate::vao::VAO::emulated()
-            };
-            vertex_array.bind_vertex_array(&gl);
-            vertex_array.bind_buffer(&gl, &vertex_buffer);
+
             let stride = std::mem::size_of::<Vertex>() as i32;
-            let position_buffer_info = vao::BufferInfo {
-                location: a_pos_loc,
-                vector_size: 2,
-                data_type: glow::FLOAT,
-                normalized: false,
-                stride,
-                offset: offset_of!(Vertex, pos) as i32,
-            };
-            let tex_coord_buffer_info = vao::BufferInfo {
-                location: a_tc_loc,
-                vector_size: 2,
-                data_type: glow::FLOAT,
-                normalized: false,
-                stride,
-                offset: offset_of!(Vertex, uv) as i32,
-            };
-            let color_buffer_info = vao::BufferInfo {
-                location: a_srgba_loc,
-                vector_size: 4,
-                data_type: glow::UNSIGNED_BYTE,
-                normalized: false,
-                stride,
-                offset: offset_of!(Vertex, color) as i32,
-            };
-            vertex_array.add_new_attribute(&gl, position_buffer_info);
-            vertex_array.add_new_attribute(&gl, tex_coord_buffer_info);
-            vertex_array.add_new_attribute(&gl, color_buffer_info);
+            let buffer_infos = vec![
+                vao::BufferInfo {
+                    location: a_pos_loc,
+                    vector_size: 2,
+                    data_type: glow::FLOAT,
+                    normalized: false,
+                    stride,
+                    offset: offset_of!(Vertex, pos) as i32,
+                },
+                vao::BufferInfo {
+                    location: a_tc_loc,
+                    vector_size: 2,
+                    data_type: glow::FLOAT,
+                    normalized: false,
+                    stride,
+                    offset: offset_of!(Vertex, uv) as i32,
+                },
+                vao::BufferInfo {
+                    location: a_srgba_loc,
+                    vector_size: 4,
+                    data_type: glow::UNSIGNED_BYTE,
+                    normalized: false,
+                    stride,
+                    offset: offset_of!(Vertex, color) as i32,
+                },
+            ];
+            let vao = crate::vao::VertexArrayObject::new(&gl, vbo, buffer_infos);
+
+            let element_array_buffer = gl.create_buffer()?;
+
             check_for_gl_error!(&gl, "after Painter::new");
 
             Ok(Painter {
@@ -224,11 +215,11 @@ impl Painter {
                 u_sampler,
                 is_webgl_1,
                 is_embedded: matches!(shader_version, ShaderVersion::Es100 | ShaderVersion::Es300),
-                vertex_array,
+                vao,
                 srgb_support,
                 texture_filter: Default::default(),
                 post_process,
-                vertex_buffer,
+                vbo,
                 element_array_buffer,
                 textures: Default::default(),
                 #[cfg(feature = "epi")]
@@ -289,8 +280,8 @@ impl Painter {
             .uniform_2_f32(Some(&self.u_screen_size), width_in_points, height_in_points);
         self.gl.uniform_1_i32(Some(&self.u_sampler), 0);
         self.gl.active_texture(glow::TEXTURE0);
-        self.vertex_array.bind_vertex_array(&self.gl);
 
+        self.vao.bind(&self.gl);
         self.gl
             .bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(self.element_array_buffer));
 
@@ -405,8 +396,9 @@ impl Painter {
                 }
             }
         }
+
         unsafe {
-            self.vertex_array.unbind_vertex_array(&self.gl);
+            self.vao.unbind(&self.gl);
             self.gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, None);
 
             if let Some(ref post_process) = self.post_process {
@@ -424,8 +416,7 @@ impl Painter {
         debug_assert!(mesh.is_valid());
         if let Some(texture) = self.get_texture(mesh.texture_id) {
             unsafe {
-                self.gl
-                    .bind_buffer(glow::ARRAY_BUFFER, Some(self.vertex_buffer));
+                self.gl.bind_buffer(glow::ARRAY_BUFFER, Some(self.vbo));
                 self.gl.buffer_data_u8_slice(
                     glow::ARRAY_BUFFER,
                     bytemuck::cast_slice(&mesh.vertices),
@@ -610,7 +601,7 @@ impl Painter {
         for tex in self.textures.values() {
             self.gl.delete_texture(*tex);
         }
-        self.gl.delete_buffer(self.vertex_buffer);
+        self.gl.delete_buffer(self.vbo);
         self.gl.delete_buffer(self.element_array_buffer);
         for t in &self.textures_to_destroy {
             self.gl.delete_texture(*t);

--- a/epaint/src/lib.rs
+++ b/epaint/src/lib.rs
@@ -31,7 +31,10 @@ pub use {
     image::{AlphaImage, ColorImage, ImageData, ImageDelta},
     mesh::{Mesh, Mesh16, Vertex},
     shadow::Shadow,
-    shape::{CircleShape, PaintCallback, PathShape, RectShape, Rounding, Shape, TextShape},
+    shape::{
+        CircleShape, PaintCallback, PaintCallbackInfo, PathShape, RectShape, Rounding, Shape,
+        TextShape,
+    },
     stats::PaintStats,
     stroke::Stroke,
     tessellator::{tessellate_shapes, TessellationOptions, Tessellator},

--- a/epaint/src/shape.rs
+++ b/epaint/src/shape.rs
@@ -642,6 +642,52 @@ fn dashes_from_line(
 
 // ----------------------------------------------------------------------------
 
+/// Information passed along with [`PaintCallback`] ([`Shape::Callback`]).
+pub struct PaintCallbackInfo {
+    /// Viewport in points.
+    pub rect: Rect,
+
+    /// Pixels per point.
+    pub pixels_per_point: f32,
+
+    /// Full size of the screen, in pixels.
+    pub screen_size_px: [u32; 2],
+}
+
+impl PaintCallbackInfo {
+    /// Physical pixel offset for left side of the viewport.
+    #[inline]
+    pub fn viewport_left_px(&self) -> f32 {
+        self.rect.min.x * self.pixels_per_point
+    }
+
+    /// Physical pixel offset for top side of the viewport.
+    #[inline]
+    pub fn viewport_top_px(&self) -> f32 {
+        self.rect.min.y * self.pixels_per_point
+    }
+
+    /// Physical pixel offset for bottom side of the viewport.
+    ///
+    /// This is what `glViewport` etc expects for the y axis.
+    #[inline]
+    pub fn viewport_from_bottom_px(&self) -> f32 {
+        self.screen_size_px[1] as f32 - self.rect.max.y * self.pixels_per_point
+    }
+
+    /// Viewport width in physical pixels.
+    #[inline]
+    pub fn viewport_width_px(&self) -> f32 {
+        self.rect.width() * self.pixels_per_point
+    }
+
+    /// Viewport width in physical pixels.
+    #[inline]
+    pub fn viewport_height_px(&self) -> f32 {
+        self.rect.height() * self.pixels_per_point
+    }
+}
+
 /// If you want to paint some 3D shapes inside an egui region, you can use this.
 ///
 /// This is advanced usage, and is backend specific.
@@ -650,21 +696,22 @@ pub struct PaintCallback {
     /// Where to paint.
     pub rect: Rect,
 
-    /// Paint something custom using.
+    /// Paint something custom (e.g. 3D stuff).
     ///
     /// The argument is the render context, and what it contains depends on the backend.
     /// In `eframe` it will be `egui_glow::Painter`.
     ///
     /// The rendering backend is responsible for first setting the active viewport to [`Self::rect`].
-    /// The rendering backend is also responsible for restoring any state it needs,
+    ///
+    /// The rendering backend is also responsible for restoring any state,
     /// such as the bound shader program and vertex array.
-    pub callback: std::sync::Arc<dyn Fn(&dyn std::any::Any) + Send + Sync>,
+    pub callback: std::sync::Arc<dyn Fn(&PaintCallbackInfo, &dyn std::any::Any) + Send + Sync>,
 }
 
 impl PaintCallback {
     #[inline]
-    pub fn call(&self, render_ctx: &dyn std::any::Any) {
-        (self.callback)(render_ctx);
+    pub fn call(&self, info: &PaintCallbackInfo, render_ctx: &dyn std::any::Any) {
+        (self.callback)(info, render_ctx);
     }
 }
 


### PR DESCRIPTION
Add `PaintCallbackInfo` to `PaintCallback`: this contains viewport information, which is useful for embedding 3D in egui.

This also refactors the glow VAO code, making it much cleaner. This is a step towards fixing https://github.com/emilk/egui/issues/1400