### PR TITLE
Add some padding to the egui-wgpu uniform buffer for WebGL

### DIFF
--- a/egui-wgpu/src/renderer.rs
+++ b/egui-wgpu/src/renderer.rs
@@ -554,7 +554,7 @@ impl RenderPass {
             0,
             bytemuck::cast_slice(&[UniformBuffer {
                 screen_size_in_points,
-                _padding: Default::default()
+                _padding: Default::default(),
             }]),
         );
 

--- a/egui-wgpu/src/renderer.rs
+++ b/egui-wgpu/src/renderer.rs
@@ -38,6 +38,7 @@ impl ScreenDescriptor {
 #[repr(C)]
 struct UniformBuffer {
     screen_size_in_points: [f32; 2],
+    _padding: [u32; 6],
 }
 
 /// Wraps the buffers and includes additional information.
@@ -82,6 +83,7 @@ impl RenderPass {
             label: Some("egui_uniform_buffer"),
             contents: bytemuck::cast_slice(&[UniformBuffer {
                 screen_size_in_points: [0.0, 0.0],
+                _padding: Default::default(),
             }]),
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
@@ -550,6 +552,7 @@ impl RenderPass {
             0,
             bytemuck::cast_slice(&[UniformBuffer {
                 screen_size_in_points,
+                _padding: Default::default()
             }]),
         );
 

--- a/egui-wgpu/src/renderer.rs
+++ b/egui-wgpu/src/renderer.rs
@@ -38,6 +38,8 @@ impl ScreenDescriptor {
 #[repr(C)]
 struct UniformBuffer {
     screen_size_in_points: [f32; 2],
+    // Uniform buffers need to be at least 16 bytes in WebGL.
+    // See https://github.com/gfx-rs/wgpu/issues/2072
     _padding: [u32; 2],
 }
 

--- a/egui-wgpu/src/renderer.rs
+++ b/egui-wgpu/src/renderer.rs
@@ -38,7 +38,7 @@ impl ScreenDescriptor {
 #[repr(C)]
 struct UniformBuffer {
     screen_size_in_points: [f32; 2],
-    _padding: [u32; 6],
+    _padding: [u32; 2],
 }
 
 /// Wraps the buffers and includes additional information.


### PR DESCRIPTION
I'm using egui-wgpu with the wgpu's WebGL backend. At the moment I get the following error on Chromium:

```
[.WebGL-0x38140334e800] GL_INVALID_OPERATION: It is undefined behaviour to use a uniform buffer that is too small.
```

with nothing rendering. I've encountered this issue before and have added some padding to the `UniformBuffer` struct. There is now no warning and it renders normally.