### PR TITLE
Make Windows specific code Windows specific

### DIFF
--- a/egui-winit/src/lib.rs
+++ b/egui-winit/src/lib.rs
@@ -499,6 +499,7 @@ impl State {
 
     fn set_cursor_icon(&mut self, window: &winit::window::Window, cursor_icon: egui::CursorIcon) {
         // prevent flickering near frame boundary when Windows OS tries to control cursor icon for window resizing
+        #[cfg(windows)]
         if self.current_cursor_icon == cursor_icon {
             return;
         }


### PR DESCRIPTION
**Issue**
#1746

There is a bit of code in `set_cursor_icon` that is intended to prevent the cursor from flashing on Windows but it causes the cursor icon to get stuck on Linux.

**Changes**
Make the Windows specific code actually Windows specific.