### PR TITLE
Constrain date picker to screen

### DIFF
--- a/egui_extras/src/datepicker/button.rs
+++ b/egui_extras/src/datepicker/button.rs
@@ -97,9 +97,7 @@ impl<'a> Widget for DatePickerButton<'a> {
             }
 
             // Check to make sure the calendar never is displayed out of window
-            if pos.x < ui.style().spacing.window_margin.left {
-                pos.x = ui.style().spacing.window_margin.left;
-            }
+            pos.x = pos.x.max(ui.style().spacing.window_margin.left);
 
             //TODO(elwerene): Better positioning
 

--- a/egui_extras/src/datepicker/button.rs
+++ b/egui_extras/src/datepicker/button.rs
@@ -95,6 +95,12 @@ impl<'a> Widget for DatePickerButton<'a> {
             if pos.x + width_with_padding > ui.clip_rect().right() {
                 pos.x = button_response.rect.right() - width_with_padding;
             }
+
+            // Check to make sure the calendar never is displayed out of window
+            if pos.x < ui.style().spacing.window_margin.left {
+                pos.x = ui.style().spacing.window_margin.left;
+            }
+
             //TODO(elwerene): Better positioning
 
             let area_response = Area::new(ui.make_persistent_id(&self.id_source))


### PR DESCRIPTION
When the DatePickerButton's available space is less than the size of the calendar and when the button is close to the left margin, the calendar will be displayed out of the window.  See screen shot in issue 1685.

This pr simply equates the pos.x to the left margin when it is less than the left margin.

Closes <https://github.com/emilk/egui/issues/1685>.
