### PR TITLE
feat: add feature for load system fonts according user input

### DIFF
--- a/eframe/Cargo.toml
+++ b/eframe/Cargo.toml
@@ -24,7 +24,7 @@ default = ["default_fonts", "glow"]
 
 # detect dark mode system preference
 dark-light = ["dep:dark-light"]
-
+system_fonts = ["egui/system_fonts"]
 # If set, egui will use `include_bytes!` to bundle some fonts.
 # If you plan on specifying your own fonts you may disable this feature.
 default_fonts = ["egui/default_fonts"]

--- a/egui/Cargo.toml
+++ b/egui/Cargo.toml
@@ -36,7 +36,7 @@ deadlock_detection = ["epaint/deadlock_detection"]
 # If set, egui will use `include_bytes!` to bundle some fonts.
 # If you plan on specifying your own fonts you may disable this feature.
 default_fonts = ["epaint/default_fonts"]
-
+system_fonts = ["epaint/system_fonts"]
 # Enable additional checks if debug assertions are enabled (debug builds).
 extra_debug_asserts = ["epaint/extra_debug_asserts"]
 # Always enable additional checks.

--- a/epaint/Cargo.toml
+++ b/epaint/Cargo.toml
@@ -52,7 +52,7 @@ mint = ["emath/mint"]
 # implement serde on most types.
 serde = ["dep:serde", "ahash/serde", "emath/serde"]
 
-system_fonts = ["skia-safe","font-kit"]
+system_fonts = ["skia-safe"]
 
 [dependencies]
 emath = { version = "0.18.0", path = "../emath" }
@@ -68,7 +68,6 @@ color-hex = { version = "0.2.0", optional = true }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
 
 skia-safe = {version = "0.49.1", optional = true, features = ["gl"]}
-font-kit = {version = "0.11.0", optional = true}
 
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/epaint/Cargo.toml
+++ b/epaint/Cargo.toml
@@ -52,6 +52,7 @@ mint = ["emath/mint"]
 # implement serde on most types.
 serde = ["dep:serde", "ahash/serde", "emath/serde"]
 
+# load font from disk automatically according to user input
 system_fonts = ["skia-safe"]
 
 [dependencies]

--- a/epaint/Cargo.toml
+++ b/epaint/Cargo.toml
@@ -52,6 +52,8 @@ mint = ["emath/mint"]
 # implement serde on most types.
 serde = ["dep:serde", "ahash/serde", "emath/serde"]
 
+system_fonts = ["skia-safe","font-kit"]
+
 [dependencies]
 emath = { version = "0.18.0", path = "../emath" }
 
@@ -64,6 +66,9 @@ bytemuck = { version = "1.7.2", optional = true, features = ["derive"] }
 cint = { version = "0.3.1", optional = true }
 color-hex = { version = "0.2.0", optional = true }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
+
+skia-safe = {version = "0.49.1", optional = true, features = ["gl"]}
+font-kit = {version = "0.11.0", optional = true}
 
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/epaint/src/text/font.rs
+++ b/epaint/src/text/font.rs
@@ -311,6 +311,18 @@ impl Font {
         self.glyph_info(c).1.advance_width
     }
 
+    pub fn has_glyph_info_and_cache(&mut self, c: char) -> bool {
+        if let Some(_font_index_glyph_info) = self.glyph_info_cache.get(&c) {
+            return true;
+        }
+
+        self.glyph_info_no_cache_or_fallback(c).is_some()
+    }
+
+    pub fn push_font_impl(&mut self, new_font_impl: Arc<FontImpl>) {
+        self.fonts.push(new_font_impl);
+    }
+
     /// `\n` will (intentionally) show up as the replacement character.
     fn glyph_info(&mut self, c: char) -> (FontIndex, GlyphInfo) {
         if let Some(font_index_glyph_info) = self.glyph_info_cache.get(&c) {

--- a/epaint/src/text/fonts.rs
+++ b/epaint/src/text/fonts.rs
@@ -7,8 +7,6 @@ use crate::{
     TextureAtlas,
 };
 use emath::NumExt as _;
-#[cfg(feature = "system_fonts")]
-use font_kit::family_handle::FamilyHandle;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -245,20 +243,18 @@ pub struct FontDefinitions {
 }
 
 impl FontDefinitions {
+    /// query a font which contains the character
     #[cfg(feature = "system_fonts")]
-    pub fn query_fonts_for_character(c: char) -> Option<FamilyHandle> {
-        use font_kit::source::SystemSource;
+    pub fn query_font_for_character(c: char) -> Option<(Vec<u8>, String)> {
         use skia_safe::{FontMgr, FontStyle};
 
-        let source = SystemSource::new();
         let font_mgr = FontMgr::new();
 
         if let Some(typeface) =
             font_mgr.match_family_style_character("", FontStyle::normal(), &[], c as i32)
         {
-            let family_name = typeface.family_name();
-            if let Ok(fonts) = source.select_family_by_name(&family_name) {
-                return Some(fonts);
+            if let Some((buf, _index)) = typeface.to_font_data() {
+                return Some((buf, typeface.family_name()));
             }
         }
         None
@@ -623,8 +619,6 @@ impl FontsImpl {
 
     #[cfg(feature = "system_fonts")]
     pub fn ensure_correct_fonts_for_text(&mut self, text: &str, main_font_id: &FontId) {
-        use font_kit::handle::Handle;
-        use std::fs;
         let FontId { size, family: _ } = main_font_id;
         let scale_in_pixels = self.font_impl_cache.scale_as_pixels(*size);
 
@@ -633,48 +627,36 @@ impl FontsImpl {
             if font_impl_manager.has_glyph_info_and_cache(c) {
                 continue;
             }
-            if let Some(fonts) = FontDefinitions::query_fonts_for_character(c) {
-                for font in fonts.fonts() {
-                    if let Handle::Path {
-                        path,
-                        font_index: _,
-                    } = font
-                    {
-                        if let Ok(buf) = fs::read(path) {
-                            let new_font_name =
-                                path.file_name().unwrap().to_str().unwrap().to_string();
-                            // update FontData
-                            let font_data = self
-                                .definitions
-                                .font_data
-                                .entry(new_font_name.clone())
-                                .or_insert_with(|| FontData::from_owned(buf));
+            if let Some((buf, new_font_name)) = FontDefinitions::query_font_for_character(c) {
+                // update FontData
+                let font_data = self
+                    .definitions
+                    .font_data
+                    .entry(new_font_name.clone())
+                    .or_insert_with(|| FontData::from_owned(buf));
 
-                            self.definitions
-                                .families
-                                .entry(FontFamily::Monospace)
-                                .or_default()
-                                .push(new_font_name.clone());
-                            self.definitions
-                                .families
-                                .entry(FontFamily::Proportional)
-                                .or_default()
-                                .push(new_font_name.clone());
-                            // update fonts_impl_cache
-                            let ab_glyph = ab_glyph_font_from_font_data(&new_font_name, font_data);
-                            let tweak = font_data.tweak;
-                            self.font_impl_cache
-                                .ab_glyph_fonts
-                                .insert(new_font_name.clone(), (tweak, ab_glyph));
-                            // update fonts_impl_cache
-                            let new_font_impl = self
-                                .font_impl_cache
-                                .font_impl(scale_in_pixels, &new_font_name);
-                            font_impl_manager = self.font(main_font_id);
-                            font_impl_manager.push_font_impl(new_font_impl);
-                        }
-                    }
-                }
+                self.definitions
+                    .families
+                    .entry(FontFamily::Monospace)
+                    .or_default()
+                    .push(new_font_name.clone());
+                self.definitions
+                    .families
+                    .entry(FontFamily::Proportional)
+                    .or_default()
+                    .push(new_font_name.clone());
+                // update fonts_impl_cache
+                let ab_glyph = ab_glyph_font_from_font_data(&new_font_name, font_data);
+                let tweak = font_data.tweak;
+                self.font_impl_cache
+                    .ab_glyph_fonts
+                    .insert(new_font_name.clone(), (tweak, ab_glyph));
+                // update fonts_impl_cache
+                let new_font_impl = self
+                    .font_impl_cache
+                    .font_impl(scale_in_pixels, &new_font_name);
+                font_impl_manager = self.font(main_font_id);
+                font_impl_manager.push_font_impl(new_font_impl);
             }
         }
     }

--- a/epaint/src/text/text_layout.rs
+++ b/epaint/src/text/text_layout.rs
@@ -94,6 +94,7 @@ fn layout_section(
         format,
     } = section;
 
+    // load font from system while we can't recognize with fonts in memory while layout
     #[cfg(feature = "system_fonts")]
     fonts.ensure_correct_fonts_for_text(&job.text, &format.font_id);
 

--- a/epaint/src/text/text_layout.rs
+++ b/epaint/src/text/text_layout.rs
@@ -93,6 +93,10 @@ fn layout_section(
         byte_range,
         format,
     } = section;
+
+    #[cfg(feature = "system_fonts")]
+    fonts.ensure_correct_fonts_for_text(&job.text, &format.font_id);
+
     let font = fonts.font(&format.font_id);
     let font_height = font.row_height();
 


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Solved the issure mentioned in <https://github.com/emilk/egui/discussions/1344>.

For now,this PR adds a `system_fonts` feature which depend the font-kits and skia-safe(`gl` feature) and it makes the binary size very big.So I add it as a optional feature in `epaint` ,`egui` and `eframe` for some people who need it.

Maybe I should develop a library to choose the font for characters.But it sounds like there are lots of work to do.If i finished it or find a proper library,i will make a PR again add as the default feature of `eframe`.So for now,Let's just make it as a experimental feature.

![图片](https://user-images.githubusercontent.com/18031428/170726808-1a9e2d98-75c2-4c50-a342-fea0e2678f35.png)
