### PR TITLE
#1652 Feature - Added columns_with_sizes method for TableBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui-w
 * Added opt-in feature `deadlock_detection` to detect double-lock of mutexes on the same thread ([#1619](https://github.com/emilk/egui/pull/1619)).
 * Added `InputState::stable_dt`: a more stable estimate for the delta-time in reactive mode ([#1625](https://github.com/emilk/egui/pull/1625)).
 * You can now specify a texture filter for your textures ([#1636](https://github.com/emilk/egui/pull/1636)).
+* Added `fn columns_with_sizes` method for `TableBuilder` ([#1652](https://github.com/emilk/egui/pull/1652)).
 
 ### Fixed 🐛
 * Fixed `ImageButton`'s changing background padding on hover ([#1595](https://github.com/emilk/egui/pull/1595)).

--- a/egui_extras/src/table.rs
+++ b/egui_extras/src/table.rs
@@ -126,8 +126,8 @@ impl<'a> TableBuilder<'a> {
     }
 
     /// Allocate space for several columns at once with varying sizes.
-    /// Example: let vec = &vec![Size::relative(0.5), Size::relative(0.3)];
-    pub fn columns_with_sizes(mut self, sizes: &Vec<Size>) -> Self {
+    /// Vector example, let vec = &vec!`[Size::relative(0.5), Size::relative(0.3)]`
+    pub fn columns_with_sizes(mut self, sizes: &[Size]) -> Self {
         for size in sizes.iter() {
             self.sizing.add(*size);
         }

--- a/egui_extras/src/table.rs
+++ b/egui_extras/src/table.rs
@@ -125,6 +125,15 @@ impl<'a> TableBuilder<'a> {
         self
     }
 
+    /// Allocate space for several columns at once with varying sizes.
+    /// Example: let vec = &vec![Size::relative(0.5), Size::relative(0.3)];
+    pub fn columns_with_sizes(mut self, sizes: &Vec<Size>) -> Self {
+        for size in sizes.iter() {
+            self.sizing.add(*size);
+        }
+        self
+    }
+
     fn available_width(&self) -> f32 {
         self.ui.available_rect_before_wrap().width()
             - if self.scroll {

--- a/egui_extras/src/table.rs
+++ b/egui_extras/src/table.rs
@@ -126,7 +126,8 @@ impl<'a> TableBuilder<'a> {
     }
 
     /// Allocate space for several columns at once with varying sizes.
-    /// Vector example, let vec = &vec!`[Size::relative(0.5), Size::relative(0.3)]`
+    ///
+    /// Example: `.columns_with_sizes(&[Size::relative(0.5), Size::relative(0.3)])`
     pub fn columns_with_sizes(mut self, sizes: &[Size]) -> Self {
         for size in sizes.iter() {
             self.sizing.add(*size);


### PR DESCRIPTION
#1652 Feature request
To reduce the lines of code when constructing table columns with varying sizes, a new fn was created by passing a &Vec<Size> parameter to new fn columns_with sizes.  The function is very similar to columns() by simply iterating over the vec. 

Closes <https://github.com/emilk/egui/issues/#1652>.
