### PR TITLE
Add `Ui::spinner` shortcut method

### DIFF
--- a/eframe/CHANGELOG.md
+++ b/eframe/CHANGELOG.md
@@ -23,6 +23,7 @@ NOTE: [`egui_web`](../egui_web/CHANGELOG.md), [`egui-winit`](../egui-winit/CHANG
 * Fixed potential scale bug when DPI scaling changes (e.g. when dragging a  window between different displays) ([#1441](https://github.com/emilk/egui/pull/1441)).
 * MSRV (Minimum Supported Rust Version) is now `1.60.0` ([#1467](https://github.com/emilk/egui/pull/1467)).
 * Added new feature `puffin` to add [`puffin profiler`](https://github.com/EmbarkStudios/puffin) scopes ([#1483](https://github.com/emilk/egui/pull/1483)).
+* Added `Ui::spinner()` shortcut method.
 
 
 ## 0.17.0 - 2022-02-22

--- a/eframe/CHANGELOG.md
+++ b/eframe/CHANGELOG.md
@@ -23,7 +23,7 @@ NOTE: [`egui_web`](../egui_web/CHANGELOG.md), [`egui-winit`](../egui-winit/CHANG
 * Fixed potential scale bug when DPI scaling changes (e.g. when dragging a  window between different displays) ([#1441](https://github.com/emilk/egui/pull/1441)).
 * MSRV (Minimum Supported Rust Version) is now `1.60.0` ([#1467](https://github.com/emilk/egui/pull/1467)).
 * Added new feature `puffin` to add [`puffin profiler`](https://github.com/EmbarkStudios/puffin) scopes ([#1483](https://github.com/emilk/egui/pull/1483)).
-* Added `Ui::spinner()` shortcut method.
+* Added `Ui::spinner()` shortcut method ([#1494](https://github.com/emilk/egui/pull/1494)).
 
 
 ## 0.17.0 - 2022-02-22

--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -1383,10 +1383,20 @@ impl Ui {
         response
     }
 
-    /// Shortcut for `add(Separator::default())` (see [`Separator`]).
+    /// Shortcut for `add(Separator::default())`
+    ///
+    /// See also [`Separator`].
     #[inline]
     pub fn separator(&mut self) -> Response {
         Separator::default().ui(self)
+    }
+
+    /// Shortcut for `add(Spinner::new())`
+    ///
+    /// See also [`Spinner`].
+    #[inline]
+    pub fn spinner(&mut self) -> Response {
+        Spinner::new().ui(self)
     }
 
     /// Modify an angle. The given angle should be in radians, but is shown to the user in degrees.

--- a/egui_demo_lib/src/apps/http_app.rs
+++ b/egui_demo_lib/src/apps/http_app.rs
@@ -101,7 +101,7 @@ impl epi::App for HttpApp {
                         }
                     }
                 } else {
-                    ui.add(egui::Spinner::new());
+                    ui.spinner();
                 }
             }
         });

--- a/examples/download_image/src/main.rs
+++ b/examples/download_image/src/main.rs
@@ -38,7 +38,7 @@ impl eframe::App for MyApp {
 
         egui::CentralPanel::default().show(ctx, |ui| match promise.ready() {
             None => {
-                ui.add(egui::Spinner::new()); // still loading
+                ui.spinner(); // still loading
             }
             Some(Err(err)) => {
                 ui.colored_label(egui::Color32::RED, err); // something went wrong


### PR DESCRIPTION
This PR adds a missing shortcut method.
I also updated `Ui::separator` doc comment to be consistent with others.