### PR TITLE
egui/memory: expose Area state to users

### DIFF
--- a/egui/src/containers/area.rs
+++ b/egui/src/containers/area.rs
@@ -10,7 +10,7 @@ use crate::*;
 // TODO(emilk): this is not currently stored in `memory().data`, but maybe it should be?
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub(crate) struct State {
+pub struct State {
     /// Last known pos
     pub pos: Pos2,
 

--- a/egui/src/containers/mod.rs
+++ b/egui/src/containers/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod window;
 
 pub use {
     area::Area,
+    area::State,
     collapsing_header::{CollapsingHeader, CollapsingResponse},
     combo_box::*,
     frame::Frame,

--- a/egui/src/memory.rs
+++ b/egui/src/memory.rs
@@ -79,7 +79,7 @@ pub struct Memory {
     #[cfg_attr(feature = "persistence", serde(skip))]
     pub(crate) drag_value: crate::widgets::drag_value::MonoState,
 
-    pub(crate) areas: Areas,
+    pub areas: Areas,
 
     /// Which popup-window is open (if any)?
     /// Could be a combo box, color picker, menu etc.
@@ -500,7 +500,7 @@ impl Areas {
         self.areas.len()
     }
 
-    pub(crate) fn get(&self, id: Id) -> Option<&area::State> {
+    pub fn get(&self, id: Id) -> Option<&area::State> {
         self.areas.get(&id)
     }
 


### PR DESCRIPTION
egui/memory: expose Area State to users

The reason I want to to make these things publicly accessible is that I want to be able to retrieve the state of an area by its Id so that I can access that area's bounding rectangle after it's been rendered in order to pull just that part of the gui app out of the GPU for the sake of sending that part of the app to Open Broadcast Software while streaming.

The practical use case of this is exposing only an inner window containing a chatbox in my stream without also exposing stream controls. I can image similar use cases for other interesting gui elements that I'd like to implement in the future. If it's helpful, I can push my motivating use case to a branch on my twitch bot repo.

I don't know if this is the best way to do what I want, so I'm definitely open to alternative approaches. I made these changes way back in April last time I was working on my dumpy twitch bot. I may have been pointed in this direction by someone in Discord, cause I have no recollection of how I figured this out.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->
