### PR TITLE
Smaller checkboxes and radiobutton without a label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * Renamed `Frame::margin` to `Frame::inner_margin`.
 * Renamed `AlphaImage` to `FontImage` to discourage any other use for it ([#1412](https://github.com/emilk/egui/pull/1412)).
 * Warnings will pe painted on screen when there is an `Id` clash for `Grid`, `Plot` or `ScrollArea` ([#1452](https://github.com/emilk/egui/pull/1452)).
+* `Checkbox` and `RadioButton` with an empty label (`""`) will now take up much less space ([#1456](https://github.com/emilk/egui/pull/1456)).
 
 ### Fixed 🐛
 * Fixed ComboBoxes always being rendered left-aligned ([#1304](https://github.com/emilk/egui/pull/1304)).

--- a/egui/src/style.rs
+++ b/egui/src/style.rs
@@ -608,7 +608,7 @@ impl Default for Spacing {
             slider_width: 100.0,
             text_edit_width: 280.0,
             icon_width: 14.0,
-            icon_spacing: 0.0,
+            icon_spacing: 4.0,
             tooltip_width: 600.0,
             combo_height: 200.0,
             scroll_bar_width: 8.0,

--- a/egui_demo_lib/src/apps/demo/misc_demo_window.rs
+++ b/egui_demo_lib/src/apps/demo/misc_demo_window.rs
@@ -16,6 +16,9 @@ pub struct MiscDemoWindow {
     colors: ColorWidgets,
     tree: Tree,
     box_painting: BoxPainting,
+
+    dummy_bool: bool,
+    dummy_usize: usize,
 }
 
 impl Default for MiscDemoWindow {
@@ -31,6 +34,9 @@ impl Default for MiscDemoWindow {
             colors: Default::default(),
             tree: Tree::demo(),
             box_painting: Default::default(),
+
+            dummy_bool: false,
+            dummy_usize: 0,
         }
     }
 }
@@ -79,6 +85,28 @@ impl View for MiscDemoWindow {
         CollapsingHeader::new("Tree")
             .default_open(false)
             .show(ui, |ui| self.tree.ui(ui));
+
+        CollapsingHeader::new("Checkboxes")
+            .default_open(false)
+            .show(ui, |ui| {
+                ui.label("Checkboxes with empty labels take up very little space:");
+                ui.spacing_mut().item_spacing = Vec2::ZERO;
+                ui.horizontal_wrapped(|ui| {
+                    for _ in 0..64 {
+                        ui.checkbox(&mut self.dummy_bool, "");
+                    }
+                });
+                ui.checkbox(&mut self.dummy_bool, "checkbox");
+
+                ui.label("Radiobuttons are similar:");
+                ui.spacing_mut().item_spacing = Vec2::ZERO;
+                ui.horizontal_wrapped(|ui| {
+                    for i in 0..64 {
+                        ui.radio_value(&mut self.dummy_usize, i, "");
+                    }
+                });
+                ui.radio_value(&mut self.dummy_usize, 64, "radio_value");
+            });
 
         ui.collapsing("Columns", |ui| {
             ui.add(Slider::new(&mut self.num_columns, 1..=10).text("Columns"));


### PR DESCRIPTION
Closes #1047
Closes #1113

![Screen Shot 2022-04-05 at 09 03 31](https://user-images.githubusercontent.com/1148717/161697506-3a6b3c08-7363-42c8-a4be-4273e47dcde6.png)

I noticed `button_padding` and `icon_spacing` were applied the wrong way, so this PR fixes than and makes (all) `Checkbox`es and `RadioButton`s a few points narrower than before.