### PR TITLE
Add with_main_align method

### DIFF
--- a/egui/src/layout.rs
+++ b/egui/src/layout.rs
@@ -252,7 +252,13 @@ impl Layout {
         Self { main_wrap, ..self }
     }
 
-    /// The aligmnet to use on the cross axis.
+    /// The alignment to use on the main axis.
+    #[inline(always)]
+    pub fn with_main_align(self, main_align: Align) -> Self {
+        Self { main_align, ..self }
+    }
+
+    /// The alignment to use on the cross axis.
     ///
     /// The "cross" axis is the one orthogonal to the main axis.
     /// For instance: in left-to-right layout, the main axis is horizontal and the cross axis is vertical.


### PR DESCRIPTION
**Problem**

I need to make a custom context menu but there's no way to set the main alignment of text, so this is the best that I can currently do:
![Screenshot from 2022-08-03 21-28-34](https://user-images.githubusercontent.com/16503728/182764425-7ea42248-ee1a-4391-b94c-b7bc76c595be.png)

**Solution**

I implemented `Layout::with_main_align` and now this is what I can achieve:
![Screenshot from 2022-08-03 21-30-14](https://user-images.githubusercontent.com/16503728/182764580-1c304a6a-049c-4d0b-8069-5f442d873b14.png)
