### PR TITLE
Add a stick to bottom feature to the `TableBuilder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: [`epaint`](epaint/CHANGELOG.md), [`eframe`](eframe/CHANGELOG.md), [`egui-w
 * Added `InputState::stable_dt`: a more stable estimate for the delta-time in reactive mode ([#1625](https://github.com/emilk/egui/pull/1625)).
 * You can now specify a texture filter for your textures ([#1636](https://github.com/emilk/egui/pull/1636)).
 * Added support for using `PaintCallback` shapes with the WGPU backend ([#1684](https://github.com/emilk/egui/pull/1684))
+* Added `TableBuilder::stick_to_bottom`: a method to force a table to follow the content as it comes.
 
 ### Changed
 * `PaintCallback` shapes now require the whole callback to be put in an `Arc<dyn Any>` with the value being a backend-specific callback type. ([#1684](https://github.com/emilk/egui/pull/1684))

--- a/egui_extras/src/table.rs
+++ b/egui_extras/src/table.rs
@@ -56,6 +56,7 @@ pub struct TableBuilder<'a> {
     striped: bool,
     resizable: bool,
     clip: bool,
+    stick_to_bottom: bool,
     cell_layout: egui::Layout,
 }
 
@@ -69,6 +70,7 @@ impl<'a> TableBuilder<'a> {
             striped: false,
             resizable: false,
             clip: true,
+            stick_to_bottom: false,
             cell_layout,
         }
     }
@@ -102,6 +104,13 @@ impl<'a> TableBuilder<'a> {
     /// Should we clip the contents of each cell? Default: `true`.
     pub fn clip(mut self, clip: bool) -> Self {
         self.clip = clip;
+        self
+    }
+
+    /// The scroll handle will stick to the bottom position even while
+    /// the content size changes dynamically.
+    pub fn stick_to_bottom(mut self) -> Self {
+        self.stick_to_bottom = true;
         self
     }
 
@@ -145,6 +154,7 @@ impl<'a> TableBuilder<'a> {
             striped,
             resizable,
             clip,
+            stick_to_bottom,
             cell_layout,
         } = self;
 
@@ -177,6 +187,7 @@ impl<'a> TableBuilder<'a> {
             scroll,
             striped,
             clip,
+            stick_to_bottom,
             cell_layout,
         }
     }
@@ -195,6 +206,7 @@ impl<'a> TableBuilder<'a> {
             striped,
             resizable,
             clip,
+            stick_to_bottom,
             cell_layout,
         } = self;
 
@@ -215,6 +227,7 @@ impl<'a> TableBuilder<'a> {
             scroll,
             striped,
             clip,
+            stick_to_bottom,
             cell_layout,
         }
         .body(body);
@@ -253,6 +266,7 @@ pub struct Table<'a> {
     scroll: bool,
     striped: bool,
     clip: bool,
+    stick_to_bottom: bool,
     cell_layout: egui::Layout,
 }
 
@@ -272,6 +286,7 @@ impl<'a> Table<'a> {
             scroll,
             striped,
             clip,
+            stick_to_bottom,
             cell_layout,
         } = self;
 
@@ -279,20 +294,24 @@ impl<'a> Table<'a> {
 
         let mut new_widths = widths.clone();
 
-        egui::ScrollArea::new([false, scroll])
-            .auto_shrink([true; 2])
-            .show(ui, move |ui| {
-                let layout = StripLayout::new(ui, CellDirection::Horizontal, clip, cell_layout);
+        let scroll_area = if stick_to_bottom {
+            egui::ScrollArea::new([false, scroll]).stick_to_bottom()
+        } else {
+            egui::ScrollArea::new([false, scroll])
+        };
 
-                body(TableBody {
-                    layout,
-                    widths,
-                    striped,
-                    row_nr: 0,
-                    start_y: avail_rect.top(),
-                    end_y: avail_rect.bottom(),
-                });
+        scroll_area.auto_shrink([true; 2]).show(ui, move |ui| {
+            let layout = StripLayout::new(ui, CellDirection::Horizontal, clip, cell_layout);
+
+            body(TableBody {
+                layout,
+                widths,
+                striped,
+                row_nr: 0,
+                start_y: avail_rect.top(),
+                end_y: avail_rect.bottom(),
             });
+        });
 
         let bottom = ui.min_rect().bottom();
 


### PR DESCRIPTION
This PR introduces a new `TableBuilder::stick_to_bottom` method that makes the table follow the content as it comes.
Do you think that I need to open an issue for this small addition? If so, I will.

I ran the `./sh.check.sh` script but it returned a warning (converted into an error), not sure this PR touches anything related to that:

```
error: associated function is never used: `post_rendering`
   --> eframe/src/native/epi_integration.rs:290:12
    |
290 |     pub fn post_rendering(&mut self, app: &mut dyn epi::App, window: &winit::window::Window) {
    |            ^^^^^^^^^^^^^^
    |
    = note: `-D dead-code` implied by `-D warnings`
```