### PR TITLE
egui/epaint 0.18.1: Change Callback from `&dyn Any` to `&mut dyn Any`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui-w
 ## Unreleased
 
 
+## 0.18.1 - 2022-05-01
+* Change `Shape::Callback` from `&dyn Any` to `&mut dyn Any` to support more backends.
+
+
 ## 0.18.0 - 2022-04-30
 
 ### Added ⭐

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "ahash 0.7.6",
  "epaint",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "ab_glyph",
  "ahash 0.7.6",

--- a/egui/Cargo.toml
+++ b/egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 description = "An easy-to-use immediate mode GUI that runs on both web and native"
 edition = "2021"
@@ -48,7 +48,7 @@ serde = ["dep:serde", "epaint/serde"]
 
 
 [dependencies]
-epaint = { version = "0.18.0", path = "../epaint", default-features = false }
+epaint = { version = "0.18.1", path = "../epaint", default-features = false }
 
 ahash = "0.7"
 nohash-hasher = "0.2"

--- a/epaint/CHANGELOG.md
+++ b/epaint/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the epaint crate will be documented in this file.
 ## Unreleased
 
 
+## 0.18.1 - 2022-05-01
+* Change `Shape::Callback` from `&dyn Any` to `&mut dyn Any` to support more backends.
+
+
 ## 0.18.0 - 2022-04-30
 * MSRV (Minimum Supported Rust Version) is now `1.60.0` ([#1467](https://github.com/emilk/egui/pull/1467)).
 * Add `Shape::Callback` for backend-specific painting ([#1351](https://github.com/emilk/egui/pull/1351)).

--- a/epaint/Cargo.toml
+++ b/epaint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epaint"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 description = "Minimal 2D graphics library for GUI work"
 edition = "2021"

--- a/epaint/src/shape.rs
+++ b/epaint/src/shape.rs
@@ -754,12 +754,12 @@ pub struct PaintCallback {
     ///
     /// The rendering backend is also responsible for restoring any state,
     /// such as the bound shader program and vertex array.
-    pub callback: Arc<dyn Fn(&PaintCallbackInfo, &dyn std::any::Any) + Send + Sync>,
+    pub callback: Arc<dyn Fn(&PaintCallbackInfo, &mut dyn std::any::Any) + Send + Sync>,
 }
 
 impl PaintCallback {
     #[inline]
-    pub fn call(&self, info: &PaintCallbackInfo, render_ctx: &dyn std::any::Any) {
+    pub fn call(&self, info: &PaintCallbackInfo, render_ctx: &mut dyn std::any::Any) {
         (self.callback)(info, render_ctx);
     }
 }


### PR DESCRIPTION
As pointed out by @Nazariglez [on twitter](https://twitter.com/Nazariglez/status/1520523102379294721) and in issue https://github.com/emilk/egui/issues/1550, it makes more sense to use `&mut`, as it will support a wider set of backends. If your painter is non-`mut` (like `glow::Context`) then you can still wrap it up in something that is `mut` (like how `egui_glow::Painter` wraps a non-`mut` `glow::Context`).

Technically this is a breaking change and so shouldn't be a patch release, but the number of integrations that have managed to update to egui 0.18.0 since yesterday is hopefully very small, and even fewer of them will have supported `Shape::Callback`.

Note that only `epaint` needs a bump – `egui_glow` is actually compatible with both `0.18.0` and `0.18.1` since `&mut Painter` works for both `&dyn Any` and `&mut dyn Any`. I still opted to do a release of `egui` too, for the sake of clarity (e.g. an integration that is not compatible with `0.18.1` can do `egui = "=0.18.0"`).

Closes https://github.com/emilk/egui/issues/1550