### PR TITLE
Add triple-click support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * Added `Frame::outer_margin`.
 * Added `Painter::hline` and `Painter::vline`.
 * Added `Link` and `ui.link`  ([#1506](https://github.com/emilk/egui/pull/1506)).
+* Added triple-click support. Triple-clicking a TextEdit field will select the whole paragraph.
 
 ### Changed 🔧
 * `ClippedMesh` has been replaced with `ClippedPrimitive` ([#1351](https://github.com/emilk/egui/pull/1351)).

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -327,6 +327,7 @@ impl Context {
             hovered,
             clicked: Default::default(),
             double_clicked: Default::default(),
+            triple_clicked: Default::default(),
             dragged: false,
             drag_released: false,
             is_pointer_button_down_on: false,
@@ -410,6 +411,8 @@ impl Context {
                                 response.clicked[click.button as usize] = clicked;
                                 response.double_clicked[click.button as usize] =
                                     clicked && click.is_double();
+                                response.triple_clicked[click.button as usize] =
+                                    clicked && click.is_triple();
                             }
                         }
                     }

--- a/egui/src/data/output.rs
+++ b/egui/src/data/output.rs
@@ -88,6 +88,7 @@ impl PlatformOutput {
             match event {
                 OutputEvent::Clicked(widget_info)
                 | OutputEvent::DoubleClicked(widget_info)
+                | OutputEvent::TripleClicked(widget_info)
                 | OutputEvent::FocusGained(widget_info)
                 | OutputEvent::TextSelectionChanged(widget_info)
                 | OutputEvent::ValueChanged(widget_info) => {
@@ -291,6 +292,8 @@ pub enum OutputEvent {
     Clicked(WidgetInfo),
     // A widget was double-clicked.
     DoubleClicked(WidgetInfo),
+    // A widget was triple-clicked.
+    TripleClicked(WidgetInfo),
     /// A widget gained keyboard focus (by tab key).
     FocusGained(WidgetInfo),
     // Text selection was updated.
@@ -304,6 +307,7 @@ impl std::fmt::Debug for OutputEvent {
         match self {
             Self::Clicked(wi) => write!(f, "Clicked({:?})", wi),
             Self::DoubleClicked(wi) => write!(f, "DoubleClicked({:?})", wi),
+            Self::TripleClicked(wi) => write!(f, "TripleClicked({:?})", wi),
             Self::FocusGained(wi) => write!(f, "FocusGained({:?})", wi),
             Self::TextSelectionChanged(wi) => write!(f, "TextSelectionChanged({:?})", wi),
             Self::ValueChanged(wi) => write!(f, "ValueChanged({:?})", wi),

--- a/egui/src/response.rs
+++ b/egui/src/response.rs
@@ -47,6 +47,9 @@ pub struct Response {
     /// The thing was double-clicked.
     pub(crate) double_clicked: [bool; NUM_POINTER_BUTTONS],
 
+    /// The thing was triple-clicked.
+    pub(crate) triple_clicked: [bool; NUM_POINTER_BUTTONS],
+
     /// The widgets is being dragged
     pub(crate) dragged: bool,
 
@@ -79,6 +82,7 @@ impl std::fmt::Debug for Response {
             hovered,
             clicked,
             double_clicked,
+            triple_clicked,
             dragged,
             drag_released,
             is_pointer_button_down_on,
@@ -94,6 +98,7 @@ impl std::fmt::Debug for Response {
             .field("hovered", hovered)
             .field("clicked", clicked)
             .field("double_clicked", double_clicked)
+            .field("triple_clicked", triple_clicked)
             .field("dragged", dragged)
             .field("drag_released", drag_released)
             .field("is_pointer_button_down_on", is_pointer_button_down_on)
@@ -138,9 +143,19 @@ impl Response {
         self.double_clicked[PointerButton::Primary as usize]
     }
 
+    /// Returns true if this widget was triple-clicked this frame by the primary button.
+    pub fn triple_clicked(&self) -> bool {
+        self.triple_clicked[PointerButton::Primary as usize]
+    }
+
     /// Returns true if this widget was double-clicked this frame by the given button.
     pub fn double_clicked_by(&self, button: PointerButton) -> bool {
         self.double_clicked[button as usize]
+    }
+
+    /// Returns true if this widget was triple-clicked this frame by the given button.
+    pub fn triple_clicked_by(&self, button: PointerButton) -> bool {
+        self.triple_clicked[button as usize]
     }
 
     /// `true` if there was a click *outside* this widget this frame.
@@ -475,6 +490,8 @@ impl Response {
             Some(OutputEvent::Clicked(make_info()))
         } else if self.double_clicked() {
             Some(OutputEvent::DoubleClicked(make_info()))
+        } else if self.triple_clicked() {
+            Some(OutputEvent::TripleClicked(make_info()))
         } else if self.gained_focus() {
             Some(OutputEvent::FocusGained(make_info()))
         } else if self.changed {
@@ -535,6 +552,11 @@ impl Response {
                 self.double_clicked[0] || other.double_clicked[0],
                 self.double_clicked[1] || other.double_clicked[1],
                 self.double_clicked[2] || other.double_clicked[2],
+            ],
+            triple_clicked: [
+                self.triple_clicked[0] || other.triple_clicked[0],
+                self.triple_clicked[1] || other.triple_clicked[1],
+                self.triple_clicked[2] || other.triple_clicked[2],
             ],
             dragged: self.dragged || other.dragged,
             drag_released: self.drag_released || other.drag_released,

--- a/egui/src/widgets/text_edit/builder.rs
+++ b/egui/src/widgets/text_edit/builder.rs
@@ -1231,15 +1231,15 @@ fn select_line_at(text: &str, ccursor: CCursor) -> CCursorRange {
         let mut it = it.skip(ccursor.index - 1);
         if let Some(char_before_cursor) = it.next() {
             if let Some(char_after_cursor) = it.next() {
-                if is_line_char(char_before_cursor) && is_line_char(char_after_cursor) {
+                if (!is_linebreak(char_before_cursor)) && (!is_linebreak(char_after_cursor)) {
                     let min = ccursor_previous_line(text, ccursor + 1);
                     let max = ccursor_next_line(text, min);
                     CCursorRange::two(min, max)
-                } else if is_line_char(char_before_cursor) {
+                } else if !is_linebreak(char_before_cursor) {
                     let min = ccursor_previous_line(text, ccursor);
                     let max = ccursor_next_line(text, min);
                     CCursorRange::two(min, max)
-                } else if is_line_char(char_after_cursor) {
+                } else if !is_linebreak(char_after_cursor) {
                     let max = ccursor_next_line(text, ccursor);
                     CCursorRange::two(ccursor, max)
                 } else {
@@ -1316,7 +1316,7 @@ fn next_line_boundary_char_index(it: impl Iterator<Item = char>, mut index: usiz
         if let Some(second) = it.next() {
             index += 1;
             for next in it {
-                if is_line_char(next) != is_line_char(second) {
+                if is_linebreak(next) != is_linebreak(second) {
                     break;
                 }
                 index += 1;
@@ -1330,8 +1330,8 @@ fn is_word_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || c == '_'
 }
 
-fn is_line_char(c: char) -> bool {
-    c != '\r' && c != '\n'
+fn is_linebreak(c: char) -> bool {
+    c == '\r' || c == '\n'
 }
 
 /// Accepts and returns character offset (NOT byte offset!).

--- a/egui_demo_lib/src/apps/demo/tests.rs
+++ b/egui_demo_lib/src/apps/demo/tests.rs
@@ -332,7 +332,7 @@ impl super::View for InputTest {
         });
 
         let response = ui.add(
-            egui::Button::new("Click, double-click or drag me with any mouse button")
+            egui::Button::new("Click, double-click, triple-click or drag me with any mouse button")
                 .sense(egui::Sense::click_and_drag()),
         );
 
@@ -347,6 +347,9 @@ impl super::View for InputTest {
             }
             if response.double_clicked_by(button) {
                 new_info += &format!("Double-clicked by {:?} button\n", button);
+            }
+            if response.triple_clicked_by(button) {
+                new_info += &format!("Triple-clicked by {:?} button\n", button);
             }
             if response.dragged_by(button) {
                 new_info += &format!(


### PR DESCRIPTION
Straightforward extension of double-click.

Line / paragraph selection in TextEdit fields is the same as word selection logic with a different character filter. There's quite a bit of copy/paste there, let me know if you want a deeper refactoring.

Thanks for egui, it's awesome!!