### PR TITLE
global font style setting (docs/example)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,6 +851,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "custom_font_style"
+version = "0.1.0"
+dependencies = [
+ "eframe",
+]
+
+[[package]]
 name = "custom_window_frame"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "examples/custom_3d_glow",
     "examples/custom_3d_three-d",
     "examples/custom_font",
+    "examples/custom_font_style",
     "examples/custom_window_frame",
     "examples/download_image",
     "examples/file_dialog",

--- a/egui/src/style.rs
+++ b/egui/src/style.rs
@@ -150,8 +150,9 @@ pub struct Style {
     ///
     /// ```
     /// # let mut ctx = egui::Context::default();
-    /// use FontFamily::Proportional;
-    /// use TextStyle::*;
+    /// use egui::FontFamily::Proportional;
+    /// use egui::FontId;
+    /// use egui::TextStyle::*;
     ///
     /// // Get current context style
     /// let mut style = (*ctx.style()).clone();

--- a/egui/src/style.rs
+++ b/egui/src/style.rs
@@ -2,11 +2,8 @@
 
 #![allow(clippy::if_same_then_else)]
 
-use crate::color::*;
-use crate::emath::*;
-use crate::{FontFamily, FontId, Response, RichText, WidgetText};
-use epaint::mutex::Arc;
-use epaint::{Rounding, Shadow, Stroke};
+use crate::{color::*, emath::*, FontFamily, FontId, Response, RichText, WidgetText};
+use epaint::{mutex::Arc, Rounding, Shadow, Stroke};
 use std::collections::BTreeMap;
 
 // ----------------------------------------------------------------------------
@@ -24,8 +21,7 @@ pub enum TextStyle {
     /// Normal labels. Easily readable, doesn't take up too much space.
     Body,
 
-    /// Same size as [`Self::Body]`, but used when monospace is important (for aligning number,
-    /// code snippets, etc).
+    /// Same size as [`Self::Body]`, but used when monospace is important (for aligning number, code snippets, etc).
     Monospace,
 
     /// Buttons. Maybe slightly bigger than [`Self::Body]`.
@@ -153,6 +149,7 @@ pub struct Style {
     /// If you would like to overwrite app text_styles
     ///
     /// ```
+    /// # let mut ctx = egui::Context::default();
     /// use FontFamily::Proportional;
     /// use TextStyle::*;
     ///
@@ -172,7 +169,7 @@ pub struct Style {
     ///
     /// // Mutate global style with above changes
     /// ctx.set_style(style);
-    /// ````
+    /// ```
     pub text_styles: BTreeMap<TextStyle, FontId>,
 
     /// If set, labels buttons wtc will use this to determine whether or not
@@ -556,8 +553,7 @@ pub struct WidgetVisuals {
     /// Button frames etc.
     pub rounding: Rounding,
 
-    /// Stroke and text color of the interactive part of a component (button text, slider grab,
-    /// check-mark, …).
+    /// Stroke and text color of the interactive part of a component (button text, slider grab, check-mark, …).
     pub fg_stroke: Stroke,
 
     /// Make the frame this much larger.
@@ -632,8 +628,7 @@ impl Default for Spacing {
             item_spacing: vec2(8.0, 3.0),
             window_margin: Margin::same(6.0),
             button_padding: vec2(4.0, 1.0),
-            indent: 18.0, /* match checkbox/radio-button with `button_padding.x + icon_width +
-                           * icon_spacing` */
+            indent: 18.0, // match checkbox/radio-button with `button_padding.x + icon_width + icon_spacing`
             interact_size: vec2(40.0, 18.0),
             slider_width: 100.0,
             text_edit_width: 280.0,
@@ -675,8 +670,7 @@ impl Visuals {
             resize_corner_size: 12.0,
             text_cursor_width: 2.0,
             text_cursor_preview: false,
-            clip_rect_margin: 3.0, /* should be at least half the size of the widest frame stroke
-                                    * + max WidgetVisuals::expansion */
+            clip_rect_margin: 3.0, // should be at least half the size of the widest frame stroke + max WidgetVisuals::expansion
             button_frame: true,
             collapsing_header_frame: false,
         }
@@ -731,7 +725,7 @@ impl Widgets {
         Self {
             noninteractive: WidgetVisuals {
                 bg_fill: Color32::from_gray(27), // window background
-                bg_stroke: Stroke::new(1.0, Color32::from_gray(60)), /* separators, indentation lines, windows outlines */
+                bg_stroke: Stroke::new(1.0, Color32::from_gray(60)), // separators, indentation lines, windows outlines
                 fg_stroke: Stroke::new(1.0, Color32::from_gray(140)), // normal text color
                 rounding: Rounding::same(2.0),
                 expansion: 0.0,
@@ -745,8 +739,7 @@ impl Widgets {
             },
             hovered: WidgetVisuals {
                 bg_fill: Color32::from_gray(70),
-                bg_stroke: Stroke::new(1.0, Color32::from_gray(150)), /* e.g. hover over window
-                                                                       * edge or button */
+                bg_stroke: Stroke::new(1.0, Color32::from_gray(150)), // e.g. hover over window edge or button
                 fg_stroke: Stroke::new(1.5, Color32::from_gray(240)),
                 rounding: Rounding::same(3.0),
                 expansion: 1.0,
@@ -771,9 +764,8 @@ impl Widgets {
     pub fn light() -> Self {
         Self {
             noninteractive: WidgetVisuals {
-                bg_fill: Color32::from_gray(248), /* window background - should be distinct from
-                                                   * TextEdit background */
-                bg_stroke: Stroke::new(1.0, Color32::from_gray(190)), /* separators, indentation lines, windows outlines */
+                bg_fill: Color32::from_gray(248), // window background - should be distinct from TextEdit background
+                bg_stroke: Stroke::new(1.0, Color32::from_gray(190)), // separators, indentation lines, windows outlines
                 fg_stroke: Stroke::new(1.0, Color32::from_gray(80)),  // normal text color
                 rounding: Rounding::same(2.0),
                 expansion: 0.0,
@@ -787,8 +779,7 @@ impl Widgets {
             },
             hovered: WidgetVisuals {
                 bg_fill: Color32::from_gray(220),
-                bg_stroke: Stroke::new(1.0, Color32::from_gray(105)), /* e.g. hover over window
-                                                                       * edge or button */
+                bg_stroke: Stroke::new(1.0, Color32::from_gray(105)), // e.g. hover over window edge or button
                 fg_stroke: Stroke::new(1.5, Color32::BLACK),
                 rounding: Rounding::same(3.0),
                 expansion: 1.0,
@@ -819,8 +810,7 @@ impl Default for Widgets {
 
 // ----------------------------------------------------------------------------
 
-use crate::widgets::*;
-use crate::Ui;
+use crate::{widgets::*, Ui};
 
 impl Style {
     pub fn ui(&mut self, ui: &mut crate::Ui) {

--- a/egui/src/style.rs
+++ b/egui/src/style.rs
@@ -2,8 +2,11 @@
 
 #![allow(clippy::if_same_then_else)]
 
-use crate::{color::*, emath::*, FontFamily, FontId, Response, RichText, WidgetText};
-use epaint::{mutex::Arc, Rounding, Shadow, Stroke};
+use crate::color::*;
+use crate::emath::*;
+use crate::{FontFamily, FontId, Response, RichText, WidgetText};
+use epaint::mutex::Arc;
+use epaint::{Rounding, Shadow, Stroke};
 use std::collections::BTreeMap;
 
 // ----------------------------------------------------------------------------
@@ -21,7 +24,8 @@ pub enum TextStyle {
     /// Normal labels. Easily readable, doesn't take up too much space.
     Body,
 
-    /// Same size as [`Self::Body]`, but used when monospace is important (for aligning number, code snippets, etc).
+    /// Same size as [`Self::Body]`, but used when monospace is important (for aligning number,
+    /// code snippets, etc).
     Monospace,
 
     /// Buttons. Maybe slightly bigger than [`Self::Body]`.
@@ -145,6 +149,30 @@ pub struct Style {
     /// The [`FontFamily`] and size you want to use for a specific [`TextStyle`].
     ///
     /// The most convenient way to look something up in this is to use [`TextStyle::resolve`].
+    ///
+    /// If you would like to overwrite app text_styles
+    ///
+    /// ```
+    /// use FontFamily::Proportional;
+    /// use TextStyle::*;
+    ///
+    /// // Get current context style
+    /// let mut style = (*ctx.style()).clone();
+    ///
+    /// // Redefine text_styles
+    /// style.text_styles = [
+    ///   (Heading, FontId::new(30.0, Proportional)),
+    ///   (Name("Heading2".into()), FontId::new(25.0, Proportional)),
+    ///   (Name("Context".into()), FontId::new(23.0, Proportional)),
+    ///   (Body, FontId::new(18.0, Proportional)),
+    ///   (Monospace, FontId::new(14.0, Proportional)),
+    ///   (Button, FontId::new(14.0, Proportional)),
+    ///   (Small, FontId::new(10.0, Proportional)),
+    /// ].into();
+    ///
+    /// // Mutate global style with above changes
+    /// ctx.set_style(style);
+    /// ````
     pub text_styles: BTreeMap<TextStyle, FontId>,
 
     /// If set, labels buttons wtc will use this to determine whether or not
@@ -528,7 +556,8 @@ pub struct WidgetVisuals {
     /// Button frames etc.
     pub rounding: Rounding,
 
-    /// Stroke and text color of the interactive part of a component (button text, slider grab, check-mark, …).
+    /// Stroke and text color of the interactive part of a component (button text, slider grab,
+    /// check-mark, …).
     pub fg_stroke: Stroke,
 
     /// Make the frame this much larger.
@@ -603,7 +632,8 @@ impl Default for Spacing {
             item_spacing: vec2(8.0, 3.0),
             window_margin: Margin::same(6.0),
             button_padding: vec2(4.0, 1.0),
-            indent: 18.0, // match checkbox/radio-button with `button_padding.x + icon_width + icon_spacing`
+            indent: 18.0, /* match checkbox/radio-button with `button_padding.x + icon_width +
+                           * icon_spacing` */
             interact_size: vec2(40.0, 18.0),
             slider_width: 100.0,
             text_edit_width: 280.0,
@@ -645,7 +675,8 @@ impl Visuals {
             resize_corner_size: 12.0,
             text_cursor_width: 2.0,
             text_cursor_preview: false,
-            clip_rect_margin: 3.0, // should be at least half the size of the widest frame stroke + max WidgetVisuals::expansion
+            clip_rect_margin: 3.0, /* should be at least half the size of the widest frame stroke
+                                    * + max WidgetVisuals::expansion */
             button_frame: true,
             collapsing_header_frame: false,
         }
@@ -700,7 +731,7 @@ impl Widgets {
         Self {
             noninteractive: WidgetVisuals {
                 bg_fill: Color32::from_gray(27), // window background
-                bg_stroke: Stroke::new(1.0, Color32::from_gray(60)), // separators, indentation lines, windows outlines
+                bg_stroke: Stroke::new(1.0, Color32::from_gray(60)), /* separators, indentation lines, windows outlines */
                 fg_stroke: Stroke::new(1.0, Color32::from_gray(140)), // normal text color
                 rounding: Rounding::same(2.0),
                 expansion: 0.0,
@@ -714,7 +745,8 @@ impl Widgets {
             },
             hovered: WidgetVisuals {
                 bg_fill: Color32::from_gray(70),
-                bg_stroke: Stroke::new(1.0, Color32::from_gray(150)), // e.g. hover over window edge or button
+                bg_stroke: Stroke::new(1.0, Color32::from_gray(150)), /* e.g. hover over window
+                                                                       * edge or button */
                 fg_stroke: Stroke::new(1.5, Color32::from_gray(240)),
                 rounding: Rounding::same(3.0),
                 expansion: 1.0,
@@ -739,8 +771,9 @@ impl Widgets {
     pub fn light() -> Self {
         Self {
             noninteractive: WidgetVisuals {
-                bg_fill: Color32::from_gray(248), // window background - should be distinct from TextEdit background
-                bg_stroke: Stroke::new(1.0, Color32::from_gray(190)), // separators, indentation lines, windows outlines
+                bg_fill: Color32::from_gray(248), /* window background - should be distinct from
+                                                   * TextEdit background */
+                bg_stroke: Stroke::new(1.0, Color32::from_gray(190)), /* separators, indentation lines, windows outlines */
                 fg_stroke: Stroke::new(1.0, Color32::from_gray(80)),  // normal text color
                 rounding: Rounding::same(2.0),
                 expansion: 0.0,
@@ -754,7 +787,8 @@ impl Widgets {
             },
             hovered: WidgetVisuals {
                 bg_fill: Color32::from_gray(220),
-                bg_stroke: Stroke::new(1.0, Color32::from_gray(105)), // e.g. hover over window edge or button
+                bg_stroke: Stroke::new(1.0, Color32::from_gray(105)), /* e.g. hover over window
+                                                                       * edge or button */
                 fg_stroke: Stroke::new(1.5, Color32::BLACK),
                 rounding: Rounding::same(3.0),
                 expansion: 1.0,
@@ -785,7 +819,8 @@ impl Default for Widgets {
 
 // ----------------------------------------------------------------------------
 
-use crate::{widgets::*, Ui};
+use crate::widgets::*;
+use crate::Ui;
 
 impl Style {
     pub fn ui(&mut self, ui: &mut crate::Ui) {

--- a/examples/custom_font_style/Cargo.toml
+++ b/examples/custom_font_style/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "custom_font_style"
+version = "0.1.0"
+authors = ["tami5 <kkharji@proton.me>"]
+license = "MIT OR Apache-2.0"
+edition = "2021"
+rust-version = "1.60"
+publish = false
+
+
+[dependencies]
+eframe = { path = "../../eframe" }

--- a/examples/custom_font_style/README.md
+++ b/examples/custom_font_style/README.md
@@ -1,0 +1,3 @@
+```sh
+cargo run -p custom_font_style
+```

--- a/examples/custom_font_style/src/main.rs
+++ b/examples/custom_font_style/src/main.rs
@@ -1,0 +1,72 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
+
+use eframe::egui;
+use egui::{FontFamily, FontId, RichText, TextStyle};
+
+#[inline]
+fn heading2() -> TextStyle {
+    TextStyle::Name("Heading2".into())
+}
+
+#[inline]
+fn heading3() -> TextStyle {
+    TextStyle::Name("ContextHeading".into())
+}
+
+fn configure_text_styles(ctx: &egui::Context) {
+    use FontFamily::Proportional;
+    use TextStyle::*;
+
+    let mut style = (*ctx.style()).clone();
+    style.text_styles = [
+        (Heading, FontId::new(30.0, Proportional)),
+        (heading2(), FontId::new(25.0, Proportional)),
+        (heading3(), FontId::new(23.0, Proportional)),
+        (Body, FontId::new(18.0, Proportional)),
+        (Monospace, FontId::new(14.0, Proportional)),
+        (Button, FontId::new(14.0, Proportional)),
+        (Small, FontId::new(10.0, Proportional)),
+    ]
+    .into();
+    ctx.set_style(style);
+}
+
+fn content(ui: &mut egui::Ui) {
+    ui.heading("Top Heading");
+    ui.add_space(5.);
+    ui.label(LOREM_IPSUM);
+    ui.add_space(15.);
+    ui.label(RichText::new("Sub Heading").text_style(heading2()).strong());
+    ui.label(LOREM_IPSUM);
+    ui.add_space(15.);
+    ui.label(RichText::new("Context").text_style(heading3()).strong());
+    ui.add_space(5.);
+    ui.label(LOREM_IPSUM);
+}
+
+struct MyApp;
+
+impl MyApp {
+    fn new(cc: &eframe::CreationContext<'_>) -> Self {
+        configure_text_styles(&cc.egui_ctx);
+        Self
+    }
+}
+
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| content(ui));
+    }
+}
+
+fn main() {
+    let options = eframe::NativeOptions::default();
+
+    eframe::run_native(
+        "egui example: global font style",
+        options,
+        Box::new(|cc| Box::new(MyApp::new(cc))),
+    );
+}
+
+pub const LOREM_IPSUM: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";

--- a/examples/custom_font_style/src/main.rs
+++ b/examples/custom_font_style/src/main.rs
@@ -55,7 +55,7 @@ impl MyApp {
 
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show(ctx, |ui| content(ui));
+        egui::CentralPanel::default().show(ctx, content);
     }
 }
 


### PR DESCRIPTION
- feat(examples): global font style setting example
- docs: docs string on how to set global font styles

While creating the example, I created an alternative version of the api, maybe worth considering 

```rust 
use TextStyle::Heading;
use TextWeight::Bold;
use UiColors::White
fn content(ui: &mut egui::Ui) {
    ui.text("Hello World")
        .style(Heading)
        .weight(Bold)
        .color(White)
        .padding(5.);
    ui.text(LOREM_IPSUM).space(15.);
    ui.text("About Me")
        .style("Heading2")
        .weight(Bold)
        .color(White)
        .padding(5.);
    ui.label(LOREM_IPSUM).space(15.);
    ui.text("Programming")
        .style("Context")
        .weight(Bold)
        .color(White)
        .padding(5.);
}
```

I kind like swiftui and audulus/rui approach in that reading the code becomes easier and writing is joyful, you just `.` into what you want. 

Any this out of the scope. but yah

I left some comment in the code and I will mark this as draft until it is answered 

cc @emilk 

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Closes #590.
