### PR TITLE
CollapsingState Improvements

### DIFF
--- a/egui/src/containers/collapsing_header.rs
+++ b/egui/src/containers/collapsing_header.rs
@@ -106,7 +106,7 @@ impl CollapsingState {
     ///
     /// let id = ui.make_persistent_id("my_collapsing_header");
     /// egui::collapsing_header::CollapsingState::load_with_default_open(ui.ctx(), id, false)
-    ///     .icon(circle_icon);
+    ///     .icon(circle_icon)
     ///     .show_header(ui, |ui| {
     ///         ui.label("Header"); // you can put checkboxes or whatever here
     ///     })


### PR DESCRIPTION
As per https://github.com/emilk/egui/discussions/1566

Concerns are the `FnOnce` > `Fn` change, which shouldn't realistically impact any icon drawing functions and the ergonomics of a "no collapser" mode, since something like https://github.com/4JX/egui/commit/f3234a1f0dd400d33bedfe46c4f3ddff6cbff423 would need to be done.