### PR TITLE
[egui_web] Fix misplaced resize and other event handlers

### DIFF
--- a/egui_web/src/lib.rs
+++ b/egui_web/src/lib.rs
@@ -498,7 +498,7 @@ fn install_document_events(runner_container: &AppRunnerContainer) -> Result<(), 
 
     for event_name in &["load", "pagehide", "pageshow", "resize"] {
         runner_container.add_event_listener(
-            &document,
+            &window,
             event_name,
             |_: web_sys::Event, runner_lock| {
                 runner_lock.needs_repaint.set_true();
@@ -507,7 +507,7 @@ fn install_document_events(runner_container: &AppRunnerContainer) -> Result<(), 
     }
 
     runner_container.add_event_listener(
-        &document,
+        &window,
         "hashchange",
         |_: web_sys::Event, mut runner_lock| {
             // `epi::Frame::info(&self)` clones `epi::IntegrationInfo`, but we need to modify the original here


### PR DESCRIPTION
Fixes copy-paste error introduced in #1306 by putting events meant for the window back on the window instead of on the document.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Closes <https://github.com/emilk/egui/issues/1500>.
