### PR TITLE
Fix `Area`'s comment

### DIFF
--- a/egui/src/containers/area.rs
+++ b/egui/src/containers/area.rs
@@ -40,6 +40,7 @@ impl State {
 ///         ui.label("Floating text!");
 ///     });
 /// # });
+/// ```
 #[must_use = "You should call .show()"]
 #[derive(Clone, Copy, Debug)]
 pub struct Area {


### PR DESCRIPTION
Small PR that adds the missing line to the comment above `Area` so that it displays correctly in VSCode