### PR TITLE
Browser Hotkey Conflicts

### DIFF
--- a/eframe/src/web/events.rs
+++ b/eframe/src/web/events.rs
@@ -50,7 +50,7 @@ pub fn install_document_events(runner_container: &AppRunnerContainer) -> Result<
         "keydown",
         |event: web_sys::KeyboardEvent, mut runner_lock| {
             if event.is_composing() || event.key_code() == 229 {
-                // https://www.fxsitecompat.dev/en-CA/docs/2018/keydown-and-keyup-events-are-now-fired-during-ime-composition/
+                // https://web.archive.org/web/20200526195704/https://www.fxsitecompat.dev/en-CA/docs/2018/keydown-and-keyup-events-are-now-fired-during-ime-composition/
                 return;
             }
 

--- a/egui-winit/src/lib.rs
+++ b/egui-winit/src/lib.rs
@@ -195,10 +195,8 @@ impl State {
                 // We need to ignore these characters that are side-effects of commands.
                 let is_mac_cmd = cfg!(target_os = "macos")
                     && (self.egui_input.modifiers.ctrl || self.egui_input.modifiers.mac_cmd);
-                let is_altshift: bool =
-                    self.egui_input.modifiers.alt && self.egui_input.modifiers.shift;
-                
-                if is_printable_char(*ch) && !is_mac_cmd && !is_altshift {
+
+                if is_printable_char(*ch) && !is_mac_cmd && !self.egui_input.modifiers.alt {
                     self.egui_input
                         .events
                         .push(egui::Event::Text(ch.to_string()));

--- a/egui-winit/src/lib.rs
+++ b/egui-winit/src/lib.rs
@@ -195,8 +195,10 @@ impl State {
                 // We need to ignore these characters that are side-effects of commands.
                 let is_mac_cmd = cfg!(target_os = "macos")
                     && (self.egui_input.modifiers.ctrl || self.egui_input.modifiers.mac_cmd);
-
-                if is_printable_char(*ch) && !is_mac_cmd {
+                let is_altshift: bool =
+                    self.egui_input.modifiers.alt && self.egui_input.modifiers.shift;
+                
+                if is_printable_char(*ch) && !is_mac_cmd && !is_altshift {
                     self.egui_input
                         .events
                         .push(egui::Event::Text(ch.to_string()));

--- a/egui/src/data/input.rs
+++ b/egui/src/data/input.rs
@@ -323,7 +323,7 @@ impl Modifiers {
         mac_cmd: false,
         command: false,
     };
-    pub const ALTSHIFT: Self = Self {
+    pub const ALT_SHIFT: Self = Self {
         alt: true,
         ctrl: false,
         shift: true,

--- a/egui/src/data/input.rs
+++ b/egui/src/data/input.rs
@@ -323,6 +323,13 @@ impl Modifiers {
         mac_cmd: false,
         command: false,
     };
+    pub const ALTSHIFT: Self = Self {
+        alt: true,
+        ctrl: false,
+        shift: true,
+        mac_cmd: false,
+        command: false,
+    };
     /// The Mac ⌘ Command key
     pub const MAC_CMD: Self = Self {
         alt: false,
@@ -429,7 +436,7 @@ impl std::ops::BitOr for Modifiers {
 /// plus a few that are useful for detecting keyboard shortcuts.
 ///
 /// Many keys are omitted because they are not always physical keys (depending on keyboard language), e.g. `;` and `§`,
-/// and are therefor unsuitable as keyboard shortcuts if you want your app to be portable.
+/// and are therefore unsuitable as keyboard shortcuts if you want your app to be portable.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Key {
@@ -474,37 +481,37 @@ pub enum Key {
 
     A, // Used for cmd+A (select All)
     B,
-    C,
-    D,
-    E,
-    F,
-    G,
-    H,
-    I,
-    J,
+    C, // |CMD COPY|
+    D, // |CMD BOOKMARK|
+    E, // |CMD SEARCH|
+    F, // |CMD FIND firefox & chrome|
+    G, // |CMD FIND chrome|
+    H, // |CMD History|
+    I, // italics
+    J, // |CMD SEARCH firefox/DOWNLOAD chrome|
     K, // Used for ctrl+K (delete text after cursor)
     L,
     M,
     N,
-    O,
-    P,
+    O, // |CMD OPEN|
+    P, // |CMD PRINT|
     Q,
-    R,
-    S,
-    T,
+    R, // |CMD REFRESH|
+    S, // |CMD SAVE|
+    T, // |CMD TAB|
     U, // Used for ctrl+U (delete text before cursor)
-    V,
+    V, // |CMD PASTE|
     W, // Used for ctrl+W (delete previous word)
-    X,
+    X, // |CMD CUT|
     Y,
-    Z, // Used for cmd+Z (undo)
+    Z, // |CMD UNDO|
 
     // The function keys:
     F1,
     F2,
     F3,
     F4,
-    F5,
+    F5, // |CMD REFRESH|
     F6,
     F7,
     F8,

--- a/egui_demo_lib/src/demo/text_edit.rs
+++ b/egui_demo_lib/src/demo/text_edit.rs
@@ -62,12 +62,12 @@ impl super::View for TextEdit {
 
         ui.add_enabled(
             anything_selected,
-            egui::Label::new("Press ctrl+T to toggle the case of selected text (cmd+T on Mac)"),
+            egui::Label::new("Press ctrl+Y to toggle the case of selected text (cmd+Y on Mac)"),
         );
 
         if ui
             .input_mut()
-            .consume_key(egui::Modifiers::COMMAND, egui::Key::T)
+            .consume_key(egui::Modifiers::COMMAND, egui::Key::Y)
         {
             if let Some(text_cursor_range) = output.cursor_range {
                 use egui::TextBuffer as _;

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -130,13 +130,13 @@ fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRang
         ccursor_range.secondary.index += advance;
     }
     for (modifier, key, surrounding) in [
-        (egui::Modifiers::COMMAND, Key::B, "*"),      // *bold*
-        (egui::Modifiers::COMMAND, Key::N, "`"),      // `code`
-        (egui::Modifiers::COMMAND, Key::I, "/"),      // /italics/
-        (egui::Modifiers::COMMAND, Key::L, "$"),      // $subscript$
-        (egui::Modifiers::COMMAND, Key::Y, "^"),      // ^superscript^
-        (egui::Modifiers::ALT_SHIFT, Key::Num3, "~"), // ~strikethrough~
-        (egui::Modifiers::COMMAND, Key::Num2, "_"),   // _underline_
+        (egui::Modifiers::COMMAND, Key::B, "*"),   // *bold*
+        (egui::Modifiers::COMMAND, Key::N, "`"),   // `code`
+        (egui::Modifiers::COMMAND, Key::I, "/"),   // /italics/
+        (egui::Modifiers::COMMAND, Key::L, "$"),   // $subscript$
+        (egui::Modifiers::COMMAND, Key::Y, "^"),   // ^superscript^
+        (egui::Modifiers::ALT_SHIFT, Key::Q, "~"), // ~strikethrough~
+        (egui::Modifiers::ALT_SHIFT, Key::W, "_"), // _underline_
     ] {
         if ui.input_mut().consume_key(modifier, key) {
             any_change = true;

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -45,15 +45,8 @@ impl EasyMarkEditor {
 
     pub fn ui(&mut self, ui: &mut egui::Ui) {
         egui::Grid::new("controls").show(ui, |ui| {
-            //ui.menu_button("File", Self::nested_file);
             ui.menu_button("Hotkeys", Self::nested_hotkeys);
-            //ui.menu_button("View", Self::nested_view);
-            if ui
-                .button(RichText::new("render").color(Color32::from_rgb(76, 139, 255)))
-                .clicked()
-            {
-                self.show_rendered = !self.show_rendered;
-            }
+            ui.checkbox(&mut self.show_rendered, "Show rendered");
             ui.checkbox(&mut self.highlight_editor, "Highlight editor");
             egui::reset_button(ui, self);
             ui.end_row();
@@ -112,31 +105,22 @@ impl EasyMarkEditor {
         }
     }
     fn nested_hotkeys(ui: &mut egui::Ui) {
-        let _ = ui.button("CTRL+B *bold*");
-        let _ = ui.button("CTRL+N `code`");
-        let _ = ui.button("CTRL+I /italics/");
-        let _ = ui.button("CTRL+L $subscript$");
-        let _ = ui.button("CTRL+Y ^superscript^");
-        let _ = ui.button("CTRL+M ~strikethrough~");
-        let _ = ui.button("ALTSHIFT+Q _underline_");
-        let _ = ui.button("ALTSHIFT+W two spaces");
+        let _ = ui.label("CTRL+B *bold*");
+        let _ = ui.label("CTRL+N `code`");
+        let _ = ui.label("CTRL+I /italics/");
+        let _ = ui.label("CTRL+L $subscript$");
+        let _ = ui.label("CTRL+Y ^superscript^");
+        let _ = ui.label("CTRL+M ~strikethrough~");
+        let _ = ui.label("ALT+SHIFT+Q _underline_");
+        let _ = ui.label("ALT+SHIFT+W two spaces");
     }
-    fn nested_file(ui: &mut egui::Ui) {
-        let _ = ui.button("CTRL+O Open");
-        let _ = ui.button("New File");
-        //let _ = ui.button("Reset");
-    }
-    /*fn nested_view(ui: &mut egui::Ui) {
-        let _ = ui.button("Highlight Editor");
-        let _ = ui.button("Show Rendered");
-    }*/
 }
 
 fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRange) -> bool {
     let mut any_change = false;
     if ui
         .input_mut()
-        .consume_key(egui::Modifiers::ALTSHIFT, Key::W)
+        .consume_key(egui::Modifiers::ALT_SHIFT, Key::W)
     {
         any_change = true;
         let [primary, _secondary] = ccursor_range.sorted();
@@ -146,13 +130,13 @@ fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRang
         ccursor_range.secondary.index += advance;
     }
     for (modifier, key, surrounding) in [
-        (egui::Modifiers::COMMAND, Key::B, "*"),     // *bold*
-        (egui::Modifiers::COMMAND, Key::N, "`"),     // `code`
-        (egui::Modifiers::COMMAND, Key::I, "/"),     // /italics/
-        (egui::Modifiers::COMMAND, Key::L, "$"),     // $subscript$
-        (egui::Modifiers::COMMAND, Key::Y, "^"),     // ^superscript^
-        (egui::Modifiers::ALTSHIFT, Key::Num3, "~"), // ~strikethrough~
-        (egui::Modifiers::COMMAND, Key::Num2, "_"),  // _underline_
+        (egui::Modifiers::COMMAND, Key::B, "*"),      // *bold*
+        (egui::Modifiers::COMMAND, Key::N, "`"),      // `code`
+        (egui::Modifiers::COMMAND, Key::I, "/"),      // /italics/
+        (egui::Modifiers::COMMAND, Key::L, "$"),      // $subscript$
+        (egui::Modifiers::COMMAND, Key::Y, "^"),      // ^superscript^
+        (egui::Modifiers::ALT_SHIFT, Key::Num3, "~"), // ~strikethrough~
+        (egui::Modifiers::COMMAND, Key::Num2, "_"),   // _underline_
     ] {
         if ui.input_mut().consume_key(modifier, key) {
             any_change = true;

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -110,9 +110,9 @@ impl EasyMarkEditor {
         let _ = ui.label("CTRL+I /italics/");
         let _ = ui.label("CTRL+L $subscript$");
         let _ = ui.label("CTRL+Y ^superscript^");
-        let _ = ui.label("CTRL+M ~strikethrough~");
-        let _ = ui.label("ALT+SHIFT+Q _underline_");
-        let _ = ui.label("ALT+SHIFT+W two spaces");
+        let _ = ui.label("ALT+SHIFT+Q ~strikethrough~");
+        let _ = ui.label("ALT+SHIFT+W _underline_");
+        let _ = ui.label("ALT+SHIFT+E two spaces");
     }
 }
 
@@ -120,7 +120,7 @@ fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRang
     let mut any_change = false;
     if ui
         .input_mut()
-        .consume_key(egui::Modifiers::ALT_SHIFT, Key::W)
+        .consume_key(egui::Modifiers::ALT_SHIFT, Key::E)
     {
         any_change = true;
         let [primary, _secondary] = ccursor_range.sorted();

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -52,7 +52,7 @@ impl EasyMarkEditor {
             ui.checkbox(&mut self.show_rendered, "Show rendered");
         });
 
-        ui.label("Use ctrl/cmd + key to toggle:   B: *strong*   C: `code`   I: /italics/   L: $lowered$   R: ^raised^   S: ~strikethrough~   U: _underline_");
+        ui.label("Use ctrl/cmd + key to toggle:   B: *strong*   N: `code`   I: /italics/   L: $lowered$   Y: ^raised^   M: ~strikethrough~   U: _underline_");
 
         ui.separator();
 
@@ -117,7 +117,7 @@ fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRang
         (Key::I, "/"), // /italics/
         (Key::L, "$"), // $subscript$
         (Key::Y, "^"), // ^superscript^
-        (Key::S, "~"), // ~strikethrough~
+        (Key::M, "~"), // ~strikethrough~
         (Key::U, "_"), // _underline_
     ] {
         if ui.input_mut().consume_key(egui::Modifiers::COMMAND, key) {

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -113,10 +113,10 @@ fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRang
     let mut any_change = false;
     for (key, surrounding) in [
         (Key::B, "*"), // *bold*
-        (Key::C, "`"), // `code`
+        (Key::N, "`"), // `code`
         (Key::I, "/"), // /italics/
         (Key::L, "$"), // $subscript$
-        (Key::R, "^"), // ^superscript^
+        (Key::Y, "^"), // ^superscript^
         (Key::S, "~"), // ~strikethrough~
         (Key::U, "_"), // _underline_
     ] {

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -44,13 +44,12 @@ impl EasyMarkEditor {
     }
 
     pub fn ui(&mut self, ui: &mut egui::Ui) {
-        let mut hotkeys_open = false;
         egui::Grid::new("controls").show(ui, |ui| {
-            ui.menu_button("File", Self::nested_file);
+            //ui.menu_button("File", Self::nested_file);
             ui.menu_button("Hotkeys", Self::nested_hotkeys);
             //ui.menu_button("View", Self::nested_view);
             if ui
-                .button(RichText::new("render").color(Color32::from_rgb(126, 130, 255)))
+                .button(RichText::new("render").color(Color32::from_rgb(76, 139, 255)))
                 .clicked()
             {
                 self.show_rendered = !self.show_rendered;
@@ -77,35 +76,6 @@ impl EasyMarkEditor {
             ScrollArea::vertical()
                 .id_source("source")
                 .show(ui, |ui| self.editor_ui(ui));
-        }
-        fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRange) -> bool {
-            let mut any_change = false;
-            if ui
-                .input_mut()
-                .consume_key(egui::Modifiers::ALTSHIFT, Key::W)
-            {
-                any_change = true;
-                let [primary, _secondary] = ccursor_range.sorted();
-
-                let advance = code.insert_text("  ", primary.index);
-                ccursor_range.primary.index += advance;
-                ccursor_range.secondary.index += advance;
-            }
-            for (modifier, key, surrounding) in [
-                (egui::Modifiers::COMMAND, Key::B, "*"),  // *bold*
-                (egui::Modifiers::COMMAND, Key::N, "`"),  // `code`
-                (egui::Modifiers::COMMAND, Key::I, "/"),  // /italics/
-                (egui::Modifiers::COMMAND, Key::L, "$"),  // $subscript$
-                (egui::Modifiers::COMMAND, Key::Y, "^"),  // ^superscript^
-                (egui::Modifiers::COMMAND, Key::M, "~"),  // ~strikethrough~
-                (egui::Modifiers::ALTSHIFT, Key::Q, "_"), // _underline_
-            ] {
-                if ui.input_mut().consume_key(modifier, key) {
-                    any_change = true;
-                    toggle_surrounding(code, ccursor_range, surrounding);
-                };
-            }
-            any_change
         }
     }
 
@@ -164,27 +134,29 @@ impl EasyMarkEditor {
 
 fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRange) -> bool {
     let mut any_change = false;
+    if ui
+        .input_mut()
+        .consume_key(egui::Modifiers::ALTSHIFT, Key::W)
+    {
+        any_change = true;
+        let [primary, _secondary] = ccursor_range.sorted();
+
+        let advance = code.insert_text("  ", primary.index);
+        ccursor_range.primary.index += advance;
+        ccursor_range.secondary.index += advance;
+    }
     for (modifier, key, surrounding) in [
-        (egui::Modifiers::COMMAND, Key::B, "*"),    // *bold*
-        (egui::Modifiers::COMMAND, Key::N, "`"),    // `code`
-        (egui::Modifiers::COMMAND, Key::I, "/"),    // /italics/
-        (egui::Modifiers::COMMAND, Key::L, "$"),    // $subscript$
-        (egui::Modifiers::COMMAND, Key::Y, "^"),    // ^superscript^
-        (egui::Modifiers::COMMAND, Key::M, "~"),    // ~strikethrough~
-        (egui::Modifiers::ALTSHIFT, Key::Q, "_"),   // _underline_
-        (egui::Modifiers::ALTSHIFT, Key::W, "tab"), // adds two spaces
+        (egui::Modifiers::COMMAND, Key::B, "*"),     // *bold*
+        (egui::Modifiers::COMMAND, Key::N, "`"),     // `code`
+        (egui::Modifiers::COMMAND, Key::I, "/"),     // /italics/
+        (egui::Modifiers::COMMAND, Key::L, "$"),     // $subscript$
+        (egui::Modifiers::COMMAND, Key::Y, "^"),     // ^superscript^
+        (egui::Modifiers::ALTSHIFT, Key::Num3, "~"), // ~strikethrough~
+        (egui::Modifiers::COMMAND, Key::Num2, "_"),  // _underline_
     ] {
         if ui.input_mut().consume_key(modifier, key) {
             any_change = true;
-            if surrounding == "tab" {
-                let [primary, _secondary] = ccursor_range.sorted();
-
-                let advance = code.insert_text("  ", primary.index);
-                ccursor_range.primary.index += advance;
-                ccursor_range.secondary.index += advance;
-            } else {
-                toggle_surrounding(code, ccursor_range, surrounding);
-            }
+            toggle_surrounding(code, ccursor_range, surrounding);
         };
     }
     any_change

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -121,7 +121,8 @@ fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRang
     if ui
         .input_mut()
         .consume_key(egui::Modifiers::ALT_SHIFT, Key::E)
-    { // TODO: Replace this with a call to indent the active line
+    { 
+        // This is a placeholder till we can indent the active line
         any_change = true;
         let [primary, _secondary] = ccursor_range.sorted();
 

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -52,7 +52,7 @@ impl EasyMarkEditor {
             ui.checkbox(&mut self.show_rendered, "Show rendered");
         });
 
-        ui.label("Use ctrl/cmd + key to toggle:   B: *strong*   N: `code`   I: /italics/   L: $lowered$   Y: ^raised^   M: ~strikethrough~   U: _underline_");
+        ui.label("CTRL+B: *strong*   CTRL+N: `code`   CTRL+I: /italics/   CTRL+L: $lowered$   CTRL+Y: ^raised^   CTRL+M: ~strikethrough~   ALTSHIFT+Q: _underline_");
 
         ui.separator();
 
@@ -112,13 +112,13 @@ impl EasyMarkEditor {
 fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRange) -> bool {
     let mut any_change = false;
     for (key, surrounding, modifier) in [
-        (Key::B, "*", egui::Modifiers::COMMAND), // *bold*
-        (Key::N, "`", egui::Modifiers::COMMAND), // `code`
-        (Key::I, "/", egui::Modifiers::COMMAND), // /italics/
-        (Key::L, "$", egui::Modifiers::COMMAND), // $subscript$
-        (Key::Y, "^", egui::Modifiers::COMMAND), // ^superscript^
-        (Key::M, "~", egui::Modifiers::COMMAND), // ~strikethrough~
-        (Key::Q, "_", egui::Modifiers::COMMAND), // _underline_
+        (Key::B, "*", egui::Modifiers::COMMAND),  // *bold*
+        (Key::N, "`", egui::Modifiers::COMMAND),  // `code`
+        (Key::I, "/", egui::Modifiers::COMMAND),  // /italics/
+        (Key::L, "$", egui::Modifiers::COMMAND),  // $subscript$
+        (Key::Y, "^", egui::Modifiers::COMMAND),  // ^superscript^
+        (Key::M, "~", egui::Modifiers::COMMAND),  // ~strikethrough~
+        (Key::Q, "_", egui::Modifiers::ALTSHIFT), // _underline_
     ] {
         if ui.input_mut().consume_key(modifier, key) {
             toggle_surrounding(code, ccursor_range, surrounding);

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -52,7 +52,7 @@ impl EasyMarkEditor {
             ui.checkbox(&mut self.show_rendered, "Show rendered");
         });
 
-        ui.label("CTRL+B: *strong*   CTRL+N: `code`   CTRL+I: /italics/   CTRL+L: $lowered$   CTRL+Y: ^raised^   CTRL+M: ~strikethrough~   ALTSHIFT+Q: _underline_");
+        ui.label("(CTRL or Mac CMD) + [B: *bold*  N: `code`  I: /italics/  L: $lower$  Y: ^raise^  M: ~Strikethrough~] ALTSHIFT+Q: _underline_");
 
         ui.separator();
 

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -109,33 +109,35 @@ impl EasyMarkEditor {
     }
 }
 
-fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRange) -> bool {
-    let mut any_change = false;
-    for (modifier, key, surrounding) in [
-        (egui::Modifiers::COMMAND, Key::B, "*"),  // *bold*
-        (egui::Modifiers::COMMAND, Key::N, "`"),  // `code`
-        (egui::Modifiers::COMMAND, Key::I, "/"),  // /italics/
-        (egui::Modifiers::COMMAND, Key::L, "$"),  // $subscript$
-        (egui::Modifiers::COMMAND, Key::Y, "^"),  // ^superscript^
-        (egui::Modifiers::COMMAND, Key::M, "~"),  // ~strikethrough~
-        (egui::Modifiers::ALTSHIFT, Key::Q, "_"), // _underline_
-        (egui::Modifiers::ALTSHIFT, Key::W, "tab"),
-    ] {
-        if ui.input_mut().consume_key(modifier, key) {
-            any_change = true;
-            if surrounding == "tab" {
+        fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRange) -> bool {
+            let mut any_change = false;
+            if ui
+                .input_mut()
+                .consume_key(egui::Modifiers::ALTSHIFT, Key::W)
+            { /// add two spaces for tab (to be replaced)
+                any_change = true;
                 let [primary, _secondary] = ccursor_range.sorted();
 
                 let advance = code.insert_text("  ", primary.index);
                 ccursor_range.primary.index += advance;
                 ccursor_range.secondary.index += advance;
-            } else {
-                toggle_surrounding(code, ccursor_range, surrounding);
             }
-        };
-    }
-    any_change
-}
+            for (modifier, key, surrounding) in [
+                (egui::Modifiers::COMMAND, Key::B, "*"),  // *bold*
+                (egui::Modifiers::COMMAND, Key::N, "`"),  // `code`
+                (egui::Modifiers::COMMAND, Key::I, "/"),  // /italics/
+                (egui::Modifiers::COMMAND, Key::L, "$"),  // $subscript$
+                (egui::Modifiers::COMMAND, Key::Y, "^"),  // ^superscript^
+                (egui::Modifiers::COMMAND, Key::M, "~"),  // ~strikethrough~
+                (egui::Modifiers::ALTSHIFT, Key::Q, "_"), // _underline_
+            ] {
+                if ui.input_mut().consume_key(modifier, key) {
+                    any_change = true;
+                    toggle_surrounding(code, ccursor_range, surrounding);
+                };
+            }
+            any_change
+        }
 
 /// E.g. toggle *strong* with `toggle_surrounding(&mut text, &mut cursor, "*")`
 fn toggle_surrounding(

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -112,7 +112,7 @@ impl EasyMarkEditor {
         let _ = ui.label("CTRL+Y ^superscript^");
         let _ = ui.label("ALT+SHIFT+Q ~strikethrough~");
         let _ = ui.label("ALT+SHIFT+W _underline_");
-        let _ = ui.label("ALT+SHIFT+E two spaces");
+        let _ = ui.label("ALT+SHIFT+E two spaces"); // Placeholder for tab indent
     }
 }
 
@@ -121,7 +121,7 @@ fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRang
     if ui
         .input_mut()
         .consume_key(egui::Modifiers::ALT_SHIFT, Key::E)
-    {
+    { // TODO: Replace this with a call to indent the active line
         any_change = true;
         let [primary, _secondary] = ccursor_range.sorted();
 
@@ -241,7 +241,9 @@ The style characters are chosen to be similar to what they are representing:
 # TODO
 - Sub-headers (`## h2`, `### h3` etc)
 - Hotkey Editor
-- Internationalize EasyMark symbols
+- International keyboard algorithm for non-letter keys
+- ALT+SHIFT+Num1 is not a functioning hotkey
+- Tab Indent Increment/Decrement CTRL+], CTRL+[
 
 - Images
   - we want to be able to optionally specify size (width and\/or height)

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -45,7 +45,7 @@ impl EasyMarkEditor {
 
     pub fn ui(&mut self, ui: &mut egui::Ui) {
         egui::Grid::new("controls").show(ui, |ui| {
-            ui.menu_button("Hotkeys", Self::nested_hotkeys);
+            let _ = ui.button("Hotkeys").on_hover_ui(nested_hotkeys_ui);
             ui.checkbox(&mut self.show_rendered, "Show rendered");
             ui.checkbox(&mut self.highlight_editor, "Highlight editor");
             egui::reset_button(ui, self);
@@ -104,16 +104,17 @@ impl EasyMarkEditor {
             }
         }
     }
-    fn nested_hotkeys(ui: &mut egui::Ui) {
-        let _ = ui.label("CTRL+B *bold*");
-        let _ = ui.label("CTRL+N `code`");
-        let _ = ui.label("CTRL+I /italics/");
-        let _ = ui.label("CTRL+L $subscript$");
-        let _ = ui.label("CTRL+Y ^superscript^");
-        let _ = ui.label("ALT+SHIFT+Q ~strikethrough~");
-        let _ = ui.label("ALT+SHIFT+W _underline_");
-        let _ = ui.label("ALT+SHIFT+E two spaces"); // Placeholder for tab indent
-    }
+}
+
+fn nested_hotkeys_ui(ui: &mut egui::Ui) {
+    let _ = ui.label("CTRL+B *bold*");
+    let _ = ui.label("CTRL+N `code`");
+    let _ = ui.label("CTRL+I /italics/");
+    let _ = ui.label("CTRL+L $subscript$");
+    let _ = ui.label("CTRL+Y ^superscript^");
+    let _ = ui.label("ALT+SHIFT+Q ~strikethrough~");
+    let _ = ui.label("ALT+SHIFT+W _underline_");
+    let _ = ui.label("ALT+SHIFT+E two spaces"); // Placeholder for tab indent
 }
 
 fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRange) -> bool {

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -121,7 +121,7 @@ fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRang
     if ui
         .input_mut()
         .consume_key(egui::Modifiers::ALT_SHIFT, Key::E)
-    { 
+    {
         // This is a placeholder till we can indent the active line
         any_change = true;
         let [primary, _secondary] = ccursor_range.sorted();

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -111,18 +111,27 @@ impl EasyMarkEditor {
 
 fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRange) -> bool {
     let mut any_change = false;
-    for (key, surrounding, modifier) in [
-        (Key::B, "*", egui::Modifiers::COMMAND),  // *bold*
-        (Key::N, "`", egui::Modifiers::COMMAND),  // `code`
-        (Key::I, "/", egui::Modifiers::COMMAND),  // /italics/
-        (Key::L, "$", egui::Modifiers::COMMAND),  // $subscript$
-        (Key::Y, "^", egui::Modifiers::COMMAND),  // ^superscript^
-        (Key::M, "~", egui::Modifiers::COMMAND),  // ~strikethrough~
-        (Key::Q, "_", egui::Modifiers::ALTSHIFT), // _underline_
+    for (modifier, key, surrounding) in [
+        (egui::Modifiers::COMMAND, Key::B, "*"),  // *bold*
+        (egui::Modifiers::COMMAND, Key::N, "`"),  // `code`
+        (egui::Modifiers::COMMAND, Key::I, "/"),  // /italics/
+        (egui::Modifiers::COMMAND, Key::L, "$"),  // $subscript$
+        (egui::Modifiers::COMMAND, Key::Y, "^"),  // ^superscript^
+        (egui::Modifiers::COMMAND, Key::M, "~"),  // ~strikethrough~
+        (egui::Modifiers::ALTSHIFT, Key::Q, "_"), // _underline_
+        (egui::Modifiers::ALTSHIFT, Key::W, "tab"),
     ] {
         if ui.input_mut().consume_key(modifier, key) {
-            toggle_surrounding(code, ccursor_range, surrounding);
             any_change = true;
+            if surrounding == "tab" {
+                let [primary, _secondary] = ccursor_range.sorted();
+
+                let advance = code.insert_text("  ", primary.index);
+                ccursor_range.primary.index += advance;
+                ccursor_range.secondary.index += advance;
+            } else {
+                toggle_surrounding(code, ccursor_range, surrounding);
+            }
         };
     }
     any_change

--- a/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -111,16 +111,16 @@ impl EasyMarkEditor {
 
 fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRange) -> bool {
     let mut any_change = false;
-    for (key, surrounding) in [
-        (Key::B, "*"), // *bold*
-        (Key::N, "`"), // `code`
-        (Key::I, "/"), // /italics/
-        (Key::L, "$"), // $subscript$
-        (Key::Y, "^"), // ^superscript^
-        (Key::M, "~"), // ~strikethrough~
-        (Key::U, "_"), // _underline_
+    for (key, surrounding, modifier) in [
+        (Key::B, "*", egui::Modifiers::COMMAND), // *bold*
+        (Key::N, "`", egui::Modifiers::COMMAND), // `code`
+        (Key::I, "/", egui::Modifiers::COMMAND), // /italics/
+        (Key::L, "$", egui::Modifiers::COMMAND), // $subscript$
+        (Key::Y, "^", egui::Modifiers::COMMAND), // ^superscript^
+        (Key::M, "~", egui::Modifiers::COMMAND), // ~strikethrough~
+        (Key::Q, "_", egui::Modifiers::COMMAND), // _underline_
     ] {
-        if ui.input_mut().consume_key(egui::Modifiers::COMMAND, key) {
+        if ui.input_mut().consume_key(modifier, key) {
             toggle_surrounding(code, ccursor_range, surrounding);
             any_change = true;
         };


### PR DESCRIPTION
### EasyMark Text Editor

**Hotkey Limitations Within Browser**
ctrl A S D F G H J K are all taken the entire second row besides L. CTRL W E R T U O P are also all taken, entire first row besides QYI. CTRL Z X C V are taken so we are left with a limited number of keys for each row, BNM in third.

LQYIBNM, 7 out of the 26 letters are all the keys we have left.

**New Hotkey Combinations**

as the project is unfinished I added ALTSHIFT modifier to enable more hotkey variations. The keys for , . ; are missing with the semicolon being noted as of not being internationally according to comment. I think we need to be able to access these keys in the future through an international keyboard interpreting algorithm.

**New view**

I thought that context menus would be more appropriate to move forward with. I want the hotkeys thing to bring up a window for editing hotkeys along with viewing what we think are the system hotkeys as well.

![caption](https://live.staticflickr.com/65535/52112557437_476f97e1b9_o.gif)
Closes <https://github.com/emilk/egui/issues/1683>.
