### PR TITLE
Official WGPU integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "ash"
+version = "0.34.0+1.2.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f780da53d0063880d45554306489f09dd8d1bda47688b4a57bc579119356df"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +479,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "cgl"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +599,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +649,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "copyless"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
 
 [[package]]
 name = "core-foundation"
@@ -863,6 +894,17 @@ name = "custom_window_frame"
 version = "0.1.0"
 dependencies = [
  "eframe",
+]
+
+[[package]]
+name = "d3d12"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2daefd788d1e96e0a9d66dee4b828b883509bc3ea9ce30665f04c3246372690c"
+dependencies = [
+ "bitflags",
+ "libloading",
+ "winapi",
 ]
 
 [[package]]
@@ -1202,6 +1244,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_wgpu"
+version = "0.18.0"
+dependencies = [
+ "bytemuck",
+ "egui",
+ "egui-winit",
+ "pollster",
+ "wgpu",
+]
+
+[[package]]
 name = "ehttp"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1520,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "gdk-pixbuf-sys"
 version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,6 +1757,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpu-alloc"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc59e5f710e310e76e6707f86c561dd646f69a8876da9131703b2f717de818d"
+dependencies = [
+ "bitflags",
+ "gpu-alloc-types",
+]
+
+[[package]]
+name = "gpu-alloc-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54804d0d6bc9d7f26db4eaec1ad10def69b599315f487d32c334a80d1efe67a5"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a538f217be4d405ff4719a283ca68323cc2384003eca5baaa87501e821c81dda"
+dependencies = [
+ "bitflags",
+ "gpu-descriptor-types",
+ "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "363e3677e55ad168fef68cf9de3a4a310b53124c5e784c53a1d70e92d23f2126"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "gtk-sys"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,6 +1838,9 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.6",
+]
 
 [[package]]
 name = "heck"
@@ -1765,6 +1869,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "humantime"
@@ -1814,6 +1924,12 @@ dependencies = [
  "autocfg",
  "hashbrown 0.11.2",
 ]
+
+[[package]]
+name = "inplace_it"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90953f308a79fe6d62a4643e51f848fbfddcd05975a38e69fdf4ab86a7baf7ca"
 
 [[package]]
 name = "instant"
@@ -1890,6 +2006,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "khronos-egl"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3"
+dependencies = [
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -2024,6 +2150,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "metal"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0514f491f4cc03632ab399ee01e2c1c1b12d3e1cf2d667c1ff5f87d6dcd2084"
+dependencies = [
+ "bitflags",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,6 +2205,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "naga"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3012f2dbcc79e8e0b5825a4836a7106a75dd9b2fe42c528163be0f572538c705"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "codespan-reporting",
+ "hexf-parse",
+ "indexmap",
+ "log",
+ "num-traits",
+ "rustc-hash",
+ "spirv",
+ "thiserror",
 ]
 
 [[package]]
@@ -2567,6 +2725,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pollster"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2590,6 +2754,12 @@ checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
+
+[[package]]
+name = "profiling"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9145ac0af1d93c638c98c40cf7d25665f427b2a44ad0a99b1dccf3e2f25bb987"
 
 [[package]]
 name = "puffin"
@@ -2666,6 +2836,12 @@ checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "range-alloc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e935c45e09cc6dcf00d2f0b2d630a58f4095320223d47fc68918722f0538b6"
 
 [[package]]
 name = "raw-window-handle"
@@ -2748,6 +2924,12 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "renderdoc-sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157"
 
 [[package]]
 name = "resvg"
@@ -3154,6 +3336,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spirv"
+version = "0.2.0+1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
+dependencies = [
+ "bitflags",
+ "num-traits",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3506,7 +3698,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 
@@ -3856,7 +4048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a3cffdb686fbb24d9fb8f03a213803277ed2300f11026a3afe1f108dc021b"
 dependencies = [
  "jni",
- "ndk-glue 0.5.2",
+ "ndk-glue 0.6.2",
  "url",
  "web-sys",
  "widestring",
@@ -3895,6 +4087,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "wgpu"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97cd781ff044d6d697b632a2e212032c2e957d1afaa21dbf58069cbb8f78567"
+dependencies = [
+ "arrayvec 0.7.2",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot 0.11.2",
+ "raw-window-handle",
+ "smallvec",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4688c000eb841ca55f7b35db659b78d6e1cd77d7caf8fb929f4e181f754047d"
+dependencies = [
+ "arrayvec 0.7.2",
+ "bitflags",
+ "cfg_aliases",
+ "codespan-reporting",
+ "copyless",
+ "fxhash",
+ "log",
+ "naga",
+ "parking_lot 0.11.2",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "thiserror",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d684ea6a34974a2fc19f1dfd183d11a62e22d75c4f187a574bb1224df8e056c2"
+dependencies = [
+ "arrayvec 0.7.2",
+ "ash",
+ "bit-set",
+ "bitflags",
+ "block",
+ "core-graphics-types",
+ "d3d12",
+ "foreign-types",
+ "fxhash",
+ "glow",
+ "gpu-alloc",
+ "gpu-descriptor",
+ "inplace_it",
+ "js-sys",
+ "khronos-egl",
+ "libloading",
+ "log",
+ "metal",
+ "naga",
+ "objc",
+ "parking_lot 0.11.2",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "renderdoc-sys",
+ "thiserror",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types",
+ "winapi",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549533d9e1cdd4b4cda7718d33ff500fc4c34b5467b71d76b547ae0324f3b2a2"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "egui_extras",
     "egui_glium",
     "egui_glow",
+    "egui_wgpu",
     "egui-winit",
     "egui",
     "emath",

--- a/egui_wgpu/Cargo.toml
+++ b/egui_wgpu/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "egui_wgpu"
+version = "0.18.0"
+description = "Bindings for using egui natively using the wgpu library"
+authors = [
+    "Nils Hasenbanck <nils@hasenbanck.de>",
+    "embotech <opensource@embotech.com>",
+]
+edition = "2021"
+
+
+[dependencies]
+egui = { version = "0.18.1", path = "../egui", default-features = false, features = [
+    "bytemuck",
+] }
+egui-winit = { version = "0.18.0", path = "../egui-winit", optional = true }
+
+wgpu = "0.12"
+bytemuck = "1.7"
+pollster = "0.2"
+
+
+[features]
+default = ["clipboard", "default_fonts", "links", "persistence", "winit"]
+
+# enable cut/copy/paste to OS clipboard.
+# if disabled a clipboard will be simulated so you can still copy/paste within the egui app.
+clipboard = ["egui-winit/clipboard"]
+
+# If set, egui will use `include_bytes!` to bundle some fonts.
+# If you plan on specifying your own fonts you may disable this feature.
+default_fonts = ["egui/default_fonts"]
+
+# enable opening links in a browser when an egui hyperlink is clicked.
+links = ["egui-winit/links"]
+
+# enable code for saving
+persistence = ["egui/persistence"]
+
+# experimental support for a screen reader
+screen_reader = ["egui-winit/screen_reader"]
+
+winit = ["egui-winit"]

--- a/egui_wgpu/LICENSE-APACHE
+++ b/egui_wgpu/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/egui_wgpu/LICENSE-MIT
+++ b/egui_wgpu/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/egui_wgpu/src/egui.wgsl
+++ b/egui_wgpu/src/egui.wgsl
@@ -1,0 +1,85 @@
+// Vertex shader bindings
+
+struct VertexOutput {
+    [[location(0)]] tex_coord: vec2<f32>;
+    [[location(1)]] color: vec4<f32>;
+    [[builtin(position)]] position: vec4<f32>;
+};
+
+struct Locals {
+    screen_size: vec2<f32>;
+};
+[[group(0), binding(0)]] var<uniform> r_locals: Locals;
+
+fn linear_from_srgb(srgb: vec3<f32>) -> vec3<f32> {
+    let cutoff = srgb < vec3<f32>(10.31475);
+    let lower = srgb / vec3<f32>(3294.6);
+    let higher = pow((srgb + vec3<f32>(14.025)) / vec3<f32>(269.025), vec3<f32>(2.4));
+    return select(higher, lower, cutoff);
+}
+
+[[stage(vertex)]]
+fn vs_main(
+    [[location(0)]] a_pos: vec2<f32>,
+    [[location(1)]] a_tex_coord: vec2<f32>,
+    [[location(2)]] a_color: u32,
+) -> VertexOutput {
+    var out: VertexOutput;
+    out.tex_coord = a_tex_coord;
+
+    // [u8; 4] SRGB as u32 -> [r, g, b, a]
+    let color = vec4<f32>(
+        f32(a_color & 255u),
+        f32((a_color >> 8u) & 255u),
+        f32((a_color >> 16u) & 255u),
+        f32((a_color >> 24u) & 255u),
+    );
+    out.color = vec4<f32>(linear_from_srgb(color.rgb), color.a / 255.0);
+
+    out.position = vec4<f32>(
+        2.0 * a_pos.x / r_locals.screen_size.x - 1.0,
+        1.0 - 2.0 * a_pos.y / r_locals.screen_size.y,
+        0.0,
+        1.0,
+    );
+
+    return out;
+}
+
+[[stage(vertex)]]
+fn vs_conv_main(
+    [[location(0)]] a_pos: vec2<f32>,
+    [[location(1)]] a_tex_coord: vec2<f32>,
+    [[location(2)]] a_color: u32,
+) -> VertexOutput {
+    var out: VertexOutput;
+    out.tex_coord = a_tex_coord;
+
+    // [u8; 4] SRGB as u32 -> [r, g, b, a]
+    let color = vec4<f32>(
+        f32(a_color & 255u),
+        f32((a_color >> 8u) & 255u),
+        f32((a_color >> 16u) & 255u),
+        f32((a_color >> 24u) & 255u),
+    );
+    out.color = vec4<f32>(color.rgba / 255.0);
+
+    out.position = vec4<f32>(
+        2.0 * a_pos.x / r_locals.screen_size.x - 1.0,
+        1.0 - 2.0 * a_pos.y / r_locals.screen_size.y,
+        0.0,
+        1.0,
+    );
+
+    return out;
+}
+
+// Fragment shader bindings
+
+[[group(1), binding(0)]] var r_tex_color: texture_2d<f32>;
+[[group(1), binding(1)]] var r_tex_sampler: sampler;
+
+[[stage(fragment)]]
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+    return in.color * textureSample(r_tex_color, r_tex_sampler, in.tex_coord);
+}

--- a/egui_wgpu/src/epi_backend.rs
+++ b/egui_wgpu/src/epi_backend.rs
@@ -1,0 +1,215 @@
+#![allow(unsafe_code)]
+
+use crate::renderer::{wgpu, RenderPass, ScreenDescriptor};
+use egui::FullOutput;
+use egui_winit::winit;
+
+/// A custom event type for the winit app.
+enum Event {
+    RequestRedraw,
+}
+
+/// This is the repaint signal type that egui needs for requesting a repaint from another thread.
+/// It sends the custom RequestRedraw event to the winit event loop.
+struct WgpuRepaintSignal(std::sync::Mutex<winit::event_loop::EventLoopProxy<Event>>);
+
+impl epi::backend::RepaintSignal for WgpuRepaintSignal {
+    fn request_repaint(&self) {
+        self.0.lock().unwrap().send_event(Event::RequestRedraw).ok();
+    }
+}
+
+/// Run an egui app
+pub fn run(app_name: &str, native_options: &epi::NativeOptions, app_creator: epi::AppCreator) -> ! {
+    let storage = epi_integration::create_storage(app_name);
+    let window_settings = epi_integration::load_window_settings(storage.as_deref());
+    let event_loop = winit::event_loop::EventLoop::with_user_event();
+    let window = window_builder(native_options, &window_settings).with_title(app_name);
+    let window_builder = epi_integration::window_builder(native_options, &window_settings)
+        .build(&event_loop)
+        .unwrap();
+
+    // TODO: Unclear what to do with this. It used to be an argument to `EpiIntegration::new`.
+    let repaint_signal = std::sync::Arc::new(WgpuRepaintSignal(std::sync::Mutex::new(
+        event_loop.create_proxy(),
+    )));
+
+    // GL is "unsupported" as backend, but it is required to run in a remote desktop environment.
+    let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY | wgpu::Backends::GL);
+    let surface = unsafe { instance.create_surface(&window) };
+
+    // WGPU 0.11+ support force fallback (if HW implementation not supported), set it to true or false (optional).
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::HighPerformance,
+        compatible_surface: Some(&surface),
+        force_fallback_adapter: false,
+    }))
+    .unwrap();
+
+    let (device, queue) = pollster::block_on(adapter.request_device(
+        &wgpu::DeviceDescriptor {
+            features: wgpu::Features::default(),
+            limits: wgpu::Limits::default(),
+            label: None,
+        },
+        None,
+    ))
+    .unwrap();
+
+    let size = window.inner_size();
+    let surface_format = surface.get_preferred_format(&adapter).unwrap();
+    let mut surface_config = wgpu::SurfaceConfiguration {
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        format: surface_format,
+        width: size.width as u32,
+        height: size.height as u32,
+        present_mode: wgpu::PresentMode::Fifo,
+    };
+    surface.configure(&device, &surface_config);
+
+    let mut integration = egui_winit::EpiIntegration::new(
+        "egui_wgpu",
+        device.limits().max_texture_dimension_2d as usize,
+        &window,
+        storage,
+    );
+    // We use the egui_wgpu_backend crate as the render backend.
+    let mut egui_rpass = RenderPass::new(&device, surface_format, 1);
+
+    let mut is_focused = true;
+
+    event_loop.run(move |event, _, control_flow| {
+        let mut redraw = || {
+            if !is_focused {
+                // On Mac, a minimized Window uses up all CPU: https://github.com/emilk/egui/issues/325
+                // We can't know if we are minimized: https://github.com/rust-windowing/winit/issues/208
+                // But we know if we are focused (in foreground). When minimized, we are not focused.
+                // However, a user may want an egui with an animation in the background,
+                // so we still need to repaint quite fast.
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+
+            let output_frame = match surface.get_current_texture() {
+                Ok(frame) => frame,
+                Err(wgpu::SurfaceError::Outdated) => {
+                    // This error occurs when the app is minimized on Windows.
+                    // Silently return here to prevent spamming the console with:
+                    // "The underlying surface has changed, and therefore the swap chain must be updated"
+                    return;
+                }
+                Err(e) => {
+                    eprintln!("Dropped frame with error: {}", e);
+                    return;
+                }
+            };
+            let output_view = output_frame
+                .texture
+                .create_view(&wgpu::TextureViewDescriptor::default());
+
+            let FullOutput {
+                platform_output,
+                needs_repaint,
+                textures_delta,
+                shapes,
+            } = integration.update(&window);
+
+            integration.handle_platform_output(&window, platform_output);
+
+            for (id, image_delta) in textures_delta.set {
+                egui_rpass.update_texture(id, image_delta)
+            }
+            for id in textures_delta.free {
+                egui_rpass.free_texture(id);
+            }
+            let clipped_meshes = integration.egui_ctx.tessellate(shapes);
+
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("encoder"),
+            });
+
+            // Upload all resources for the GPU.
+            let screen_descriptor = ScreenDescriptor {
+                physical_width: surface_config.width,
+                physical_height: surface_config.height,
+                scale_factor: integration.egui_ctx.pixels_per_point(),
+            };
+
+            egui_rpass.update_textures(&device, &queue);
+            egui_rpass.update_buffers(&device, &queue, &clipped_meshes, &screen_descriptor);
+
+            let clear_color = integration.app.clear_color();
+
+            // Record all render passes.
+            egui_rpass
+                .execute(
+                    &mut encoder,
+                    &output_view,
+                    &clipped_meshes,
+                    &screen_descriptor,
+                    Some(wgpu::Color {
+                        r: clear_color.r() as f64,
+                        g: clear_color.g() as f64,
+                        b: clear_color.b() as f64,
+                        a: clear_color.a() as f64,
+                    }),
+                )
+                .unwrap();
+
+            // Submit the commands.
+            queue.submit(std::iter::once(encoder.finish()));
+
+            // Redraw egui
+            output_frame.present();
+
+            integration.maybe_autosave(&window);
+
+            *control_flow = if integration.should_quit() {
+                winit::event_loop::ControlFlow::Exit
+            } else if needs_repaint {
+                window.request_redraw();
+                winit::event_loop::ControlFlow::Poll
+            } else {
+                winit::event_loop::ControlFlow::Wait
+            };
+        };
+
+        match event {
+            winit::event::Event::WindowEvent { event, .. } => {
+                match event {
+                    winit::event::WindowEvent::Focused(new_focused) => {
+                        is_focused = new_focused;
+                    }
+                    winit::event::WindowEvent::Resized(size) => {
+                        // Resize with 0 width and height is used by winit to signal a minimize event on Windows.
+                        // See: https://github.com/rust-windowing/winit/issues/208
+                        // This solves an issue where the app would panic when minimizing on Windows.
+                        if size.width > 0 && size.height > 0 {
+                            surface_config.width = size.width;
+                            surface_config.height = size.height;
+                            surface.configure(&device, &surface_config);
+                        }
+                    }
+                    winit::event::WindowEvent::CloseRequested => {
+                        *control_flow = winit::event_loop::ControlFlow::Exit;
+                    }
+                    _ => {}
+                };
+                integration.on_event(&event);
+                if integration.should_quit() {
+                    *control_flow = winit::event_loop::ControlFlow::Exit;
+                }
+                window.request_redraw();
+            }
+            // Platform-dependent event handlers to workaround a winit bug
+            // See: https://github.com/rust-windowing/winit/issues/987
+            // See: https://github.com/rust-windowing/winit/issues/1619
+            winit::event::Event::RedrawEventsCleared if cfg!(windows) => redraw(),
+            winit::event::Event::RedrawRequested(_) if !cfg!(windows) => redraw(),
+            winit::event::Event::UserEvent(Event::RequestRedraw) => window.request_redraw(),
+            winit::event::Event::LoopDestroyed => {
+                integration.on_exit(&window);
+            }
+            _ => (),
+        }
+    });
+}

--- a/egui_wgpu/src/epi_backend.rs
+++ b/egui_wgpu/src/epi_backend.rs
@@ -24,8 +24,8 @@ pub fn run(app_name: &str, native_options: &epi::NativeOptions, app_creator: epi
     let storage = epi_integration::create_storage(app_name);
     let window_settings = epi_integration::load_window_settings(storage.as_deref());
     let event_loop = winit::event_loop::EventLoop::with_user_event();
-    let window = window_builder(native_options, &window_settings).with_title(app_name);
-    let window_builder = epi_integration::window_builder(native_options, &window_settings)
+    let window = epi_integration::window_builder(native_options, &window_settings)
+        .with_title(app_name)
         .build(&event_loop)
         .unwrap();
 

--- a/egui_wgpu/src/lib.rs
+++ b/egui_wgpu/src/lib.rs
@@ -1,0 +1,4 @@
+mod epi_backend;
+mod renderer;
+
+pub use epi_backend::run;

--- a/egui_wgpu/src/renderer.rs
+++ b/egui_wgpu/src/renderer.rs
@@ -1,0 +1,582 @@
+#![allow(unsafe_code)]
+
+use std::{borrow::Cow, collections::HashMap, fmt::Formatter, num::NonZeroU32};
+
+use bytemuck::{Pod, Zeroable};
+use egui::epaint::Primitive;
+pub use wgpu;
+use wgpu::util::DeviceExt;
+
+/// Error that the backend can return.
+#[derive(Debug)]
+pub enum BackendError {
+    /// The given `egui::TextureId` was invalid.
+    InvalidTextureId(String),
+    /// Internal implementation error.
+    Internal(String),
+}
+
+impl std::fmt::Display for BackendError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BackendError::InvalidTextureId(msg) => {
+                write!(f, "invalid TextureId: `{:?}`", msg)
+            }
+            BackendError::Internal(msg) => {
+                write!(f, "internal error: `{:?}`", msg)
+            }
+        }
+    }
+}
+
+impl std::error::Error for BackendError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
+
+/// Enum for selecting the right buffer type.
+#[derive(Debug)]
+enum BufferType {
+    Uniform,
+    Index,
+    Vertex,
+}
+
+/// Information about the screen used for rendering.
+pub struct ScreenDescriptor {
+    /// Width of the window in physical pixel.
+    pub physical_width: u32,
+    /// Height of the window in physical pixel.
+    pub physical_height: u32,
+    /// HiDPI scale factor.
+    pub scale_factor: f32,
+}
+
+impl ScreenDescriptor {
+    fn logical_size(&self) -> (u32, u32) {
+        let logical_width = self.physical_width as f32 / self.scale_factor;
+        let logical_height = self.physical_height as f32 / self.scale_factor;
+        (logical_width as u32, logical_height as u32)
+    }
+}
+
+/// Uniform buffer used when rendering.
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+struct UniformBuffer {
+    screen_size: [f32; 2],
+}
+
+unsafe impl Pod for UniformBuffer {}
+
+unsafe impl Zeroable for UniformBuffer {}
+
+/// Wraps the buffers and includes additional information.
+#[derive(Debug)]
+struct SizedBuffer {
+    buffer: wgpu::Buffer,
+    size: usize,
+}
+
+/// RenderPass to render a egui based GUI.
+pub struct RenderPass {
+    render_pipeline: wgpu::RenderPipeline,
+    index_buffers: Vec<SizedBuffer>,
+    vertex_buffers: Vec<SizedBuffer>,
+    uniform_buffer: SizedBuffer,
+    uniform_bind_group: wgpu::BindGroup,
+    texture_bind_group_layout: wgpu::BindGroupLayout,
+    pending_textures_add: Vec<(egui::TextureId, egui::epaint::ImageDelta)>,
+    pending_textures_free: Vec<egui::TextureId>,
+    textures: HashMap<egui::TextureId, (wgpu::Texture, wgpu::BindGroup)>,
+}
+
+impl RenderPass {
+    /// Creates a new render pass to render a egui UI.
+    ///
+    /// If the format passed is not a *Srgb format, the shader will automatically convert to sRGB colors in the shader.
+    pub fn new(
+        device: &wgpu::Device,
+        output_format: wgpu::TextureFormat,
+        msaa_samples: u32,
+    ) -> Self {
+        let shader = wgpu::ShaderModuleDescriptor {
+            label: Some("egui_shader"),
+            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("egui.wgsl"))),
+        };
+        let module = device.create_shader_module(&shader);
+
+        let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("egui_uniform_buffer"),
+            contents: bytemuck::cast_slice(&[UniformBuffer {
+                screen_size: [0.0, 0.0],
+            }]),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+        let uniform_buffer = SizedBuffer {
+            buffer: uniform_buffer,
+            size: std::mem::size_of::<UniformBuffer>(),
+        };
+
+        let uniform_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("egui_uniform_bind_group_layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                        ty: wgpu::BufferBindingType::Uniform,
+                    },
+                    count: None,
+                }],
+            });
+
+        let uniform_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("egui_uniform_bind_group"),
+            layout: &uniform_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &uniform_buffer.buffer,
+                    offset: 0,
+                    size: None,
+                }),
+            }],
+        });
+
+        let texture_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("egui_texture_bind_group_layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            multisampled: false,
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("egui_pipeline_layout"),
+            bind_group_layouts: &[&uniform_bind_group_layout, &texture_bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("egui_pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                entry_point: if output_format.describe().srgb {
+                    "vs_main"
+                } else {
+                    "vs_conv_main"
+                },
+                module: &module,
+                buffers: &[wgpu::VertexBufferLayout {
+                    array_stride: 5 * 4,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    // 0: vec2 position
+                    // 1: vec2 texture coordinates
+                    // 2: uint color
+                    attributes: &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x2, 2 => Uint32],
+                }],
+            },
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                unclipped_depth: false,
+                conservative: false,
+                cull_mode: None,
+                front_face: wgpu::FrontFace::default(),
+                polygon_mode: wgpu::PolygonMode::default(),
+                strip_index_format: None,
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState {
+                alpha_to_coverage_enabled: false,
+                count: msaa_samples,
+                mask: !0,
+            },
+
+            fragment: Some(wgpu::FragmentState {
+                module: &module,
+                entry_point: "fs_main",
+                targets: &[wgpu::ColorTargetState {
+                    format: output_format,
+                    blend: Some(wgpu::BlendState {
+                        color: wgpu::BlendComponent {
+                            src_factor: wgpu::BlendFactor::One,
+                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                        alpha: wgpu::BlendComponent {
+                            src_factor: wgpu::BlendFactor::OneMinusDstAlpha,
+                            dst_factor: wgpu::BlendFactor::One,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                    }),
+                    write_mask: wgpu::ColorWrites::ALL,
+                }],
+            }),
+            multiview: None,
+        });
+
+        Self {
+            render_pipeline,
+            vertex_buffers: Vec::with_capacity(64),
+            index_buffers: Vec::with_capacity(64),
+            uniform_buffer,
+            uniform_bind_group,
+            texture_bind_group_layout,
+            pending_textures_add: Vec::new(),
+            pending_textures_free: Vec::new(),
+            textures: HashMap::new(),
+        }
+    }
+
+    /// Executes the egui render pass. When `clear_on_draw` is set, the output target will get cleared before writing to it.
+    pub fn execute(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        color_attachment: &wgpu::TextureView,
+        paint_jobs: &[egui::epaint::ClippedPrimitive],
+        screen_descriptor: &ScreenDescriptor,
+        clear_color: Option<wgpu::Color>,
+    ) -> Result<(), BackendError> {
+        let load_operation = if let Some(color) = clear_color {
+            wgpu::LoadOp::Clear(color)
+        } else {
+            wgpu::LoadOp::Load
+        };
+
+        let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            color_attachments: &[wgpu::RenderPassColorAttachment {
+                view: color_attachment,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: load_operation,
+                    store: true,
+                },
+            }],
+            depth_stencil_attachment: None,
+            label: Some("egui main render pass"),
+        });
+        rpass.push_debug_group("egui_pass");
+
+        self.execute_with_renderpass(&mut rpass, paint_jobs, screen_descriptor)?;
+
+        rpass.pop_debug_group();
+
+        Ok(())
+    }
+
+    /// Executes the egui render pass onto an existing wgpu renderpass.
+    pub fn execute_with_renderpass<'rpass>(
+        &'rpass self,
+        rpass: &mut wgpu::RenderPass<'rpass>,
+        paint_jobs: &[egui::epaint::ClippedPrimitive],
+        screen_descriptor: &ScreenDescriptor,
+    ) -> Result<(), BackendError> {
+        rpass.set_pipeline(&self.render_pipeline);
+
+        rpass.set_bind_group(0, &self.uniform_bind_group, &[]);
+
+        let scale_factor = screen_descriptor.scale_factor;
+        let physical_width = screen_descriptor.physical_width;
+        let physical_height = screen_descriptor.physical_height;
+
+        for (
+            (
+                egui::ClippedPrimitive {
+                    clip_rect,
+                    primitive,
+                },
+                vertex_buffer,
+            ),
+            index_buffer,
+        ) in paint_jobs
+            .iter()
+            .zip(self.vertex_buffers.iter())
+            .zip(self.index_buffers.iter())
+        {
+            // Transform clip rect to physical pixels.
+            let clip_min_x = scale_factor * clip_rect.min.x;
+            let clip_min_y = scale_factor * clip_rect.min.y;
+            let clip_max_x = scale_factor * clip_rect.max.x;
+            let clip_max_y = scale_factor * clip_rect.max.y;
+
+            // Make sure clip rect can fit within an `u32`.
+            let clip_min_x = clip_min_x.clamp(0.0, physical_width as f32);
+            let clip_min_y = clip_min_y.clamp(0.0, physical_height as f32);
+            let clip_max_x = clip_max_x.clamp(clip_min_x, physical_width as f32);
+            let clip_max_y = clip_max_y.clamp(clip_min_y, physical_height as f32);
+
+            let clip_min_x = clip_min_x.round() as u32;
+            let clip_min_y = clip_min_y.round() as u32;
+            let clip_max_x = clip_max_x.round() as u32;
+            let clip_max_y = clip_max_y.round() as u32;
+
+            let width = (clip_max_x - clip_min_x).max(1);
+            let height = (clip_max_y - clip_min_y).max(1);
+
+            {
+                // Clip scissor rectangle to target size.
+                let x = clip_min_x.min(physical_width);
+                let y = clip_min_y.min(physical_height);
+                let width = width.min(physical_width - x);
+                let height = height.min(physical_height - y);
+
+                // Skip rendering with zero-sized clip areas.
+                if width == 0 || height == 0 {
+                    continue;
+                }
+
+                rpass.set_scissor_rect(x, y, width, height);
+            }
+
+            match primitive {
+                Primitive::Mesh(mesh) => {
+                    let (_texture, bind_group) =
+                        self.textures.get(&mesh.texture_id).ok_or_else(|| {
+                            BackendError::Internal("Texture bind group not found".to_string())
+                        })?;
+                    rpass.set_bind_group(1, bind_group, &[]);
+                    rpass
+                        .set_index_buffer(index_buffer.buffer.slice(..), wgpu::IndexFormat::Uint32);
+                    rpass.set_vertex_buffer(0, vertex_buffer.buffer.slice(..));
+                    rpass.draw_indexed(0..mesh.indices.len() as u32, 0, 0..1);
+                }
+                Primitive::Callback(_) => todo!(),
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Add a new texture in raw RGBA format to be added on the next call to `update_textures`.
+    pub fn update_texture(&mut self, id: egui::TextureId, image: egui::epaint::ImageDelta) {
+        self.pending_textures_add.push((id, image))
+    }
+
+    /// Mark a texture to be destroyed on the next call to `update_textures`.
+    pub fn free_texture(&mut self, id: egui::TextureId) {
+        self.pending_textures_free.push(id);
+    }
+
+    /// Updates the textures that the app allocated. Should be called before `execute()`.
+    pub fn update_textures(&mut self, device: &wgpu::Device, queue: &wgpu::Queue) {
+        for (id, image_delta) in self.pending_textures_add.drain(..) {
+            let size = wgpu::Extent3d {
+                width: image_delta.image.size()[0] as u32,
+                height: image_delta.image.size()[1] as u32,
+                depth_or_array_layers: 1,
+            };
+
+            let data_color32 = match &image_delta.image {
+                egui::ImageData::Color(image) => {
+                    assert_eq!(
+                        image.width() * image.height(),
+                        image.pixels.len(),
+                        "Mismatch between texture size and texel count"
+                    );
+                    Cow::Borrowed(&image.pixels)
+                }
+                egui::ImageData::Alpha(image) => {
+                    assert_eq!(
+                        image.width() * image.height(),
+                        image.pixels.len(),
+                        "Mismatch between texture size and texel count"
+                    );
+                    Cow::Owned(image.srgba_pixels(1.0).collect::<Vec<_>>())
+                }
+            };
+            let data_bytes: &[u8] = bytemuck::cast_slice(data_color32.as_slice());
+
+            let queue_write_data_to_texture = |texture, origin| {
+                queue.write_texture(
+                    wgpu::ImageCopyTexture {
+                        texture,
+                        mip_level: 0,
+                        origin,
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    data_bytes,
+                    wgpu::ImageDataLayout {
+                        offset: 0,
+                        bytes_per_row: NonZeroU32::new((4 * image_delta.image.width()) as u32),
+                        rows_per_image: NonZeroU32::new(image_delta.image.height() as u32),
+                    },
+                    size,
+                );
+            };
+
+            if let Some(pos) = image_delta.pos {
+                // update the existing texture
+                let (texture, _bind_group) = self
+                    .textures
+                    .get(&id)
+                    .expect("Tried to update a texture that has not been allocated yet.");
+                let origin = wgpu::Origin3d {
+                    x: pos[0] as u32,
+                    y: pos[1] as u32,
+                    z: 0,
+                };
+                queue_write_data_to_texture(texture, origin);
+            } else {
+                // allocate a new texture
+                let texture = device.create_texture(&wgpu::TextureDescriptor {
+                    label: None,
+                    size,
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    dimension: wgpu::TextureDimension::D2,
+                    format: wgpu::TextureFormat::Rgba8UnormSrgb,
+                    usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+                });
+                let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+                    label: None,
+                    mag_filter: wgpu::FilterMode::Linear,
+                    min_filter: wgpu::FilterMode::Linear,
+                    ..Default::default()
+                });
+                let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: None,
+                    layout: &self.texture_bind_group_layout,
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: wgpu::BindingResource::TextureView(
+                                &texture.create_view(&wgpu::TextureViewDescriptor::default()),
+                            ),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: wgpu::BindingResource::Sampler(&sampler),
+                        },
+                    ],
+                });
+                let origin = wgpu::Origin3d::ZERO;
+                queue_write_data_to_texture(&texture, origin);
+                self.textures.insert(id, (texture, bind_group));
+            };
+        }
+        for id in self.pending_textures_free.drain(..) {
+            self.textures.remove(&id);
+        }
+    }
+
+    /// Uploads the uniform, vertex and index data used by the render pass.
+    /// Should be called before `execute()`.
+    pub fn update_buffers(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        paint_jobs: &[egui::epaint::ClippedPrimitive],
+        screen_descriptor: &ScreenDescriptor,
+    ) {
+        let index_size = self.index_buffers.len();
+        let vertex_size = self.vertex_buffers.len();
+
+        let (logical_width, logical_height) = screen_descriptor.logical_size();
+
+        self.update_buffer(
+            device,
+            queue,
+            BufferType::Uniform,
+            0,
+            bytemuck::cast_slice(&[UniformBuffer {
+                screen_size: [logical_width as f32, logical_height as f32],
+            }]),
+        );
+
+        for (i, egui::ClippedPrimitive { primitive, .. }) in paint_jobs.iter().enumerate() {
+            match primitive {
+                Primitive::Mesh(mesh) => {
+                    let data: &[u8] = bytemuck::cast_slice(&mesh.indices);
+                    if i < index_size {
+                        self.update_buffer(device, queue, BufferType::Index, i, data)
+                    } else {
+                        let buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                            label: Some("egui_index_buffer"),
+                            contents: data,
+                            usage: wgpu::BufferUsages::INDEX | wgpu::BufferUsages::COPY_DST,
+                        });
+                        self.index_buffers.push(SizedBuffer {
+                            buffer,
+                            size: data.len(),
+                        });
+                    }
+
+                    let data: &[u8] = bytemuck::cast_slice(&mesh.vertices);
+                    if i < vertex_size {
+                        self.update_buffer(device, queue, BufferType::Vertex, i, data)
+                    } else {
+                        let buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                            label: Some("egui_vertex_buffer"),
+                            contents: data,
+                            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+                        });
+
+                        self.vertex_buffers.push(SizedBuffer {
+                            buffer,
+                            size: data.len(),
+                        });
+                    }
+                }
+                Primitive::Callback(_) => todo!(),
+            }
+        }
+    }
+
+    /// Updates the buffers used by egui. Will properly re-size the buffers if needed.
+    fn update_buffer(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        buffer_type: BufferType,
+        index: usize,
+        data: &[u8],
+    ) {
+        let (buffer, storage, name) = match buffer_type {
+            BufferType::Index => (
+                &mut self.index_buffers[index],
+                wgpu::BufferUsages::INDEX,
+                "index",
+            ),
+            BufferType::Vertex => (
+                &mut self.vertex_buffers[index],
+                wgpu::BufferUsages::VERTEX,
+                "vertex",
+            ),
+            BufferType::Uniform => (
+                &mut self.uniform_buffer,
+                wgpu::BufferUsages::UNIFORM,
+                "uniform",
+            ),
+        };
+
+        if data.len() > buffer.size {
+            buffer.size = data.len();
+            buffer.buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some(format!("egui_{}_buffer", name).as_str()),
+                contents: bytemuck::cast_slice(data),
+                usage: storage | wgpu::BufferUsages::COPY_DST,
+            });
+        } else {
+            queue.write_buffer(&buffer.buffer, 0, data);
+        }
+    }
+}


### PR DESCRIPTION
Based on the discussion in #1555, it looks like providing an official wgpu backend might have its benefits.

This builds on Nils Hasenbanck's [egui_wgpu_backend](https://github.com/hasenbanck/egui_wgpu_backend) but removes the need for [egui_winit_platform](https://github.com/hasenbanck/egui_winit_platform) and some boilerplate code and instead uses egui's own `egui-winit` and `eframe`. This approach worked well in egui 0.17 using the separate `epi` crate. 0.18 made this approach invalid as `epi` was moved into `eframe`.

@hasenbanck Since this is a heavily modified fork from your repository from around egui 0.16, you are still listed as the primary author. I also left the original license files in here, at least for now. Let me know if this is okay for you.

This does not compile right now. But as outlined in #1555, there is some potential for sharing code between the glow and wgpu backend which we can experiment with in this PR.

