### PR TITLE
Fix crash in text layout

### DIFF
--- a/epaint/src/text/text_layout.rs
+++ b/epaint/src/text/text_layout.rs
@@ -172,9 +172,7 @@ fn rows_from_paragraphs(
                 });
             } else {
                 line_break(fonts, &paragraph, job, &mut rows);
-                if let Some(last_row) = rows.last_mut() {
-                    last_row.ends_with_newline = !is_last_paragraph;
-                }
+                rows.last_mut().unwrap().ends_with_newline = !is_last_paragraph;
             }
         }
     }

--- a/epaint/src/text/text_layout.rs
+++ b/epaint/src/text/text_layout.rs
@@ -251,7 +251,7 @@ fn line_break(
     }
 
     if row_start_idx < paragraph.glyphs.len() {
-        if non_empty_rows == job.wrap.max_rows {
+        if job.wrap.max_rows > 0 && non_empty_rows == job.wrap.max_rows {
             if let Some(last_row) = out_rows.last_mut() {
                 replace_last_glyph_with_overflow_character(fonts, job, last_row);
             }

--- a/epaint/src/text/text_layout.rs
+++ b/epaint/src/text/text_layout.rs
@@ -172,7 +172,9 @@ fn rows_from_paragraphs(
                 });
             } else {
                 line_break(fonts, &paragraph, job, &mut rows);
-                rows.last_mut().unwrap().ends_with_newline = !is_last_paragraph;
+                if let Some(last_row) = rows.last_mut() {
+                    last_row.ends_with_newline = !is_last_paragraph;
+                }
             }
         }
     }

--- a/epaint/src/text/text_layout.rs
+++ b/epaint/src/text/text_layout.rs
@@ -775,3 +775,14 @@ fn is_chinese(c: char) -> bool {
         || ('\u{3400}' <= c && c <= '\u{4DBF}')
         || ('\u{2B740}' <= c && c <= '\u{2B81F}')
 }
+
+// ----------------------------------------------------------------------------
+
+#[test]
+fn test_zero_max_width() {
+    let mut fonts = FontsImpl::new(1.0, 1024, super::FontDefinitions::default());
+    let mut layout_job = LayoutJob::single_section("W".into(), super::TextFormat::default());
+    layout_job.wrap.max_width = 0.0;
+    let galley = super::layout(&mut fonts, layout_job.into());
+    assert_eq!(galley.rows.len(), 1);
+}


### PR DESCRIPTION
This happened when `max_width == 0.0` and `max_rows == 0`. Bug introduced in #1291