### PR TITLE
Add CI for android

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -195,3 +195,18 @@ jobs:
       - run: rustup target add wasm32-unknown-unknown
       - run: ./sh/setup_web.sh
       - run: ./sh/wasm_bindgen_check.sh
+
+  android:
+    name: android
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.61.0
+          target: aarch64-linux-android
+          override: true
+
+      - run: cargo check --features wgpu --target aarch64-linux-android
+        working-directory: eframe

--- a/egui-winit/Cargo.toml
+++ b/egui-winit/Cargo.toml
@@ -49,7 +49,6 @@ tracing = { version = "0.1", default-features = false, features = ["std"] }
 winit = "0.27.2"
 
 #! ### Optional dependencies
-arboard = { version = "2.1", optional = true, default-features = false }
 
 ## Enable this when generating docs.
 document-features = { version = "0.2", optional = true }
@@ -64,3 +63,6 @@ webbrowser = { version = "0.7", optional = true }
 
 [target.'cfg(any(target_os="linux", target_os="dragonfly", target_os="freebsd", target_os="netbsd", target_os="openbsd"))'.dependencies]
 smithay-clipboard = { version = "0.6.3", optional = true }
+
+[target.'cfg(not(target_os = "android"))'.dependencies]
+arboard = { version = "2.1", optional = true, default-features = false }

--- a/egui-winit/src/clipboard.rs
+++ b/egui-winit/src/clipboard.rs
@@ -5,7 +5,7 @@ use std::os::raw::c_void;
 /// If the "clipboard" feature is off, or we cannot connect to the OS clipboard,
 /// then a fallback clipboard that just works works within the same app is used instead.
 pub struct Clipboard {
-    #[cfg(feature = "arboard")]
+    #[cfg(all(feature = "arboard", not(target_os = "android")))]
     arboard: Option<arboard::Clipboard>,
 
     #[cfg(all(
@@ -28,7 +28,7 @@ impl Clipboard {
     #[allow(unused_variables)]
     pub fn new(#[allow(unused_variables)] wayland_display: Option<*mut c_void>) -> Self {
         Self {
-            #[cfg(feature = "arboard")]
+            #[cfg(all(feature = "arboard", not(target_os = "android")))]
             arboard: init_arboard(),
             #[cfg(all(
                 any(
@@ -66,7 +66,7 @@ impl Clipboard {
             };
         }
 
-        #[cfg(feature = "arboard")]
+        #[cfg(all(feature = "arboard", not(target_os = "android")))]
         if let Some(clipboard) = &mut self.arboard {
             return match clipboard.get_text() {
                 Ok(text) => Some(text),
@@ -96,7 +96,7 @@ impl Clipboard {
             return;
         }
 
-        #[cfg(feature = "arboard")]
+        #[cfg(all(feature = "arboard", not(target_os = "android")))]
         if let Some(clipboard) = &mut self.arboard {
             if let Err(err) = clipboard.set_text(text) {
                 tracing::error!("Copy/Cut error: {}", err);
@@ -108,7 +108,7 @@ impl Clipboard {
     }
 }
 
-#[cfg(feature = "arboard")]
+#[cfg(all(feature = "arboard", not(target_os = "android")))]
 fn init_arboard() -> Option<arboard::Clipboard> {
     match arboard::Clipboard::new() {
         Ok(clipboard) => Some(clipboard),


### PR DESCRIPTION
This just runs `cargo check` on `eframe` for an Android target. It doesn't currently pass due to [`arboard` intentionally not building on unsupported platforms](https://github.com/1Password/arboard/pull/50). Not quite sure where that should be resolved.