### PR TITLE
Add single-threaded deadlock detection to RwMutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui-w
 * Added `*_released` & `*_clicked` methods for `PointerState` ([#1582](https://github.com/emilk/egui/pull/1582)).
 * Added `egui::hex_color!` to create `Color32`'s from hex strings under the `color-hex` feature ([#1596](https://github.com/emilk/egui/pull/1596)).
 * Optimized painting of filled circles (e.g. for scatter plots) by 10x or more ([#1616](https://github.com/emilk/egui/pull/1616)).
+* Added opt-in feature `deadlock_detection` to detect double-lock of mutexes on the same thread ([#1619](https://github.com/emilk/egui/pull/1619)).
 * Added `InputState::stable_dt`: a more stable estimate for the delta-time in reactive mode ([#1625](https://github.com/emilk/egui/pull/1625)).
 
 ### Fixed 🐛

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,6 +1352,7 @@ dependencies = [
  "ab_glyph",
  "ahash 0.7.6",
  "atomic_refcell",
+ "backtrace",
  "bytemuck",
  "cint",
  "color-hex",

--- a/egui/Cargo.toml
+++ b/egui/Cargo.toml
@@ -28,6 +28,11 @@ cint = ["epaint/cint"]
 # implement bytemuck on most types.
 bytemuck = ["epaint/bytemuck"]
 
+# This will automatically detect deadlocks due to double-locking on the same thread.
+# If your app freezes, you may want to enable this!
+# Only affects `epaint::mutex::RwLock` (which egui uses a lot).
+deadlock_detection = ["epaint/deadlock_detection"]
+
 # If set, egui will use `include_bytes!` to bundle some fonts.
 # If you plan on specifying your own fonts you may disable this feature.
 default_fonts = ["epaint/default_fonts"]

--- a/epaint/CHANGELOG.md
+++ b/epaint/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to the epaint crate will be documented in this file.
 
 
 ## Unreleased
-* Optimize tessellation of filled circles by 10x or more ([#1616](https://github.com/emilk/egui/pull/1616)).
 * Added `epaint::hex_color!` to create `Color32`'s from hex strings under the `color-hex` feature ([#1596](https://github.com/emilk/egui/pull/1596)).
+* Optimize tessellation of filled circles by 10x or more ([#1616](https://github.com/emilk/egui/pull/1616)).
+* Added opt-in feature `deadlock_detection` to detect double-lock of mutexes on the same thread ([#1619](https://github.com/emilk/egui/pull/1619)).
 
 
 ## 0.18.1 - 2022-05-01

--- a/epaint/Cargo.toml
+++ b/epaint/Cargo.toml
@@ -32,6 +32,11 @@ default = ["default_fonts"]
 # implement bytemuck on most types.
 bytemuck = ["dep:bytemuck", "emath/bytemuck"]
 
+# This will automatically detect deadlocks due to double-locking on the same thread.
+# If your app freezes, you may want to enable this!
+# Only affects `epaint::mutex::RwLock` (which epaint and egui uses a lot).
+deadlock_detection = ["dep:backtrace"]
+
 # If set, epaint will use `include_bytes!` to bundle some fonts.
 # If you plan on specifying your own fonts you may disable this feature.
 default_fonts = []
@@ -51,17 +56,18 @@ serde = ["dep:serde", "ahash/serde", "emath/serde"]
 emath = { version = "0.18.0", path = "../emath" }
 
 ab_glyph = "0.2.11"
+ahash = { version = "0.7", default-features = false, features = ["std"] }
 nohash-hasher = "0.2"
 
 # Optional:
-color-hex = { version = "0.2.0", optional = true }
-ahash = { version = "0.7", default-features = false, features = ["std"] }
 bytemuck = { version = "1.7.2", optional = true, features = ["derive"] }
 cint = { version = "0.3.1", optional = true }
+color-hex = { version = "0.2.0", optional = true }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
 
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+backtrace = { version = "0.3", optional = true }
 parking_lot = "0.12" # Using parking_lot over std::sync::Mutex gives 50% speedups in some real-world scenarios.
 
 # web:


### PR DESCRIPTION
Closes https://github.com/emilk/egui/issues/1560

This is just a draft - it only works for single-threaded environments (double-locking the same `RwLock` on the same thread), but it was what helped me find the problem in https://github.com/emilk/egui/pull/1618

It slows down the app a lot, but at least on my mac it is fast enough to be interacted with, so if your app freezes you can recompile with the `deadlock_detection` feature and try to reproduce.