### PR TITLE
Allow cursors to be linked for plots

### DIFF
--- a/crates/egui/src/widgets/plot/items/bar.rs
+++ b/crates/egui/src/widgets/plot/items/bar.rs
@@ -2,7 +2,7 @@ use crate::emath::NumExt;
 use crate::epaint::{Color32, RectShape, Rounding, Shape, Stroke};
 
 use super::{add_rulers_and_text, highlighted_color, Orientation, PlotConfig, RectElement};
-use crate::plot::{BarChart, PlotPoint, ScreenTransform};
+use crate::plot::{BarChart, Cursor, PlotPoint, ScreenTransform};
 
 /// One bar in a [`BarChart`]. Potentially floating, allowing stacked bar charts.
 /// Width can be changed to allow variable-width histograms.
@@ -142,13 +142,14 @@ impl Bar {
         parent: &BarChart,
         plot: &PlotConfig<'_>,
         shapes: &mut Vec<Shape>,
+        cursors: &mut Vec<Cursor>,
     ) {
         let text: Option<String> = parent
             .element_formatter
             .as_ref()
             .map(|fmt| fmt(self, parent));
 
-        add_rulers_and_text(self, plot, text, shapes);
+        add_rulers_and_text(self, plot, text, shapes, cursors);
     }
 }
 

--- a/crates/egui/src/widgets/plot/items/box_elem.rs
+++ b/crates/egui/src/widgets/plot/items/box_elem.rs
@@ -2,7 +2,7 @@ use crate::emath::NumExt;
 use crate::epaint::{Color32, RectShape, Rounding, Shape, Stroke};
 
 use super::{add_rulers_and_text, highlighted_color, Orientation, PlotConfig, RectElement};
-use crate::plot::{BoxPlot, PlotPoint, ScreenTransform};
+use crate::plot::{BoxPlot, Cursor, PlotPoint, ScreenTransform};
 
 /// Contains the values of a single box in a box plot.
 #[derive(Clone, Debug, PartialEq)]
@@ -221,13 +221,14 @@ impl BoxElem {
         parent: &BoxPlot,
         plot: &PlotConfig<'_>,
         shapes: &mut Vec<Shape>,
+        cursors: &mut Vec<Cursor>,
     ) {
         let text: Option<String> = parent
             .element_formatter
             .as_ref()
             .map(|fmt| fmt(self, parent));
 
-        add_rulers_and_text(self, plot, text, shapes);
+        add_rulers_and_text(self, plot, text, shapes, cursors);
     }
 }
 

--- a/crates/egui/src/widgets/plot/items/mod.rs
+++ b/crates/egui/src/widgets/plot/items/mod.rs
@@ -1611,31 +1611,21 @@ fn add_rulers_and_text(
 
     // Rulers for argument (usually vertical)
     if show_argument {
-        let push_argument_ruler = |argument: PlotPoint, cursors: &mut Vec<Cursor>| {
-            let cursor = match orientation {
-                Orientation::Horizontal => Cursor::Horizontal { y: argument.y },
-                Orientation::Vertical => Cursor::Vertical { x: argument.x },
-            };
-            cursors.push(cursor);
-        };
-
         for pos in elem.arguments_with_ruler() {
-            push_argument_ruler(pos, cursors);
+            cursors.push(match orientation {
+                Orientation::Horizontal => Cursor::Horizontal { y: pos.y },
+                Orientation::Vertical => Cursor::Vertical { x: pos.x },
+            });
         }
     }
 
     // Rulers for values (usually horizontal)
     if show_values {
-        let push_value_ruler = |value: PlotPoint, cursors: &mut Vec<Cursor>| {
-            let cursor = match orientation {
-                Orientation::Horizontal => Cursor::Vertical { x: value.x },
-                Orientation::Vertical => Cursor::Horizontal { y: value.y },
-            };
-            cursors.push(cursor);
-        };
-
         for pos in elem.values_with_ruler() {
-            push_value_ruler(pos, cursors);
+            cursors.push(match orientation {
+                Orientation::Horizontal => Cursor::Vertical { x: pos.x },
+                Orientation::Vertical => Cursor::Horizontal { y: pos.y },
+            });
         }
     }
 

--- a/crates/egui/src/widgets/plot/items/mod.rs
+++ b/crates/egui/src/widgets/plot/items/mod.rs
@@ -1613,8 +1613,8 @@ fn add_rulers_and_text(
     if show_argument {
         let push_argument_ruler = |argument: PlotPoint, cursors: &mut Vec<Cursor>| {
             let cursor = match orientation {
-                Orientation::Horizontal => Cursor::horizontal(argument.y),
-                Orientation::Vertical => Cursor::vertical(argument.x),
+                Orientation::Horizontal => Cursor::Horizontal { y: argument.y },
+                Orientation::Vertical => Cursor::Vertical { x: argument.x },
             };
             cursors.push(cursor);
         };
@@ -1628,8 +1628,8 @@ fn add_rulers_and_text(
     if show_values {
         let push_value_ruler = |value: PlotPoint, cursors: &mut Vec<Cursor>| {
             let cursor = match orientation {
-                Orientation::Horizontal => Cursor::vertical(value.x),
-                Orientation::Vertical => Cursor::horizontal(value.y),
+                Orientation::Horizontal => Cursor::Vertical { x: value.x },
+                Orientation::Vertical => Cursor::Horizontal { y: value.y },
             };
             cursors.push(cursor);
         };
@@ -1676,10 +1676,10 @@ pub(super) fn rulers_at_value(
     label_formatter: &LabelFormatter,
 ) {
     if plot.show_x {
-        cursors.push(Cursor::vertical(value.x));
+        cursors.push(Cursor::Vertical { x: value.x });
     }
     if plot.show_y {
-        cursors.push(Cursor::horizontal(value.y));
+        cursors.push(Cursor::Horizontal { y: value.y });
     }
 
     let mut prefix = String::new();

--- a/crates/egui/src/widgets/plot/items/mod.rs
+++ b/crates/egui/src/widgets/plot/items/mod.rs
@@ -7,7 +7,7 @@ use epaint::Mesh;
 
 use crate::*;
 
-use super::{LabelFormatter, PlotBounds, ScreenTransform};
+use super::{Cursor, LabelFormatter, PlotBounds, ScreenTransform};
 use rect_elem::*;
 use values::{ClosestElem, PlotGeometry};
 
@@ -28,7 +28,7 @@ pub(super) struct PlotConfig<'a> {
     pub transform: &'a ScreenTransform,
     pub show_x: bool,
     pub show_y: bool,
-    pub cursors: &'a RefCell<Vec<(Orientation, f64)>>,
+    pub cursors: &'a RefCell<Vec<Cursor>>,
 }
 
 /// Trait shared by things that can be drawn in the plot.
@@ -1670,15 +1670,17 @@ pub(super) fn rulers_at_value(
     let line_color = rulers_color(plot.ui);
     if plot.show_x {
         shapes.push(vertical_line(pointer, plot.transform, line_color));
-        plot.cursors
-            .borrow_mut()
-            .push((Orientation::Vertical, value.x));
+        plot.cursors.borrow_mut().push(Cursor {
+            orientation: Orientation::Vertical,
+            point: value.x,
+        });
     }
     if plot.show_y {
         shapes.push(horizontal_line(pointer, plot.transform, line_color));
-        plot.cursors
-            .borrow_mut()
-            .push((Orientation::Horizontal, value.y));
+        plot.cursors.borrow_mut().push(Cursor {
+            orientation: Orientation::Horizontal,
+            point: value.y,
+        });
     }
 
     let mut prefix = String::new();

--- a/crates/egui/src/widgets/plot/mod.rs
+++ b/crates/egui/src/widgets/plot/mod.rs
@@ -585,7 +585,7 @@ impl Plot {
         self
     }
 
-    /// Add a [`LinkedCursorGroup`] so that this plot will share the bounds with other plots that have this
+    /// Add a [`LinkedCursorsGroup`] so that this plot will share the bounds with other plots that have this
     /// group assigned. A plot cannot belong to more than one group.
     pub fn link_cursor(mut self, group: LinkedCursorsGroup) -> Self {
         self.linked_cursors = Some(group);

--- a/crates/egui/src/widgets/plot/mod.rs
+++ b/crates/egui/src/widgets/plot/mod.rs
@@ -120,26 +120,11 @@ impl PlotMemory {
 
 // ----------------------------------------------------------------------------
 
+/// Indicates a vertical or horizontal cursor line in plot coordinates.
 #[derive(Copy, Clone, PartialEq)]
-struct Cursor {
-    orientation: Orientation,
-    point: f64,
-}
-
-impl Cursor {
-    fn vertical(point: f64) -> Self {
-        Self {
-            orientation: Orientation::Vertical,
-            point,
-        }
-    }
-
-    fn horizontal(point: f64) -> Self {
-        Self {
-            orientation: Orientation::Horizontal,
-            point,
-        }
-    }
+enum Cursor {
+    Horizontal { y: f64 },
+    Vertical { x: f64 },
 }
 
 /// Contains the cursors drawn for a specific frame of a plot.
@@ -1280,21 +1265,21 @@ impl PreparedPlot {
         let line_color = rulers_color(ui);
 
         let mut draw_cursor = |cursors: &Vec<Cursor>, always| {
-            for cursor in cursors {
-                match cursor.orientation {
-                    Orientation::Horizontal => {
+            for &cursor in cursors {
+                match cursor {
+                    Cursor::Horizontal { y } => {
                         if self.draw_cursor_y || always {
                             shapes.push(horizontal_line(
-                                transform.position_from_point(&PlotPoint::new(0.0, cursor.point)),
+                                transform.position_from_point(&PlotPoint::new(0.0, y)),
                                 &self.transform,
                                 line_color,
                             ));
                         }
                     }
-                    Orientation::Vertical => {
+                    Cursor::Vertical { x } => {
                         if self.draw_cursor_x || always {
                             shapes.push(vertical_line(
-                                transform.position_from_point(&PlotPoint::new(cursor.point, 0.0)),
+                                transform.position_from_point(&PlotPoint::new(x, 0.0)),
                                 &self.transform,
                                 line_color,
                             ));

--- a/crates/egui_demo_lib/src/demo/plot_demo.rs
+++ b/crates/egui_demo_lib/src/demo/plot_demo.rs
@@ -456,6 +456,7 @@ impl CustomAxisDemo {
 
 #[derive(PartialEq)]
 struct LinkedAxisDemo {
+    link_cursor: bool,
     link_x: bool,
     link_y: bool,
     group: plot::LinkedAxisGroup,
@@ -466,6 +467,7 @@ impl Default for LinkedAxisDemo {
         let link_x = true;
         let link_y = false;
         Self {
+            link_cursor: true,
             link_x,
             link_y,
             group: plot::LinkedAxisGroup::new(link_x, link_y),
@@ -508,10 +510,12 @@ impl LinkedAxisDemo {
 
     fn ui(&mut self, ui: &mut Ui) -> Response {
         ui.horizontal(|ui| {
+            ui.checkbox(&mut &mut self.link_cursor, "Link cursor");
             ui.label("Linked axes:");
             ui.checkbox(&mut self.link_x, "X");
             ui.checkbox(&mut self.link_y, "Y");
         });
+        self.group.set_link_cursor(self.link_cursor);
         self.group.set_link_x(self.link_x);
         self.group.set_link_y(self.link_y);
         ui.horizontal(|ui| {

--- a/crates/egui_demo_lib/src/demo/plot_demo.rs
+++ b/crates/egui_demo_lib/src/demo/plot_demo.rs
@@ -456,21 +456,27 @@ impl CustomAxisDemo {
 
 #[derive(PartialEq)]
 struct LinkedAxisDemo {
-    link_cursor: bool,
     link_x: bool,
     link_y: bool,
     group: plot::LinkedAxisGroup,
+    cursor_group: plot::LinkedCursorsGroup,
+    link_cursor_x: bool,
+    link_cursor_y: bool,
 }
 
 impl Default for LinkedAxisDemo {
     fn default() -> Self {
         let link_x = true;
         let link_y = false;
+        let link_cursor_x = true;
+        let link_cursor_y = false;
         Self {
-            link_cursor: true,
             link_x,
             link_y,
             group: plot::LinkedAxisGroup::new(link_x, link_y),
+            cursor_group: plot::LinkedCursorsGroup::new(link_cursor_x, link_cursor_y),
+            link_cursor_x,
+            link_cursor_y,
         }
     }
 }
@@ -510,26 +516,33 @@ impl LinkedAxisDemo {
 
     fn ui(&mut self, ui: &mut Ui) -> Response {
         ui.horizontal(|ui| {
-            ui.checkbox(&mut &mut self.link_cursor, "Link cursor");
             ui.label("Linked axes:");
             ui.checkbox(&mut self.link_x, "X");
             ui.checkbox(&mut self.link_y, "Y");
         });
-        self.group.set_link_cursor(self.link_cursor);
         self.group.set_link_x(self.link_x);
         self.group.set_link_y(self.link_y);
+        ui.horizontal(|ui| {
+            ui.label("Linked cursors:");
+            ui.checkbox(&mut self.link_cursor_x, "X");
+            ui.checkbox(&mut self.link_cursor_y, "Y");
+        });
+        self.cursor_group.set_link_x(self.link_cursor_x);
+        self.cursor_group.set_link_y(self.link_cursor_y);
         ui.horizontal(|ui| {
             Plot::new("linked_axis_1")
                 .data_aspect(1.0)
                 .width(250.0)
                 .height(250.0)
                 .link_axis(self.group.clone())
+                .link_cursor(self.cursor_group.clone())
                 .show(ui, LinkedAxisDemo::configure_plot);
             Plot::new("linked_axis_2")
                 .data_aspect(2.0)
                 .width(150.0)
                 .height(250.0)
                 .link_axis(self.group.clone())
+                .link_cursor(self.cursor_group.clone())
                 .show(ui, LinkedAxisDemo::configure_plot);
         });
         Plot::new("linked_axis_3")
@@ -537,6 +550,7 @@ impl LinkedAxisDemo {
             .width(250.0)
             .height(150.0)
             .link_axis(self.group.clone())
+            .link_cursor(self.cursor_group.clone())
             .show(ui, LinkedAxisDemo::configure_plot)
             .response
     }


### PR DESCRIPTION
This adds `set_link_cursor` to `LinkedAxisGroup` which allow the cursor to show up in linked plots.

This only handles the default `PlotItem` case. I think changing `PlotItem::on_hover` to produce a list of cursors would make sense.

The `PartialEq` implementation for `LinkedAxisGroup` also seems a bit questionable given it carries identity.