### PR TITLE
Add support for ctrl+h as backspace

### DIFF
--- a/egui/src/widgets/text_edit/builder.rs
+++ b/egui/src/widgets/text_edit/builder.rs
@@ -1090,6 +1090,11 @@ fn on_key_press(
             None
         }
 
+        Key::H if modifiers.ctrl => {
+            let ccursor = delete_previous_char(text, cursor_range.primary.ccursor);
+            Some(CCursorRange::one(ccursor))
+        }
+
         Key::K if modifiers.ctrl => {
             let ccursor = delete_paragraph_after_cursor(text, galley, cursor_range);
             Some(CCursorRange::one(ccursor))


### PR DESCRIPTION
Ctrl+h is commonly supported when editing text input. Would be good to have for the egui textedits as well.