### PR TITLE
Don't force the webgl backend in egui-wgpu

### DIFF
--- a/egui-wgpu/Cargo.toml
+++ b/egui-wgpu/Cargo.toml
@@ -40,7 +40,7 @@ egui = { version = "0.18.1", path = "../egui", default-features = false, feature
 bytemuck = "1.7"
 tracing = "0.1"
 type-map = "0.5.0"
-wgpu = { version = "0.12", features = ["webgl"] }
+wgpu = "0.12"
 
 #! ### Optional dependencies
 ## Enable this when generating docs.


### PR DESCRIPTION
See https://github.com/emilk/egui/issues/1755#issuecomment-1159812326. At the moment we force the backend of `wgpu` when compiling for `wasm32-unknown-unknown` to be webgl, but we don't need to do this.

This PR should probably have some testing to make sure that egui works with a WebGPU backend. If no tests for `wasm32-unknown-unknown` exist, I'm not sure I have the time to set that them at this time.
