### PR TITLE
Add `egui/default_fonts` feature to `pure_glow` example

### DIFF
--- a/egui_glow/Cargo.toml
+++ b/egui_glow/Cargo.toml
@@ -77,4 +77,4 @@ glutin = "0.28.0" # examples/pure_glow
 
 [[example]]
 name = "pure_glow"
-required-features = ["winit"]
+required-features = ["winit", "egui/default_fonts"]


### PR DESCRIPTION
It seems to me like the `pure_glow` example was broken sometime in april because of changes to feature flags. The text simply didn't show up which is due to missing fonts unless you figured out that you needed the `egui/default_fonts` feature flag. This change enforces the use of the `egui/default_fonts` feature flag in this example.
