### PR TITLE
Make egui_wgpu::RenderPass Send and Sync

### DIFF
--- a/egui-wgpu/CHANGELOG.md
+++ b/egui-wgpu/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the `egui-wgpu` integration will be noted in this file.
 
 ## Unreleased
 Enables deferred render + surface state initialization for Android ([#1634](https://github.com/emilk/egui/pull/1634))
+Make `RenderPass` `Send` and `Sync` ([#1883](https://github.com/emilk/egui/pull/1883))
 
 ## 0.18.0 - 2022-05-15
 First published version since moving the code into the `egui` repository from <https://github.com/LU15W1R7H/eww>.

--- a/egui-wgpu/CHANGELOG.md
+++ b/egui-wgpu/CHANGELOG.md
@@ -3,8 +3,8 @@ All notable changes to the `egui-wgpu` integration will be noted in this file.
 
 
 ## Unreleased
-Enables deferred render + surface state initialization for Android ([#1634](https://github.com/emilk/egui/pull/1634))
-Make `RenderPass` `Send` and `Sync` ([#1883](https://github.com/emilk/egui/pull/1883))
+* Enables deferred render + surface state initialization for Android ([#1634](https://github.com/emilk/egui/pull/1634)).
+* Make `RenderPass` `Send` and `Sync` ([#1883](https://github.com/emilk/egui/pull/1883)).
 
 ## 0.18.0 - 2022-05-15
 First published version since moving the code into the `egui` repository from <https://github.com/LU15W1R7H/eww>.

--- a/egui-wgpu/src/renderer.rs
+++ b/egui-wgpu/src/renderer.rs
@@ -806,3 +806,9 @@ impl ScissorRect {
         }
     }
 }
+
+#[test]
+fn render_pass_impl_send_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<RenderPass>();
+}

--- a/egui-wgpu/src/renderer.rs
+++ b/egui-wgpu/src/renderer.rs
@@ -3,7 +3,7 @@
 use std::{borrow::Cow, collections::HashMap, num::NonZeroU32};
 
 use egui::{epaint::Primitive, NumExt, PaintCallbackInfo};
-use type_map::TypeMap;
+use type_map::concurrent::TypeMap;
 use wgpu;
 use wgpu::util::DeviceExt as _;
 
@@ -132,7 +132,7 @@ pub struct RenderPass {
     next_user_texture_id: u64,
     /// Storage for use by [`egui::PaintCallback`]'s that need to store resources such as render
     /// pipelines that must have the lifetime of the renderpass.
-    pub paint_callback_resources: type_map::TypeMap,
+    pub paint_callback_resources: TypeMap,
 }
 
 impl RenderPass {


### PR DESCRIPTION
I didn't open an issue as this is a tiny change.

I believe `RenderPass` was supposed to be `Send + Sync` since the callback has the bounds.
This PR changes the flavor of `TypeMap` used and make `RenderPass` `Send + Sync`.