### PR TITLE
Reset the scissor rect after rendering onto a renderpass

### DIFF
--- a/egui-wgpu/src/renderer.rs
+++ b/egui-wgpu/src/renderer.rs
@@ -451,6 +451,8 @@ impl RenderPass {
                 }
             }
         }
+
+        rpass.set_scissor_rect(0, 0, size_in_pixels[0], size_in_pixels[1]);
     }
 
     /// Should be called before `execute()`.


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

This prevents a easy-to-hit stumbling block when using egui-wgpu.

This actively resets the wgpu scissor rect back to being the whole output texture. For people who don't use scissor rects - this is the behavior that they expect - for people who do use them the value of the scissor rect doesn't matter because they will need to manually set it afterwards.
