### PR TITLE
WGPU PaintCallback Fixes

### DIFF
--- a/egui-wgpu/src/renderer.rs
+++ b/egui-wgpu/src/renderer.rs
@@ -139,7 +139,7 @@ impl RenderPass {
     /// Creates a new render pass to render a egui UI.
     ///
     /// If the format passed is not a *Srgb format, the shader will automatically convert to `sRGB` colors in the shader.
-    pub fn new(
+    pub(crate) fn new(
         device: &wgpu::Device,
         output_format: wgpu::TextureFormat,
         msaa_samples: u32,
@@ -292,7 +292,7 @@ impl RenderPass {
     }
 
     /// Executes the egui render pass.
-    pub fn execute(
+    pub(crate) fn execute(
         &self,
         encoder: &mut wgpu::CommandEncoder,
         color_attachment: &wgpu::TextureView,
@@ -326,7 +326,7 @@ impl RenderPass {
     }
 
     /// Executes the egui render pass onto an existing wgpu renderpass.
-    pub fn execute_with_renderpass<'rpass>(
+    pub(crate) fn execute_with_renderpass<'rpass>(
         &'rpass self,
         rpass: &mut wgpu::RenderPass<'rpass>,
         paint_jobs: &[egui::epaint::ClippedPrimitive],
@@ -452,7 +452,7 @@ impl RenderPass {
     }
 
     /// Should be called before `execute()`.
-    pub fn update_texture(
+    pub(crate) fn update_texture(
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
@@ -564,8 +564,20 @@ impl RenderPass {
         };
     }
 
-    pub fn free_texture(&mut self, id: &egui::TextureId) {
+    pub(crate) fn free_texture(&mut self, id: &egui::TextureId) {
         self.textures.remove(id);
+    }
+
+    /// Get the WGPU texture and bind group associated to a texture that has been allocated by egui.
+    ///
+    /// This could be used by custom paint hooks to render images that have been added through with
+    /// [`egui_extras::RetainedImage`](https://docs.rs/egui_extras/latest/egui_extras/image/struct.RetainedImage.html)
+    /// or [`egui::Context::load_texture`].
+    pub fn get_texture(
+        &self,
+        id: &egui::TextureId,
+    ) -> Option<&(Option<wgpu::Texture>, wgpu::BindGroup)> {
+        self.textures.get(id)
     }
 
     /// Registers a `wgpu::Texture` with a `egui::TextureId`.
@@ -649,7 +661,7 @@ impl RenderPass {
 
     /// Uploads the uniform, vertex and index data used by the render pass.
     /// Should be called before `execute()`.
-    pub fn update_buffers(
+    pub(crate) fn update_buffers(
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,

--- a/egui-wgpu/src/renderer.rs
+++ b/egui-wgpu/src/renderer.rs
@@ -139,7 +139,7 @@ impl RenderPass {
     /// Creates a new render pass to render a egui UI.
     ///
     /// If the format passed is not a *Srgb format, the shader will automatically convert to `sRGB` colors in the shader.
-    pub(crate) fn new(
+    pub fn new(
         device: &wgpu::Device,
         output_format: wgpu::TextureFormat,
         msaa_samples: u32,
@@ -292,7 +292,7 @@ impl RenderPass {
     }
 
     /// Executes the egui render pass.
-    pub(crate) fn execute(
+    pub fn execute(
         &self,
         encoder: &mut wgpu::CommandEncoder,
         color_attachment: &wgpu::TextureView,
@@ -326,7 +326,7 @@ impl RenderPass {
     }
 
     /// Executes the egui render pass onto an existing wgpu renderpass.
-    pub(crate) fn execute_with_renderpass<'rpass>(
+    pub fn execute_with_renderpass<'rpass>(
         &'rpass self,
         rpass: &mut wgpu::RenderPass<'rpass>,
         paint_jobs: &[egui::epaint::ClippedPrimitive],
@@ -449,7 +449,7 @@ impl RenderPass {
     }
 
     /// Should be called before `execute()`.
-    pub(crate) fn update_texture(
+    pub fn update_texture(
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
@@ -561,7 +561,7 @@ impl RenderPass {
         };
     }
 
-    pub(crate) fn free_texture(&mut self, id: &egui::TextureId) {
+    pub fn free_texture(&mut self, id: &egui::TextureId) {
         self.textures.remove(id);
     }
 
@@ -658,7 +658,7 @@ impl RenderPass {
 
     /// Uploads the uniform, vertex and index data used by the render pass.
     /// Should be called before `execute()`.
-    pub(crate) fn update_buffers(
+    pub fn update_buffers(
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,

--- a/egui-wgpu/src/renderer.rs
+++ b/egui-wgpu/src/renderer.rs
@@ -339,19 +339,13 @@ impl RenderPass {
         // run.
         let mut needs_reset = true;
 
-        for (
-            (
-                egui::ClippedPrimitive {
-                    clip_rect,
-                    primitive,
-                },
-                vertex_buffer,
-            ),
-            index_buffer,
-        ) in paint_jobs
-            .iter()
-            .zip(&self.vertex_buffers)
-            .zip(&self.index_buffers)
+        let mut index_buffers = self.index_buffers.iter();
+        let mut vertex_buffers = self.vertex_buffers.iter();
+
+        for egui::ClippedPrimitive {
+            clip_rect,
+            primitive,
+        } in paint_jobs
         {
             if needs_reset {
                 rpass.set_viewport(
@@ -384,6 +378,9 @@ impl RenderPass {
             match primitive {
                 Primitive::Mesh(mesh) => {
                     if let Some((_texture, bind_group)) = self.textures.get(&mesh.texture_id) {
+                        let index_buffer = index_buffers.next().unwrap();
+                        let vertex_buffer = vertex_buffers.next().unwrap();
+
                         rpass.set_bind_group(1, bind_group, &[]);
                         rpass.set_index_buffer(
                             index_buffer.buffer.slice(..),
@@ -681,12 +678,13 @@ impl RenderPass {
             }]),
         );
 
-        for (i, egui::ClippedPrimitive { primitive, .. }) in paint_jobs.iter().enumerate() {
+        let mut mesh_idx = 0;
+        for egui::ClippedPrimitive { primitive, .. } in paint_jobs.iter() {
             match primitive {
                 Primitive::Mesh(mesh) => {
                     let data: &[u8] = bytemuck::cast_slice(&mesh.indices);
-                    if i < self.index_buffers.len() {
-                        self.update_buffer(device, queue, &BufferType::Index, i, data);
+                    if mesh_idx < self.index_buffers.len() {
+                        self.update_buffer(device, queue, &BufferType::Index, mesh_idx, data);
                     } else {
                         let buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                             label: Some("egui_index_buffer"),
@@ -700,8 +698,8 @@ impl RenderPass {
                     }
 
                     let data: &[u8] = bytemuck::cast_slice(&mesh.vertices);
-                    if i < self.vertex_buffers.len() {
-                        self.update_buffer(device, queue, &BufferType::Vertex, i, data);
+                    if mesh_idx < self.vertex_buffers.len() {
+                        self.update_buffer(device, queue, &BufferType::Vertex, mesh_idx, data);
                     } else {
                         let buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                             label: Some("egui_vertex_buffer"),
@@ -714,6 +712,8 @@ impl RenderPass {
                             size: data.len(),
                         });
                     }
+
+                    mesh_idx += 1;
                 }
                 Primitive::Callback(callback) => {
                     let cbfn = if let Some(c) = callback.callback.downcast_ref::<CallbackFn>() {


### PR DESCRIPTION
Makes a couple of fixes to the WGPU paint callback implementation:

- Makes the egui textures public. Similar to the glow backend, this lets you access textures allocated by EGUI for custom rendering.
- Fixes a subtle but crucial bug: depending on the relative order of egui meshes and paint callbacks being rendered, some of the last rendered items would just be skipped in apparently random ways.