### PR TITLE
Add Context::request_repaint_after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui-w
 
 ### Changed
 * `PaintCallback` shapes now require the whole callback to be put in an `Arc<dyn Any>` with the value being a backend-specific callback type. ([#1684](https://github.com/emilk/egui/pull/1684))
-* Replaced `needs_repaint` in `FullOutput` with `repaint_after`. used to force repaint after the set duration in reactive mode.([#1694](https://github.com/emilk/egui/pull/1694))
+* Replaced `needs_repaint` in `FullOutput` with `repaint_after`. Used to force repaint after the set duration in reactive mode.([#1694](https://github.com/emilk/egui/pull/1694)).
 
 ### Fixed 🐛
 * Fixed `ImageButton`'s changing background padding on hover ([#1595](https://github.com/emilk/egui/pull/1595)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui-w
 
 ### Changed
 * `PaintCallback` shapes now require the whole callback to be put in an `Arc<dyn Any>` with the value being a backend-specific callback type. ([#1684](https://github.com/emilk/egui/pull/1684))
+* Replaced `needs_repaint` in `FullOutput` with `repaint_after`. used to force repaint after the set duration in reactive mode.([#1694](https://github.com/emilk/egui/pull/1694))
 
 ### Fixed 🐛
 * Fixed `ImageButton`'s changing background padding on hover ([#1595](https://github.com/emilk/egui/pull/1595)).

--- a/eframe/src/native/run.rs
+++ b/eframe/src/native/run.rs
@@ -399,7 +399,7 @@ pub fn run_wgpu(
             }
             winit::event::Event::UserEvent(RequestRepaintEvent) => window.request_redraw(),
             winit::event::Event::NewEvents(winit::event::StartCause::ResumeTimeReached {
-            ..
+                ..
             }) => {
                 window.request_redraw();
             }

--- a/eframe/src/native/run.rs
+++ b/eframe/src/native/run.rs
@@ -398,6 +398,11 @@ pub fn run_wgpu(
                 painter.destroy();
             }
             winit::event::Event::UserEvent(RequestRepaintEvent) => window.request_redraw(),
+            winit::event::Event::NewEvents(winit::event::StartCause::ResumeTimeReached {
+            ..
+            }) => {
+                window.request_redraw();
+            }
             _ => (),
         }
     });

--- a/eframe/src/web/backend.rs
+++ b/eframe/src/web/backend.rs
@@ -245,7 +245,7 @@ impl AppRunner {
         Ok(())
     }
 
-    /// Returns `true` if egui requests a repaint.
+    /// Returns how long to wait until the next repaint.
     ///
     /// Call [`Self::paint`] later to paint
     pub fn logic(&mut self) -> Result<(std::time::Duration, Vec<egui::ClippedPrimitive>), JsValue> {

--- a/eframe/src/web/backend.rs
+++ b/eframe/src/web/backend.rs
@@ -248,7 +248,7 @@ impl AppRunner {
     /// Returns `true` if egui requests a repaint.
     ///
     /// Call [`Self::paint`] later to paint
-    pub fn logic(&mut self) -> Result<(bool, Vec<egui::ClippedPrimitive>), JsValue> {
+    pub fn logic(&mut self) -> Result<(std::time::Duration, Vec<egui::ClippedPrimitive>), JsValue> {
         let frame_start = now_sec();
 
         resize_canvas_to_screen_size(self.canvas_id(), self.app.max_size_points());
@@ -260,7 +260,7 @@ impl AppRunner {
         });
         let egui::FullOutput {
             platform_output,
-            needs_repaint,
+            repaint_after,
             textures_delta,
             shapes,
         } = full_output;
@@ -282,7 +282,7 @@ impl AppRunner {
         }
 
         self.frame.info.cpu_usage = Some((now_sec() - frame_start) as f32);
-        Ok((needs_repaint, clipped_primitives))
+        Ok((repaint_after, clipped_primitives))
     }
 
     pub fn clear_color_buffer(&self) {

--- a/eframe/src/web/events.rs
+++ b/eframe/src/web/events.rs
@@ -9,9 +9,9 @@ pub fn paint_and_schedule(
         let mut runner_lock = runner_ref.lock();
         if runner_lock.needs_repaint.fetch_and_clear() {
             runner_lock.clear_color_buffer();
-            let (needs_repaint, clipped_primitives) = runner_lock.logic()?;
+            let (repaint_after, clipped_primitives) = runner_lock.logic()?;
             runner_lock.paint(&clipped_primitives)?;
-            if needs_repaint {
+            if repaint_after.is_zero() {
                 runner_lock.needs_repaint.set_true();
             }
             runner_lock.auto_save();

--- a/eframe/src/web/events.rs
+++ b/eframe/src/web/events.rs
@@ -14,6 +14,7 @@ pub fn paint_and_schedule(
             if repaint_after.is_zero() {
                 runner_lock.needs_repaint.set_true();
             }
+            // TODO: schedule a repaint after `repaint_after` when it is not zero
             runner_lock.auto_save();
         }
 

--- a/egui-winit/src/lib.rs
+++ b/egui-winit/src/lib.rs
@@ -469,13 +469,14 @@ impl State {
 
         let egui::PlatformOutput {
             cursor_icon,
+            idle_timeout_interval,
             open_url,
             copied_text,
             events: _,                    // handled above
             mutable_text_under_cursor: _, // only used in eframe web
             text_cursor_pos,
         } = platform_output;
-
+        let _ = idle_timeout_interval;
         self.current_pixels_per_point = egui_ctx.pixels_per_point(); // someone can have changed it to scale the UI
 
         self.set_cursor_icon(window, cursor_icon);

--- a/egui-winit/src/lib.rs
+++ b/egui-winit/src/lib.rs
@@ -469,14 +469,12 @@ impl State {
 
         let egui::PlatformOutput {
             cursor_icon,
-            idle_timeout_interval,
             open_url,
             copied_text,
             events: _,                    // handled above
             mutable_text_under_cursor: _, // only used in eframe web
             text_cursor_pos,
         } = platform_output;
-        let _ = idle_timeout_interval;
         self.current_pixels_per_point = egui_ctx.pixels_per_point(); // someone can have changed it to scale the UI
 
         self.set_cursor_icon(window, cursor_icon);

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -839,10 +839,15 @@ impl Context {
 
         let platform_output: PlatformOutput = std::mem::take(&mut self.output());
 
-        if self.read().repaint_requests > 0 {
+        // if repaint_requests is greater than zero. just set the duration to zero for immediate
+        // repaint. if there's no repaint requests, then we can use the actual repaint_after instead.
+        let repaint_after = if self.read().repaint_requests > 0 {
             self.write().repaint_requests -= 1;
-        }
-        let repaint_after = self.read().repaint_after;
+            std::time::Duration::ZERO
+        } else {
+            self.read().repaint_after;
+        };
+
         self.write().requested_repaint_last_frame = repaint_after.is_zero();
         // make sure we reset the repaint_after duration.
         // otherwise, if repaint_after is low, then any widget setting repaint_after next frame,

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -839,6 +839,9 @@ impl Context {
 
         let platform_output: PlatformOutput = std::mem::take(&mut self.output());
 
+        if self.read().repaint_requests > 0 {
+            self.write().repaint_requests -= 1;
+        }
         let repaint_after = self.read().repaint_after;
         self.write().requested_repaint_last_frame = repaint_after.is_zero();
         // make sure we reset the repaint_after duration.

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -575,18 +575,18 @@ impl Context {
         }
     }
 
-    /// request repaint after the specified duration elapses in the case of no new input
+    /// Request repaint after the specified duration elapses in the case of no new input
     /// events being received.
     ///
-    /// function can be multiple times, but only the *smallest* duration will be considered.
-    /// so, if the function is called two times with `1 second` and `2 seconds`, egui will repaint
+    /// The function can be multiple times, but only the *smallest* duration will be considered.
+    /// So, if the function is called two times with `1 second` and `2 seconds`, egui will repaint
     /// after `1 second`
     ///
-    /// this is primarily useful for applications who would like to save battery by avoiding wasted
-    /// redraws when the app is not in focus. but sometimes the GUI of the app might become stale
+    /// This is primarily useful for applications who would like to save battery by avoiding wasted
+    /// redraws when the app is not in focus. But sometimes the GUI of the app might become stale
     /// and outdated if it is not updated for too long.
     ///
-    /// lets say, something like a stop watch widget that displays the time in seconds. you would waste
+    /// Lets say, something like a stop watch widget that displays the time in seconds. You would waste
     /// resources repainting multiple times within the same second (when you have no input),
     /// just calculate the difference of duration between current time and next second change,
     /// and call this function, to make sure that you are displaying the latest updated time, but
@@ -595,15 +595,15 @@ impl Context {
     /// NOTE: only works if called before `Context::end_frame()`. to force egui to update,
     /// use `Context::request_repaint()` instead.
     ///
-    /// Quirk:
-    ///     duration begins at the next frame. lets say for example that its a very inefficient app
-    ///     and takes 500 milliseconds per frame at 2 fps. the widget / user might want a repaint in
-    ///     next 500 milliseconds. now, app takes 1000 ms per frame (1 fps) because the backend event
-    ///     timeout takes 500 milli seconds AFTER the vsync swap buffer.
-    ///     so, its not that we are requesting repaint within X duration. we are rather timing out
-    ///     during app idle time where we are not receiving any new input events.
+    /// ### Quirk:
+    /// Duration begins at the next frame. lets say for example that its a very inefficient app
+    /// and takes 500 milliseconds per frame at 2 fps. The widget / user might want a repaint in
+    /// next 500 milliseconds. Now, app takes 1000 ms per frame (1 fps) because the backend event
+    /// timeout takes 500 milli seconds AFTER the vsync swap buffer.
+    /// So, its not that we are requesting repaint within X duration. We are rather timing out
+    /// during app idle time where we are not receiving any new input events.
     pub fn request_repaint_after(&self, duration: std::time::Duration) {
-        // maybe we can check if duration is ZERO, and call self.request_repaint()?
+        // Maybe we can check if duration is ZERO, and call self.request_repaint()?
         let mut ctx = self.write();
         ctx.repaint_after = ctx.repaint_after.min(duration);
     }

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -845,7 +845,7 @@ impl Context {
             self.write().repaint_requests -= 1;
             std::time::Duration::ZERO
         } else {
-            self.read().repaint_after;
+            self.read().repaint_after
         };
 
         self.write().requested_repaint_last_frame = repaint_after.is_zero();

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -596,7 +596,6 @@ impl Context {
     /// use `Context::request_repaint()` instead.
     ///
     /// Quirk:
-    ///
     ///     duration begins at the next frame. lets say for example that its a very inefficient app
     ///     and takes 500 milliseconds per frame at 2 fps. the widget / user might want a repaint in
     ///     next 500 milliseconds. now, app takes 1000 ms per frame (1 fps) because the backend event
@@ -608,6 +607,7 @@ impl Context {
         let mut ctx = self.write();
         ctx.repaint_after = ctx.repaint_after.min(duration);
     }
+
     /// For integrations: this callback will be called when an egui user calls [`Self::request_repaint`].
     ///
     /// This lets you wake up a sleeping UI thread.

--- a/egui/src/context.rs
+++ b/egui/src/context.rs
@@ -582,6 +582,14 @@ impl Context {
         self.write().request_repaint_callbacks = Some(callback);
     }
 
+    /// in reactive mode, egui is only repainted upon new input events
+    /// but, your gui might become too stale due to long periods of inactivity in cases where app is
+    /// idling in the background.
+    /// this function can set a idle repaint interval, and when egui has been idling without any
+    /// new input for the duration of the interval, the app will be forced to update.
+    pub fn set_idle_repaint_interval(&mut self, interval: Option<std::time::Duration>) {
+        self.write().output.idle_timeout_interval = interval;
+    }
     /// Tell `egui` which fonts to use.
     ///
     /// The default `egui` fonts only support latin and cyrillic alphabets,

--- a/egui/src/data/output.rs
+++ b/egui/src/data/output.rs
@@ -10,10 +10,15 @@ pub struct FullOutput {
     /// Non-rendering related output.
     pub platform_output: PlatformOutput,
 
-    /// If `true`, egui is requesting immediate repaint (i.e. on the next frame).
+    /// If `Duration::is_zero()`, egui is requesting immediate repaint (i.e. on the next frame).
     ///
     /// This happens for instance when there is an animation, or if a user has called `Context::request_repaint()`.
-    pub needs_repaint: bool,
+    ///
+    /// If `Duration` is greater than zero, egui wants to be repainted at or before the specified
+    /// duration elapses. when in reactive mode, egui spends forever waiting for input and only then,
+    /// will it repaint itself. this can be used to make sure that backend will only wait for a
+    /// specified amount of time, and repaint egui without any new input.
+    pub repaint_after: std::time::Duration,
 
     /// Texture changes since last frame (including the font texture).
     ///
@@ -32,13 +37,13 @@ impl FullOutput {
     pub fn append(&mut self, newer: Self) {
         let Self {
             platform_output,
-            needs_repaint,
+            repaint_after,
             textures_delta,
             shapes,
         } = newer;
 
         self.platform_output.append(platform_output);
-        self.needs_repaint = needs_repaint; // if the last frame doesn't need a repaint, then we don't need to repaint
+        self.repaint_after = repaint_after; // if the last frame doesn't need a repaint, then we don't need to repaint
         self.textures_delta.append(textures_delta);
         self.shapes = shapes; // Only paint the latest
     }
@@ -49,14 +54,11 @@ impl FullOutput {
 /// You can access (and modify) this with [`crate::Context::output`].
 ///
 /// The backend should use this.
-#[derive(Clone, PartialEq)]
+#[derive(Default, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct PlatformOutput {
     /// Set the cursor to this icon.
     pub cursor_icon: CursorIcon,
-
-    /// Interval duration to wait for events before forcing update
-    pub idle_timeout_interval: Option<std::time::Duration>,
 
     /// If set, open this url.
     pub open_url: Option<OpenUrl>,
@@ -76,19 +78,7 @@ pub struct PlatformOutput {
     /// Screen-space position of text edit cursor (used for IME).
     pub text_cursor_pos: Option<crate::Pos2>,
 }
-impl Default for PlatformOutput {
-    fn default() -> Self {
-        Self {
-            cursor_icon: Default::default(),
-            idle_timeout_interval: Some(std::time::Duration::from_secs(1)),
-            open_url: None,
-            copied_text: "".to_string(),
-            events: vec![],
-            mutable_text_under_cursor: false,
-            text_cursor_pos: None,
-        }
-    }
-}
+
 impl PlatformOutput {
     /// Open the given url in a web browser.
     /// If egui is running in a browser, the same tab will be reused.
@@ -118,7 +108,6 @@ impl PlatformOutput {
     pub fn append(&mut self, newer: Self) {
         let Self {
             cursor_icon,
-            idle_timeout_interval,
             open_url,
             copied_text,
             mut events,
@@ -127,9 +116,6 @@ impl PlatformOutput {
         } = newer;
 
         self.cursor_icon = cursor_icon;
-        if idle_timeout_interval.is_some() {
-            self.idle_timeout_interval = idle_timeout_interval;
-        }
         if open_url.is_some() {
             self.open_url = open_url;
         }
@@ -145,7 +131,6 @@ impl PlatformOutput {
     pub fn take(&mut self) -> Self {
         let taken = std::mem::take(self);
         self.cursor_icon = taken.cursor_icon; // eveything else is ephemeral
-        self.idle_timeout_interval = taken.idle_timeout_interval;
         taken
     }
 }

--- a/egui_demo_app/src/backend_panel.rs
+++ b/egui_demo_app/src/backend_panel.rs
@@ -245,13 +245,13 @@ impl BackendPanel {
             ui.label("Only running UI code when there are animations or input.");
             ui.label("but if there's no input for the repaint_after duration, we force an update");
             ui.label("repaint_after (in seconds)");
-            let mut milli_seconds = self.repaint_after_timeout.as_secs_f32();
-            if egui::DragValue::new(&mut milli_seconds)
+            let mut seconds = self.repaint_after_timeout.as_secs_f32();
+            if egui::DragValue::new(&mut seconds)
                 .clamp_range(0.1..=10.0)
                 .ui(ui)
                 .changed()
             {
-                self.repaint_after_timeout = std::time::Duration::from_secs_f32(milli_seconds);
+                self.repaint_after_timeout = std::time::Duration::from_secs_f32(seconds);
             }
         }
     }

--- a/egui_glium/examples/native_texture.rs
+++ b/egui_glium/examples/native_texture.rs
@@ -24,7 +24,7 @@ fn main() {
         let mut redraw = || {
             let mut quit = false;
 
-            let needs_repaint = egui_glium.run(&display, |egui_ctx| {
+            let repaint_after = egui_glium.run(&display, |egui_ctx| {
                 egui::SidePanel::left("my_side_panel").show(egui_ctx, |ui| {
                     if ui
                         .add(egui::Button::image_and_text(
@@ -44,9 +44,13 @@ fn main() {
 
             *control_flow = if quit {
                 glutin::event_loop::ControlFlow::Exit
-            } else if needs_repaint {
+            } else if repaint_after.is_zero() {
                 display.gl_window().window().request_redraw();
                 glutin::event_loop::ControlFlow::Poll
+            } else if let Some(repaint_after_instant) =
+                std::time::Instant::now().checked_add(repaint_after)
+            {
+                glutin::event_loop::ControlFlow::WaitUntil(repaint_after_instant)
             } else {
                 glutin::event_loop::ControlFlow::Wait
             };

--- a/egui_glium/examples/native_texture.rs
+++ b/egui_glium/examples/native_texture.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use egui_winit::winit;
 use glium::glutin;
 
 fn main() {

--- a/egui_glium/examples/native_texture.rs
+++ b/egui_glium/examples/native_texture.rs
@@ -93,7 +93,7 @@ fn main() {
             glutin::event::Event::NewEvents(glutin::event::StartCause::ResumeTimeReached {
                 ..
             }) => {
-                window.request_redraw();
+                display.gl_window().window().request_redraw();
             }
 
             _ => (),

--- a/egui_glium/examples/native_texture.rs
+++ b/egui_glium/examples/native_texture.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
 use glium::glutin;
+use egui_winit::winit;
 
 fn main() {
     let event_loop = glutin::event_loop::EventLoop::with_user_event();
@@ -88,6 +89,11 @@ fn main() {
                 egui_glium.on_event(&event);
 
                 display.gl_window().window().request_redraw(); // TODO(emilk): ask egui if the events warrants a repaint instead
+            }
+            glutin::event::Event::NewEvents(glutin::event::StartCause::ResumeTimeReached {
+            ..
+            }) => {
+                window.request_redraw();
             }
 
             _ => (),

--- a/egui_glium/examples/native_texture.rs
+++ b/egui_glium/examples/native_texture.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use glium::glutin;
 use egui_winit::winit;
+use glium::glutin;
 
 fn main() {
     let event_loop = glutin::event_loop::EventLoop::with_user_event();
@@ -91,7 +91,7 @@ fn main() {
                 display.gl_window().window().request_redraw(); // TODO(emilk): ask egui if the events warrants a repaint instead
             }
             glutin::event::Event::NewEvents(glutin::event::StartCause::ResumeTimeReached {
-            ..
+                ..
             }) => {
                 window.request_redraw();
             }

--- a/egui_glium/examples/pure_glium.rs
+++ b/egui_glium/examples/pure_glium.rs
@@ -73,7 +73,7 @@ fn main() {
             glutin::event::Event::NewEvents(glutin::event::StartCause::ResumeTimeReached {
                 ..
             }) => {
-                window.request_redraw();
+                display.gl_window().window().request_redraw();
             }
             _ => (),
         }

--- a/egui_glium/examples/pure_glium.rs
+++ b/egui_glium/examples/pure_glium.rs
@@ -14,7 +14,7 @@ fn main() {
         let mut redraw = || {
             let mut quit = false;
 
-            let needs_repaint = egui_glium.run(&display, |egui_ctx| {
+            let repaint_after = egui_glium.run(&display, |egui_ctx| {
                 egui::SidePanel::left("my_side_panel").show(egui_ctx, |ui| {
                     ui.heading("Hello World!");
                     if ui.button("Quit").clicked() {
@@ -25,9 +25,13 @@ fn main() {
 
             *control_flow = if quit {
                 glutin::event_loop::ControlFlow::Exit
-            } else if needs_repaint {
+            } else if repaint_after.is_zero() {
                 display.gl_window().window().request_redraw();
                 glutin::event_loop::ControlFlow::Poll
+            } else if let Some(repaint_after_instant) =
+                std::time::Instant::now().checked_add(repaint_after)
+            {
+                glutin::event_loop::ControlFlow::WaitUntil(repaint_after_instant)
             } else {
                 glutin::event_loop::ControlFlow::Wait
             };

--- a/egui_glium/examples/pure_glium.rs
+++ b/egui_glium/examples/pure_glium.rs
@@ -70,7 +70,11 @@ fn main() {
 
                 display.gl_window().window().request_redraw(); // TODO(emilk): ask egui if the events warrants a repaint instead
             }
-
+            glutin::event::Event::NewEvents(glutin::event::StartCause::ResumeTimeReached {
+                                                ..
+                                            }) => {
+                window.request_redraw();
+            }
             _ => (),
         }
     });

--- a/egui_glium/examples/pure_glium.rs
+++ b/egui_glium/examples/pure_glium.rs
@@ -71,8 +71,8 @@ fn main() {
                 display.gl_window().window().request_redraw(); // TODO(emilk): ask egui if the events warrants a repaint instead
             }
             glutin::event::Event::NewEvents(glutin::event::StartCause::ResumeTimeReached {
-                                                ..
-                                            }) => {
+                ..
+            }) => {
                 window.request_redraw();
             }
             _ => (),

--- a/egui_glium/src/lib.rs
+++ b/egui_glium/src/lib.rs
@@ -56,13 +56,17 @@ impl EguiGlium {
     /// Returns `true` if egui requests a repaint.
     ///
     /// Call [`Self::paint`] later to paint.
-    pub fn run(&mut self, display: &glium::Display, run_ui: impl FnMut(&egui::Context)) -> bool {
+    pub fn run(
+        &mut self,
+        display: &glium::Display,
+        run_ui: impl FnMut(&egui::Context),
+    ) -> std::time::Duration {
         let raw_input = self
             .egui_winit
             .take_egui_input(display.gl_window().window());
         let egui::FullOutput {
             platform_output,
-            needs_repaint,
+            repaint_after,
             textures_delta,
             shapes,
         } = self.egui_ctx.run(raw_input, run_ui);
@@ -76,7 +80,7 @@ impl EguiGlium {
         self.shapes = shapes;
         self.textures_delta.append(textures_delta);
 
-        needs_repaint
+        repaint_after
     }
 
     /// Paint the results of the last call to [`Self::run`].

--- a/egui_glow/examples/pure_glow.rs
+++ b/egui_glow/examples/pure_glow.rs
@@ -3,6 +3,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 #![allow(unsafe_code)]
 
+use web_sys::window;
+
 fn main() {
     let mut clear_color = [0.1, 0.1, 0.1];
 
@@ -52,7 +54,7 @@ fn main() {
 
                 // draw things on top of egui here
 
-                gl_window.window().swap_buffers().unwrap();
+                gl_window.swap_buffers().unwrap();
             }
         };
 
@@ -89,7 +91,7 @@ fn main() {
             glutin::event::Event::NewEvents(glutin::event::StartCause::ResumeTimeReached {
                 ..
             }) => {
-                gl_window..window().request_redraw();
+                gl_window.window().request_redraw();
             }
 
             _ => (),

--- a/egui_glow/examples/pure_glow.rs
+++ b/egui_glow/examples/pure_glow.rs
@@ -3,6 +3,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 #![allow(unsafe_code)]
 
+use web_sys::window;
+
 fn main() {
     let mut clear_color = [0.1, 0.1, 0.1];
 
@@ -85,6 +87,11 @@ fn main() {
             }
             glutin::event::Event::LoopDestroyed => {
                 egui_glow.destroy();
+            }
+            glutin::event::Event::NewEvents(glutin::event::StartCause::ResumeTimeReached {
+                                                ..
+                                            }) => {
+                gl_window..window().request_redraw();
             }
 
             _ => (),

--- a/egui_glow/examples/pure_glow.rs
+++ b/egui_glow/examples/pure_glow.rs
@@ -3,8 +3,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 #![allow(unsafe_code)]
 
-use web_sys::window;
-
 fn main() {
     let mut clear_color = [0.1, 0.1, 0.1];
 
@@ -54,7 +52,7 @@ fn main() {
 
                 // draw things on top of egui here
 
-                gl_window.swap_buffers().unwrap();
+                gl_window.window().swap_buffers().unwrap();
             }
         };
 

--- a/egui_glow/examples/pure_glow.rs
+++ b/egui_glow/examples/pure_glow.rs
@@ -89,8 +89,8 @@ fn main() {
                 egui_glow.destroy();
             }
             glutin::event::Event::NewEvents(glutin::event::StartCause::ResumeTimeReached {
-                                                ..
-                                            }) => {
+                ..
+            }) => {
                 gl_window..window().request_redraw();
             }
 

--- a/egui_glow/examples/pure_glow.rs
+++ b/egui_glow/examples/pure_glow.rs
@@ -16,7 +16,7 @@ fn main() {
         let mut redraw = || {
             let mut quit = false;
 
-            let needs_repaint = egui_glow.run(gl_window.window(), |egui_ctx| {
+            let repaint_after = egui_glow.run(gl_window.window(), |egui_ctx| {
                 egui::SidePanel::left("my_side_panel").show(egui_ctx, |ui| {
                     ui.heading("Hello World!");
                     if ui.button("Quit").clicked() {
@@ -28,9 +28,13 @@ fn main() {
 
             *control_flow = if quit {
                 glutin::event_loop::ControlFlow::Exit
-            } else if needs_repaint {
+            } else if repaint_after.is_zero() {
                 gl_window.window().request_redraw();
                 glutin::event_loop::ControlFlow::Poll
+            } else if let Some(repaint_after_instant) =
+                std::time::Instant::now().checked_add(repaint_after)
+            {
+                glutin::event_loop::ControlFlow::WaitUntil(repaint_after_instant)
             } else {
                 glutin::event_loop::ControlFlow::Wait
             };

--- a/egui_glow/examples/pure_glow.rs
+++ b/egui_glow/examples/pure_glow.rs
@@ -3,8 +3,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 #![allow(unsafe_code)]
 
-use web_sys::window;
-
 fn main() {
     let mut clear_color = [0.1, 0.1, 0.1];
 

--- a/egui_glow/src/winit.rs
+++ b/egui_glow/src/winit.rs
@@ -48,11 +48,11 @@ impl EguiGlow {
         &mut self,
         window: &winit::window::Window,
         run_ui: impl FnMut(&egui::Context),
-    ) -> bool {
+    ) -> std::time::Duration {
         let raw_input = self.egui_winit.take_egui_input(window);
         let egui::FullOutput {
             platform_output,
-            needs_repaint,
+            repaint_after,
             textures_delta,
             shapes,
         } = self.egui_ctx.run(raw_input, run_ui);
@@ -62,7 +62,7 @@ impl EguiGlow {
 
         self.shapes = shapes;
         self.textures_delta.append(textures_delta);
-        needs_repaint
+        repaint_after
     }
 
     /// Paint the results of the last call to [`Self::run`].

--- a/egui_glow/src/winit.rs
+++ b/egui_glow/src/winit.rs
@@ -41,7 +41,7 @@ impl EguiGlow {
         self.egui_winit.on_event(&self.egui_ctx, event)
     }
 
-    /// Returns `true` if egui requests a repaint.
+    /// Returns the `Duration` of the timeout after which egui should be repainted even if there's no new events.
     ///
     /// Call [`Self::paint`] later to paint.
     pub fn run(


### PR DESCRIPTION
Closes <https://github.com/emilk/egui/issues/1691>.

kinda my first PR. 

I am wondering whether i should store this idle timeout interval in `platform output` our `full output`. I did not implement this for wgpu yet, but should be pretty similar. 

by storing it in platform output, it affects the `take` function and the `Default` derive to be manually implemented. 