### PR TITLE
Add Shape::galley_with_color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * Added `Plot::allow_scroll`, `Plot::allow_zoom` no longer affects scrolling ([#1382](https://github.com/emilk/egui/pull/1382)).
 * Added `Ui::push_id` to resolve id clashes ([#1374](https://github.com/emilk/egui/pull/1374)).
 * Added `Frame::outer_margin`.
+* Added `Shape::galley_with_color` which adds the functionality of `Painter::galley_with_color` into the Shape enum. ([#1461](https://github.com/emilk/egui/pull/1461))
 
 ### Changed 🔧
 * `ClippedMesh` has been replaced with `ClippedPrimitive` ([#1351](https://github.com/emilk/egui/pull/1351)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * Added `Plot::allow_scroll`, `Plot::allow_zoom` no longer affects scrolling ([#1382](https://github.com/emilk/egui/pull/1382)).
 * Added `Ui::push_id` to resolve id clashes ([#1374](https://github.com/emilk/egui/pull/1374)).
 * Added `Frame::outer_margin`.
-* Added `Shape::galley_with_color` which adds the functionality of `Painter::galley_with_color` into the Shape enum. ([#1461](https://github.com/emilk/egui/pull/1461))
 
 ### Changed 🔧
 * `ClippedMesh` has been replaced with `ClippedPrimitive` ([#1351](https://github.com/emilk/egui/pull/1351)).

--- a/egui/src/painter.rs
+++ b/egui/src/painter.rs
@@ -6,7 +6,7 @@ use crate::{
 use epaint::{
     mutex::{Arc, RwLockReadGuard, RwLockWriteGuard},
     text::{Fonts, Galley},
-    CircleShape, RectShape, Rounding, Shape, Stroke, TextShape,
+    CircleShape, RectShape, Rounding, Shape, Stroke,
 };
 
 /// Helper to paint shapes and text to a specific region on a specific layer.
@@ -403,10 +403,7 @@ impl Painter {
     #[inline(always)]
     pub fn galley_with_color(&self, pos: Pos2, galley: Arc<Galley>, text_color: Color32) {
         if !galley.is_empty() {
-            self.add(TextShape {
-                override_text_color: Some(text_color),
-                ..TextShape::new(pos, galley)
-            });
+            self.add(Shape::galley_with_color(pos, galley, text_color));
         }
     }
 }

--- a/epaint/CHANGELOG.md
+++ b/epaint/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the epaint crate will be documented in this file.
 * Renamed `AlphaImage` to `FontImage` to discourage any other use for it ([#1412](https://github.com/emilk/egui/pull/1412)).
 * Dark text is darker and more readable on bright backgrounds ([#1412](https://github.com/emilk/egui/pull/1412)).
 * Fix panic when tessellating a [`Shape::Vec`] containing meshes with differing `TextureId`:s ([#1445](https://github.com/emilk/egui/pull/1445)).
+* Added `Shape::galley_with_color` which adds the functionality of `Painter::galley_with_color` into the Shape enum. ([#1461](https://github.com/emilk/egui/pull/1461))
 
 
 ## 0.17.0 - 2022-02-22

--- a/epaint/src/shape.rs
+++ b/epaint/src/shape.rs
@@ -179,6 +179,20 @@ impl Shape {
         TextShape::new(pos, galley).into()
     }
 
+    #[inline]
+    /// The text color in the [`Galley`] will be replaced with the given color.
+    pub fn galley_with_color(
+        pos: Pos2,
+        galley: crate::mutex::Arc<Galley>,
+        text_color: Color32,
+    ) -> Self {
+        TextShape {
+            override_text_color: Some(text_color),
+            ..TextShape::new(pos, galley)
+        }
+        .into()
+    }
+
     pub fn mesh(mesh: Mesh) -> Self {
         crate::epaint_assert!(mesh.is_valid());
         Self::Mesh(mesh)


### PR DESCRIPTION
This PR adds `Shape::galley_with_color` which adds the functionality of `Painter::galley_with_color` into the `Shape` enum.

This brings `Painter::galley_with_color`'s implementation inline with that of `Painter::galley` by just deferring to the shape implementation.

https://github.com/emilk/egui/blob/68d5806b41725fb8f8a5e62d7acd94b5ac9140f0/egui/src/painter.rs#L386-L396

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->
