### PR TITLE
Continue execution after closing native eframe window

### DIFF
--- a/eframe/src/epi.rs
+++ b/eframe/src/epi.rs
@@ -270,10 +270,10 @@ pub struct NativeOptions {
     /// Default: `Theme::Dark`.
     pub default_theme: Theme,
 
-    /// This controls what happens when you close the main egui window.
+    /// This controls what happens when you close the main eframe window.
     ///
-    /// If `true`, execution will continue after the egui window is closed.
-    /// If `false`, the app will close once the egui window is closed.
+    /// If `true`, execution will continue after the eframe window is closed.
+    /// If `false`, the app will close once the eframe window is closed.
     ///
     /// This is `true` by default, and the `false` option is only there
     /// so we can revert if we find any bugs.

--- a/eframe/src/epi.rs
+++ b/eframe/src/epi.rs
@@ -270,14 +270,19 @@ pub struct NativeOptions {
     /// Default: `Theme::Dark`.
     pub default_theme: Theme,
 
-    /// If `true`, the app will close once the egui window is closed.
-    /// If `false`, execution will continue.
+    /// This controls what happens when you close the main egui window.
     ///
-    /// This is `true` by default.
+    /// If `true`, execution will continue after the egui window is closed.
+    /// If `false`, the app will close once the egui window is closed.
     ///
-    /// When `true`, [`winit::event_loop::EventLoop::run`] is used.
-    /// When `false`, [`winit::platform::run_return::EventLoopExtRunReturn::run_return`] is used.
-    pub exit_on_window_close: bool,
+    /// This is `true` by default, and the `false` option is only there
+    /// so we can revert if we find any bugs.
+    ///
+    /// This feature was introduced in <https://github.com/emilk/egui/pull/1889>.
+    ///
+    /// When `true`, [`winit::platform::run_return::EventLoopExtRunReturn::run_return`] is used.
+    /// When `false`, [`winit::event_loop::EventLoop::run`] is used.
+    pub run_and_return: bool,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -304,7 +309,7 @@ impl Default for NativeOptions {
             renderer: Renderer::default(),
             follow_system_theme: cfg!(target_os = "macos") || cfg!(target_os = "windows"),
             default_theme: Theme::Dark,
-            exit_on_window_close: false,
+            run_and_return: true,
         }
     }
 }

--- a/eframe/src/epi.rs
+++ b/eframe/src/epi.rs
@@ -170,6 +170,20 @@ pub enum HardwareAcceleration {
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone)]
 pub struct NativeOptions {
+    /// If `true`, the app will close once the egui window is closed.
+    /// If `false`, execution will continue.
+    ///
+    /// This is `true` by default, because setting it to `false` has several downsides,
+    /// at least on Mac:
+    ///
+    /// * Window resizing is now longer instantaneous
+    /// * CPU usage is higher when idle
+    /// * [`Frame::drag_window`] doesn't work as expected
+    ///
+    /// When `true`, [`winit::event_loop::EventLoop::run`] is used.
+    /// When `false`, [`winit::platform::run_return::EventLoopExtRunReturn::run_return`] is used.
+    pub exit_on_window_close: bool,
+
     /// Sets whether or not the window will always be on top of other windows.
     pub always_on_top: bool,
 
@@ -275,6 +289,7 @@ pub struct NativeOptions {
 impl Default for NativeOptions {
     fn default() -> Self {
         Self {
+            exit_on_window_close: true,
             always_on_top: false,
             maximized: false,
             decorated: true,

--- a/eframe/src/epi.rs
+++ b/eframe/src/epi.rs
@@ -176,7 +176,7 @@ pub struct NativeOptions {
     /// This is `true` by default, because setting it to `false` has several downsides,
     /// at least on Mac:
     ///
-    /// * Window resizing is now longer instantaneous
+    /// * Window resizing is no longer instantaneous
     /// * CPU usage is higher when idle
     /// * [`Frame::drag_window`] doesn't work as expected
     ///

--- a/eframe/src/epi.rs
+++ b/eframe/src/epi.rs
@@ -170,20 +170,6 @@ pub enum HardwareAcceleration {
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone)]
 pub struct NativeOptions {
-    /// If `true`, the app will close once the egui window is closed.
-    /// If `false`, execution will continue.
-    ///
-    /// This is `true` by default, because setting it to `false` has several downsides,
-    /// at least on Mac:
-    ///
-    /// * Window resizing is no longer instantaneous
-    /// * CPU usage is higher when idle
-    /// * [`Frame::drag_window`] doesn't work as expected
-    ///
-    /// When `true`, [`winit::event_loop::EventLoop::run`] is used.
-    /// When `false`, [`winit::platform::run_return::EventLoopExtRunReturn::run_return`] is used.
-    pub exit_on_window_close: bool,
-
     /// Sets whether or not the window will always be on top of other windows.
     pub always_on_top: bool,
 
@@ -283,13 +269,21 @@ pub struct NativeOptions {
     ///
     /// Default: `Theme::Dark`.
     pub default_theme: Theme,
+
+    /// If `true`, the app will close once the egui window is closed.
+    /// If `false`, execution will continue.
+    ///
+    /// This is `true` by default.
+    ///
+    /// When `true`, [`winit::event_loop::EventLoop::run`] is used.
+    /// When `false`, [`winit::platform::run_return::EventLoopExtRunReturn::run_return`] is used.
+    pub exit_on_window_close: bool,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 impl Default for NativeOptions {
     fn default() -> Self {
         Self {
-            exit_on_window_close: true,
             always_on_top: false,
             maximized: false,
             decorated: true,
@@ -310,6 +304,7 @@ impl Default for NativeOptions {
             renderer: Renderer::default(),
             follow_system_theme: cfg!(target_os = "macos") || cfg!(target_os = "windows"),
             default_theme: Theme::Dark,
+            exit_on_window_close: false,
         }
     }
 }

--- a/eframe/src/lib.rs
+++ b/eframe/src/lib.rs
@@ -174,9 +174,11 @@ pub fn run_native(app_name: &str, native_options: NativeOptions, app_creator: Ap
         #[cfg(feature = "wgpu")]
         Renderer::Wgpu => {
             tracing::debug!("Using the wgpu renderer");
-            native::run::run_wgpu(app_name, &native_options, app_creator)
+            native::run::run_wgpu(app_name, &native_options, app_creator);
         }
     }
+
+    tracing::debug!("eframe window closed");
 }
 
 // ---------------------------------------------------------------------------

--- a/eframe/src/lib.rs
+++ b/eframe/src/lib.rs
@@ -161,14 +161,14 @@ mod native;
 /// ```
 #[cfg(not(target_arch = "wasm32"))]
 #[allow(clippy::needless_pass_by_value)]
-pub fn run_native(app_name: &str, native_options: NativeOptions, app_creator: AppCreator) -> ! {
+pub fn run_native(app_name: &str, native_options: NativeOptions, app_creator: AppCreator) {
     let renderer = native_options.renderer;
 
     match renderer {
         #[cfg(feature = "glow")]
         Renderer::Glow => {
             tracing::debug!("Using the glow renderer");
-            native::run::run_glow(app_name, &native_options, app_creator)
+            native::run::run_glow(app_name, &native_options, app_creator);
         }
 
         #[cfg(feature = "wgpu")]

--- a/eframe/src/lib.rs
+++ b/eframe/src/lib.rs
@@ -177,8 +177,6 @@ pub fn run_native(app_name: &str, native_options: NativeOptions, app_creator: Ap
             native::run::run_wgpu(app_name, &native_options, app_creator);
         }
     }
-
-    tracing::debug!("eframe window closed");
 }
 
 // ---------------------------------------------------------------------------

--- a/eframe/src/native/epi_integration.rs
+++ b/eframe/src/native/epi_integration.rs
@@ -350,6 +350,10 @@ impl EpiIntegration {
             storage.flush();
         }
     }
+
+    pub fn files_are_hovering(&self) -> bool {
+        !self.egui_winit.egui_input().hovered_files.is_empty()
+    }
 }
 
 #[cfg(feature = "persistence")]

--- a/eframe/src/native/epi_integration.rs
+++ b/eframe/src/native/epi_integration.rs
@@ -350,10 +350,6 @@ impl EpiIntegration {
             storage.flush();
         }
     }
-
-    pub fn files_are_hovering(&self) -> bool {
-        !self.egui_winit.egui_input().hovered_files.is_empty()
-    }
 }
 
 #[cfg(feature = "persistence")]

--- a/eframe/src/native/run.rs
+++ b/eframe/src/native/run.rs
@@ -72,7 +72,7 @@ trait WinitApp {
     fn on_event(&mut self, event: winit::event::Event<'_, RequestRepaintEvent>) -> EventResult;
 }
 
-fn run_and_continue(mut event_loop: EventLoop<RequestRepaintEvent>, mut winit_app: impl WinitApp) {
+fn run_and_return(mut event_loop: EventLoop<RequestRepaintEvent>, mut winit_app: impl WinitApp) {
     use winit::platform::run_return::EventLoopExtRunReturn as _;
 
     tracing::debug!("event_loop.run_return");
@@ -133,7 +133,7 @@ fn run_and_continue(mut event_loop: EventLoop<RequestRepaintEvent>, mut winit_ap
     winit_app.save_and_destroy();
 }
 
-fn run_then_exit(
+fn run_and_exit(
     event_loop: EventLoop<RequestRepaintEvent>,
     mut winit_app: impl WinitApp + 'static,
 ) -> ! {
@@ -425,10 +425,10 @@ mod glow_integration {
         let event_loop = EventLoop::with_user_event();
         let glow_eframe = GlowWinitApp::new(&event_loop, app_name, native_options, app_creator);
 
-        if native_options.exit_on_window_close {
-            run_then_exit(event_loop, glow_eframe);
+        if native_options.run_and_return {
+            run_and_return(event_loop, glow_eframe);
         } else {
-            run_and_continue(event_loop, glow_eframe);
+            run_and_exit(event_loop, glow_eframe);
         }
     }
 }
@@ -681,10 +681,10 @@ mod wgpu_integration {
         let event_loop = EventLoop::with_user_event();
         let wgpu_eframe = WgpuWinitApp::new(&event_loop, app_name, native_options, app_creator);
 
-        if native_options.exit_on_window_close {
-            run_then_exit(event_loop, wgpu_eframe);
+        if native_options.run_and_return {
+            run_and_return(event_loop, wgpu_eframe);
         } else {
-            run_and_continue(event_loop, wgpu_eframe);
+            run_and_exit(event_loop, wgpu_eframe);
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/emilk/egui/issues/1223

This adds `NativeOptions::run_and_return` with default value `true`.

If `true`, execution will continue after the eframe window is closed. This is a new behavior introduced in this PR.
If `false`, the app will close once the eframe window is closed. The is the old behavior.

This is `true` by default, and the `false` option is only there so we can revert if we find any bugs.

When `true`, [`winit::platform::run_return::EventLoopExtRunReturn::run_return`](https://docs.rs/winit/latest/winit/platform/run_return/trait.EventLoopExtRunReturn.html#tymethod.run_return) is used. The winit docs warns of its usage, recommending `EventLoop::run`, but 🤷 
When `false`, [`winit::event_loop::EventLoop::run`](https://docs.rs/winit/latest/winit/event_loop/struct.EventLoop.html#method.run) is used.

This is a really useful feature. You can now use `eframe` to quickly open up a window and show some data or options, and then continue your program after the `eframe` window is closed

My previous attempt at this caused some problems, but my new attempt seems to be working much better, at least on my Mac.
