### PR TITLE
Refactor common code in `egui-wgpu` vertex shader entry points

### DIFF
--- a/egui-wgpu/src/egui.wgsl
+++ b/egui-wgpu/src/egui.wgsl
@@ -19,6 +19,25 @@ fn linear_from_srgb(srgb: vec3<f32>) -> vec3<f32> {
     return select(higher, lower, cutoff);
 }
 
+// [u8; 4] SRGB as u32 -> [r, g, b, a]
+fn unpack_color(color: u32) -> vec4<f32> {
+    return vec4<f32>(
+        f32(color & 255u),
+        f32((color >> 8u) & 255u),
+        f32((color >> 16u) & 255u),
+        f32((color >> 24u) & 255u),
+    );
+}
+
+fn position_from_screen(screen_pos: vec2<f32>) -> vec4<f32> {
+    return vec4<f32>(
+        2.0 * screen_pos.x / r_locals.screen_size.x - 1.0,
+        1.0 - 2.0 * screen_pos.y / r_locals.screen_size.y,
+        0.0,
+        1.0,
+    );
+}
+
 [[stage(vertex)]]
 fn vs_main(
     [[location(0)]] a_pos: vec2<f32>,
@@ -27,23 +46,9 @@ fn vs_main(
 ) -> VertexOutput {
     var out: VertexOutput;
     out.tex_coord = a_tex_coord;
-
-    // [u8; 4] SRGB as u32 -> [r, g, b, a]
-    let color = vec4<f32>(
-        f32(a_color & 255u),
-        f32((a_color >> 8u) & 255u),
-        f32((a_color >> 16u) & 255u),
-        f32((a_color >> 24u) & 255u),
-    );
+    let color = unpack_color(a_color);
     out.color = vec4<f32>(linear_from_srgb(color.rgb), color.a / 255.0);
-
-    out.position = vec4<f32>(
-        2.0 * a_pos.x / r_locals.screen_size.x - 1.0,
-        1.0 - 2.0 * a_pos.y / r_locals.screen_size.y,
-        0.0,
-        1.0,
-    );
-
+    out.position = position_from_screen(a_pos);
     return out;
 }
 
@@ -55,23 +60,9 @@ fn vs_conv_main(
 ) -> VertexOutput {
     var out: VertexOutput;
     out.tex_coord = a_tex_coord;
-
-    // [u8; 4] SRGB as u32 -> [r, g, b, a]
-    let color = vec4<f32>(
-        f32(a_color & 255u),
-        f32((a_color >> 8u) & 255u),
-        f32((a_color >> 16u) & 255u),
-        f32((a_color >> 24u) & 255u),
-    );
+    let color = unpack_color(a_color);
     out.color = vec4<f32>(color.rgba / 255.0);
-
-    out.position = vec4<f32>(
-        2.0 * a_pos.x / r_locals.screen_size.x - 1.0,
-        1.0 - 2.0 * a_pos.y / r_locals.screen_size.y,
-        0.0,
-        1.0,
-    );
-
+    out.position = position_from_screen(a_pos);
     return out;
 }
 


### PR DESCRIPTION
Creates `unpack_color` and `position_from_screen` functions to share common logic between the alternative vertex shader entry points. Behaviour remains the same.

I noticed these when checking the difference between `vs_main` and `vs_conv_main` in order to solve some breakage in colour output after updating from 0.15 to 0.18 (I'll open a separate issue/PR about this).