### PR TITLE
Fix uneven table striping

### DIFF
--- a/egui_extras/src/layout.rs
+++ b/egui_extras/src/layout.rs
@@ -110,7 +110,7 @@ impl<'l> StripLayout<'l> {
         let rect = self.cell_rect(&width, &height);
 
         // Make sure we don't have a gap in the stripe background:
-        let rect = rect.expand2(egui::vec2(0.5 * self.ui.spacing().item_spacing.x, 0.0));
+        let rect = rect.expand2(egui::vec2(0.5 * self.ui.spacing().item_spacing.x, 0.5 * self.ui.spacing().item_spacing.y));
 
         self.ui
             .painter()

--- a/egui_extras/src/layout.rs
+++ b/egui_extras/src/layout.rs
@@ -110,7 +110,7 @@ impl<'l> StripLayout<'l> {
         let rect = self.cell_rect(&width, &height);
 
         // Make sure we don't have a gap in the stripe background:
-        let rect = rect.expand2(egui::vec2(0.5 * self.ui.spacing().item_spacing.x, 0.5 * self.ui.spacing().item_spacing.y));
+        let rect = rect.expand2(0.5 * self.ui.spacing().item_spacing);
 
         self.ui
             .painter()


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->
Closes #1679 

The problem was caused by the painted stripes not being expanded to include vertical spacing. The rows are the correct size, just painted with too small of stripes.

Before:
![image](https://user-images.githubusercontent.com/28285686/170102149-a573b2a2-6c27-4912-aa85-f82ad51a10ab.png)

After:
![image](https://user-images.githubusercontent.com/28285686/170102169-f6666b05-dfac-451a-86dc-f7ea011909a6.png)

Edited to show overlay:
![image](https://user-images.githubusercontent.com/28285686/170102263-04903071-5b30-4738-9932-17e478616fc8.png)
