### PR TITLE
Ensure docs for `winit` feature are generated.

### DIFF
--- a/egui-wgpu/Cargo.toml
+++ b/egui-wgpu/Cargo.toml
@@ -23,6 +23,8 @@ include = [
   "Cargo.toml",
 ]
 
+[package.metadata.docs.rs]
+all-features = true
 
 
 [features]


### PR DESCRIPTION
### Purpose

Without this patch the documentation for [`egui-wgpu::winit`](https://github.com/emilk/egui/blob/e6cfa5028e2dd222ead311cf790d192ff401d0b9/egui-wgpu/src/winit.rs) is not generated which makes Ferris sad.

The configuration was copied from https://github.com/emilk/egui/blob/f27f67b76be7ce614680487e85fb2728d5c53ea8/egui-winit/Cargo.toml#L16-L19 but is currently untested.

### Current state

Currently the only mention of the [`winit` feature](https://github.com/emilk/egui/blob/e6cfa5028e2dd222ead311cf790d192ff401d0b9/egui-wgpu/Cargo.toml#L28-L30) on docs.rs is [here](https://docs.rs/crate/egui-wgpu/0.18.0/features) which (unhelpfully :D ) states "This feature flag does not enable additional features".[0]

### Other context

My particular interest was in `paint_and_update_textures()` which, perhaps ironically, turns out not to be documented (but even documentation of its mere existence would be helpful):
https://github.com/emilk/egui/blob/e6cfa5028e2dd222ead311cf790d192ff401d0b9/egui-wgpu/src/winit.rs#L215-L222

### Other related code

https://github.com/emilk/egui/blob/e6cfa5028e2dd222ead311cf790d192ff401d0b9/egui-wgpu/src/lib.rs#L11-L15

### References

 * https://docs.rs/about/metadata
 * https://github.com/emilk/egui/commit/442b9539643e4ce037da768bc2cd26fe095e0df1
 * https://github.com/emilk/egui/issues/381#issuecomment-839707073

[0] Which according to [this](https://stackoverflow.com/questions/71636468/rust-claims-dashmap-into-par-iter-trait-bounds-not-satisfied#71637846) is intended to be read as "[this] feature does not activate other feature _flags_."