### PR TITLE
Don't call scroll if TextEdit is fully in view

### DIFF
--- a/egui/src/widgets/text_edit/builder.rs
+++ b/egui/src/widgets/text_edit/builder.rs
@@ -590,8 +590,8 @@ impl<'t> TextEdit<'t> {
                             &cursor_range.primary,
                         );
 
-                        if (response.changed || selection_changed)
-                            && !ui.clip_rect().contains_rect(rect)
+                        let is_fully_visible = ui.clip_rect().contains_rect(rect); // TODO: remove this HACK workaround for https://github.com/emilk/egui/issues/1531
+                        if (response.changed || selection_changed) && !is_fully_visible
                         {
                             ui.scroll_to_rect(cursor_pos, None); // keep cursor in view
                         }

--- a/egui/src/widgets/text_edit/builder.rs
+++ b/egui/src/widgets/text_edit/builder.rs
@@ -590,7 +590,9 @@ impl<'t> TextEdit<'t> {
                             &cursor_range.primary,
                         );
 
-                        if response.changed || selection_changed {
+                        if (response.changed || selection_changed)
+                            && !ui.clip_rect().contains_rect(rect)
+                        {
                             ui.scroll_to_rect(cursor_pos, None); // keep cursor in view
                         }
 

--- a/egui/src/widgets/text_edit/builder.rs
+++ b/egui/src/widgets/text_edit/builder.rs
@@ -591,8 +591,7 @@ impl<'t> TextEdit<'t> {
                         );
 
                         let is_fully_visible = ui.clip_rect().contains_rect(rect); // TODO: remove this HACK workaround for https://github.com/emilk/egui/issues/1531
-                        if (response.changed || selection_changed) && !is_fully_visible
-                        {
+                        if (response.changed || selection_changed) && !is_fully_visible {
                             ui.scroll_to_rect(cursor_pos, None); // keep cursor in view
                         }
 


### PR DESCRIPTION
Very narrow fix for #1531

I believe the logic implemented to scroll a `TextEdit` into view is just incorrect (see comments in issue) but this change will at least prevent an adjacent scroll area from scrolling while entering text.
