### PR TITLE
Fix CircleShape::visual_bounding_rect()

### DIFF
--- a/epaint/src/shape.rs
+++ b/epaint/src/shape.rs
@@ -331,7 +331,7 @@ impl CircleShape {
         } else {
             Rect::from_center_size(
                 self.center,
-                Vec2::splat(self.radius + self.stroke.width / 2.0),
+                Vec2::splat(self.radius * 2.0 + self.stroke.width),
             )
         }
     }


### PR DESCRIPTION
I fixed a bug that `CircleShape::visual_bounding_rect()` returns the wrong value.
The Rect returned was the half size of the circle.