### PR TITLE
Tessellate: Implement precomputed vertices for rounding

### DIFF
--- a/epaint/src/tessellator.rs
+++ b/epaint/src/tessellator.rs
@@ -200,7 +200,7 @@ pub mod path {
             [
                 vec2(1.000000, 0.000000),
                 vec2(0.707107, 0.707107),
-                vec2(-0.000000, 1.000000)
+                vec2(-0.000000, 1.000000),
             ],
             // quadrant 1: left bottom
             [
@@ -347,26 +347,17 @@ pub mod path {
     //   - quadrant 3: right top
     // * angle 4 * TAU / 4 = right
     pub fn add_circle_quadrant(path: &mut Vec<Pos2>, center: Pos2, radius: f32, quadrant: f32) {
-        if radius == 0.0 {
+        if radius <= 0.0 {
             path.push(center);
         } else if radius <= 5.0 {
             let quadrant_vertices = QUADRANTS_0_5[quadrant as usize];
-            path.reserve(quadrant_vertices.len());
-            quadrant_vertices
-                .iter()
-                .for_each(|v| path.push(center + radius * *v));
-        } else if radius > 5.0 && radius <= 10.0 {
+            path.extend(quadrant_vertices.iter().map(|v| center + radius * *v));
+        } else if radius <= 10.0 {
             let quadrant_vertices = QUADRANTS_5_10[quadrant as usize];
-            path.reserve(quadrant_vertices.len());
-            quadrant_vertices
-                .iter()
-                .for_each(|v| path.push(center + radius * *v));
+            path.extend(quadrant_vertices.iter().map(|v| center + radius * *v));
         } else {
             let quadrant_vertices = QUADRANTS_10_20[quadrant as usize];
-            path.reserve(quadrant_vertices.len());
-            quadrant_vertices
-                .iter()
-                .for_each(|v| path.push(center + radius * *v));
+            path.extend(quadrant_vertices.iter().map(|v| center + radius * *v));
         }
     }
 

--- a/epaint/src/tessellator.rs
+++ b/epaint/src/tessellator.rs
@@ -192,6 +192,7 @@ pub mod path {
 
     use super::*;
 
+    #[allow(clippy::approx_constant)]
     mod precomputed_quadrants {
         use emath::{vec2, Vec2};
 


### PR DESCRIPTION
## Before:
```
demo_with_tessellate__realistic
                        time:   [328.77 us 329.22 us 329.70 us]
                        change: [-2.6116% -1.1978% +0.2520%] (p = 0.10 > 0.05)
                        No change in performance detected.

demo_no_tessellate      time:   [164.67 us 165.82 us 167.30 us]

demo_only_tessellate    time:   [159.34 us 159.85 us 160.67 us]
```

## After:
```
demo_with_tessellate__realistic
                        time:   [309.48 us 309.92 us 310.41 us]
                        change: [-7.1042% -5.6164% -4.0262%] (p = 0.00 < 0.05)
                        Performance has improved.

demo_no_tessellate      time:   [160.44 us 161.30 us 162.49 us]
                        change: [-4.5692% -2.8617% -1.3549%] (p = 0.00 < 0.05)
                        Performance has improved.

demo_only_tessellate    time:   [139.45 us 140.23 us 141.25 us]
                        change: [-13.637% -12.245% -10.695%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Not sure this is the right path. So i didn't bother to port `Path::add_point()`

Also we might want to fallback to computed vertices for radii >= 20 or add
another precomputed batch.