### PR TITLE
Added support for 20 fn keys

### DIFF
--- a/eframe/src/web/input.rs
+++ b/eframe/src/web/input.rs
@@ -170,6 +170,27 @@ pub fn translate_key(key: &str) -> Option<egui::Key> {
         "y" | "Y" => Some(egui::Key::Y),
         "z" | "Z" => Some(egui::Key::Z),
 
+        "F1" => Some(egui::Key::F1),
+        "F2" => Some(egui::Key::F2),
+        "F3" => Some(egui::Key::F3),
+        "F4" => Some(egui::Key::F4),
+        "F5" => Some(egui::Key::F5),
+        "F6" => Some(egui::Key::F6),
+        "F7" => Some(egui::Key::F7),
+        "F8" => Some(egui::Key::F8),
+        "F9" => Some(egui::Key::F9),
+        "F10" => Some(egui::Key::F10),
+        "F11" => Some(egui::Key::F11),
+        "F12" => Some(egui::Key::F12),
+        "F13" => Some(egui::Key::F13),
+        "F14" => Some(egui::Key::F14),
+        "F15" => Some(egui::Key::F15),
+        "F16" => Some(egui::Key::F16),
+        "F17" => Some(egui::Key::F17),
+        "F18" => Some(egui::Key::F18),
+        "F19" => Some(egui::Key::F19),
+        "F20" => Some(egui::Key::F20),
+
         _ => None,
     }
 }

--- a/egui-winit/src/lib.rs
+++ b/egui-winit/src/lib.rs
@@ -628,6 +628,27 @@ fn translate_virtual_key_code(key: winit::event::VirtualKeyCode) -> Option<egui:
         VirtualKeyCode::Y => Key::Y,
         VirtualKeyCode::Z => Key::Z,
 
+        VirtualKeyCode::F1 => Key::F1,
+        VirtualKeyCode::F2 => Key::F2,
+        VirtualKeyCode::F3 => Key::F3,
+        VirtualKeyCode::F4 => Key::F4,
+        VirtualKeyCode::F5 => Key::F5,
+        VirtualKeyCode::F6 => Key::F6,
+        VirtualKeyCode::F7 => Key::F7,
+        VirtualKeyCode::F8 => Key::F8,
+        VirtualKeyCode::F9 => Key::F9,
+        VirtualKeyCode::F10 => Key::F10,
+        VirtualKeyCode::F11 => Key::F11,
+        VirtualKeyCode::F12 => Key::F12,
+        VirtualKeyCode::F13 => Key::F13,
+        VirtualKeyCode::F14 => Key::F14,
+        VirtualKeyCode::F15 => Key::F15,
+        VirtualKeyCode::F16 => Key::F16,
+        VirtualKeyCode::F17 => Key::F17,
+        VirtualKeyCode::F18 => Key::F18,
+        VirtualKeyCode::F19 => Key::F19,
+        VirtualKeyCode::F20 => Key::F20,
+
         _ => {
             return None;
         }

--- a/egui/src/data/input.rs
+++ b/egui/src/data/input.rs
@@ -498,6 +498,26 @@ pub enum Key {
     X,
     Y,
     Z, // Used for cmd+Z (undo)
+    F1,
+    F2,
+    F3,
+    F4,
+    F5,
+    F6,
+    F7,
+    F8,
+    F9,
+    F10,
+    F11,
+    F12,
+    F13,
+    F14,
+    F15,
+    F16,
+    F17,
+    F18,
+    F19,
+    F20,
 }
 
 impl RawInput {

--- a/egui/src/data/input.rs
+++ b/egui/src/data/input.rs
@@ -498,7 +498,7 @@ pub enum Key {
     X,
     Y,
     Z, // Used for cmd+Z (undo)
-    
+
     // The function keys:
     F1,
     F2,

--- a/egui/src/data/input.rs
+++ b/egui/src/data/input.rs
@@ -498,6 +498,8 @@ pub enum Key {
     X,
     Y,
     Z, // Used for cmd+Z (undo)
+    
+    // The function keys:
     F1,
     F2,
     F3,


### PR DESCRIPTION
This PR adds support for 20 fn keys. I chose 20 keys because that's how many keys are defined in Mozilla's web documentation. Winit supports all 20 keys and 4 more, that are not included in this pr.