### PR TITLE
Implement `From` and `FromIterator` for `widgets::plot::Value(s)`

### DIFF
--- a/egui/src/widgets/plot/items/values.rs
+++ b/egui/src/widgets/plot/items/values.rs
@@ -36,6 +36,26 @@ impl Value {
     }
 }
 
+impl<T: Into<f64>> From<[T; 2]> for Value {
+    #[inline(always)]
+    fn from(xy: [T; 2]) -> Self {
+        let [x, y] = xy;
+        Self::new(x, y)
+    }
+}
+
+impl<T, U> From<(T, U)> for Value
+where
+    T: Into<f64>,
+    U: Into<f64>,
+{
+    #[inline(always)]
+    fn from(xy: (T, U)) -> Self {
+        let (x, y) = xy;
+        Self::new(x, y)
+    }
+}
+
 // ----------------------------------------------------------------------------
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -154,8 +174,8 @@ impl Values {
         }
     }
 
-    pub fn from_values_iter(iter: impl Iterator<Item = Value>) -> Self {
-        Self::from_values(iter.collect())
+    pub fn from_values_iter(iter: impl IntoIterator<Item = Value>) -> Self {
+        Self::from_values(iter.into_iter().collect())
     }
 
     /// Draw a line based on a function `y=f(x)`, a range (which can be infinite) for x and the number of points.
@@ -277,6 +297,12 @@ impl Values {
             }
             bounds
         }
+    }
+}
+
+impl<V: Into<Value>> FromIterator<V> for Values {
+    fn from_iter<T: IntoIterator<Item = V>>(iter: T) -> Self {
+        Self::from_values_iter(iter.into_iter().map(Into::into))
     }
 }
 


### PR DESCRIPTION
+ Implement `From` for `widgets::plot::Value`, for `[f64; 2]`, `(f64, f64)` and their valid type.
+ Implement `FromIterator` for `widgets::plot::Values`, for any iterator containing `Value` type.
+ Use `IntoIterator` to support the types that can deconstruct themselves.

This PR makes the following code work:

```rust
use egui::widgets::plot::Values;

let v: Vec<MyType>;
let values = v.iter()
    // do the iterator things
    .map(|my| [my.x(), my.y()])
    .collect::<Values>();
```

Before:

```rust
use egui::widgets::plot::{Value, Values};

let v: Vec<MyType>;
let iter = v.iter()
    // do the iterator things
    .map(|my| Value::new(my.x(), my.y()));
let values = Values::from_values_iter(iter);
```