### PR TITLE
Collapsing header with custom header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui_w
 * Added `Ui::spinner()` shortcut method ([#1494](https://github.com/emilk/egui/pull/1494)).
 * Added `CursorIcon`s for resizing columns, rows, and the eight cardinal directions.
 * Added `Ui::toggle_value`.
+* Added ability to add any widgets to the header of a collapsing region ([#1538](https://github.com/emilk/egui/pull/1538)).
 
 ### Changed 🔧
 * `ClippedMesh` has been replaced with `ClippedPrimitive` ([#1351](https://github.com/emilk/egui/pull/1351)).

--- a/egui/src/containers/collapsing_header.rs
+++ b/egui/src/containers/collapsing_header.rs
@@ -3,6 +3,9 @@ use std::hash::Hash;
 use crate::*;
 use epaint::Shape;
 
+/// This is a a building block for building collapsing regions.
+///
+/// It is used by [`CollapsingHeader`] and [`Window`], but can also be used on its own.
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct CollapsingState {
@@ -36,13 +39,12 @@ impl CollapsingState {
         })
     }
 
-    /// `None` if this is is a new [`CollapsingState`].
-    pub fn is_open(ctx: &Context, id: Id) -> Option<bool> {
-        if ctx.memory().everything_is_visible() {
-            Some(true)
-        } else {
-            CollapsingState::load(ctx, id).map(|state| state.open)
-        }
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    pub fn set_open(&mut self, open: bool) {
+        self.open = open;
     }
 
     pub fn toggle(&mut self, ui: &Ui) {

--- a/egui/src/containers/collapsing_header.rs
+++ b/egui/src/containers/collapsing_header.rs
@@ -17,7 +17,7 @@ pub(crate) struct InnerState {
 ///
 /// It is used by [`CollapsingHeader`] and [`Window`], but can also be used on its own.
 ///
-/// See [`CollapsingState::show_custom_header`] for how to show a collapsing header with a custom header.
+/// See [`CollapsingState::show_header`] for how to show a collapsing header with a custom header.
 #[derive(Clone, Debug)]
 pub struct CollapsingState {
     id: Id,
@@ -122,13 +122,13 @@ impl CollapsingState {
     /// # egui::__run_test_ui(|ui| {
     /// let id = ui.make_persistent_id("my_collapsing_header");
     /// egui::collapsing_header::CollapsingState::load_with_default_open(ui.ctx(), id, false)
-    ///     .show_custom_header(ui, |ui| {
+    ///     .show_header(ui, |ui| {
     ///         ui.label("Header"); // you can put checkboxes or whatever here
     ///     })
     ///     .body(|ui| ui.label("Body"));
     /// # });
     /// ```
-    pub fn show_custom_header<HeaderRet>(
+    pub fn show_header<HeaderRet>(
         mut self,
         ui: &mut Ui,
         add_header: impl FnOnce(&mut Ui) -> HeaderRet,
@@ -219,7 +219,7 @@ impl CollapsingState {
     }
 }
 
-/// From [`CollapsingState::show_custom_header`].
+/// From [`CollapsingState::show_header`].
 #[must_use = "Remember to show the body"]
 pub struct HeaderResponse<'ui, HeaderRet> {
     state: CollapsingState,
@@ -288,7 +288,7 @@ pub type IconPainter = Box<dyn FnOnce(&mut Ui, f32, &Response)>;
 /// # });
 /// ```
 ///
-/// If you want to customize the header contents, see [`CollapsingState::show_custom_header`].
+/// If you want to customize the header contents, see [`CollapsingState::show_header`].
 #[must_use = "You should call .show()"]
 pub struct CollapsingHeader {
     text: WidgetText,

--- a/egui/src/containers/collapsing_header.rs
+++ b/egui/src/containers/collapsing_header.rs
@@ -219,7 +219,7 @@ impl CollapsingState {
     }
 }
 
-/// From [`CollapsingHeaderState::show_custom_header`].
+/// From [`CollapsingState::show_custom_header`].
 #[must_use = "Remember to show the body"]
 pub struct HeaderResponse<'ui, HeaderRet> {
     state: CollapsingState,

--- a/egui/src/containers/collapsing_header.rs
+++ b/egui/src/containers/collapsing_header.rs
@@ -29,7 +29,7 @@ impl CollapsingState {
     }
 
     pub fn load_with_default_open(ctx: &Context, id: Id, default_open: bool) -> Self {
-        Self::load(ctx, id).unwrap_or_else(|| CollapsingState {
+        Self::load(ctx, id).unwrap_or(CollapsingState {
             id,
             open: default_open,
             open_height: None,

--- a/egui/src/containers/mod.rs
+++ b/egui/src/containers/mod.rs
@@ -3,7 +3,7 @@
 //! For instance, a [`Frame`] adds a frame and background to some contained UI.
 
 pub(crate) mod area;
-pub(crate) mod collapsing_header;
+pub mod collapsing_header;
 mod combo_box;
 pub(crate) mod frame;
 pub mod panel;

--- a/egui/src/containers/window.rs
+++ b/egui/src/containers/window.rs
@@ -794,7 +794,7 @@ fn show_title_bar(
 
         if collapsible {
             ui.add_space(pad);
-            collapsing.show_default_button(ui, button_size);
+            collapsing.show_default_button_with_size(ui, button_size);
         }
 
         let title_galley = title.into_galley(ui, Some(false), f32::INFINITY, TextStyle::Heading);

--- a/egui/src/containers/window.rs
+++ b/egui/src/containers/window.rs
@@ -346,7 +346,7 @@ impl<'open> Window<'open> {
             };
 
             let (content_inner, content_response) = collapsing
-                .show_contents_unindented(&mut frame.content_ui, |ui| {
+                .show_body_unindented(&mut frame.content_ui, |ui| {
                     resize.show(ui, |ui| {
                         if title_bar.is_some() {
                             ui.add_space(title_content_spacing);

--- a/egui/src/containers/window.rs
+++ b/egui/src/containers/window.rs
@@ -270,10 +270,10 @@ impl<'open> Window<'open> {
         let area_id = area.id;
         let area_layer_id = area.layer();
         let resize_id = area_id.with("resize");
-        let collapsing_id = area_id.with("collapsing");
+        let mut collapsing =
+            CollapsingState::load_with_default_open(ctx, area_id.with("collapsing"), true);
 
-        let is_collapsed =
-            with_title_bar && !CollapsingState::is_open(ctx, collapsing_id).unwrap_or_default();
+        let is_collapsed = with_title_bar && !collapsing.is_open();
         let possible = PossibleInteractions::new(&area, &resize, is_collapsed);
 
         let area = area.movable(false); // We move it manually, or the area will move the window when we want to resize it
@@ -327,9 +327,6 @@ impl<'open> Window<'open> {
             let frame_stroke = frame.stroke;
             let mut frame = frame.begin(&mut area_content_ui);
 
-            let default_expanded = true;
-            let mut collapsing =
-                CollapsingState::load_with_default_open(ctx, collapsing_id, default_expanded);
             let show_close_button = open.is_some();
             let title_bar = if with_title_bar {
                 let title_bar = show_title_bar(

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -1238,11 +1238,12 @@ impl Context {
         ui.horizontal(|ui| {
             ui.label(format!(
                 "{} collapsing headers",
-                self.data().count::<containers::collapsing_header::State>()
+                self.data()
+                    .count::<containers::collapsing_header::CollapsingState>()
             ));
             if ui.button("Reset").clicked() {
                 self.data()
-                    .remove_by_type::<containers::collapsing_header::State>();
+                    .remove_by_type::<containers::collapsing_header::CollapsingState>();
             }
         });
 

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -1239,11 +1239,11 @@ impl Context {
             ui.label(format!(
                 "{} collapsing headers",
                 self.data()
-                    .count::<containers::collapsing_header::CollapsingState>()
+                    .count::<containers::collapsing_header::InnerState>()
             ));
             if ui.button("Reset").clicked() {
                 self.data()
-                    .remove_by_type::<containers::collapsing_header::CollapsingState>();
+                    .remove_by_type::<containers::collapsing_header::InnerState>();
             }
         });
 

--- a/egui/src/style.rs
+++ b/egui/src/style.rs
@@ -293,10 +293,10 @@ pub struct Spacing {
 impl Spacing {
     /// Returns small icon rectangle and big icon rectangle
     pub fn icon_rectangles(&self, rect: Rect) -> (Rect, Rect) {
-        let box_side = self.icon_width;
+        let icon_width = self.icon_width;
         let big_icon_rect = Rect::from_center_size(
-            pos2(rect.left() + box_side / 2.0, rect.center().y),
-            vec2(box_side, box_side),
+            pos2(rect.left() + icon_width / 2.0, rect.center().y),
+            vec2(icon_width, icon_width),
         );
 
         let small_icon_rect =

--- a/egui/src/style.rs
+++ b/egui/src/style.rs
@@ -267,8 +267,12 @@ pub struct Spacing {
     pub text_edit_width: f32,
 
     /// Checkboxes, radio button and collapsing headers have an icon at the start.
-    /// This is the width/height of this icon.
+    /// This is the width/height of the outer part of this icon (e.g. the BOX of the checkbox).
     pub icon_width: f32,
+
+    /// Checkboxes, radio button and collapsing headers have an icon at the start.
+    /// This is the width/height of the inner part of this icon (e.g. the check of the checkbox).
+    pub icon_width_inner: f32,
 
     /// Checkboxes, radio button and collapsing headers have an icon at the start.
     /// This is the spacing between the icon and the text
@@ -295,9 +299,8 @@ impl Spacing {
             vec2(box_side, box_side),
         );
 
-        let small_rect_side = 8.0; // TODO: make a parameter
         let small_icon_rect =
-            Rect::from_center_size(big_icon_rect.center(), Vec2::splat(small_rect_side));
+            Rect::from_center_size(big_icon_rect.center(), Vec2::splat(self.icon_width_inner));
 
         (small_icon_rect, big_icon_rect)
     }
@@ -634,6 +637,7 @@ impl Default for Spacing {
             slider_width: 100.0,
             text_edit_width: 280.0,
             icon_width: 14.0,
+            icon_width_inner: 8.0,
             icon_spacing: 4.0,
             tooltip_width: 600.0,
             combo_height: 200.0,
@@ -909,6 +913,7 @@ impl Spacing {
             slider_width,
             text_edit_width,
             icon_width,
+            icon_width_inner,
             icon_spacing,
             tooltip_width,
             indent_ends_with_horizontal_line,
@@ -972,7 +977,12 @@ impl Spacing {
             ui.label("Checkboxes etc:");
             ui.add(
                 DragValue::new(icon_width)
-                    .prefix("width:")
+                    .prefix("outer icon width:")
+                    .clamp_range(0.0..=60.0),
+            );
+            ui.add(
+                DragValue::new(icon_width_inner)
+                    .prefix("inner icon width:")
                     .clamp_range(0.0..=60.0),
             );
             ui.add(

--- a/egui_demo_lib/src/apps/demo/misc_demo_window.rs
+++ b/egui_demo_lib/src/apps/demo/misc_demo_window.rs
@@ -361,8 +361,7 @@ impl BoxPainting {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 struct CustomCollapsingHeader {
     selected: bool,
-    value: i32,
-    checkbox: bool,
+    radio_value: bool,
 }
 
 impl CustomCollapsingHeader {
@@ -375,9 +374,9 @@ impl CustomCollapsingHeader {
                 ui,
                 |ui| {
                     // header:
-                    ui.label("Some widgets:");
-                    ui.add(DragValue::new(&mut self.value));
-                    ui.checkbox(&mut self.checkbox, "");
+                    ui.toggle_value(&mut self.selected, "Click to select/unselect");
+                    ui.radio_value(&mut self.radio_value, false, "");
+                    ui.radio_value(&mut self.radio_value, true, "");
                 },
                 |ui| {
                     // body:

--- a/egui_demo_lib/src/apps/demo/misc_demo_window.rs
+++ b/egui_demo_lib/src/apps/demo/misc_demo_window.rs
@@ -371,7 +371,7 @@ impl CustomCollapsingHeader {
 
         let id = ui.make_persistent_id("my_collapsing_header");
         egui::collapsing_header::CollapsingState::load_with_default_open(ui.ctx(), id, true)
-            .show_custom_header_and_contents(
+            .show_custom_header(
                 ui,
                 |ui| {
                     // header:
@@ -380,8 +380,8 @@ impl CustomCollapsingHeader {
                     ui.checkbox(&mut self.checkbox, "");
                 },
                 |ui| {
-                    // content:
-                    ui.label("The content is always custom");
+                    // body:
+                    ui.label("The body is always custom");
                 },
             );
 

--- a/egui_demo_lib/src/apps/demo/misc_demo_window.rs
+++ b/egui_demo_lib/src/apps/demo/misc_demo_window.rs
@@ -378,7 +378,7 @@ impl CustomCollapsingHeader {
 
         let id = ui.make_persistent_id("my_collapsing_header");
         egui::collapsing_header::CollapsingState::load_with_default_open(ui.ctx(), id, true)
-            .show_custom_header(ui, |ui| {
+            .show_header(ui, |ui| {
                 ui.toggle_value(&mut self.selected, "Click to select/unselect");
                 ui.radio_value(&mut self.radio_value, false, "");
                 ui.radio_value(&mut self.radio_value, true, "");

--- a/egui_demo_lib/src/apps/demo/misc_demo_window.rs
+++ b/egui_demo_lib/src/apps/demo/misc_demo_window.rs
@@ -357,11 +357,19 @@ impl BoxPainting {
 
 // ----------------------------------------------------------------------------
 
-#[derive(Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 struct CustomCollapsingHeader {
     selected: bool,
     radio_value: bool,
+}
+
+impl Default for CustomCollapsingHeader {
+    fn default() -> Self {
+        Self {
+            selected: true,
+            radio_value: false,
+        }
+    }
 }
 
 impl CustomCollapsingHeader {
@@ -370,19 +378,14 @@ impl CustomCollapsingHeader {
 
         let id = ui.make_persistent_id("my_collapsing_header");
         egui::collapsing_header::CollapsingState::load_with_default_open(ui.ctx(), id, true)
-            .show_custom_header(
-                ui,
-                |ui| {
-                    // header:
-                    ui.toggle_value(&mut self.selected, "Click to select/unselect");
-                    ui.radio_value(&mut self.radio_value, false, "");
-                    ui.radio_value(&mut self.radio_value, true, "");
-                },
-                |ui| {
-                    // body:
-                    ui.label("The body is always custom");
-                },
-            );
+            .show_custom_header(ui, |ui| {
+                ui.toggle_value(&mut self.selected, "Click to select/unselect");
+                ui.radio_value(&mut self.radio_value, false, "");
+                ui.radio_value(&mut self.radio_value, true, "");
+            })
+            .body(|ui| {
+                ui.label("The body is always custom");
+            });
 
         CollapsingHeader::new("Normal collapsing header for comparison").show(ui, |ui| {
             ui.label("Nothing exciting here");


### PR DESCRIPTION
This makes it possible to construct collapsing headers with custom header contents.

Closes https://github.com/emilk/egui/pull/754
Closes https://github.com/emilk/egui/issues/1036


```rust
let id = ui.make_persistent_id("my_collapsing_header");
egui::collapsing_header::CollapsingState::load_with_default_open(ui.ctx(), id, false)
    .show_header(ui, |ui| {
        ui.label("Header"); // you can put checkboxes or whatever here
    })
    .body(|ui| ui.label("Body"));
```

I think this is a better approach for making header selectable, which means we could/should deprecate `CollapsingHeader::selectable`, which is buggy anyway (i.e. clicking both selects and toggles, which is very annoying).

This introduces a separate `CollapsingState` which is perhaps a bit confusing, but `CollapsingHeader` is a bit overloaded with features and I didn't want to pile onto it. `CollapsingState` can also be used as a more low-level building block (and is indeed used by `CollapsingHeader` and by `Window`).

# TODO
* [x] Fix window collapse animation
* [x] Improve UI: break up `show_custom_header` into two calls