### PR TITLE
Add dry run feature for anchor calculation. (#1)

### DIFF
--- a/egui/src/containers/area.rs
+++ b/egui/src/containers/area.rs
@@ -172,7 +172,12 @@ pub(crate) struct Prepared {
     pub(crate) movable: bool,
     enabled: bool,
     drag_bounds: Option<Rect>,
-    dry_run: bool,
+    /// Set the first frame of new windows with anchors.
+    ///
+    /// This is so that we use the first frame to calculate the window size,
+    /// and then can correctly position the window the next frame,
+    /// without having one frame where the window is positioned in the wrong place.
+    temporarily_invisible: bool,
 }
 
 impl Area {
@@ -215,11 +220,11 @@ impl Area {
         });
         state.pos = new_pos.unwrap_or(state.pos);
         state.interactable = interactable;
-        let mut dry_run = false;
+        let mut temporarily_invisible = false;
 
         if let Some((anchor, offset)) = anchor {
             if is_new {
-                dry_run = true;
+                temporarily_invisible = true;
             } else {
                 let screen = ctx.available_rect();
                 state.pos = anchor.align_size_within_rect(state.size, screen).min + offset;
@@ -234,7 +239,7 @@ impl Area {
             movable,
             enabled,
             drag_bounds,
-            dry_run,
+            temporarily_invisible,
         }
     }
 
@@ -316,7 +321,7 @@ impl Prepared {
             clip_rect,
         );
         ui.set_enabled(self.enabled);
-        ui.set_visible(!self.dry_run);
+        ui.set_visible(!self.temporarily_invisible);
         ui
     }
 
@@ -328,7 +333,7 @@ impl Prepared {
             movable,
             enabled,
             drag_bounds,
-            dry_run: _,
+            temporarily_invisible: _,
         } = self;
 
         state.size = content_ui.min_rect().size();

--- a/egui/src/containers/area.rs
+++ b/egui/src/containers/area.rs
@@ -172,6 +172,7 @@ pub(crate) struct Prepared {
     pub(crate) movable: bool,
     enabled: bool,
     drag_bounds: Option<Rect>,
+    dry_run: bool,
 }
 
 impl Area {
@@ -214,11 +215,11 @@ impl Area {
         });
         state.pos = new_pos.unwrap_or(state.pos);
         state.interactable = interactable;
+        let mut dry_run = false;
 
         if let Some((anchor, offset)) = anchor {
             if is_new {
-                // unknown size
-                ctx.request_repaint();
+                dry_run = true;
             } else {
                 let screen = ctx.available_rect();
                 state.pos = anchor.align_size_within_rect(state.size, screen).min + offset;
@@ -233,6 +234,7 @@ impl Area {
             movable,
             enabled,
             drag_bounds,
+            dry_run,
         }
     }
 
@@ -314,7 +316,7 @@ impl Prepared {
             clip_rect,
         );
         ui.set_enabled(self.enabled);
-
+        ui.set_visible(!self.dry_run);
         ui
     }
 
@@ -326,6 +328,7 @@ impl Prepared {
             movable,
             enabled,
             drag_bounds,
+            dry_run: _,
         } = self;
 
         state.size = content_ui.min_rect().size();


### PR DESCRIPTION
This PR resolves issue: emilk#1852
We introduce dry_run flag which makes component invisible until we do second pass of rendering - which allows us to properly calculate position for anchor. (This removes rapid flicker when new window is drawn for the first time).
