### PR TITLE
Add depth buffer in native 3D example

### DIFF
--- a/examples/custom_3d_three-d/src/main.rs
+++ b/examples/custom_3d_three-d/src/main.rs
@@ -7,6 +7,7 @@ fn main() {
         initial_window_size: Some(egui::vec2(550.0, 610.0)),
         multisampling: 8,
         renderer: eframe::Renderer::Glow,
+        depth_buffer: 32,
         ..Default::default()
     };
     eframe::run_native(


### PR DESCRIPTION
The `custom_3d_three-d` example does not enable a depth buffer since it is only rendering a triangle. However, if it is used as a starting point for other projects, it is highly likely that a depth buffer is actually needed, therefore I propose to enable it by default.
Also see [this](https://github.com/asny/three-d/issues/268) issue for full context.

