### PR TITLE
Remove calls to gl.getError in release builds

### DIFF
--- a/eframe/CHANGELOG.md
+++ b/eframe/CHANGELOG.md
@@ -5,6 +5,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 
 
 ## Unreleased
+* `egui_glow`: remove calls to `gl.get_error` in release builds to speed up rendering ([#1583](https://github.com/emilk/egui/pull/1583)).
 
 
 ## 0.18.0 - 2022-04-30

--- a/egui_glow/CHANGELOG.md
+++ b/egui_glow/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to the `egui_glow` integration will be noted in this file.
 
 
 ## Unreleased
+* Remove calls to `gl.get_error` in release builds to speed up rendering ([#1583](https://github.com/emilk/egui/pull/1583)).
 
 
 ## 0.18.0 - 2022-04-30

--- a/egui_glow/src/lib.rs
+++ b/egui_glow/src/lib.rs
@@ -22,6 +22,8 @@ pub use winit::*;
 
 /// Check for OpenGL error and report it using `tracing::error`.
 ///
+/// Only active in debug builds!
+///
 /// ``` no_run
 /// # let glow_context = todo!();
 /// use egui_glow::check_for_gl_error;
@@ -30,6 +32,30 @@ pub use winit::*;
 /// ```
 #[macro_export]
 macro_rules! check_for_gl_error {
+    ($gl: expr) => {{
+        if cfg!(debug_assertions) {
+            $crate::check_for_gl_error_impl($gl, file!(), line!(), "")
+        }
+    }};
+    ($gl: expr, $context: literal) => {{
+        if cfg!(debug_assertions) {
+            $crate::check_for_gl_error_impl($gl, file!(), line!(), $context)
+        }
+    }};
+}
+
+/// Check for OpenGL error and report it using `tracing::error`.
+///
+/// WARNING: slow! Only use during setup!
+///
+/// ``` no_run
+/// # let glow_context = todo!();
+/// use egui_glow::check_for_gl_error_even_in_release;
+/// check_for_gl_error_even_in_release!(glow_context);
+/// check_for_gl_error_even_in_release!(glow_context, "during painting");
+/// ```
+#[macro_export]
+macro_rules! check_for_gl_error_even_in_release {
     ($gl: expr) => {{
         $crate::check_for_gl_error_impl($gl, file!(), line!(), "")
     }};

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -96,7 +96,7 @@ impl Painter {
         shader_prefix: &str,
     ) -> Result<Painter, String> {
         crate::profile_function!();
-        check_for_gl_error!(&gl, "before Painter::new");
+        crate::check_for_gl_error_even_in_release!(&gl, "before Painter::new");
 
         let max_texture_side = unsafe { gl.get_parameter_i32(glow::MAX_TEXTURE_SIZE) } as usize;
 
@@ -204,7 +204,7 @@ impl Painter {
 
             let element_array_buffer = gl.create_buffer()?;
 
-            check_for_gl_error!(&gl, "after Painter::new");
+            crate::check_for_gl_error_even_in_release!(&gl, "after Painter::new");
 
             Ok(Painter {
                 gl,

--- a/egui_glow/src/post_process.rs
+++ b/egui_glow/src/post_process.rs
@@ -75,7 +75,7 @@ impl PostProcess {
             glow::UNSIGNED_BYTE,
             None,
         );
-        check_for_gl_error!(&gl, "post process texture initialization");
+        crate::check_for_gl_error_even_in_release!(&gl, "post process texture initialization");
 
         gl.framebuffer_texture_2d(
             glow::FRAMEBUFFER,
@@ -160,7 +160,7 @@ impl PostProcess {
         gl.buffer_data_u8_slice(glow::ELEMENT_ARRAY_BUFFER, &indices, glow::STATIC_DRAW);
 
         gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, None);
-        check_for_gl_error!(&gl, "post process initialization");
+        crate::check_for_gl_error_even_in_release!(&gl, "post process initialization");
 
         Ok(PostProcess {
             gl,

--- a/sh/build_demo_web.sh
+++ b/sh/build_demo_web.sh
@@ -17,14 +17,19 @@ while test $# -gt 0; do
       echo "  --open: open the result in a browser"
       exit 0
       ;;
+
+    # Skip running `wasm-opt`.
+    # --fast also preserves debug symbols, which is great for profiling.
     --fast)
       shift
       FAST=true
       ;;
+
     --open)
       shift
       OPEN=true
       ;;
+
     *)
       break
       ;;


### PR DESCRIPTION
This slows down the web version a lot, especially on some browsers. I never meant to leave these calls in, but I forgot to remove them 🤦 

I suspect this is responsible for the performance regression some have noticed in egui 0.18.