### PR TITLE
Make Popups Dodge Window Edges

### DIFF
--- a/egui/src/containers/popup.rs
+++ b/egui/src/containers/popup.rs
@@ -297,7 +297,7 @@ pub fn popup_below_widget<R>(
     if ui.memory().is_popup_open(popup_id) {
         let inner = Area::new(popup_id)
             .order(Order::Foreground)
-            .fixed_pos(widget_response.rect.left_bottom())
+            .default_pos(widget_response.rect.left_bottom())
             .show(ui.ctx(), |ui| {
                 // Note: we use a separate clip-rect for this area, so the popup can be outside the parent.
                 // See https://github.com/emilk/egui/issues/825


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

I was using a popup to show a fixed-pallet color picker, using `popup_below_widget`, but it was getting cut off because it was close to the right side of the window and it was a wide popup:

![image](https://user-images.githubusercontent.com/25393315/169599841-a736542e-a443-45a7-8c72-d230e05917fa.png)

By changing this line to use `.default_pos` instead of `.fixed_pos`, it fixes my issue, and seems like it would be a good improvement, but I'm not sure if there are side-effects I'm unaware of.

https://github.com/emilk/egui/blob/3c685d7bf6a36bda9ffbee36ee822b4205b29b36/egui/src/containers/popup.rs#L300

