### PR TITLE
Graceful exit from web 

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -33,6 +33,8 @@
             overflow: hidden;
             margin: 0 !important;
             padding: 0 !important;
+            height: 100%;
+            width: 100%;
         }
 
         /* Position canvas in center-top: */

--- a/docs/multiple_apps.html
+++ b/docs/multiple_apps.html
@@ -17,6 +17,12 @@
             /* Light mode background color for what is not covered by the egui canvas,
             or where the egui canvas is translucent. */
             background: #909090;
+            display:flex;
+        }
+
+        .canvas_wrap{
+            /* height: 200px; */
+            width: 400px;
         }
 
         @media (prefers-color-scheme: dark) {
@@ -39,13 +45,15 @@
 
         /* Position canvas in center-top: */
         canvas {
-            margin-right: auto;
-            margin-left: auto;
-            display: block;
+            /* margin-right: auto;
+            margin-left: auto; */
+            /* display: block;
             position: absolute;
             top: 0%;
             left: 50%;
-            transform: translate(-50%, 0%);
+            transform: translate(-50%, 0%); */
+            width:90%;
+            height:90%;
         }
 
         .centered {
@@ -96,7 +104,23 @@
 
 <body>
     <!-- The WASM code will resize the canvas dynamically -->
-    <canvas id="the_canvas_id"></canvas>
+
+    <div>controls</div>
+
+    <button class="stop_one">
+    stop    
+    </button>
+
+    <div class="canvas_wrap one">
+        <canvas id="the_canvas_id_one"></canvas>
+    </div>
+
+    <div  class="canvas_wrap two">
+        <canvas id="the_canvas_id_two"></canvas>
+    </div>
+
+
+
     <div class="centered" id="center_text">
         <p style="font-size:16px">
             Loading…
@@ -133,11 +157,23 @@
             console.debug("wasm loaded. starting app…");
 
             // This call installs a bunch of callbacks and then returns:
-            const handle = wasm_bindgen.start("the_canvas_id");
+
+            wasm_bindgen.init_wasm_hooks()
+
+            const handle_one = wasm_bindgen.start_separate("the_canvas_id_one");
+            const handle_two = wasm_bindgen.start_separate("the_canvas_id_two");
+
+            const button = document.getElementsByClassName("stop_one")[0]
+
+            button.addEventListener("click", ()=>{
+                handle_one.stop_web()
+                handle_one.free()
+            });
+    
 
             // call `handle.stop_web()` to stop
             // uncomment to quick result
-            // setTimeout(() => {handle.stop_web(); handle.free())}, 2000)
+            // setTimeout(() => {handle.stop_web()}, 2000)
 
             console.debug("app started.");
             document.getElementById("center_text").remove();

--- a/eframe/CHANGELOG.md
+++ b/eframe/CHANGELOG.md
@@ -28,7 +28,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 
 #### Web:
 * Added option to select WebGL version ([#1803](https://github.com/emilk/egui/pull/1803)).
-* Added ability to stop/re-run web app from JavaScript ([#1803](https://github.com/emilk/egui/pull/1650)). This change is also finds parent html container and resizes canvas to it's size. So settings `html, body: [height: 100%; width: 100%;]` for older demos is required.
+* Added ability to stop/re-run web app from JavaScript. ⚠️ You need to update your CSS with `html, body: { height: 100%; width: 100%; }` ([#1803](https://github.com/emilk/egui/pull/1650)).
 
 
 

--- a/eframe/CHANGELOG.md
+++ b/eframe/CHANGELOG.md
@@ -28,6 +28,8 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 
 #### Web:
 * Added option to select WebGL version ([#1803](https://github.com/emilk/egui/pull/1803)).
+* Added ability to stop/re-run web app from JavaScript ([#1803](https://github.com/emilk/egui/pull/1650)). This change is also finds parent html container and resizes canvas to it's size. So settings `html, body: [height: 100%; width: 100%;]` for older demos is required.
+
 
 
 ## 0.18.0 - 2022-04-30

--- a/eframe/src/lib.rs
+++ b/eframe/src/lib.rs
@@ -103,7 +103,7 @@ pub use web_sys;
 /// /// This is the entry-point for all the web-assembly.
 /// /// This is called from the HTML.
 /// /// It loads the app, installs some callbacks, then returns.
-/// /// It creates singleton app-handle that could be stopped calling `stop_web`
+/// /// It returns a handle to the running app that can be stopped calling `AppRunner::stop_web`.
 /// /// You can add more callbacks like this if you want to call in to your code.
 /// #[cfg(target_arch = "wasm32")]
 /// #[wasm_bindgen]

--- a/eframe/src/lib.rs
+++ b/eframe/src/lib.rs
@@ -77,11 +77,19 @@ pub use epi::*;
 // When compiling for web
 
 #[cfg(target_arch = "wasm32")]
-mod web;
+use egui::mutex::Mutex;
+
+#[cfg(target_arch = "wasm32")]
+use std::sync::Arc;
+
+#[cfg(target_arch = "wasm32")]
+pub mod web;
 
 #[cfg(target_arch = "wasm32")]
 pub use wasm_bindgen;
 
+#[cfg(target_arch = "wasm32")]
+use web::AppRunner;
 #[cfg(target_arch = "wasm32")]
 pub use web_sys;
 
@@ -93,12 +101,13 @@ pub use web_sys;
 /// use wasm_bindgen::prelude::*;
 ///
 /// /// This is the entry-point for all the web-assembly.
-/// /// This is called once from the HTML.
+/// /// This is called from the HTML.
 /// /// It loads the app, installs some callbacks, then returns.
+/// /// It creates singleton app-handle that could be stopped calling `stop_web`
 /// /// You can add more callbacks like this if you want to call in to your code.
 /// #[cfg(target_arch = "wasm32")]
 /// #[wasm_bindgen]
-/// pub fn start(canvas_id: &str) -> Result<(), eframe::wasm_bindgen::JsValue> {
+/// pub fn start(canvas_id: &str) -> Result<Arc<Mutex<AppRunner>>, eframe::wasm_bindgen::JsValue> {
 ///     let web_options = eframe::WebOptions::default();
 ///     eframe::start_web(canvas_id, web_options, Box::new(|cc| Box::new(MyEguiApp::new(cc))))
 /// }
@@ -108,9 +117,10 @@ pub fn start_web(
     canvas_id: &str,
     web_options: WebOptions,
     app_creator: AppCreator,
-) -> Result<(), wasm_bindgen::JsValue> {
-    web::start(canvas_id, web_options, app_creator)?;
-    Ok(())
+) -> Result<Arc<Mutex<AppRunner>>, wasm_bindgen::JsValue> {
+    let handle = web::start(canvas_id, web_options, app_creator)?;
+
+    Ok(handle)
 }
 
 // ----------------------------------------------------------------------------

--- a/eframe/src/web/glow_wrapping.rs
+++ b/eframe/src/web/glow_wrapping.rs
@@ -87,6 +87,10 @@ impl WrappedGlowPainter {
 
         Ok(())
     }
+
+    pub fn destroy(&mut self) {
+        self.painter.destroy()
+    }
 }
 
 /// Returns glow context and shader prefix.

--- a/eframe/src/web/mod.rs
+++ b/eframe/src/web/mod.rs
@@ -11,6 +11,7 @@ pub mod storage;
 mod text_agent;
 
 pub use backend::*;
+use egui::Vec2;
 pub use events::*;
 pub use storage::*;
 
@@ -41,6 +42,7 @@ pub fn now_sec() -> f64 {
         / 1000.0
 }
 
+#[allow(dead_code)]
 pub fn screen_size_in_native_points() -> Option<egui::Vec2> {
     let window = web_sys::window()?;
     Some(egui::vec2(
@@ -96,13 +98,21 @@ pub fn canvas_size_in_points(canvas_id: &str) -> egui::Vec2 {
 
 pub fn resize_canvas_to_screen_size(canvas_id: &str, max_size_points: egui::Vec2) -> Option<()> {
     let canvas = canvas_element(canvas_id)?;
+    let parent = canvas.parent_element()?;
 
-    let screen_size_points = screen_size_in_native_points()?;
+    let width = parent.scroll_width();
+    let height = parent.scroll_height();
+
+    let canvas_real_size = Vec2 {
+        x: width as f32,
+        y: height as f32,
+    };
+
     let pixels_per_point = native_pixels_per_point();
 
     let max_size_pixels = pixels_per_point * max_size_points;
 
-    let canvas_size_pixels = pixels_per_point * screen_size_points;
+    let canvas_size_pixels = pixels_per_point * canvas_real_size;
     let canvas_size_pixels = canvas_size_pixels.min(max_size_pixels);
     let canvas_size_points = canvas_size_pixels / pixels_per_point;
 

--- a/eframe/src/web/text_agent.rs
+++ b/eframe/src/web/text_agent.rs
@@ -22,7 +22,7 @@ pub fn text_agent() -> web_sys::HtmlInputElement {
 }
 
 /// Text event handler,
-pub fn install_text_agent(runner_container: &AppRunnerContainer) -> Result<(), JsValue> {
+pub fn install_text_agent(runner_container: &mut AppRunnerContainer) -> Result<(), JsValue> {
     use wasm_bindgen::JsCast;
     let window = web_sys::window().unwrap();
     let document = window.document().unwrap();

--- a/egui_demo_app/src/lib.rs
+++ b/egui_demo_app/src/lib.rs
@@ -40,15 +40,45 @@ impl WebHandle {
     #[wasm_bindgen]
     #[cfg(target_arch = "wasm32")]
     pub fn stop_web(&self) -> Result<(), wasm_bindgen::JsValue> {
-        let res = self.handle.lock().destroy();
+        let mut app = self.handle.lock();
+        let res = app.destroy();
 
-        // let numw = Arc::weak_count(&uu);
-        // let nums = Arc::strong_count(&uu);
+        // let numw = Arc::weak_count(&app);
+        // let nums = Arc::strong_count(&app);
         // tracing::debug!("runner ref {:?}, {:?}", numw, nums);
 
         res
     }
 }
+
+
+
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn init_wasm_hooks(){
+    // Make sure panics are logged using `console.error`.
+    console_error_panic_hook::set_once();
+
+    // Redirect tracing to console.log and friends:
+    tracing_wasm::set_as_global_default();
+}
+
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn start_separate(canvas_id: &str) -> Result<WebHandle, wasm_bindgen::JsValue> {
+    let web_options = eframe::WebOptions::default();
+    let handle = eframe::start_web(
+        canvas_id,
+        web_options,
+        Box::new(|cc| Box::new(WrapApp::new(cc))),
+    )
+    .map(|handle| WebHandle { handle });
+    
+    handle
+}
+
 
 /// This is the entry-point for all the web-assembly.
 /// This is called once from the HTML.
@@ -57,19 +87,7 @@ impl WebHandle {
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn start(canvas_id: &str) -> Result<WebHandle, wasm_bindgen::JsValue> {
-    // Make sure panics are logged using `console.error`.
-    console_error_panic_hook::set_once();
 
-    // Redirect tracing to console.log and friends:
-    tracing_wasm::set_as_global_default();
-
-    let web_options = eframe::WebOptions::default();
-    let handle = eframe::start_web(
-        canvas_id,
-        web_options,
-        Box::new(|cc| Box::new(WrapApp::new(cc))),
-    )
-    .map(|handle| WebHandle { handle });
-
-    handle
+    init_wasm_hooks();
+    start_separate(canvas_id)
 }

--- a/egui_demo_app/src/lib.rs
+++ b/egui_demo_app/src/lib.rs
@@ -5,6 +5,15 @@ mod backend_panel;
 pub(crate) mod frame_history;
 mod wrap_app;
 
+#[cfg(target_arch = "wasm32")]
+use std::sync::Arc;
+
+#[cfg(target_arch = "wasm32")]
+use eframe::web::AppRunner;
+
+#[cfg(target_arch = "wasm32")]
+use egui::mutex::Mutex;
+
 pub use wrap_app::WrapApp;
 
 /// Time of day as seconds since midnight. Used for clock in demo app.
@@ -19,13 +28,35 @@ pub(crate) fn seconds_since_midnight() -> f64 {
 #[cfg(target_arch = "wasm32")]
 use eframe::wasm_bindgen::{self, prelude::*};
 
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub struct WebHandle {
+    handle: Arc<Mutex<AppRunner>>,
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+impl WebHandle {
+    #[wasm_bindgen]
+    #[cfg(target_arch = "wasm32")]
+    pub fn stop_web(&self) -> Result<(), wasm_bindgen::JsValue> {
+        let res = self.handle.lock().destroy();
+
+        // let numw = Arc::weak_count(&uu);
+        // let nums = Arc::strong_count(&uu);
+        // tracing::debug!("runner ref {:?}, {:?}", numw, nums);
+
+        res
+    }
+}
+
 /// This is the entry-point for all the web-assembly.
 /// This is called once from the HTML.
 /// It loads the app, installs some callbacks, then returns.
 /// You can add more callbacks like this if you want to call in to your code.
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
-pub fn start(canvas_id: &str) -> Result<(), wasm_bindgen::JsValue> {
+pub fn start(canvas_id: &str) -> Result<WebHandle, wasm_bindgen::JsValue> {
     // Make sure panics are logged using `console.error`.
     console_error_panic_hook::set_once();
 
@@ -33,9 +64,12 @@ pub fn start(canvas_id: &str) -> Result<(), wasm_bindgen::JsValue> {
     tracing_wasm::set_as_global_default();
 
     let web_options = eframe::WebOptions::default();
-    eframe::start_web(
+    let handle = eframe::start_web(
         canvas_id,
         web_options,
         Box::new(|cc| Box::new(WrapApp::new(cc))),
     )
+    .map(|handle| WebHandle { handle });
+
+    handle
 }

--- a/egui_demo_app/src/lib.rs
+++ b/egui_demo_app/src/lib.rs
@@ -51,19 +51,15 @@ impl WebHandle {
     }
 }
 
-
-
-
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
-pub fn init_wasm_hooks(){
+pub fn init_wasm_hooks() {
     // Make sure panics are logged using `console.error`.
     console_error_panic_hook::set_once();
 
     // Redirect tracing to console.log and friends:
     tracing_wasm::set_as_global_default();
 }
-
 
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
@@ -75,10 +71,9 @@ pub fn start_separate(canvas_id: &str) -> Result<WebHandle, wasm_bindgen::JsValu
         Box::new(|cc| Box::new(WrapApp::new(cc))),
     )
     .map(|handle| WebHandle { handle });
-    
+
     handle
 }
-
 
 /// This is the entry-point for all the web-assembly.
 /// This is called once from the HTML.
@@ -87,7 +82,6 @@ pub fn start_separate(canvas_id: &str) -> Result<WebHandle, wasm_bindgen::JsValu
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn start(canvas_id: &str) -> Result<WebHandle, wasm_bindgen::JsValue> {
-
     init_wasm_hooks();
     start_separate(canvas_id)
 }


### PR DESCRIPTION
- holds all event-handles and gracefully unsubscribes them.
- destroys GL painter.
- tries to resize canvas to previous container's size, not screen size (it should be 100% height thought)

With this PR egui could be running as a part of web-app and stop and start again without resource leaks(I hope)

Fixes #1642

# ⚠️ IMPORTANT!
You need to update your CSS with `html, body: { height: 100%; width: 100%; }`!