### PR TITLE
Draft: Premultiply font textures for linear blending

### DIFF
--- a/egui-wgpu/src/renderer.rs
+++ b/egui-wgpu/src/renderer.rs
@@ -485,7 +485,7 @@ impl RenderPass {
                     image.pixels.len(),
                     "Mismatch between texture size and texel count"
                 );
-                Cow::Owned(image.srgba_pixels(1.0).collect::<Vec<_>>())
+                Cow::Owned(image.linear_premultiplied_srgb_pixels().collect::<Vec<_>>())
             }
         };
         let data_bytes: &[u8] = bytemuck::cast_slice(data_color32.as_slice());

--- a/egui_glium/src/painter.rs
+++ b/egui_glium/src/painter.rs
@@ -235,13 +235,10 @@ impl Painter {
                 );
                 image.pixels.iter().map(|color| color.to_tuple()).collect()
             }
-            egui::ImageData::Font(image) => {
-                let gamma = 1.0;
-                image
-                    .srgba_pixels(gamma)
-                    .map(|color| color.to_tuple())
-                    .collect()
-            }
+            egui::ImageData::Font(image) => image
+                .linear_premultiplied_srgb_pixels()
+                .map(|color| color.to_tuple())
+                .collect(),
         };
         let glium_image = glium::texture::RawImage2d {
             data: std::borrow::Cow::Owned(pixels),

--- a/egui_glow/src/painter.rs
+++ b/egui_glow/src/painter.rs
@@ -505,13 +505,14 @@ impl Painter {
                     "Mismatch between texture size and texel count"
                 );
 
+                // TODO (felix): confirm what this conditional is about
                 let gamma = if self.is_embedded && self.post_process.is_none() {
                     1.0 / 2.2
                 } else {
                     1.0
                 };
                 let data: Vec<u8> = image
-                    .srgba_pixels(gamma)
+                    .linear_premultiplied_srgb_pixels()
                     .flat_map(|a| a.to_array())
                     .collect();
 


### PR DESCRIPTION
It is my understanding that egui blends colours in linear space (which is arguably more correct than the SRGB blending of yore). However font textures in egui currently use alpha premultiplied pixels values in srgb space. This leads to darkened text edges when using linear blending, this is particularly noticeable with white text on a white background (see below).

![image](https://user-images.githubusercontent.com/5576638/175312103-6cc74d23-5543-4a24-b08e-82c007b14cf1.png)

This PR changes the font pixel premultiplication function to get (afaict) correctly premultiplied values for linear blending.

![image](https://user-images.githubusercontent.com/5576638/175314239-23e6e9ed-820d-440f-b528-c57fd9d75578.png)
 
This problem and solution is well described in this article: https://hacksoflife.blogspot.com/2022/06/srgb-pre-multiplied-alpha-and.html

Notes: The Ubuntu thin font on white backgrounds can appear thinner due to this change (because it removes the grey border around text). I think the result is still legible and looks better but some other users may disagree.  A future release may wish to use a slightly thicker default font if this comes up in feedback.

Related: 
https://github.com/emilk/egui/issues/1410
https://github.com/emilk/egui/pull/1412
https://github.com/emilk/egui/pull/1411

