### PR TITLE
Placed dark-light behind a feature gate in eframe and egui_glow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * `ClippedMesh` has been replaced with `ClippedPrimitive` ([#1351](https://github.com/emilk/egui/pull/1351)).
 * Renamed `Frame::margin` to `Frame::inner_margin`.
 * Renamed `AlphaImage` to `FontImage` to discourage any other use for it ([#1412](https://github.com/emilk/egui/pull/1412)).
+* `dark-light` is not an opt-in feature for `eframe` and `egui_glow`.
 
 ### Fixed 🐛
 * Fixed ComboBoxes always being rendered left-aligned ([#1304](https://github.com/emilk/egui/pull/1304)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * `ClippedMesh` has been replaced with `ClippedPrimitive` ([#1351](https://github.com/emilk/egui/pull/1351)).
 * Renamed `Frame::margin` to `Frame::inner_margin`.
 * Renamed `AlphaImage` to `FontImage` to discourage any other use for it ([#1412](https://github.com/emilk/egui/pull/1412)).
-* `dark-light` is not an opt-in feature for `eframe` and `egui_glow`.
+* `dark-light` is now an opt-in feature for `eframe` and `egui_glow`.
 
 ### Fixed 🐛
 * Fixed ComboBoxes always being rendered left-aligned ([#1304](https://github.com/emilk/egui/pull/1304)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * `ClippedMesh` has been replaced with `ClippedPrimitive` ([#1351](https://github.com/emilk/egui/pull/1351)).
 * Renamed `Frame::margin` to `Frame::inner_margin`.
 * Renamed `AlphaImage` to `FontImage` to discourage any other use for it ([#1412](https://github.com/emilk/egui/pull/1412)).
-* `dark-light` is now an opt-in feature for `eframe` and `egui_glow`.
+* `dark-light` (dark mode detection) is now an opt-in feature for `eframe` and `egui_glow` ([#1437](https://github.com/emilk/egui/pull/1437)).
 
 ### Fixed 🐛
 * Fixed ComboBoxes always being rendered left-aligned ([#1304](https://github.com/emilk/egui/pull/1304)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,6 +1104,7 @@ name = "egui_glow"
 version = "0.17.0"
 dependencies = [
  "bytemuck",
+ "dark-light",
  "egui",
  "egui-winit",
  "epi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,6 @@ name = "egui_glow"
 version = "0.17.0"
 dependencies = [
  "bytemuck",
- "dark-light",
  "egui",
  "egui-winit",
  "epi",

--- a/eframe/Cargo.toml
+++ b/eframe/Cargo.toml
@@ -42,6 +42,8 @@ screen_reader = [
   "egui_web/screen_reader",
 ]
 
+dark-light = [ "egui-winit/dark-light"]              # detect dark mode system preference
+
 
 [dependencies]
 egui = { version = "0.17.0", path = "../egui", default-features = false }

--- a/egui_glow/Cargo.toml
+++ b/egui_glow/Cargo.toml
@@ -53,6 +53,8 @@ screen_reader = ["egui-winit/screen_reader"]
 # if you want to use glow painter on web disable this feature.
 winit = ["egui-winit", "glutin"]
 
+dark-light = ["egui-winit/dark-light"]                 # detect dark mode system preference
+
 
 [dependencies]
 egui = { version = "0.17.0", path = "../egui", default-features = false, features = [
@@ -70,7 +72,6 @@ egui-winit = { version = "0.17.0", path = "../egui-winit", optional = true, defa
   "epi_backend",
 ] }
 glutin = { version = "0.28.0", optional = true }
-dark-light = { version = "0.2.1", optional = true }                 # detect dark mode system preference
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ["console"] }

--- a/egui_glow/Cargo.toml
+++ b/egui_glow/Cargo.toml
@@ -67,10 +67,10 @@ tracing = "0.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 egui-winit = { version = "0.17.0", path = "../egui-winit", optional = true, default-features = false, features = [
-  "dark-light",
   "epi_backend",
 ] }
 glutin = { version = "0.28.0", optional = true }
+dark-light = { version = "0.2.1", optional = true }                 # detect dark mode system preference
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ["console"] }


### PR DESCRIPTION
I placed dark-light behind a feature gate in `eframe` and `egui_glow` because of a bug in dark-light that causes `dark_light::detect()` to block for extended periods of time on some Linux systems. It is not disabled by default, but can be enabled with the `dark-light` feature flag.