### PR TITLE
Update wgpu to 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20ae67ce26261f218e2b3f2f0d01887a9818283ca6fb260fa7c67e253d61c92"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,9 +143,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ash"
-version = "0.34.0+1.2.203"
+version = "0.37.0+1.3.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f780da53d0063880d45554306489f09dd8d1bda47688b4a57bc579119356df"
+checksum = "006ca68e0f2b03f22d6fa9f2860f85aed430d257fec20f8879b2145e7c7ae1a6"
 dependencies = [
  "libloading",
 ]
@@ -904,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "d3d12"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2daefd788d1e96e0a9d66dee4b828b883509bc3ea9ce30665f04c3246372690c"
+checksum = "827914e1f53b1e0e025ecd3d967a7836b7bcb54520f90e21ef8df7b4d88a2759"
 dependencies = [
  "bitflags",
  "libloading",
@@ -2031,9 +2040,9 @@ checksum = "744c24117572563a98a7e9168a5ac1ee4a1ca7f702211258797bbe0ed0346c3c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2046,6 +2055,7 @@ checksum = "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3"
 dependencies = [
  "libc",
  "libloading",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2077,9 +2087,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libloading"
@@ -2181,9 +2191,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0514f491f4cc03632ab399ee01e2c1c1b12d3e1cf2d667c1ff5f87d6dcd2084"
+checksum = "de11355d1f6781482d027a3b4d4de7825dcedb197bf573e0596d00008402d060"
 dependencies = [
  "bitflags",
  "block",
@@ -2239,9 +2249,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3012f2dbcc79e8e0b5825a4836a7106a75dd9b2fe42c528163be0f572538c705"
+checksum = "5f50357e1167a3ab92d6b3c7f4bf5f7fd13fde3f4b28bf0d5ea07b5100fdb6c0"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -2252,7 +2262,9 @@ dependencies = [
  "num-traits",
  "rustc-hash",
  "spirv",
+ "termcolor",
  "thiserror",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3810,9 +3822,9 @@ checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "unicode_names2"
@@ -3937,9 +3949,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3949,9 +3961,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3964,9 +3976,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3976,9 +3988,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3986,9 +3998,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3999,9 +4011,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
 
 [[package]]
 name = "wayland-client"
@@ -4088,9 +4100,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4146,15 +4158,15 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97cd781ff044d6d697b632a2e212032c2e957d1afaa21dbf58069cbb8f78567"
+checksum = "fd28e7c69ffd19c02e609322e4170738ac3340e699d8adfa16f5745625e4aa8c"
 dependencies = [
  "arrayvec 0.7.2",
  "js-sys",
  "log",
  "naga",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "raw-window-handle",
  "smallvec",
  "wasm-bindgen",
@@ -4167,11 +4179,12 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4688c000eb841ca55f7b35db659b78d6e1cd77d7caf8fb929f4e181f754047d"
+checksum = "0bb155661d02bf104303589fbf9206fa971c80dbb6d4763e66879253bd0a072c"
 dependencies = [
  "arrayvec 0.7.2",
+ "bit-vec",
  "bitflags",
  "cfg_aliases",
  "codespan-reporting",
@@ -4179,21 +4192,23 @@ dependencies = [
  "fxhash",
  "log",
  "naga",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "profiling",
  "raw-window-handle",
  "smallvec",
  "thiserror",
+ "web-sys",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "0.12.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d684ea6a34974a2fc19f1dfd183d11a62e22d75c4f187a574bb1224df8e056c2"
+checksum = "a9f9cb367209e2ad214afa8d823348334994dc1579f4a521d53a3bc4d0848e73"
 dependencies = [
+ "android_system_properties",
  "arrayvec 0.7.2",
  "ash",
  "bit-set",
@@ -4214,7 +4229,7 @@ dependencies = [
  "metal",
  "naga",
  "objc",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "profiling",
  "range-alloc",
  "raw-window-handle",
@@ -4228,9 +4243,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549533d9e1cdd4b4cda7718d33ff500fc4c34b5467b71d76b547ae0324f3b2a2"
+checksum = "f48d691b733b9d50ea8cb18f377fd1ed927c90c55ad1ec5b90f68885471977f7"
 dependencies = [
  "bitflags",
 ]

--- a/eframe/Cargo.toml
+++ b/eframe/Cargo.toml
@@ -76,7 +76,7 @@ egui-wgpu = { version = "0.18.0", path = "../egui-wgpu", optional = true, featur
 glow = { version = "0.11", optional = true }
 ron = { version = "0.7", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
-wgpu = { version = "0.12", optional = true }
+wgpu = { version = "0.13", optional = true }
 
 # -------------------------------------------
 # native:

--- a/egui-wgpu/Cargo.toml
+++ b/egui-wgpu/Cargo.toml
@@ -40,7 +40,7 @@ egui = { version = "0.18.1", path = "../egui", default-features = false, feature
 bytemuck = "1.7"
 tracing = "0.1"
 type-map = "0.5.0"
-wgpu = { version = "0.12", features = ["webgl"] }
+wgpu = { version = "0.13", features = ["webgl"] }
 
 #! ### Optional dependencies
 ## Enable this when generating docs.

--- a/egui-wgpu/src/egui.wgsl
+++ b/egui-wgpu/src/egui.wgsl
@@ -1,15 +1,15 @@
 // Vertex shader bindings
 
 struct VertexOutput {
-    [[location(0)]] tex_coord: vec2<f32>;
-    [[location(1)]] color: vec4<f32>;
-    [[builtin(position)]] position: vec4<f32>;
+    @location(0) tex_coord: vec2<f32>,
+    @location(1) color: vec4<f32>,
+    @builtin(position) position: vec4<f32>,
 };
 
 struct Locals {
-    screen_size: vec2<f32>;
+    screen_size: vec2<f32>,
 };
-[[group(0), binding(0)]] var<uniform> r_locals: Locals;
+@group(0) @binding(0) var<uniform> r_locals: Locals;
 
 // 0-1 from 0-255
 fn linear_from_srgb(srgb: vec3<f32>) -> vec3<f32> {
@@ -19,11 +19,11 @@ fn linear_from_srgb(srgb: vec3<f32>) -> vec3<f32> {
     return select(higher, lower, cutoff);
 }
 
-[[stage(vertex)]]
+@vertex
 fn vs_main(
-    [[location(0)]] a_pos: vec2<f32>,
-    [[location(1)]] a_tex_coord: vec2<f32>,
-    [[location(2)]] a_color: u32,
+    @location(0) a_pos: vec2<f32>,
+    @location(1) a_tex_coord: vec2<f32>,
+    @location(2) a_color: u32,
 ) -> VertexOutput {
     var out: VertexOutput;
     out.tex_coord = a_tex_coord;
@@ -47,11 +47,11 @@ fn vs_main(
     return out;
 }
 
-[[stage(vertex)]]
+@vertex
 fn vs_conv_main(
-    [[location(0)]] a_pos: vec2<f32>,
-    [[location(1)]] a_tex_coord: vec2<f32>,
-    [[location(2)]] a_color: u32,
+    @location(0) a_pos: vec2<f32>,
+    @location(1) a_tex_coord: vec2<f32>,
+    @location(2) a_color: u32,
 ) -> VertexOutput {
     var out: VertexOutput;
     out.tex_coord = a_tex_coord;
@@ -77,10 +77,10 @@ fn vs_conv_main(
 
 // Fragment shader bindings
 
-[[group(1), binding(0)]] var r_tex_color: texture_2d<f32>;
-[[group(1), binding(1)]] var r_tex_sampler: sampler;
+@group(1) @binding(0) var r_tex_color: texture_2d<f32>;
+@group(1) @binding(1) var r_tex_sampler: sampler;
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     return in.color * textureSample(r_tex_color, r_tex_sampler, in.tex_coord);
 }

--- a/egui-wgpu/src/egui.wgsl
+++ b/egui-wgpu/src/egui.wgsl
@@ -8,6 +8,9 @@ struct VertexOutput {
 
 struct Locals {
     screen_size: vec2<f32>,
+    // Uniform buffers need to be at least 16 bytes in WebGL.
+    // See https://github.com/gfx-rs/wgpu/issues/2072
+    _padding: vec2<u32>,
 };
 @group(0) @binding(0) var<uniform> r_locals: Locals;
 

--- a/egui-wgpu/src/renderer.rs
+++ b/egui-wgpu/src/renderer.rs
@@ -148,7 +148,7 @@ impl RenderPass {
             label: Some("egui_shader"),
             source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("egui.wgsl"))),
         };
-        let module = device.create_shader_module(&shader);
+        let module = device.create_shader_module(shader);
 
         let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("egui_uniform_buffer"),
@@ -258,7 +258,7 @@ impl RenderPass {
             fragment: Some(wgpu::FragmentState {
                 module: &module,
                 entry_point: "fs_main",
-                targets: &[wgpu::ColorTargetState {
+                targets: &[Some(wgpu::ColorTargetState {
                     format: output_format,
                     blend: Some(wgpu::BlendState {
                         color: wgpu::BlendComponent {
@@ -273,7 +273,7 @@ impl RenderPass {
                         },
                     }),
                     write_mask: wgpu::ColorWrites::ALL,
-                }],
+                })],
             }),
             multiview: None,
         });
@@ -307,14 +307,14 @@ impl RenderPass {
         };
 
         let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-            color_attachments: &[wgpu::RenderPassColorAttachment {
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                 view: color_attachment,
                 resolve_target: None,
                 ops: wgpu::Operations {
                     load: load_operation,
                     store: true,
                 },
-            }],
+            })],
             depth_stencil_attachment: None,
             label: Some("egui main render pass"),
         });

--- a/egui-wgpu/src/winit.rs
+++ b/egui-wgpu/src/winit.rs
@@ -114,7 +114,7 @@ impl<'a> Painter<'a> {
 
         if self.render_state.is_none() {
             let adapter = self.adapter.as_ref().unwrap();
-            let swapchain_format = surface.get_supported_formats(adapter).first().unwrap();
+            let swapchain_format = surface.get_supported_formats(adapter)[0];
 
             let rs = pollster::block_on(self.init_render_state(adapter, swapchain_format));
             self.render_state = Some(rs);

--- a/egui-wgpu/src/winit.rs
+++ b/egui-wgpu/src/winit.rs
@@ -114,7 +114,7 @@ impl<'a> Painter<'a> {
 
         if self.render_state.is_none() {
             let adapter = self.adapter.as_ref().unwrap();
-            let swapchain_format = surface.get_preferred_format(adapter).unwrap();
+            let swapchain_format = surface.get_supported_formats(adapter).first().unwrap();
 
             let rs = pollster::block_on(self.init_render_state(adapter, swapchain_format));
             self.render_state = Some(rs);

--- a/egui_demo_app/src/apps/custom3d_wgpu.rs
+++ b/egui_demo_app/src/apps/custom3d_wgpu.rs
@@ -17,7 +17,7 @@ impl Custom3d {
 
         let device = &render_state.device;
 
-        let shader = device.create_shader_module(&wgpu::ShaderModuleDescriptor {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: None,
             source: wgpu::ShaderSource::Wgsl(include_str!("./custom3d_wgpu_shader.wgsl").into()),
         });
@@ -53,7 +53,7 @@ impl Custom3d {
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_main",
-                targets: &[render_state.target_format.into()],
+                targets: &[Some(render_state.target_format.into())],
             }),
             primitive: wgpu::PrimitiveState::default(),
             depth_stencil: None,

--- a/egui_demo_app/src/apps/custom3d_wgpu_shader.wgsl
+++ b/egui_demo_app/src/apps/custom3d_wgpu_shader.wgsl
@@ -1,13 +1,13 @@
 struct VertexOut {
-    [[location(0)]] color: vec4<f32>;
-    [[builtin(position)]] position: vec4<f32>;
+    @location(0) color: vec4<f32>,
+    @builtin(position) position: vec4<f32>,
 };
 
 struct Uniforms {
-    angle: f32;
+    angle: f32,
 };
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<uniform> uniforms: Uniforms;
 
 var<private> v_positions: array<vec2<f32>, 3> = array<vec2<f32>, 3>(
@@ -22,8 +22,8 @@ var<private> v_colors: array<vec4<f32>, 3> = array<vec4<f32>, 3>(
     vec4<f32>(0.0, 0.0, 1.0, 1.0),
 );
 
-[[stage(vertex)]]
-fn vs_main([[builtin(vertex_index)]] v_idx: u32) -> VertexOut {
+@vertex
+fn vs_main(@builtin(vertex_index) v_idx: u32) -> VertexOut {
     var out: VertexOut;
 
     out.position = vec4<f32>(v_positions[v_idx], 0.0, 1.0);
@@ -33,7 +33,7 @@ fn vs_main([[builtin(vertex_index)]] v_idx: u32) -> VertexOut {
     return out;
 }
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOut) -> [[location(0)]] vec4<f32> {
+@fragment
+fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
     return in.color;
 }


### PR DESCRIPTION
**This should only be merged when a new wgpu release is made**

I'm using the git version of [naga](https://github.com/gfx-rs/naga/) and currently egui-wgpu panics during shader processing with that because it expects a different syntax for decorations, so I needed to make these changes to get it to work.