### PR TITLE
(eframe) add Frame.set_visible

### DIFF
--- a/eframe/src/epi.rs
+++ b/eframe/src/epi.rs
@@ -544,7 +544,7 @@ impl Frame {
     }
 
     /// Set the visibility of the window.
-    pub fn set_visibility(&mut self, visible: bool) {
+    pub fn set_visible(&mut self, visible: bool) {
         self.output.visible = Some(visible);
     }
 

--- a/eframe/src/epi.rs
+++ b/eframe/src/epi.rs
@@ -543,6 +543,11 @@ impl Frame {
         self.output.drag_window = true;
     }
 
+    /// Set the visibility of the window.
+    pub fn set_visibility(&mut self, visible: bool) {
+        self.output.visible = Some(visible);
+    }
+
     /// for integrations only: call once per frame
     #[doc(hidden)]
     pub fn take_app_output(&mut self) -> backend::AppOutput {
@@ -718,5 +723,8 @@ pub mod backend {
 
         /// Set to some position to move the outer window (e.g. glium window) to this position
         pub window_pos: Option<egui::Pos2>,
+
+        /// Set to some bool to change window visibility.
+        pub visible: Option<bool>,
     }
 }

--- a/eframe/src/native/epi_integration.rs
+++ b/eframe/src/native/epi_integration.rs
@@ -120,6 +120,7 @@ pub fn handle_app_output(
         decorated,
         drag_window,
         window_pos,
+        visible,
     } = app_output;
 
     if let Some(decorated) = decorated {
@@ -149,6 +150,10 @@ pub fn handle_app_output(
 
     if drag_window {
         let _ = window.drag_window();
+    }
+
+    if let Some(visible) = visible {
+        window.set_visible(visible);
     }
 }
 

--- a/eframe/src/web/backend.rs
+++ b/eframe/src/web/backend.rs
@@ -299,6 +299,7 @@ impl AppRunner {
                 decorated: _,    // Can't toggle decorations
                 drag_window: _,  // Can't be dragged
                 window_pos: _,   // Can't set position of a web page
+                visible: _,      // Can't hide a web page
             } = app_output;
         }
 


### PR DESCRIPTION
Closes <https://github.com/emilk/egui/issues/1800>.

You can use `frame.set_visibility(false);` to hide the window - good for background applications that open from a hotkey.