### PR TITLE
eframe: read native window position and size

### DIFF
--- a/eframe/src/epi.rs
+++ b/eframe/src/epi.rs
@@ -341,6 +341,17 @@ pub struct WebInfo {
     pub location: Location,
 }
 
+/// Information about the application's main window, if available.
+#[derive(Clone, Debug)]
+pub struct WindowInfo {
+    /// Coordinates of the window's top left corner, relative to the top left corner
+    /// of a user's first monitor.
+    pub position: egui::Vec2,
+
+    /// Window dimensions, in pixels.
+    pub size: egui::Vec2,
+}
+
 /// Information about the URL.
 ///
 /// Everything has been percent decoded (`%20` -> ` ` etc).
@@ -411,6 +422,9 @@ pub struct IntegrationInfo {
 
     /// The OS native pixels-per-point
     pub native_pixels_per_point: Option<f32>,
+
+    /// Window-specific geometry information, if provided by the platform.
+    pub window_info: Option<WindowInfo>,
 }
 
 // ----------------------------------------------------------------------------

--- a/eframe/src/epi.rs
+++ b/eframe/src/epi.rs
@@ -344,7 +344,7 @@ pub struct WebInfo {
 /// Information about the application's main window, if available.
 #[derive(Clone, Debug)]
 pub struct WindowInfo {
-    /// Coordinates of the window's outer top left corner, relative to the top left corner.
+    /// Coordinates of the window's outer top left corner, relative to the top left corner of the first display.
     /// Unit: egui points (logical pixels).
     pub position: egui::Pos2,
 

--- a/eframe/src/epi.rs
+++ b/eframe/src/epi.rs
@@ -344,11 +344,11 @@ pub struct WebInfo {
 /// Information about the application's main window, if available.
 #[derive(Clone, Debug)]
 pub struct WindowInfo {
-    /// Coordinates of the window's top left corner, relative to the top left corner
-    /// of a user's first monitor.
-    pub position: egui::Vec2,
+    /// Coordinates of the window's outer top left corner, relative to the top left corner.
+    /// Unit: egui points (logical pixels).
+    pub position: egui::Pos2,
 
-    /// Window dimensions, in pixels.
+    /// Window inner size in egui points (logical pixels).
     pub size: egui::Vec2,
 }
 

--- a/eframe/src/native/epi_integration.rs
+++ b/eframe/src/native/epi_integration.rs
@@ -8,18 +8,21 @@ pub fn points_to_size(points: egui::Vec2) -> winit::dpi::LogicalSize<f64> {
     }
 }
 
-pub fn read_window_info(window: &winit::window::Window) -> Option<WindowInfo> {
+pub fn read_window_info(
+    window: &winit::window::Window,
+    pixels_per_point: f32,
+) -> Option<WindowInfo> {
     match window.outer_position() {
         Ok(pos) => {
-            let size = window.inner_size();
+            let pos = pos.to_logical::<f32>(pixels_per_point.into());
+            let size = window
+                .inner_size()
+                .to_logical::<f32>(pixels_per_point.into());
             Some(WindowInfo {
-                position: egui::Vec2 {
-                    x: pos.x as f32,
-                    y: pos.y as f32,
-                },
+                position: egui::Pos2 { x: pos.x, y: pos.y },
                 size: egui::Vec2 {
-                    x: size.width as f32,
-                    y: size.height as f32,
+                    x: size.width,
+                    y: size.height,
                 },
             })
         }
@@ -195,7 +198,7 @@ impl EpiIntegration {
                 prefer_dark_mode,
                 cpu_usage: None,
                 native_pixels_per_point: Some(native_pixels_per_point(window)),
-                window_info: read_window_info(window),
+                window_info: read_window_info(window, egui_ctx.pixels_per_point()),
             },
             output: Default::default(),
             storage,
@@ -258,7 +261,7 @@ impl EpiIntegration {
     ) -> egui::FullOutput {
         let frame_start = std::time::Instant::now();
 
-        self.frame.info.window_info = read_window_info(window);
+        self.frame.info.window_info = read_window_info(window, self.egui_ctx.pixels_per_point());
         let raw_input = self.egui_winit.take_egui_input(window);
         let full_output = self.egui_ctx.run(raw_input, |egui_ctx| {
             crate::profile_scope!("App::update");

--- a/eframe/src/web/backend.rs
+++ b/eframe/src/web/backend.rs
@@ -152,6 +152,7 @@ impl AppRunner {
             prefer_dark_mode,
             cpu_usage: None,
             native_pixels_per_point: Some(native_pixels_per_point()),
+            window_info: None,
         };
         let storage = LocalStorage::default();
 


### PR DESCRIPTION
the window's position and dimensions are now available via `eframe::Frame::info().window_info` on desktop (and probably mobile platforms as well, as I've patched the native backend). no issue to close, as this is mostly my own need.

this is my first PR in Rust, so feel free to point out anything you deem poor.