### PR TITLE
Remove dependency on AsRef trait for TextBuffer

### DIFF
--- a/egui/src/widgets/text_edit/builder.rs
+++ b/egui/src/widgets/text_edit/builder.rs
@@ -378,7 +378,7 @@ impl<'t> TextEdit<'t> {
             // .unwrap_or_else(|| ui.style().interact(&response).text_color()); // too bright
             .unwrap_or_else(|| ui.visuals().widgets.inactive.text_color());
 
-        let prev_text = text.as_ref().to_owned();
+        let prev_text = text.as_str().to_owned();
 
         let font_id = font_selection.resolve(ui.style());
         let row_height = ui.fonts().row_height(&font_id);
@@ -403,7 +403,7 @@ impl<'t> TextEdit<'t> {
 
         let layouter = layouter.unwrap_or(&mut default_layouter);
 
-        let mut galley = layouter(ui, text.as_ref(), wrap_width);
+        let mut galley = layouter(ui, text.as_str(), wrap_width);
 
         let desired_width = if multiline {
             galley.size().x.max(wrap_width) // always show everything in multiline
@@ -473,7 +473,7 @@ impl<'t> TextEdit<'t> {
                 if response.double_clicked() {
                     // Select word:
                     let center = cursor_at_pointer;
-                    let ccursor_range = select_word_at(text.as_ref(), center.ccursor);
+                    let ccursor_range = select_word_at(text.as_str(), center.ccursor);
                     state.set_cursor_range(Some(CursorRange {
                         primary: galley.from_ccursor(ccursor_range.primary),
                         secondary: galley.from_ccursor(ccursor_range.secondary),
@@ -481,7 +481,7 @@ impl<'t> TextEdit<'t> {
                 } else if response.triple_clicked() {
                     // Select line:
                     let center = cursor_at_pointer;
-                    let ccursor_range = select_line_at(text.as_ref(), center.ccursor);
+                    let ccursor_range = select_line_at(text.as_str(), center.ccursor);
                     state.set_cursor_range(Some(CursorRange {
                         primary: galley.from_ccursor(ccursor_range.primary),
                         secondary: galley.from_ccursor(ccursor_range.secondary),
@@ -584,7 +584,7 @@ impl<'t> TextEdit<'t> {
         if ui.is_rect_visible(rect) {
             painter.galley(text_draw_pos, galley.clone());
 
-            if text.as_ref().is_empty() && !hint_text.is_empty() {
+            if text.as_str().is_empty() && !hint_text.is_empty() {
                 let hint_text_color = ui.visuals().weak_text_color();
                 let galley = if multiline {
                     hint_text.into_galley(ui, Some(true), desired_size.x, font_id)
@@ -703,7 +703,7 @@ fn events(
     // so that the undoer creates automatic saves even when there are no events for a while.
     state.undoer.lock().feed_state(
         ui.input().time,
-        &(cursor_range.as_ccursor_range(), text.as_ref().to_owned()),
+        &(cursor_range.as_ccursor_range(), text.as_str().to_owned()),
     );
 
     let copy_if_not_password = |ui: &Ui, text: String| {
@@ -719,7 +719,7 @@ fn events(
         let did_mutate_text = match event {
             Event::Copy => {
                 if cursor_range.is_empty() {
-                    copy_if_not_password(ui, text.as_ref().to_owned());
+                    copy_if_not_password(ui, text.as_str().to_owned());
                 } else {
                     copy_if_not_password(ui, selected_str(text, &cursor_range).to_owned());
                 }
@@ -795,7 +795,7 @@ fn events(
                 if let Some((undo_ccursor_range, undo_txt)) = state
                     .undoer
                     .lock()
-                    .undo(&(cursor_range.as_ccursor_range(), text.as_ref().to_owned()))
+                    .undo(&(cursor_range.as_ccursor_range(), text.as_str().to_owned()))
                 {
                     text.replace(undo_txt);
                     Some(*undo_ccursor_range)
@@ -849,7 +849,7 @@ fn events(
             any_change = true;
 
             // Layout again to avoid frame delay, and to keep `text` and `galley` in sync.
-            *galley = layouter(ui, text.as_ref(), wrap_width);
+            *galley = layouter(ui, text.as_str(), wrap_width);
 
             // Set cursor_range using new galley:
             cursor_range = CursorRange {
@@ -863,7 +863,7 @@ fn events(
 
     state.undoer.lock().feed_state(
         ui.input().time,
-        &(cursor_range.as_ccursor_range(), text.as_ref().to_owned()),
+        &(cursor_range.as_ccursor_range(), text.as_str().to_owned()),
     );
 
     (any_change, cursor_range)
@@ -993,12 +993,12 @@ fn delete_next_char(text: &mut dyn TextBuffer, ccursor: CCursor) -> CCursor {
 }
 
 fn delete_previous_word(text: &mut dyn TextBuffer, max_ccursor: CCursor) -> CCursor {
-    let min_ccursor = ccursor_previous_word(text.as_ref(), max_ccursor);
+    let min_ccursor = ccursor_previous_word(text.as_str(), max_ccursor);
     delete_selected_ccursor_range(text, [min_ccursor, max_ccursor])
 }
 
 fn delete_next_word(text: &mut dyn TextBuffer, min_ccursor: CCursor) -> CCursor {
-    let max_ccursor = ccursor_next_word(text.as_ref(), min_ccursor);
+    let max_ccursor = ccursor_next_word(text.as_str(), min_ccursor);
     delete_selected_ccursor_range(text, [min_ccursor, max_ccursor])
 }
 
@@ -1380,11 +1380,11 @@ fn find_line_start(text: &str, current_index: CCursor) -> CCursor {
 }
 
 fn decrease_identation(ccursor: &mut CCursor, text: &mut dyn TextBuffer) {
-    let line_start = find_line_start(text.as_ref(), *ccursor);
+    let line_start = find_line_start(text.as_str(), *ccursor);
 
-    let remove_len = if text.as_ref()[line_start.index..].starts_with('\t') {
+    let remove_len = if text.as_str()[line_start.index..].starts_with('\t') {
         Some(1)
-    } else if text.as_ref()[line_start.index..]
+    } else if text.as_str()[line_start.index..]
         .chars()
         .take(text::TAB_SIZE)
         .all(|c| c == ' ')

--- a/egui/src/widgets/text_edit/text_buffer.rs
+++ b/egui/src/widgets/text_edit/text_buffer.rs
@@ -4,17 +4,12 @@ use std::ops::Range;
 /// an underlying buffer.
 ///
 /// Most likely you will use a [`String`] which implements [`TextBuffer`].
-pub trait TextBuffer: AsRef<str> {
+pub trait TextBuffer {
     /// Can this text be edited?
     fn is_mutable(&self) -> bool;
 
     /// Returns this buffer as a `str`.
-    ///
-    /// This is an utility method, as it simply relies on the `AsRef<str>`
-    /// implementation.
-    fn as_str(&self) -> &str {
-        self.as_ref()
-    }
+    fn as_str(&self) -> &str;
 
     /// Reads the given character range.
     fn char_range(&self, char_range: Range<usize>) -> &str {
@@ -45,7 +40,7 @@ pub trait TextBuffer: AsRef<str> {
 
     /// Clears all characters in this buffer
     fn clear(&mut self) {
-        self.delete_char_range(0..self.as_ref().len());
+        self.delete_char_range(0..self.as_str().len());
     }
 
     /// Replaces all contents of this string with `text`
@@ -56,7 +51,7 @@ pub trait TextBuffer: AsRef<str> {
 
     /// Clears all characters in this buffer and returns a string of the contents.
     fn take(&mut self) -> String {
-        let s = self.as_ref().to_owned();
+        let s = self.as_str().to_owned();
         self.clear();
         s
     }
@@ -65,6 +60,10 @@ pub trait TextBuffer: AsRef<str> {
 impl TextBuffer for String {
     fn is_mutable(&self) -> bool {
         true
+    }
+
+    fn as_str(&self) -> &str {
+        self.as_ref()
     }
 
     fn insert_text(&mut self, text: &str, char_index: usize) -> usize {
@@ -105,6 +104,10 @@ impl TextBuffer for String {
 impl<'a> TextBuffer for &'a str {
     fn is_mutable(&self) -> bool {
         false
+    }
+
+    fn as_str(&self) -> &str {
+        self
     }
 
     fn insert_text(&mut self, _text: &str, _ch_idx: usize) -> usize {


### PR DESCRIPTION
**Summary**
Remove the dependency on the `AsRef<str>` trait for `TextBuffer`.

**Rationale**
That dependency is not needed as it is trivial to implement `fn as_str(&self) -> &str` for both `str` and `String` which are the default implementations provided by `egui` and very likely the one that most user will ever need. Then `TextEdit` can just use `as_str()` in places where it was using `as_ref()` before, which in my opinion makes it more consistent with the trait definition.

In one of the project I am working on we did implement a custom `TextBuffer` for our `struct Var`. The forced dependency on `AsRef<str>` caused some pains because:
* our `struct Var` is a kind of container that can have all kind of underlying data type (not only string).
* in other places, it forced us to use the turbofish where it was not needed before:
```rust
// before implementing TextBuffer for Var
let headers: &mut Var = self.some_function();
let mut headers: Table = headers.as_ref().try_into()?; // here it uses the usual as_ref()

// after
let headers: &mut Var = self.some_function();
let mut headers: Table = <&mut Var as AsRef<Var>>::.as_ref(&headers).try_into()?; // here as_ref() was ambiguous
```
We anticipate that other occurrences will appear over time and we would like to avoid them.

**Checklist**
- [x] It is a trivial change.
- [x] I have run `./sh/check.sh`.
  - *There are errors but unrelated to this change.*

