### PR TITLE
Add flag to disable hardware acceleration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui-w
 
 ## Unreleased
 ### Added ⭐
+* Added `NativeOptions::hardware_acceleration` to allow opting out of hardware acceleration for less power consumption ([#1681](https://github.com/emilk/egui/pull/1681)).
 * Added `*_released` & `*_clicked` methods for `PointerState` ([#1582](https://github.com/emilk/egui/pull/1582)).
 * Added `egui::hex_color!` to create `Color32`'s from hex strings under the `color-hex` feature ([#1596](https://github.com/emilk/egui/pull/1596)).
 * Optimized painting of filled circles (e.g. for scatter plots) by 10x or more ([#1616](https://github.com/emilk/egui/pull/1616)).

--- a/eframe/src/epi.rs
+++ b/eframe/src/epi.rs
@@ -211,6 +211,11 @@ pub struct NativeOptions {
     /// `egui` doesn't need the stencil buffer, so the default value is 0.
     pub stencil_buffer: u8,
 
+    /// Use hardware acceleration if available. On macOS, this will possibly
+    /// use a dedicated GPU which will lead to higher power consumption.
+    /// The default value is `Some(true)`
+    pub hardware_acceleration: Option<bool>,
+
     /// What rendering backend to use.
     pub renderer: Renderer,
 }
@@ -233,6 +238,7 @@ impl Default for NativeOptions {
             multisampling: 0,
             depth_buffer: 0,
             stencil_buffer: 0,
+            hardware_acceleration: Some(true),
             renderer: Renderer::default(),
         }
     }

--- a/eframe/src/native/epi_integration.rs
+++ b/eframe/src/native/epi_integration.rs
@@ -47,11 +47,12 @@ pub fn window_builder(
         max_window_size,
         resizable,
         transparent,
-        vsync: _,          // used in `fn create_display`
-        multisampling: _,  // used in `fn create_display`
-        depth_buffer: _,   // used in `fn create_display`
-        stencil_buffer: _, // used in `fn create_display`
-        renderer: _,       // used in `fn run_native`
+        vsync: _,                 // used in `fn create_display`
+        multisampling: _,         // used in `fn create_display`
+        depth_buffer: _,          // used in `fn create_display`
+        stencil_buffer: _,        // used in `fn create_display`
+        hardware_acceleration: _, // used in `fn create_display`
+        renderer: _,              // used in `fn run_native`
     } = native_options;
 
     let window_icon = icon_data.clone().and_then(load_icon);

--- a/eframe/src/native/run.rs
+++ b/eframe/src/native/run.rs
@@ -17,6 +17,7 @@ fn create_display(
     crate::profile_function!();
     let gl_window = unsafe {
         glutin::ContextBuilder::new()
+            .with_hardware_acceleration(native_options.hardware_acceleration)
             .with_depth_buffer(native_options.depth_buffer)
             .with_multisampling(native_options.multisampling)
             .with_srgb(true)


### PR DESCRIPTION
Closes <https://github.com/emilk/egui/issues/1095>

This is a fix for the behaviour on macOS platforms where any egui app would use the dedicated GPU and consume more power than needed. Not all apps might have dedicated GPU requirements.

The change here is to allow the user to opt in / out of hardware acceleration via the `glutin::ContextBuilder` [with_hardware_acceleration](https://docs.rs/glutin/latest/glutin/struct.ContextBuilder.html#method.with_hardware_acceleration) method.

The setting has been added to `NativeOptions` ans is used in the `glutin` setup.

Closes <https://github.com/emilk/egui/issues/THE_RELEVANT_ISSUE>.
