### PR TITLE
Fix dead-lock when alt-tabbing while also showing a tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui-w
 
 
 ## Unreleased
+### Added ⭐
 * Add `*_released` & `*_clicked` methods for `PointerState` ([#1582](https://github.com/emilk/egui/pull/1582)).
 * Optimize painting of filled circles (e.g. for scatter plots) by 10x or more ([#1616](https://github.com/emilk/egui/pull/1616)).
+
+### Fixed 🐛
 * Fixed `ImageButton`'s changing background padding on hover ([#1595](https://github.com/emilk/egui/pull/1595)).
+* Fix dead-lock when alt-tabbing while also showing a tooltip ([#1618](https://github.com/emilk/egui/pull/1618)).
+
 
 ## 0.18.1 - 2022-05-01
 * Change `Shape::Callback` from `&dyn Any` to `&mut dyn Any` to support more backends.

--- a/egui/src/containers/popup.rs
+++ b/egui/src/containers/popup.rs
@@ -160,13 +160,13 @@ fn show_tooltip_at_avoid_dyn<'c, R>(
     let mut tooltip_rect = Rect::NOTHING;
     let mut count = 0;
 
-    let mut position = if let Some((stored_id, stored_tooltip_rect, stored_count)) =
-        ctx.frame_state().tooltip_rect
-    {
+    let stored = ctx.frame_state().tooltip_rect;
+
+    let mut position = if let Some(stored) = stored {
         // if there are multiple tooltips open they should use the same id for the `tooltip_size` caching to work.
-        id = stored_id;
-        tooltip_rect = stored_tooltip_rect;
-        count = stored_count;
+        id = stored.id;
+        tooltip_rect = stored.rect;
+        count = stored.count;
         avoid_rect = avoid_rect.union(tooltip_rect);
         if above {
             tooltip_rect.left_top()
@@ -214,7 +214,11 @@ fn show_tooltip_at_avoid_dyn<'c, R>(
     state.set_tooltip_size(id, count, response.rect.size());
     state.store(ctx);
 
-    ctx.frame_state().tooltip_rect = Some((id, tooltip_rect.union(response.rect), count + 1));
+    ctx.frame_state().tooltip_rect = Some(crate::frame_state::TooltipRect {
+        id,
+        rect: tooltip_rect.union(response.rect),
+        count: count + 1,
+    });
     Some(inner)
 }
 

--- a/egui/src/frame_state.rs
+++ b/egui/src/frame_state.rs
@@ -2,6 +2,13 @@ use std::ops::RangeInclusive;
 
 use crate::*;
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct TooltipRect {
+    pub id: Id,
+    pub rect: Rect,
+    pub count: usize,
+}
+
 /// State that is collected during a frame and then cleared.
 /// Short-term (single frame) memory.
 #[derive(Clone)]
@@ -25,7 +32,7 @@ pub(crate) struct FrameState {
     /// If a tooltip has been shown this frame, where was it?
     /// This is used to prevent multiple tooltips to cover each other.
     /// Initialized to `None` at the start of each frame.
-    pub(crate) tooltip_rect: Option<(Id, Rect, usize)>,
+    pub(crate) tooltip_rect: Option<TooltipRect>,
 
     /// Set to [`InputState::scroll_delta`] on the start of each frame.
     ///


### PR DESCRIPTION
Closes https://github.com/emilk/egui/issues/1609

It only affects tooltips that follow the mouse cursor (`show_tooltip_at_pointer`, `show_tooltip_text`, …) and only sometimes.

The fact that `if let(Some) = mutex.lock().this_is_copy {` still keeps the mutex locked keeps biting us in the butt. :(