### PR TITLE
Fail docs build when warnings are generated

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,7 @@ env:
   # https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Clipboard.html
   # https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html
   RUSTFLAGS: --cfg=web_sys_unstable_apis
+  RUSTDOCFLAGS: -D warnings
 
 jobs:
   check_default:


### PR DESCRIPTION
This PR fails `rustdoc` builds, when it emits warnings.

We're applying the `-D warnings` flag to all invocations of `rustdoc` throughout the workflow. I'm unsure whether that's desired behavior or not from the feature request. Alternatives may be to only deny `rustdoc::broken_intra_doc_links` or only apply the environment variable to either one of the `doc` jobs.

The environment variable is discussed on the [Cargo Reference > Environment Variables](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-reads) page, and you may verify that `rustdoc` accepts the `-D / --deny LINT` flag by running
```sh
$ rustdoc --help
```

The PR is based upon https://github.com/emilk/egui/commit/901b7c7994565795279c6d094aa52531ce660937, and you may see the effect on Github Actions runs by browsing the actions that has been run on my fork [here](https://github.com/nicklasmoeller/egui/actions), with the aforementioned commit as the first run, and the patch as the second.

Resolves #1448 