### PR TITLE
egui_extras: enable virtual scroll for heterogenous rows

### DIFF
--- a/egui_demo_lib/src/apps/demo/table_demo.rs
+++ b/egui_demo_lib/src/apps/demo/table_demo.rs
@@ -1,5 +1,5 @@
 use egui::TextStyle;
-use egui_extras::{Size, StripBuilder, TableBuilder, TableRow, TableRowBuilder};
+use egui_extras::{Size, StripBuilder, TableBuilder, TableRow};
 
 /// Shows off a table with dynamic layout
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -91,7 +91,7 @@ impl TableDemo {
                     });
                 });
             })
-            .body(|body| {
+            .body(|mut body| {
                 if !self.heterogeneous_rows {
                     body.rows(text_height, self.num_rows, |row_index, mut row| {
                         row.col(|ui| {
@@ -107,17 +107,11 @@ impl TableDemo {
                         });
                     });
                 } else {
-                    let row_builder = DemoRowBuilder {
-                        row_count: self.num_rows,
-                    };
-                    body.heterogeneous_rows(row_builder);
+                    let rows = DemoRows::new(self.num_rows);
+                    body.heterogeneous_rows(rows, DemoRows::populate_row);
                 }
             });
     }
-}
-
-struct DemoRowBuilder {
-    row_count: usize,
 }
 
 struct DemoRows {
@@ -125,29 +119,15 @@ struct DemoRows {
     current_row: usize,
 }
 
-impl Iterator for DemoRows {
-    type Item = f32;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.current_row < self.row_count {
-            let thick = self.current_row % 6 == 0;
-            self.current_row += 1;
-            Some(if thick { 30.0 } else { 18.0 })
-        } else {
-            None
+impl DemoRows {
+    fn new(row_count: usize) -> Self {
+        Self {
+            row_count,
+            current_row: 0,
         }
     }
-}
 
-impl TableRowBuilder for DemoRowBuilder {
-    fn row_heights(&self, _: &Vec<f32>) -> Box<dyn Iterator<Item = f32>> {
-        Box::new(DemoRows {
-            row_count: self.row_count,
-            current_row: 0,
-        })
-    }
-
-    fn populate_row(&self, index: usize, mut row: TableRow<'_, '_>) {
+    fn populate_row(index: usize, mut row: TableRow<'_, '_>) {
         let thick = index % 6 == 0;
         row.col(|ui| {
             ui.centered_and_justified(|ui| {
@@ -169,6 +149,20 @@ impl TableRowBuilder for DemoRowBuilder {
                 }
             });
         });
+    }
+}
+
+impl Iterator for DemoRows {
+    type Item = f32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current_row < self.row_count {
+            let thick = self.current_row % 6 == 0;
+            self.current_row += 1;
+            Some(if thick { 30.0 } else { 18.0 })
+        } else {
+            None
+        }
     }
 }
 

--- a/egui_demo_lib/src/apps/demo/table_demo.rs
+++ b/egui_demo_lib/src/apps/demo/table_demo.rs
@@ -6,6 +6,7 @@ use egui_extras::{Size, StripBuilder, TableBuilder, TableRow};
 #[derive(Default)]
 pub struct TableDemo {
     heterogeneous_rows: bool,
+    virtual_scroll: bool,
     resizable: bool,
     num_rows: usize,
 }
@@ -31,7 +32,7 @@ impl super::View for TableDemo {
     fn ui(&mut self, ui: &mut egui::Ui) {
         // Leave room for the source code link after the table demo:
         StripBuilder::new(ui)
-            .size(Size::exact(50.0)) // for the settings
+            .size(Size::exact(66.0)) // for the settings
             .size(Size::remainder()) // for the table
             .size(Size::exact(10.0)) // for the source code link
             .vertical(|mut strip| {
@@ -42,6 +43,7 @@ impl super::View for TableDemo {
                         .horizontal(|mut strip| {
                             strip.cell(|ui| {
                                 ui.checkbox(&mut self.heterogeneous_rows, "Heterogeneous rows");
+                                ui.checkbox(&mut self.virtual_scroll, "Virtual Scroll");
                                 ui.checkbox(&mut self.resizable, "Resizable columns");
                             });
                             strip.cell(|ui| {
@@ -106,9 +108,36 @@ impl TableDemo {
                             );
                         });
                     });
-                } else {
+                } else if self.virtual_scroll {
                     let rows = DemoRows::new(self.num_rows);
                     body.heterogeneous_rows(rows, DemoRows::populate_row);
+                } else {
+                    for row_index in 0..20 {
+                        let thick = row_index % 6 == 0;
+                        let row_height = if thick { 30.0 } else { 18.0 };
+                        body.row(row_height, |mut row| {
+                            row.col(|ui| {
+                                ui.centered_and_justified(|ui| {
+                                    ui.label(row_index.to_string());
+                                });
+                            });
+                            row.col(|ui| {
+                                ui.centered_and_justified(|ui| {
+                                    ui.label(clock_emoji(row_index));
+                                });
+                            });
+                            row.col(|ui| {
+                                ui.centered_and_justified(|ui| {
+                                    ui.style_mut().wrap = Some(false);
+                                    if thick {
+                                        ui.heading("Extra thick row");
+                                    } else {
+                                        ui.label("Normal row");
+                                    }
+                                });
+                            });
+                        });
+                    }
                 }
             });
     }

--- a/egui_extras/src/table.rs
+++ b/egui_extras/src/table.rs
@@ -421,7 +421,7 @@ impl<'a> TableBody<'a> {
         // iterator with the boolean built in based on the enumerated index of the iterator element
         let mut striped_heights = heights
             .enumerate()
-            .map(|(index, height)| (index % 2 == 0, height));
+            .map(|(index, height)| (index, index % 2 == 0, height));
 
         let max_height = self.end_y - self.start_y + VIRTUAL_EXTENSION;
         let delta = self.delta() - VIRTUAL_EXTENSION;
@@ -431,16 +431,13 @@ impl<'a> TableBody<'a> {
         // cumulative height of all rows below those being displayed
         let mut height_below_visible: f64 = 0.0;
 
-        let mut row_index = 0;
-
         // calculate height above visible table range
-        while let Some((_, height)) = striped_heights.next() {
+        while let Some((_, _, height)) = striped_heights.next() {
             // when delta is greater than height above 0, we need to increment the row index and
             // update the height above visble with the current height then continue
             if height_above_visible >= delta as f64 {
                 break;
             }
-            row_index += 1;
             height_above_visible += height as f64;
         }
 
@@ -452,7 +449,7 @@ impl<'a> TableBody<'a> {
 
         // populate visible rows
         let mut current_height: f64 = 0.0; // used to track height of visible rows
-        while let Some((striped, height)) = striped_heights.next() {
+        while let Some((row_index, striped, height)) = striped_heights.next() {
             if current_height > max_height as f64 {
                 break;
             }
@@ -464,12 +461,11 @@ impl<'a> TableBody<'a> {
             };
             self.row_nr += 1;
             populate_row(row_index, tr);
-            row_index += 1;
             current_height += height as f64;
         }
 
         // calculate height below the visible table range
-        while let Some((_, height)) = striped_heights.next() {
+        while let Some((_, _, height)) = striped_heights.next() {
             height_below_visible += height as f64
         }
 

--- a/egui_extras/src/table.rs
+++ b/egui_extras/src/table.rs
@@ -352,10 +352,22 @@ pub struct TableBody<'a> {
 }
 
 impl<'a> TableBody<'a> {
+    /// Return a vector containing all column widths for this table body.
+    ///
+    /// This is primarily meant for use with [`TableBody::heterogeneous_rows`] in cases where row
+    /// heights are expected to according to the width of one or more cells -- for example, if text
+    /// is wrapped rather than clippped within the cell.
     pub fn widths(&self) -> &Vec<f32> {
         &self.widths
     }
 
+    /// Add rows with varying heights.
+    ///
+    /// This takes a very slight performance hit compared to [`TableBody::rows`] due to the need to
+    /// iterate over all row heights in to calculate the virtual table height above and below the
+    /// visible region, but it is many orders of magnitude more performant than adding individual
+    /// heterogenously-sized rows using [`TableBody::row`] at the cost of the additional complexity
+    /// that comes with pre-calculating row heights and representing them as an iterator.
     pub fn heterogeneous_rows(
         &mut self,
         mut heights: impl Iterator<Item = f32>,

--- a/egui_extras/src/table.rs
+++ b/egui_extras/src/table.rs
@@ -376,31 +376,16 @@ impl<'a> TableBody<'a> {
     /// ### Example
     /// ```
     /// # egui::__run_test_ui(|ui| {
-    /// use egui_extras::{TableBuilderSize};
+    /// use egui_extras::{TableBuilder, Size};
     /// TableBuilder::new(ui)
     ///     .column(Size::remainder().at_least(100.0))
     ///     .body(|mut body| {
     ///         let row_heights: Vec<f32> = vec![60.0, 18.0, 31.0, 240.0];
-    ///         body.heterogeneous_rows(row_heights.iter(), |row_index, mut row| {
+    ///         body.heterogeneous_rows(row_heights.into_iter(), |row_index, mut row| {
     ///             let thick = row_index % 6 == 0;
     ///             row.col(|ui| {
     ///                 ui.centered_and_justified(|ui| {
     ///                     ui.label(row_index.to_string());
-    ///                 });
-    ///             });
-    ///             row.col(|ui| {
-    ///                 ui.centered_and_justified(|ui| {
-    ///                     ui.label(clock_emoji(row_index));
-    ///                 });
-    ///             });
-    ///             row.col(|ui| {
-    ///                 ui.centered_and_justified(|ui| {
-    ///                     ui.style_mut().wrap = Some(false);
-    ///                     if thick {
-    ///                         ui.heading("Extra thick row");
-    ///                     } else {
-    ///                         ui.label("Normal row");
-    ///                     }
     ///                 });
     ///             });
     ///         });
@@ -531,7 +516,7 @@ impl<'a> TableBody<'a> {
             layout: &mut self.layout,
             widths: &self.widths,
             striped: false,
-            height: height,
+            height,
         }
         .col(|_| ()); // advances the cursor
     }

--- a/egui_extras/src/table.rs
+++ b/egui_extras/src/table.rs
@@ -352,7 +352,7 @@ pub struct TableBody<'a> {
 }
 
 impl<'a> TableBody<'a> {
-    fn delta(&self) -> f32 {
+    fn y_progress(&self) -> f32 {
         self.start_y - self.layout.current_y()
     }
 
@@ -424,7 +424,7 @@ impl<'a> TableBody<'a> {
             .map(|(index, height)| (index, index % 2 == 0, height));
 
         let max_height = self.end_y - self.start_y + VIRTUAL_EXTENSION;
-        let delta = self.delta() - VIRTUAL_EXTENSION;
+        let y_progress = self.y_progress() - VIRTUAL_EXTENSION;
 
         // cumulative height of all rows above those being displayed
         let mut height_above_visible: f64 = 0.0;
@@ -433,9 +433,9 @@ impl<'a> TableBody<'a> {
 
         // calculate height above visible table range
         while let Some((_, _, height)) = striped_heights.next() {
-            // when delta is greater than height above 0, we need to increment the row index and
-            // update the height above visble with the current height then continue
-            if height_above_visible >= delta as f64 {
+            // when y_progress is greater than height above 0, we need to increment the row index
+            // and update the height above visble with the current height then continue
+            if height_above_visible >= y_progress as f64 {
                 break;
             }
             height_above_visible += height as f64;
@@ -480,13 +480,13 @@ impl<'a> TableBody<'a> {
     ///
     /// Is a lot more performant than adding each individual row as non visible rows must not be rendered
     pub fn rows(mut self, height: f32, rows: usize, mut row: impl FnMut(usize, TableRow<'_, '_>)) {
-        let delta = self.delta();
+        let y_progress = self.y_progress();
         let mut start = 0;
 
-        if delta < 0.0 {
-            start = (delta / height).floor() as usize;
+        if y_progress > 0.0 {
+            start = (y_progress / height).floor() as usize;
 
-            self.buffer(delta);
+            self.buffer(y_progress);
         }
 
         let max_height = self.end_y - self.start_y;

--- a/egui_extras/src/table.rs
+++ b/egui_extras/src/table.rs
@@ -361,7 +361,7 @@ impl<'a> TableBody<'a> {
     /// This is primarily meant for use with [`TableBody::heterogeneous_rows`] in cases where row
     /// heights are expected to according to the width of one or more cells -- for example, if text
     /// is wrapped rather than clippped within the cell.
-    pub fn widths(&self) -> &Vec<f32> {
+    pub fn widths(&self) -> &[f32] {
         &self.widths
     }
 

--- a/egui_extras/src/table.rs
+++ b/egui_extras/src/table.rs
@@ -472,7 +472,7 @@ impl<'a> TableBody<'a> {
             height_below_visible += height as f64
         }
 
-        // if height bloew visible is > 0 here then we need to add a buffer to allow the table to
+        // if height below visible is > 0 here then we need to add a buffer to allow the table to
         // accurately calculate the "virtual" scrollbar position
         if height_below_visible > 0.0 {
             self.add_buffer(height_below_visible as f32);

--- a/egui_extras/src/table.rs
+++ b/egui_extras/src/table.rs
@@ -372,6 +372,41 @@ impl<'a> TableBody<'a> {
     /// visible region, but it is many orders of magnitude more performant than adding individual
     /// heterogenously-sized rows using [`TableBody::row`] at the cost of the additional complexity
     /// that comes with pre-calculating row heights and representing them as an iterator.
+    ///
+    /// ### Example
+    /// ```
+    /// # egui::__run_test_ui(|ui| {
+    /// use egui_extras::{TableBuilderSize};
+    /// TableBuilder::new(ui)
+    ///     .column(Size::remainder().at_least(100.0))
+    ///     .body(|mut body| {
+    ///         let row_heights: Vec<f32> = vec![60.0, 18.0, 31.0, 240.0];
+    ///         body.heterogeneous_rows(row_heights.iter(), |row_index, mut row| {
+    ///             let thick = row_index % 6 == 0;
+    ///             row.col(|ui| {
+    ///                 ui.centered_and_justified(|ui| {
+    ///                     ui.label(row_index.to_string());
+    ///                 });
+    ///             });
+    ///             row.col(|ui| {
+    ///                 ui.centered_and_justified(|ui| {
+    ///                     ui.label(clock_emoji(row_index));
+    ///                 });
+    ///             });
+    ///             row.col(|ui| {
+    ///                 ui.centered_and_justified(|ui| {
+    ///                     ui.style_mut().wrap = Some(false);
+    ///                     if thick {
+    ///                         ui.heading("Extra thick row");
+    ///                     } else {
+    ///                         ui.label("Normal row");
+    ///                     }
+    ///                 });
+    ///             });
+    ///         });
+    ///     });
+    /// # });
+    /// ```
     pub fn heterogeneous_rows(
         &mut self,
         heights: impl Iterator<Item = f32>,

--- a/egui_extras/src/table.rs
+++ b/egui_extras/src/table.rs
@@ -351,15 +351,16 @@ pub struct TableBody<'a> {
     end_y: f32,
 }
 
-pub trait TableRowBuilder {
-    fn row_heights(&self, widths: &Vec<f32>) -> Box<dyn Iterator<Item = f32> + '_>;
-    fn populate_row(&self, index: usize, row: TableRow<'_, '_>);
-}
-
 impl<'a> TableBody<'a> {
-    pub fn heterogeneous_rows(mut self, builder: impl TableRowBuilder) {
-        let mut heights = builder.row_heights(&self.widths);
+    pub fn widths(&self) -> &Vec<f32> {
+        &self.widths
+    }
 
+    pub fn heterogeneous_rows(
+        &mut self,
+        mut heights: impl Iterator<Item = f32>,
+        mut populate_row: impl FnMut(usize, TableRow<'_, '_>),
+    ) {
         let max_height = self.end_y - self.start_y;
         let delta = self.start_y - self.layout.current_y();
 
@@ -398,7 +399,7 @@ impl<'a> TableBody<'a> {
                     height: height,
                 };
                 self.row_nr += 1;
-                builder.populate_row(row_index, tr);
+                populate_row(row_index, tr);
                 row_index += 1;
                 current_height += height;
                 continue;

--- a/egui_extras/src/table.rs
+++ b/egui_extras/src/table.rs
@@ -415,7 +415,7 @@ impl<'a> TableBody<'a> {
         // because this row is meant to slide under the top bound of the visual table we calculate
         // height_of_first_row + height_above_visible >= y_progress as our break condition rather
         // than just height_above_visible >= y_progress
-        while let Some((row_index, striped, height)) = striped_heights.next() {
+        for (row_index, striped, height) in &mut striped_heights {
             if height as f64 + height_above_visible >= y_progress as f64 {
                 self.add_buffer(height_above_visible as f32);
                 let tr = TableRow {
@@ -434,7 +434,7 @@ impl<'a> TableBody<'a> {
         // populate visible rows, including the final row that should slide under the bottom bound
         // of the visible table.
         let mut current_height: f64 = 0.0;
-        while let Some((row_index, striped, height)) = striped_heights.next() {
+        for (row_index, striped, height) in &mut striped_heights {
             if height as f64 + current_height > max_height as f64 {
                 break;
             }
@@ -450,7 +450,7 @@ impl<'a> TableBody<'a> {
         }
 
         // calculate height below the visible table range
-        while let Some((_, _, height)) = striped_heights.next() {
+        for (_, _, height) in striped_heights {
             height_below_visible += height as f64
         }
 

--- a/egui_extras/src/table.rs
+++ b/egui_extras/src/table.rs
@@ -357,7 +357,7 @@ pub trait TableRowBuilder {
 }
 
 impl<'a> TableBody<'a> {
-    pub fn heterogenous_rows(mut self, builder: impl TableRowBuilder) {
+    pub fn heterogeneous_rows(mut self, builder: impl TableRowBuilder) {
         let mut heights = builder.row_heights(&self.widths);
 
         let max_height = self.end_y - self.start_y;


### PR DESCRIPTION
Introduce `TableBody.heterogenous_rows` and `TableRowBuilder`, the former of which takes as an argument the latter. `TableRowBuilder` provides two methods that enable virtual scrolling for rows with non-uniform heights. Those methods are:

* `TableRowBuilder.row_heights` which returns an iterator over `f32` to allow incremental virtual scroll buffer calculation.
* `TableRowBuilder.populate_row` which `TableBody.heterogenous_rows` uses to allow `TableRowBuilder` implementations to, you guessed it, populate rows that are visible.

One thought that occurs to me while writing this description is that `TableBody.heterogenous_rows` could look more like the following:

```
    pub fn heterogenous_rows(
        mut self,
        row_heights: impl Iterator<Item = f32> + '_,
        mut row: impl FnMut(usize, TableRow<'_, '_>),
    )
```

This could potentially be easier to use, considering all the trouble I had coming up with and implementing the trait. Happy to make this change if the maintainers prefer.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and it is green.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Closes <https://github.com/emilk/egui/issues/THE_RELEVANT_ISSUE>.

