### PR TITLE
Fix image button padding on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui-w
 
 ## Unreleased
 * Add `*_released` & `*_clicked` methods for `PointerState`.
-* Fixed `ImageButton`'s changing background padding on hover ([#1528](https://github.com/emilk/egui/pull/1595)).
+* Fixed `ImageButton`'s changing background padding on hover ([#1595](https://github.com/emilk/egui/pull/1595)).
 
 ## 0.18.1 - 2022-05-01
 * Change `Shape::Callback` from `&dyn Any` to `&mut dyn Any` to support more backends.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui-w
 
 ## Unreleased
 * Add `*_released` & `*_clicked` methods for `PointerState`.
+* Fixed `ImageButton`'s changing background padding on hover ([#1528](https://github.com/emilk/egui/pull/1595)).
 
 ## 0.18.1 - 2022-05-01
 * Change `Shape::Callback` from `&dyn Any` to `&mut dyn Any` to support more backends.

--- a/egui/src/widgets/button.rs
+++ b/egui/src/widgets/button.rs
@@ -489,7 +489,7 @@ impl Widget for ImageButton {
             let (expansion, rounding, fill, stroke) = if selected {
                 let selection = ui.visuals().selection;
                 (
-                    Vec2::splat(0.0),
+                    Vec2::ZERO,
                     Rounding::none(),
                     selection.bg_fill,
                     selection.stroke,

--- a/egui/src/widgets/button.rs
+++ b/egui/src/widgets/button.rs
@@ -489,18 +489,14 @@ impl Widget for ImageButton {
             let (expansion, rounding, fill, stroke) = if selected {
                 let selection = ui.visuals().selection;
                 (
-                    -padding,
+                    Vec2::splat(0.0),
                     Rounding::none(),
                     selection.bg_fill,
                     selection.stroke,
                 )
             } else if frame {
                 let visuals = ui.style().interact(&response);
-                let expansion = if response.hovered {
-                    Vec2::splat(visuals.expansion) - padding
-                } else {
-                    Vec2::splat(visuals.expansion)
-                };
+                let expansion = Vec2::splat(visuals.expansion);
                 (
                     expansion,
                     visuals.rounding,


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

This PR addresses one issue that has been encountered by multiple people where image buttons don't display correctly when hovering. This updates 2 lines of code that fix the problem as shown in the image below.

There are no clippy warnings.

./sh/check.sh was not able to be completed for some unrelated error below in speech-dispatcher:

```
error[E0308]: mismatched types
  --> /home/luke/.cargo/registry/src/github.com-1ecc6299db9ec823/speech-dispatcher-0.12.0/src/lib.rs:35:13
   |
35 |     Male1 = SPDVoiceType::SPD_MALE1,
   |             ^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`
```

The fixed image buttons shown:

![fixed_egui](https://user-images.githubusercontent.com/16246849/167233985-b5aea39a-8b72-4d2f-9a5b-d35075c4eb9a.png)

Closes <https://github.com/emilk/egui/issues/1528>.
