### PR TITLE
Fix typo in ui.rs

### DIFF
--- a/egui/src/ui.rs
+++ b/egui/src/ui.rs
@@ -1251,7 +1251,7 @@ impl Ui {
         Label::new(text.into().strong()).ui(self)
     }
 
-    /// Show text that is waker (fainter color).
+    /// Show text that is weaker (fainter color).
     ///
     /// Shortcut for `ui.label(RichText::new(text).weak())`
     pub fn weak(&mut self, text: impl Into<RichText>) -> Response {


### PR DESCRIPTION
Was browsing the docs (https://docs.rs/egui/latest/egui/struct.Ui.html#method.weak) and saw the use of 'waker' in reference to the text of the `Ui.weak` method, didn't look intentional so thought I'd make a PR. This simply changes the text from 'waker' to 'weaker'.
