### PR TITLE
Add `body_unindented` to `HeaderResponse`

### DIFF
--- a/egui/src/containers/collapsing_header.rs
+++ b/egui/src/containers/collapsing_header.rs
@@ -247,6 +247,23 @@ impl<'ui, HeaderRet> HeaderResponse<'ui, HeaderRet> {
             body_response,
         )
     }
+
+    /// Returns the response of the collapsing button, the custom header, and the custom body, without indentation.
+    pub fn body_unindented<BodyRet>(
+        mut self,
+        add_body: impl FnOnce(&mut Ui) -> BodyRet,
+    ) -> (
+        Response,
+        InnerResponse<HeaderRet>,
+        Option<InnerResponse<BodyRet>>,
+    ) {
+        let body_response = self.state.show_body_unindented(self.ui, add_body);
+        (
+            self.toggle_button_response,
+            self.header_response,
+            body_response,
+        )
+    }
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
With the current implementation of `HeaderResponse`, it's impossible to use `show_body_unindented` since the `HeaderResponse` fields are private.

This change adds a `body_unindented` function to mirror the `body` function in `HeaderResponse`, but without the indentation.