### PR TITLE
`eframe`: selectively expose parts of the API based on compile target

### DIFF
--- a/eframe/CHANGELOG.md
+++ b/eframe/CHANGELOG.md
@@ -14,6 +14,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 * Use `Arc` for `glow::Context` instead of `Rc` ([#1640](https://github.com/emilk/egui/pull/1640)).
 * Fixed bug where the result returned from `App::on_exit_event` would sometimes be ignored ([#1696](https://github.com/emilk/egui/pull/1696)).
 * Added `NativeOptions::follow_system_theme` and `NativeOptions::default_theme` ([#1726](https://github.com/emilk/egui/pull/1726)).
+* Selectively expose parts of the API based on target arch (`wasm32` or not) ([#1867](https://github.com/emilk/egui/pull/1867)).
 
 #### Desktop/Native:
 * Fixed clipboard on Wayland ([#1613](https://github.com/emilk/egui/pull/1613)).

--- a/eframe/src/native/epi_integration.rs
+++ b/eframe/src/native/epi_integration.rs
@@ -9,26 +9,24 @@ pub fn points_to_size(points: egui::Vec2) -> winit::dpi::LogicalSize<f64> {
     }
 }
 
-pub fn read_window_info(
-    window: &winit::window::Window,
-    pixels_per_point: f32,
-) -> Option<WindowInfo> {
-    match window.outer_position() {
-        Ok(pos) => {
-            let pos = pos.to_logical::<f32>(pixels_per_point.into());
-            let size = window
-                .inner_size()
-                .to_logical::<f32>(pixels_per_point.into());
-            Some(WindowInfo {
-                position: egui::Pos2 { x: pos.x, y: pos.y },
-                fullscreen: window.fullscreen().is_some(),
-                size: egui::Vec2 {
-                    x: size.width,
-                    y: size.height,
-                },
-            })
-        }
-        Err(_) => None,
+pub fn read_window_info(window: &winit::window::Window, pixels_per_point: f32) -> WindowInfo {
+    let position = window
+        .outer_position()
+        .ok()
+        .map(|pos| pos.to_logical::<f32>(pixels_per_point.into()))
+        .map(|pos| egui::Pos2 { x: pos.x, y: pos.y });
+
+    let size = window
+        .inner_size()
+        .to_logical::<f32>(pixels_per_point.into());
+
+    WindowInfo {
+        position,
+        fullscreen: window.fullscreen().is_some(),
+        size: egui::Vec2 {
+            x: size.width,
+            y: size.height,
+        },
     }
 }
 
@@ -206,7 +204,6 @@ impl EpiIntegration {
 
         let frame = epi::Frame {
             info: epi::IntegrationInfo {
-                web_info: None,
                 system_theme,
                 cpu_usage: None,
                 native_pixels_per_point: Some(native_pixels_per_point(window)),

--- a/eframe/src/web/backend.rs
+++ b/eframe/src/web/backend.rs
@@ -170,13 +170,12 @@ impl AppRunner {
         };
 
         let info = epi::IntegrationInfo {
-            web_info: Some(epi::WebInfo {
+            web_info: epi::WebInfo {
                 location: web_location(),
-            }),
+            },
             system_theme,
             cpu_usage: None,
             native_pixels_per_point: Some(native_pixels_per_point()),
-            window_info: None,
         };
         let storage = LocalStorage::default();
 
@@ -293,16 +292,7 @@ impl AppRunner {
 
         {
             let app_output = self.frame.take_app_output();
-            let epi::backend::AppOutput {
-                quit: _,         // Can't quit a web page
-                window_size: _,  // Can't resize a web page
-                window_title: _, // TODO(emilk): change title of window
-                decorated: _,    // Can't toggle decorations
-                fullscreen: _,   // TODO(emilk): fullscreen web window
-                drag_window: _,  // Can't be dragged
-                window_pos: _,   // Can't set position of a web page
-                visible: _,      // Can't hide a web page
-            } = app_output;
+            let epi::backend::AppOutput {} = app_output;
         }
 
         self.frame.info.cpu_usage = Some((now_sec() - frame_start) as f32);

--- a/eframe/src/web/events.rs
+++ b/eframe/src/web/events.rs
@@ -181,9 +181,7 @@ pub fn install_document_events(runner_container: &AppRunnerContainer) -> Result<
         "hashchange",
         |_: web_sys::Event, mut runner_lock| {
             // `epi::Frame::info(&self)` clones `epi::IntegrationInfo`, but we need to modify the original here
-            if let Some(web_info) = &mut runner_lock.frame.info.web_info {
-                web_info.location.hash = location_hash();
-            }
+            runner_lock.frame.info.web_info.location.hash = location_hash();
         },
     )?;
 

--- a/egui_demo_app/src/backend_panel.rs
+++ b/egui_demo_app/src/backend_panel.rs
@@ -136,7 +136,8 @@ impl BackendPanel {
             ui.ctx().options().screen_reader = screen_reader;
         }
 
-        if !frame.is_web() {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
             ui.separator();
             if ui.button("Quit").clicked() {
                 frame.quit();
@@ -159,11 +160,10 @@ impl BackendPanel {
             ui.label(".");
         });
 
-        if let Some(web_info) = &frame.info().web_info {
-            ui.collapsing("Web info (location)", |ui| {
-                ui.monospace(format!("{:#?}", web_info.location));
-            });
-        }
+        #[cfg(target_arch = "wasm32")]
+        ui.collapsing("Web info (location)", |ui| {
+            ui.monospace(format!("{:#?}", frame.info().web_info.location));
+        });
 
         // For instance: `eframe` web sets `pixels_per_point` every frame to force
         // egui to use the same scale as the web zoom factor.
@@ -174,10 +174,11 @@ impl BackendPanel {
             }
         }
 
-        if !frame.is_web() {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
             ui.horizontal(|ui| {
-                if let Some(window_info) = &frame.info().window_info {
-                    let mut fullscreen = window_info.fullscreen;
+                {
+                    let mut fullscreen = frame.info().window_info.fullscreen;
                     ui.checkbox(&mut fullscreen, "🗖 Fullscreen")
                         .on_hover_text("Fullscreen the window");
                     frame.set_fullscreen(fullscreen);

--- a/egui_demo_app/src/wrap_app.rs
+++ b/egui_demo_app/src/wrap_app.rs
@@ -168,10 +168,9 @@ impl eframe::App for WrapApp {
     }
 
     fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
-        if let Some(web_info) = frame.info().web_info.as_ref() {
-            if let Some(anchor) = web_info.location.hash.strip_prefix('#') {
-                self.state.selected_anchor = anchor.to_owned();
-            }
+        #[cfg(target_arch = "wasm32")]
+        if let Some(anchor) = frame.info().web_info.location.hash.strip_prefix('#') {
+            self.state.selected_anchor = anchor.to_owned();
         }
 
         if self.state.selected_anchor.is_empty() {


### PR DESCRIPTION
A lot of the `eframe` API is native-only or web-only. With this PR, only the parts that are implemented for each platform is exposed.

This means you'll need to add `#[cfg(target_arch = "wasm32")]` around code that uses the web-parts of the eframe API, and add `#[cfg(not(target_arch = "wasm32"))]` around the parts that are for native/desktop.
