### PR TITLE
Fix clipboard on Wayland

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,7 @@ dependencies = [
  "instant",
  "puffin",
  "serde",
+ "smithay-clipboard",
  "tracing",
  "tts",
  "webbrowser",
@@ -3306,6 +3307,16 @@ dependencies = [
  "wayland-client",
  "wayland-cursor",
  "wayland-protocols",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610b551bd25378bfd2b8e7a0fcbd83d427e8f2f6a40c47ae0f70688e9949dd55"
+dependencies = [
+ "smithay-client-toolkit",
+ "wayland-client",
 ]
 
 [[package]]

--- a/egui-winit/Cargo.toml
+++ b/egui-winit/Cargo.toml
@@ -25,7 +25,7 @@ bytemuck = ["egui/bytemuck"]
 
 # enable cut/copy/paste to OS clipboard.
 # if disabled a clipboard will be simulated so you can still copy/paste within the egui app.
-clipboard = ["arboard"]
+clipboard = ["arboard", "smithay-clipboard"]
 
 # enable opening links in a browser when an egui hyperlink is clicked.
 links = ["webbrowser"]
@@ -55,3 +55,6 @@ webbrowser = { version = "0.7", optional = true }
 
 # feature screen_reader
 tts = { version = "0.20", optional = true } # stuck on old version due to compilation problems on linux
+
+[target.'cfg(any(target_os="linux", target_os="dragonfly", target_os="freebsd", target_os="netbsd", target_os="openbsd"))'.dependencies]
+smithay-clipboard = { version = "0.6.3", optional = true }


### PR DESCRIPTION
arboard advertises that it works with Wayland, but in reality it only works with Wayland terminal applications. To make the clipboard work with applications that draw Wayland surfaces, arboard isn't going to work.

Copypasta does support Wayland's graphical clipboard, but the usage isn't documented. However, for the reasons mentioned in #1474 the move from Copypasta to arboard makes sense.

To resolve the issue, this commit brings in an optional dependency smithay-clipboard, that is a crate that correctly handles the Wayland clipboard in graphical applications. It is used by default if a Wayland window handle is found. If for some reason the handle to the Wayland window handle cannot be fetched, arboard is used as a backup.

It feels a bit wrong adding the `wayland_display` argument to `from_pixels_per_point`, but I couldn't figure out any better alternatives. Maybe pass the whole window to it?

Fixes https://github.com/emilk/egui/issues/1612