### PR TITLE
Enable depth buffer in WebGL backend

### DIFF
--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -111,7 +111,7 @@ impl Painter {
             // WebGL2 support sRGB default
             (ShaderVersion::Es300, _) | (ShaderVersion::Es100, true) => unsafe {
                 // Add sRGB support marker for fragment shader
-                if let Some([width, height]) = pp_fb_extent {
+                if let Some(size) = pp_fb_extent {
                     tracing::debug!("WebGL with sRGB enabled. Turning on post processing for linear framebuffer blending.");
                     // install post process to correct sRGB color:
                     (
@@ -119,8 +119,7 @@ impl Painter {
                             gl.clone(),
                             shader_prefix,
                             is_webgl_1,
-                            width,
-                            height,
+                            size,
                         )?),
                         "#define SRGB_SUPPORTED",
                     )
@@ -341,6 +340,7 @@ impl Painter {
         if let Some(ref mut post_process) = self.post_process {
             unsafe {
                 post_process.begin(inner_size[0] as i32, inner_size[1] as i32);
+                post_process.bind();
             }
         }
         let size_in_pixels = unsafe { self.prepare_painting(inner_size, pixels_per_point) };

--- a/epaint/src/shape.rs
+++ b/epaint/src/shape.rs
@@ -663,7 +663,7 @@ pub struct PaintCallbackInfo {
     /// This specifies where on the screen to paint, and the borders of this
     /// Rect is the [-1, +1] of the Normalized Device Coordinates.
     ///
-    /// Note than only a portion of this may be visible due to [`Self::clip`].
+    /// Note than only a portion of this may be visible due to [`Self::clip_rect`].
     pub viewport: Rect,
 
     /// Clip rectangle in points.
@@ -706,12 +706,12 @@ impl PaintCallbackInfo {
         }
     }
 
-    /// The viewport rectangle.
+    /// The viewport rectangle. This is what you would use in e.g. `glViewport`.
     pub fn viewport_in_pixels(&self) -> ViewportInPixels {
         self.points_to_pixels(&self.viewport)
     }
 
-    /// The "scissor" or "clip" rectangle.
+    /// The "scissor" or "clip" rectangle. This is what you would use in e.g. `glScissor`.
     pub fn clip_rect_in_pixels(&self) -> ViewportInPixels {
         self.points_to_pixels(&self.clip_rect)
     }


### PR DESCRIPTION
This is useful when embedding 3D into eframe using `egui::PaintCallback`. Otherwise it is slightly wasteful, so perhaps it would be nice to put it behind a feature flag.