### PR TITLE
Add to_hex_str convenience methods for Rgba and Color32

### DIFF
--- a/epaint/src/color.rs
+++ b/epaint/src/color.rs
@@ -154,6 +154,15 @@ impl Color32 {
         Rgba::from(self).to_opaque().into()
     }
 
+    // Returns a hex string representing the rgb value
+    #[inline(always)]
+    pub fn to_hex_str(&self) -> String {
+        format!(
+            "#{:02x}{:02x}{:02x}",
+            self.0[0] as i32, self.0[1] as i32, self.0[2] as i32
+        )
+    }
+
     /// Returns an additive version of self
     #[inline(always)]
     pub fn additive(self) -> Self {
@@ -345,6 +354,15 @@ impl Rgba {
                 self.b() / self.a(),
             )
         }
+    }
+
+    // Returns a hex string representing the rgb value
+    #[inline(always)]
+    pub fn to_hex_str(&self) -> String {
+        format!(
+            "#{:02x}{:02x}{:02x}",
+            self.0[0] as i32, self.0[1] as i32, self.0[2] as i32
+        )
     }
 
     /// Premultiplied RGBA


### PR DESCRIPTION
This is really a pretty simple convenience method for `Rgba` and `Color32`, it creates a standard lowercase formatted hex color.

```rust
pub fn to_hex_str(&self) -> String {
    format!(
        "#{:02x}{:02x}{:02x}",
        self.0[0] as i32, self.0[1] as i32, self.0[2] as i32
    )
}
```

Here's what it would look like in action:
```rust
assert_eq!(
    Rgba::from_rgb(92.0, 117.0, 51.0).to_hex_str(),
    "#5c7533".to_string()
);

assert_eq!(
    Color32::from_rgb(174, 81, 164).to_hex_str(),
    "#ae51a4".to_string()
);
```

I don't know if this is out of scope for `Rgba` and `Color32`, but it seems pretty useful to me :)