### PR TITLE
TEST: Check if CI catches this clippy issue

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -144,9 +144,7 @@ jobs:
       - run: rustup component add clippy
       - run: sudo apt-get update && sudo apt-get install libspeechd-dev libgtk-3-dev # libgtk-3-dev is used by rfd
       - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --all-targets --all-features --  -D warnings -W clippy::all
+      - run: cargo clippy --workspace --all-targets --all-features --  -D warnings -W clippy::all
 
   doc:
     name: cargo doc

--- a/emath/src/rect.rs
+++ b/emath/src/rect.rs
@@ -102,7 +102,7 @@ impl Rect {
     pub fn from_points(points: &[Pos2]) -> Self {
         let mut rect = Rect::NOTHING;
         for &p in points {
-            rect.extend_with(p);
+            rect.extend_with(p)
         }
         rect
     }


### PR DESCRIPTION
Testing if clippy works on CI (https://github.com/emilk/egui/issues/1439).

Checking out this PR and running `cargo clippy --workspace --all-targets --all-features --  -D warnings -W clippy::all` locally gives this:

``` 
error: consider adding a `;` to the last statement for consistent formatting
   --> emath/src/rect.rs:105:13
    |
105 |             rect.extend_with(p)
    |             ^^^^^^^^^^^^^^^^^^^ help: add a `;` here: `rect.extend_with(p);`
    |
    = note: `-D clippy::semicolon-if-nothing-returned` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#semicolon_if_nothing_returned

error: could not compile `emath` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed
```

However, this is NOT reported on the CI: https://github.com/emilk/egui/runs/5813804213?check_suite_focus=true despite using the exact same invocation: https://github.com/emilk/egui/blob/master/.github/workflows/rust.yml#L149

I suspect the CI somehow ignores the contents of `.cargo/config.toml` where `-Wclippy::semicolon_if_nothing_returned` is set.