### PR TITLE
Storage and frame refactor

### DIFF
--- a/eframe/CHANGELOG.md
+++ b/eframe/CHANGELOG.md
@@ -8,8 +8,16 @@ NOTE: [`egui_web`](../egui_web/CHANGELOG.md), [`egui-winit`](../egui-winit/CHANG
 * Change default for `NativeOptions::drag_and_drop_support` to `true` ([#1329](https://github.com/emilk/egui/pull/1329)).
 * Remove the `egui_glium` feature. `eframe` will now always use `egui_glow` as the native backend ([#1357](https://github.com/emilk/egui/pull/1357)).
 * Removed `Frame::request_repaint` - just call `egui::Context::request_repaint` for the same effect ([#1366](https://github.com/emilk/egui/pull/1366)).
-* Use full browser width by default  ([#1378](https://github.com/emilk/egui/pull/1378)).
-* Add new `NativeOptions`: `vsync`, `multisampling`, `depth_buffer`, `stencil_buffer`.
+* Use full browser width by default ([#1378](https://github.com/emilk/egui/pull/1378)).
+* Added new `NativeOptions`: `vsync`, `multisampling`, `depth_buffer`, `stencil_buffer`.
+* Changed app creation/setup ([#1363](https://github.com/emilk/egui/pull/1363)):
+  * Removed `App::setup` and `App::name`.
+  * Provide `CreationContext` when creating app with egui context, storage, integration info and glow context.
+  * Change interface of `run_native` and `start_web`.
+* Added `Frame::storage()` and `Frame::storage_mut()` ([#1418](https://github.com/emilk/egui/pull/1418)).
+  * You can now load/save state in `App::update`
+  * Changed `App::update` to take `&mut Frame` instead of `&Frame`.
+  * `Frame` is no longer `Clone` or `Sync`.
 
 
 ## 0.17.0 - 2022-02-22

--- a/eframe/examples/confirm_exit.rs
+++ b/eframe/examples/confirm_exit.rs
@@ -23,7 +23,7 @@ impl eframe::App for MyApp {
         self.can_exit
     }
 
-    fn update(&mut self, ctx: &egui::Context, frame: &eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("Try to close the window");
         });

--- a/eframe/examples/custom_3d_glow.rs
+++ b/eframe/examples/custom_3d_glow.rs
@@ -46,7 +46,7 @@ impl MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.horizontal(|ui| {
                 ui.spacing_mut().item_spacing.x = 0.0;

--- a/eframe/examples/custom_3d_three-d.rs
+++ b/eframe/examples/custom_3d_three-d.rs
@@ -37,7 +37,7 @@ impl MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             egui::widgets::global_dark_light_mode_buttons(ui);
 

--- a/eframe/examples/custom_font.rs
+++ b/eframe/examples/custom_font.rs
@@ -54,7 +54,7 @@ impl MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("egui using custom fonts");
             ui.text_edit_multiline(&mut self.text);

--- a/eframe/examples/custom_window_frame.rs
+++ b/eframe/examples/custom_window_frame.rs
@@ -28,7 +28,7 @@ impl eframe::App for MyApp {
         egui::Rgba::TRANSPARENT // Make sure we don't paint anything behind the rounded corners
     }
 
-    fn update(&mut self, ctx: &egui::Context, frame: &eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
         custon_window_frame(ctx, frame, "egui with custom frame", |ui| {
             ui.label("This is just the contents of the window");
             ui.horizontal(|ui| {
@@ -41,7 +41,7 @@ impl eframe::App for MyApp {
 
 fn custon_window_frame(
     ctx: &egui::Context,
-    frame: &eframe::Frame,
+    frame: &mut eframe::Frame,
     title: &str,
     add_contents: impl FnOnce(&mut egui::Ui),
 ) {

--- a/eframe/examples/download_image.rs
+++ b/eframe/examples/download_image.rs
@@ -20,7 +20,7 @@ struct MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         let promise = self.promise.get_or_insert_with(|| {
             // Begin download.
             // We download the image using `ehttp`, a library that works both in WASM and on native.

--- a/eframe/examples/file_dialog.rs
+++ b/eframe/examples/file_dialog.rs
@@ -21,7 +21,7 @@ struct MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.label("Drag-and-drop files onto the window!");
 

--- a/eframe/examples/hello_world.rs
+++ b/eframe/examples/hello_world.rs
@@ -26,7 +26,7 @@ impl Default for MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("My egui Application");
             ui.horizontal(|ui| {

--- a/eframe/examples/image.rs
+++ b/eframe/examples/image.rs
@@ -32,7 +32,7 @@ impl Default for MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("This is an image:");
             self.image.show(ui);

--- a/eframe/examples/svg.rs
+++ b/eframe/examples/svg.rs
@@ -35,7 +35,7 @@ impl Default for MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("SVG example");
             ui.label("The SVG is rasterized and displayed as a texture.");

--- a/eframe/src/lib.rs
+++ b/eframe/src/lib.rs
@@ -37,7 +37,7 @@
 //! }
 //!
 //! impl eframe::App for MyEguiApp {
-//!    fn update(&mut self, ctx: &egui::Context, frame: &eframe::Frame) {
+//!    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
 //!        egui::CentralPanel::default().show(ctx, |ui| {
 //!            ui.heading("Hello World!");
 //!        });
@@ -126,7 +126,7 @@ pub fn start_web(canvas_id: &str, app_creator: AppCreator) -> Result<(), wasm_bi
 /// }
 ///
 /// impl eframe::App for MyEguiApp {
-///    fn update(&mut self, ctx: &egui::Context, frame: &eframe::Frame) {
+///    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
 ///        egui::CentralPanel::default().show(ctx, |ui| {
 ///            ui.heading("Hello World!");
 ///        });

--- a/egui-winit/src/epi.rs
+++ b/egui-winit/src/epi.rs
@@ -289,9 +289,9 @@ impl EpiIntegration {
 }
 
 #[cfg(feature = "persistence")]
-const STORAGE_EGUI_MEMORY_KEY: &'static str = "egui";
+const STORAGE_EGUI_MEMORY_KEY: &str = "egui";
 #[cfg(feature = "persistence")]
-const STORAGE_WINDOW_KEY: &'static str = "window";
+const STORAGE_WINDOW_KEY: &str = "window";
 
 pub fn load_window_settings(_storage: Option<&dyn epi::Storage>) -> Option<crate::WindowSettings> {
     #[cfg(feature = "persistence")]

--- a/egui-winit/src/epi.rs
+++ b/egui-winit/src/epi.rs
@@ -155,7 +155,7 @@ impl EpiIntegration {
     ) -> Self {
         let egui_ctx = egui::Context::default();
 
-        *egui_ctx.memory() = load_memory(storage.as_deref()).unwrap_or_default();
+        *egui_ctx.memory() = load_egui_memory(storage.as_deref()).unwrap_or_default();
 
         let prefer_dark_mode = prefer_dark_mode();
 
@@ -302,7 +302,7 @@ pub fn load_window_settings(_storage: Option<&dyn epi::Storage>) -> Option<crate
     None
 }
 
-pub fn load_memory(_storage: Option<&dyn epi::Storage>) -> Option<egui::Memory> {
+pub fn load_egui_memory(_storage: Option<&dyn epi::Storage>) -> Option<egui::Memory> {
     #[cfg(feature = "persistence")]
     {
         epi::get_value(_storage?, STORAGE_EGUI_MEMORY_KEY)

--- a/egui-winit/src/epi.rs
+++ b/egui-winit/src/epi.rs
@@ -248,7 +248,7 @@ impl EpiIntegration {
 
         let prefer_dark_mode = prefer_dark_mode();
 
-        let frame = epi::Frame::new(epi::backend::FrameData {
+        let frame = epi::Frame {
             info: epi::IntegrationInfo {
                 name: integration_name,
                 web_info: None,
@@ -258,7 +258,7 @@ impl EpiIntegration {
             },
             output: Default::default(),
             storage,
-        });
+        };
 
         if prefer_dark_mode == Some(true) {
             egui_ctx.set_visuals(egui::Visuals::dark());
@@ -333,7 +333,7 @@ impl EpiIntegration {
         }
 
         let frame_time = (instant::Instant::now() - frame_start).as_secs_f64() as f32;
-        self.frame.0.info.cpu_usage = Some(frame_time);
+        self.frame.info.cpu_usage = Some(frame_time);
 
         full_output
     }
@@ -348,7 +348,7 @@ impl EpiIntegration {
     }
 
     pub fn maybe_autosave(&mut self, app: &mut dyn epi::App, window: &winit::window::Window) {
-        let storage = self.frame.0.storage.as_deref_mut();
+        let storage = self.frame.storage.as_deref_mut();
         if let Some(storage) = storage {
             self.persistence
                 .maybe_autosave(Some(storage), &mut *app, &self.egui_ctx, window);

--- a/egui_demo_lib/src/apps/color_test.rs
+++ b/egui_demo_lib/src/apps/color_test.rs
@@ -30,7 +30,7 @@ impl Default for ColorTest {
 }
 
 impl epi::App for ColorTest {
-    fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
+    fn update(&mut self, ctx: &egui::Context, frame: &mut epi::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             if frame.is_web() {
                 ui.label(

--- a/egui_demo_lib/src/apps/demo/app.rs
+++ b/egui_demo_lib/src/apps/demo/app.rs
@@ -6,7 +6,7 @@ pub struct DemoApp {
 }
 
 impl epi::App for DemoApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut epi::Frame) {
         self.demo_windows.ui(ctx);
     }
 }

--- a/egui_demo_lib/src/apps/fractal_clock.rs
+++ b/egui_demo_lib/src/apps/fractal_clock.rs
@@ -33,7 +33,7 @@ impl Default for FractalClock {
 }
 
 impl epi::App for FractalClock {
-    fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut epi::Frame) {
         egui::CentralPanel::default()
             .frame(Frame::dark_canvas(&ctx.style()))
             .show(ctx, |ui| self.ui(ui, crate::seconds_since_midnight()));

--- a/egui_demo_lib/src/apps/http_app.rs
+++ b/egui_demo_lib/src/apps/http_app.rs
@@ -54,7 +54,7 @@ impl Default for HttpApp {
 }
 
 impl epi::App for HttpApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
+    fn update(&mut self, ctx: &egui::Context, frame: &mut epi::Frame) {
         egui::TopBottomPanel::bottom("http_bottom").show(ctx, |ui| {
             let layout = egui::Layout::top_down(egui::Align::Center).with_main_justify(true);
             ui.allocate_ui_with_layout(ui.available_size(), layout, |ui| {
@@ -108,7 +108,7 @@ impl epi::App for HttpApp {
     }
 }
 
-fn ui_url(ui: &mut egui::Ui, frame: &epi::Frame, url: &mut String) -> bool {
+fn ui_url(ui: &mut egui::Ui, frame: &mut epi::Frame, url: &mut String) -> bool {
     let mut trigger_fetch = false;
 
     ui.horizontal(|ui| {

--- a/egui_demo_lib/src/backend_panel.rs
+++ b/egui_demo_lib/src/backend_panel.rs
@@ -73,7 +73,7 @@ impl Default for BackendPanel {
 }
 
 impl BackendPanel {
-    pub fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
+    pub fn update(&mut self, ctx: &egui::Context, frame: &mut epi::Frame) {
         self.frame_history
             .on_new_frame(ctx.input().time, frame.info().cpu_usage);
 
@@ -87,7 +87,7 @@ impl BackendPanel {
         self.egui_windows.windows(ctx);
     }
 
-    pub fn ui(&mut self, ui: &mut egui::Ui, frame: &epi::Frame) {
+    pub fn ui(&mut self, ui: &mut egui::Ui, frame: &mut epi::Frame) {
         egui::trace!(ui);
         ui.vertical_centered(|ui| {
             ui.heading("💻 Backend");
@@ -142,7 +142,7 @@ impl BackendPanel {
         }
     }
 
-    fn integration_ui(&mut self, ui: &mut egui::Ui, frame: &epi::Frame) {
+    fn integration_ui(&mut self, ui: &mut egui::Ui, frame: &mut epi::Frame) {
         if frame.is_web() {
             ui.label("egui is an immediate mode GUI written in Rust, compiled to WebAssembly, rendered with WebGL.");
             ui.label(

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -30,7 +30,7 @@ impl Default for EasyMarkEditor {
 }
 
 impl epi::App for EasyMarkEditor {
-    fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut epi::Frame) {
         egui::TopBottomPanel::bottom("easy_mark_bottom").show(ctx, |ui| {
             let layout = egui::Layout::top_down(egui::Align::Center).with_main_justify(true);
             ui.allocate_ui_with_layout(ui.available_size(), layout, |ui| {

--- a/egui_demo_lib/src/wrap_app.rs
+++ b/egui_demo_lib/src/wrap_app.rs
@@ -69,7 +69,7 @@ impl epi::App for WrapApp {
         egui::Rgba::TRANSPARENT // we set a `CentralPanel` fill color in `demo_windows.rs`
     }
 
-    fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
+    fn update(&mut self, ctx: &egui::Context, frame: &mut epi::Frame) {
         if let Some(web_info) = frame.info().web_info.as_ref() {
             if let Some(anchor) = web_info.location.hash.strip_prefix('#') {
                 self.selected_anchor = anchor.to_owned();
@@ -130,7 +130,7 @@ impl epi::App for WrapApp {
 }
 
 impl WrapApp {
-    fn bar_contents(&mut self, ui: &mut egui::Ui, frame: &epi::Frame) {
+    fn bar_contents(&mut self, ui: &mut egui::Ui, frame: &mut epi::Frame) {
         // A menu-bar is a horizontal layout with some special styles applied.
         // egui::menu::bar(ui, |ui| {
         ui.horizontal_wrapped(|ui| {

--- a/egui_glow/src/epi_backend.rs
+++ b/egui_glow/src/epi_backend.rs
@@ -37,8 +37,8 @@ pub use epi::NativeOptions;
 /// Run an egui app
 #[allow(unsafe_code)]
 pub fn run(app_name: &str, native_options: &epi::NativeOptions, app_creator: epi::AppCreator) -> ! {
-    let (storage, persistence) = egui_winit::epi::Persistence::from_app_name(app_name);
-    let window_settings = persistence.load_window_settings(storage.as_deref());
+    let storage = egui_winit::epi::create_storage(app_name);
+    let window_settings = egui_winit::epi::load_window_settings(storage.as_deref());
     let window_builder =
         egui_winit::epi::window_builder(native_options, &window_settings).with_title(app_name);
     let event_loop = winit::event_loop::EventLoop::with_user_event();
@@ -53,7 +53,6 @@ pub fn run(app_name: &str, native_options: &epi::NativeOptions, app_creator: epi
         painter.max_texture_side(),
         gl_window.window(),
         storage,
-        persistence,
     );
 
     {
@@ -155,14 +154,7 @@ pub fn run(app_name: &str, native_options: &epi::NativeOptions, app_creator: epi
                 gl_window.window().request_redraw(); // TODO: ask egui if the events warrants a repaint instead
             }
             winit::event::Event::LoopDestroyed => {
-                if let Some(storage) = integration.frame.storage_mut() {
-                    integration.persistence.save(
-                        Some(storage),
-                        &mut *app,
-                        &integration.egui_ctx,
-                        gl_window.window(),
-                    );
-                }
+                integration.save(&mut *app, gl_window.window());
                 app.on_exit(&gl);
                 painter.destroy();
             }

--- a/egui_web/CHANGELOG.md
+++ b/egui_web/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the `egui_web` integration will be noted in this file.
 ## Unreleased
 * egui code will no longer be called after panic ([#1306](https://github.com/emilk/egui/pull/1306)).
 * Remove the "webgl" feature. `egui_web` now always use `glow` (which in turn wraps WebGL) ([#1356](https://github.com/emilk/egui/pull/1356)).
-* Use full browser width by default  ([#1378](https://github.com/emilk/egui/pull/1378)).
+* Use full browser width by default ([#1378](https://github.com/emilk/egui/pull/1378)).
 
 
 ## 0.17.0 - 2022-02-22

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -143,7 +143,7 @@ impl AppRunner {
 
         let prefer_dark_mode = crate::prefer_dark_mode();
 
-        let frame = epi::Frame::new(epi::backend::FrameData {
+        let frame = epi::Frame {
             info: epi::IntegrationInfo {
                 name: "egui_web",
                 web_info: Some(epi::WebInfo {
@@ -155,7 +155,7 @@ impl AppRunner {
             },
             output: Default::default(),
             storage: Some(Box::new(LocalStorage::default())),
-        });
+        };
 
         let needs_repaint: std::sync::Arc<NeedRepaint> = Default::default();
 
@@ -270,7 +270,7 @@ impl AppRunner {
             } = app_output;
         }
 
-        self.frame.0.info.cpu_usage = Some((now_sec() - frame_start) as f32);
+        self.frame.info.cpu_usage = Some((now_sec() - frame_start) as f32);
         Ok((needs_repaint, clipped_primitives))
     }
 

--- a/egui_web/src/backend.rs
+++ b/egui_web/src/backend.rs
@@ -130,7 +130,6 @@ pub struct AppRunner {
     pub(crate) input: WebInput,
     app: Box<dyn epi::App>,
     pub(crate) needs_repaint: std::sync::Arc<NeedRepaint>,
-    storage: LocalStorage,
     last_save_time: f64,
     screen_reader: crate::screen_reader::ScreenReader,
     pub(crate) text_cursor_pos: Option<egui::Pos2>,
@@ -155,6 +154,7 @@ impl AppRunner {
                 native_pixels_per_point: Some(native_pixels_per_point()),
             },
             output: Default::default(),
+            storage: Some(Box::new(LocalStorage::default())),
         });
 
         let needs_repaint: std::sync::Arc<NeedRepaint> = Default::default();
@@ -175,12 +175,10 @@ impl AppRunner {
             egui_ctx.set_visuals(egui::Visuals::light());
         }
 
-        let storage = LocalStorage::default();
-
         let app = app_creator(&epi::CreationContext {
             egui_ctx: egui_ctx.clone(),
             integration_info: frame.info(),
-            storage: Some(&storage),
+            storage: frame.storage(),
             gl: painter.painter.gl().clone(),
         });
 
@@ -191,7 +189,6 @@ impl AppRunner {
             input: Default::default(),
             app,
             needs_repaint,
-            storage,
             last_save_time: now_sec(),
             screen_reader: Default::default(),
             text_cursor_pos: None,
@@ -216,7 +213,9 @@ impl AppRunner {
             if self.app.persist_egui_memory() {
                 save_memory(&self.egui_ctx);
             }
-            self.app.save(&mut self.storage);
+            if let Some(storage) = self.frame.storage_mut() {
+                self.app.save(storage);
+            }
             self.last_save_time = now;
         }
     }
@@ -247,7 +246,7 @@ impl AppRunner {
         let raw_input = self.input.new_frame(canvas_size);
 
         let full_output = self.egui_ctx.run(raw_input, |egui_ctx| {
-            self.app.update(egui_ctx, &self.frame);
+            self.app.update(egui_ctx, &mut self.frame);
         });
         let egui::FullOutput {
             platform_output,
@@ -271,7 +270,7 @@ impl AppRunner {
             } = app_output;
         }
 
-        self.frame.lock().info.cpu_usage = Some((now_sec() - frame_start) as f32);
+        self.frame.0.info.cpu_usage = Some((now_sec() - frame_start) as f32);
         Ok((needs_repaint, clipped_primitives))
     }
 

--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -511,7 +511,7 @@ fn install_document_events(runner_container: &AppRunnerContainer) -> Result<(), 
         "hashchange",
         |_: web_sys::Event, mut runner_lock| {
             // `epi::Frame::info(&self)` clones `epi::IntegrationInfo`, but we need to modify the original here
-            if let Some(web_info) = &mut runner_lock.frame.0.info.web_info {
+            if let Some(web_info) = &mut runner_lock.frame.info.web_info {
                 web_info.location.hash = location_hash();
             }
         },

--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -509,11 +509,9 @@ fn install_document_events(runner_container: &AppRunnerContainer) -> Result<(), 
     runner_container.add_event_listener(
         &document,
         "hashchange",
-        |_: web_sys::Event, runner_lock| {
-            let mut frame_lock = runner_lock.frame.lock();
-
+        |_: web_sys::Event, mut runner_lock| {
             // `epi::Frame::info(&self)` clones `epi::IntegrationInfo`, but we need to modify the original here
-            if let Some(web_info) = &mut frame_lock.info.web_info {
+            if let Some(web_info) = &mut runner_lock.frame.0.info.web_info {
                 web_info.location.hash = location_hash();
             }
         },

--- a/epaint/CHANGELOG.md
+++ b/epaint/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to the epaint crate will be documented in this file.
 
 
 ## 0.16.0 - 2021-12-29
-* Anti-alias path ends  ([#893](https://github.com/emilk/egui/pull/893)).
+* Anti-alias path ends ([#893](https://github.com/emilk/egui/pull/893)).
 * `Rgba` now implements `Hash` ([#886](https://github.com/emilk/egui/pull/886)).
 * Renamed `Texture` to `FontImage`.
 

--- a/epaint/src/image.rs
+++ b/epaint/src/image.rs
@@ -34,8 +34,7 @@ impl ImageData {
 
     pub fn bytes_per_pixel(&self) -> usize {
         match self {
-            Self::Color(_) => 4,
-            Self::Font(_) => 4,
+            Self::Color(_) | Self::Font(_) => 4,
         }
     }
 }

--- a/epi/src/lib.rs
+++ b/epi/src/lib.rs
@@ -15,8 +15,6 @@ pub mod file_storage;
 pub use egui; // Re-export for user convenience
 pub use glow; // Re-export for user convenience
 
-use std::sync::{Arc, Mutex};
-
 /// The is is how your app is created.
 ///
 /// You can use the [`CreationContext`] to setup egui, restore state, setup OpenGL things, etc.
@@ -50,10 +48,10 @@ pub trait App {
     ///
     /// Put your widgets into a [`egui::SidePanel`], [`egui::TopBottomPanel`], [`egui::CentralPanel`], [`egui::Window`] or [`egui::Area`].
     ///
-    /// The [`egui::Context`] and [`Frame`] can be cloned and saved if you like.
+    /// The [`egui::Context`] can be cloned and saved if you like.
     ///
     /// To force a repaint, call [`egui::Context::request_repaint`] at any time (e.g. from another thread).
-    fn update(&mut self, ctx: &egui::Context, frame: &Frame);
+    fn update(&mut self, ctx: &egui::Context, frame: &mut Frame);
 
     /// Called on shutdown, and perhaps at regular intervals. Allows you to save state.
     ///
@@ -252,74 +250,70 @@ pub struct IconData {
 /// allocate textures, and change settings (e.g. window size).
 ///
 /// [`Frame`] is cheap to clone and is safe to pass to other threads.
-#[derive(Clone)]
-pub struct Frame(pub Arc<Mutex<backend::FrameData>>);
+pub struct Frame(pub backend::FrameData);
 
 impl Frame {
     /// Create a `Frame` - called by the integration.
     #[doc(hidden)]
     pub fn new(frame_data: backend::FrameData) -> Self {
-        Self(Arc::new(Mutex::new(frame_data)))
-    }
-
-    /// Access the underlying [`backend::FrameData`].
-    #[doc(hidden)]
-    #[inline]
-    pub fn lock(&self) -> std::sync::MutexGuard<'_, backend::FrameData> {
-        self.0.lock().unwrap()
+        Self(frame_data)
     }
 
     /// True if you are in a web environment.
     pub fn is_web(&self) -> bool {
-        self.lock().info.web_info.is_some()
+        self.0.info.web_info.is_some()
     }
 
     /// Information about the integration.
     pub fn info(&self) -> IntegrationInfo {
-        self.lock().info.clone()
+        self.0.info.clone()
+    }
+
+    /// A place where you can store custom data in a way that persists when you restart the app.
+    pub fn storage(&self) -> Option<&dyn Storage> {
+        self.0.storage.as_deref()
+    }
+
+    /// A place where you can store custom data in a way that persists when you restart the app.
+    pub fn storage_mut(&mut self) -> Option<&mut (dyn Storage + 'static)> {
+        self.0.storage.as_deref_mut()
     }
 
     /// Signal the app to stop/exit/quit the app (only works for native apps, not web apps).
     /// The framework will not quit immediately, but at the end of the this frame.
-    pub fn quit(&self) {
-        self.lock().output.quit = true;
+    pub fn quit(&mut self) {
+        self.0.output.quit = true;
     }
 
     /// Set the desired inner size of the window (in egui points).
-    pub fn set_window_size(&self, size: egui::Vec2) {
-        self.lock().output.window_size = Some(size);
+    pub fn set_window_size(&mut self, size: egui::Vec2) {
+        self.0.output.window_size = Some(size);
     }
 
     /// Set the desired title of the window.
-    pub fn set_window_title(&self, title: &str) {
-        self.lock().output.window_title = Some(title.to_owned());
+    pub fn set_window_title(&mut self, title: &str) {
+        self.0.output.window_title = Some(title.to_owned());
     }
 
     /// Set whether to show window decorations (i.e. a frame around you app).
     /// If false it will be difficult to move and resize the app.
-    pub fn set_decorations(&self, decorated: bool) {
-        self.lock().output.decorated = Some(decorated);
+    pub fn set_decorations(&mut self, decorated: bool) {
+        self.0.output.decorated = Some(decorated);
     }
 
     /// When called, the native window will follow the
     /// movement of the cursor while the primary mouse button is down.
     ///
     /// Does not work on the web.
-    pub fn drag_window(&self) {
-        self.lock().output.drag_window = true;
+    pub fn drag_window(&mut self) {
+        self.0.output.drag_window = true;
     }
 
     /// for integrations only: call once per frame
-    pub fn take_app_output(&self) -> crate::backend::AppOutput {
-        std::mem::take(&mut self.lock().output)
+    #[doc(hidden)]
+    pub fn take_app_output(&mut self) -> crate::backend::AppOutput {
+        std::mem::take(&mut self.0.output)
     }
-}
-
-#[cfg(test)]
-#[test]
-fn frame_impl_send_sync() {
-    fn assert_send_sync<T: Send + Sync>() {}
-    assert_send_sync::<Frame>();
 }
 
 /// Information about the web environment (if applicable).
@@ -474,10 +468,13 @@ pub mod backend {
 
         /// Where the app can issue commands back to the integration.
         pub output: AppOutput,
+
+        /// A place where you can store custom data in a way that persists when you restart the app.
+        pub storage: Option<Box<dyn Storage>>,
     }
 
     /// Action that can be taken by the user app.
-    #[derive(Default)]
+    #[derive(Clone, Debug, Default)]
     #[must_use]
     pub struct AppOutput {
         /// Set to `true` to stop the app.


### PR DESCRIPTION
The purpose of this is to expose `frame.storage()` and `frame.storage_mut()` so users can save/load app state from the `App::update` function, without having to add another parameter to that function.

Changes:
* Added `Frame::storage()` and `Frame::storage_mut()`
* `App::update` now takes a `&mut Frame` rather than just `&Frame`
* `Frame` is no longer `Clone` or `Sync` (doesn't have to be since https://github.com/emilk/egui/pull/1366)