### PR TITLE
Improve custom_3d_three-d example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.*.json
 /.vscode
 /media/*
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.5.3",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -898,10 +898,13 @@ dependencies = [
 name = "custom_3d_three-d"
 version = "0.1.0"
 dependencies = [
+ "console_error_panic_hook",
  "eframe",
  "egui_glow",
  "glow",
  "three-d",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -1002,16 +1005,6 @@ name = "dconf_rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7046468a81e6a002061c01e6a7c83139daf91b11c30e66795b13217c2d885c8b"
-
-[[package]]
-name = "deflate"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
-dependencies = [
- "adler32",
- "byteorder",
-]
 
 [[package]]
 name = "deflate"
@@ -1123,7 +1116,7 @@ dependencies = [
  "eframe",
  "egui_extras",
  "ehttp",
- "image 0.24.2",
+ "image",
  "poll-promise",
 ]
 
@@ -1258,7 +1251,7 @@ dependencies = [
  "egui_demo_lib",
  "egui_extras",
  "ehttp",
- "image 0.24.2",
+ "image",
  "poll-promise",
  "pollster",
  "serde",
@@ -1290,7 +1283,7 @@ dependencies = [
  "chrono",
  "document-features",
  "egui",
- "image 0.24.2",
+ "image",
  "resvg",
  "serde",
  "tiny-skia",
@@ -1308,7 +1301,7 @@ dependencies = [
  "egui",
  "egui-winit",
  "glium",
- "image 0.24.2",
+ "image",
 ]
 
 [[package]]
@@ -1491,7 +1484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.5.3",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1787,16 +1780,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "gloo-timers"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb7d06c1c8cc2a29bee7ec961009a0b2caa0793ee4900c2ffb348734ba1c8f9"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "glow"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,7 +1931,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 dependencies = [
  "num-traits",
- "serde",
  "zerocopy",
 ]
 
@@ -2035,22 +2017,6 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.23.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
-dependencies = [
- "bytemuck",
- "byteorder",
- "color_quant",
- "jpeg-decoder 0.1.22",
- "num-iter",
- "num-rational 0.3.2",
- "num-traits",
- "png 0.16.8",
-]
-
-[[package]]
-name = "image"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28edd9d7bc256be2502e325ac0628bde30b7001b9b52e0abe31a1a9dc2701212"
@@ -2058,11 +2024,11 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
- "jpeg-decoder 0.2.6",
+ "jpeg-decoder",
  "num-iter",
- "num-rational 0.4.1",
+ "num-rational",
  "num-traits",
- "png 0.17.5",
+ "png",
 ]
 
 [[package]]
@@ -2142,12 +2108,6 @@ checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "jpeg-decoder"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2"
 
 [[package]]
 name = "jpeg-decoder"
@@ -2325,15 +2285,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
-dependencies = [
- "adler32",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -2546,17 +2497,6 @@ name = "num-iter"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2874,26 +2814,14 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.16.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
-dependencies = [
- "bitflags",
- "crc32fast",
- "deflate 0.8.6",
- "miniz_oxide 0.3.7",
-]
-
-[[package]]
-name = "png"
 version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc38c0ad57efb786dd57b9864e5b18bae478c00c824dc55a38bbc9da95dde3ba"
 dependencies = [
  "bitflags",
  "crc32fast",
- "deflate 1.0.0",
- "miniz_oxide 0.5.3",
+ "deflate",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -3150,10 +3078,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34489194784b86c03c3d688258e2ba73f3c82700ba4673ee2ecad5ae540b9438"
 dependencies = [
  "gif",
- "jpeg-decoder 0.2.6",
+ "jpeg-decoder",
  "log",
  "pico-args",
- "png 0.17.5",
+ "png",
  "rgb",
  "svgfilters",
  "svgtypes",
@@ -3167,7 +3095,7 @@ version = "0.1.0"
 dependencies = [
  "eframe",
  "egui_extras",
- "image 0.24.2",
+ "image",
 ]
 
 [[package]]
@@ -3813,32 +3741,27 @@ dependencies = [
 
 [[package]]
 name = "three-d"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc0ef660c02244f00fc2d1759e67d30a3c282541458490de641f0e832c8d3c9"
+checksum = "f7a5a1017829335f6761bdbae2daf3021a88314a1f8d5f188c9b62ce62e2fd31"
 dependencies = [
  "cgmath",
- "gloo-timers",
  "glow",
- "half",
- "js-sys",
- "serde",
+ "instant",
  "thiserror",
  "three-d-asset",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
 ]
 
 [[package]]
 name = "three-d-asset"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1886553d8b51093705b6d1a02ec2c41ac78260f68b40682d94d9976960d689"
+checksum = "e953f34aa4169e098621a1ff23a68c47b7798711f7c769bf741248e850e93fbe"
 dependencies = [
  "cgmath",
  "half",
- "image 0.23.14",
  "thiserror",
  "web-sys",
 ]
@@ -3875,7 +3798,7 @@ dependencies = [
  "arrayvec 0.5.2",
  "bytemuck",
  "cfg-if",
- "png 0.17.5",
+ "png",
  "safe_arch",
 ]
 
@@ -4229,8 +4152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/examples/custom_3d_three-d/Cargo.toml
+++ b/examples/custom_3d_three-d/Cargo.toml
@@ -7,9 +7,18 @@ edition = "2021"
 rust-version = "1.61"
 publish = false
 
+[lib]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 eframe = { path = "../../eframe", features = ["glow"] }
 egui_glow = { path = "../../egui_glow" }
 glow = "0.11"
-three-d = { version = "0.12", default-features = false } # 2022-05-22
+three-d = { path = "../../../three-d", default-features = false }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies] # Web dependencies
+wasm-bindgen = "0.2" # Core bindings
+wasm-bindgen-futures = "0.4" # Core bindings
+web-sys = "0.3" # Core bindings
+tracing-wasm = "0.2" # For logging
+console_error_panic_hook = "0.1" # For logging

--- a/examples/custom_3d_three-d/Cargo.toml
+++ b/examples/custom_3d_three-d/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 eframe = { path = "../../eframe", features = ["glow"] }
 egui_glow = { path = "../../egui_glow" }
 glow = "0.11"
-three-d = { path = "../../../three-d", default-features = false }
+three-d = { version = "0.13", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies] # Web dependencies
 wasm-bindgen = "0.2" # Core bindings

--- a/examples/custom_3d_three-d/Cargo.toml
+++ b/examples/custom_3d_three-d/Cargo.toml
@@ -19,6 +19,4 @@ three-d = { version = "0.13", default-features = false }
 [target.'cfg(target_arch = "wasm32")'.dependencies] # Web dependencies
 wasm-bindgen = "0.2" # Core bindings
 wasm-bindgen-futures = "0.4" # Core bindings
-web-sys = "0.3" # Core bindings
-tracing-wasm = "0.2" # For logging
 console_error_panic_hook = "0.1" # For logging

--- a/examples/custom_3d_three-d/README.md
+++ b/examples/custom_3d_three-d/README.md
@@ -14,3 +14,7 @@ If you are content of having egui sit on top of a 3D background, take a look at:
 ```sh
 cargo run -p custom_3d_three-d
 ```
+
+```
+wasm-pack build examples/custom_3d_three-d --target web
+```

--- a/examples/custom_3d_three-d/index.html
+++ b/examples/custom_3d_three-d/index.html
@@ -1,0 +1,38 @@
+<html>
+  <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
+  </head>
+  <body>
+    <canvas id="my" style="position: absolute;top:0;bottom: 0;left: 0;right: 0;margin:auto;"></canvas>
+    <!-- Note the usage of `type=module` here as this is an ES6 module -->
+    <script type="module">
+      // Use ES module import syntax to import functionality from the module
+      // that we have compiled.
+      //
+      // Note that the `default` import is an initialization function which
+      // will "boot" the module and make it ready to use. Currently browsers
+      // don't support natively imported WebAssembly as an ES module, but
+      // eventually the manual initialization won't be required!
+      import init from './pkg/web.js';
+
+      async function run() {
+        // First up we need to actually load the wasm file, so we use the
+        // default export to inform it where the wasm file is located on the
+        // server, and then we wait on the returned promise to wait for the
+        // wasm to be loaded.
+        // It may look like this: `await init('./pkg/without_a_bundler_bg.wasm');`,
+        // but there is also a handy default inside `init` function, which uses
+        // `import.meta` to locate the wasm file relatively to js file
+        //
+        // Note that instead of a string here you can also pass in an instance
+        // of `WebAssembly.Module` which allows you to compile your own module.
+        // Also note that the promise, when resolved, yields the wasm module's
+        // exports which is the same as importing the `*_bg` module in other
+        // modes
+        await init('./pkg/web_bg.wasm');
+      }
+
+      run();
+    </script>
+  </body>
+</html>

--- a/examples/custom_3d_three-d/index.html
+++ b/examples/custom_3d_three-d/index.html
@@ -13,7 +13,7 @@
       // will "boot" the module and make it ready to use. Currently browsers
       // don't support natively imported WebAssembly as an ES module, but
       // eventually the manual initialization won't be required!
-      import init from './pkg/web.js';
+      import init from './pkg/custom_3d_three_d.js';
 
       async function run() {
         // First up we need to actually load the wasm file, so we use the
@@ -29,7 +29,7 @@
         // Also note that the promise, when resolved, yields the wasm module's
         // exports which is the same as importing the `*_bg` module in other
         // modes
-        await init('./pkg/web_bg.wasm');
+        await init('./pkg/custom_3d_three_d_bg.wasm');
       }
 
       run();

--- a/examples/custom_3d_three-d/src/lib.rs
+++ b/examples/custom_3d_three-d/src/lib.rs
@@ -1,0 +1,19 @@
+mod main;
+
+// Entry point for wasm
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(start)]
+pub async fn start() -> Result<(), JsValue> {
+    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+
+    let web_options = eframe::WebOptions::default();
+    eframe::start_web(
+        "my",
+        web_options,
+        Box::new(|cc| Box::new(main::MyApp::new(cc))),
+    )?;
+    Ok(())
+}

--- a/examples/custom_3d_three-d/src/main.rs
+++ b/examples/custom_3d_three-d/src/main.rs
@@ -68,12 +68,11 @@ impl MyApp {
                     let screen = painter
                         .intermediate_fbo()
                         .map(|fbo| {
-                            dbg!(fbo);
-                            RenderTarget::from_raw(
+                            RenderTarget::from_framebuffer(
                                 three_d,
-                                fbo,
                                 info.viewport.width() as u32,
                                 info.viewport.height() as u32,
+                                fbo,
                             )
                         })
                         .unwrap_or(RenderTarget::screen(
@@ -100,7 +99,8 @@ impl MyApp {
                         height: clip_rect.height_px.round() as _,
                     };
 
-                    paint_with_three_d(three_d, screen, viewport, scissor_box, angle);
+                    paint_with_three_d(three_d, &screen, viewport, scissor_box, angle);
+                    screen.into_framebuffer(); // Take back the screen fbo, we will continue to use it.
                 });
             })),
         };
@@ -140,7 +140,7 @@ fn with_three_d_context<R>(
 
 fn paint_with_three_d(
     context: &three_d::Context,
-    screen: three_d::RenderTarget,
+    screen: &three_d::RenderTarget,
     viewport: three_d::Viewport,
     scissor_box: three_d::ScissorBox,
     angle: f32,

--- a/examples/custom_3d_three-d/src/main.rs
+++ b/examples/custom_3d_three-d/src/main.rs
@@ -42,7 +42,25 @@ impl eframe::App for MyApp {
 
             egui::ScrollArea::both().show(ui, |ui| {
                 egui::Frame::canvas(ui.style()).show(ui, |ui| {
-                    self.custom_painting(ui);
+                    let (rect, response) =
+                        ui.allocate_exact_size(egui::Vec2::splat(512.0), egui::Sense::drag());
+
+                    self.angle += response.drag_delta().x * 0.01;
+
+                    // Clone locals so we can move them into the paint callback:
+                    let angle = self.angle;
+
+                    let callback = egui::PaintCallback {
+                        rect,
+                        callback: std::sync::Arc::new(egui_glow::CallbackFn::new(
+                            move |info, painter| {
+                                with_three_d_context(painter.gl(), |three_d| {
+                                    three_d.custom_painting(info, painter, angle);
+                                });
+                            },
+                        )),
+                    };
+                    ui.painter().add(callback);
                 });
                 ui.label("Drag to rotate!");
             });
@@ -50,61 +68,123 @@ impl eframe::App for MyApp {
     }
 }
 
-impl MyApp {
-    fn custom_painting(&mut self, ui: &mut egui::Ui) {
-        let (rect, response) =
-            ui.allocate_exact_size(egui::Vec2::splat(512.0), egui::Sense::drag());
+use three_d::*;
+struct ThreeDApp {
+    context: Context,
+}
 
-        self.angle += response.drag_delta().x * 0.01;
+impl ThreeDApp {
+    pub fn new(gl: std::sync::Arc<glow::Context>) -> Self {
+        Self {
+            context: Context::from_gl_context(gl).unwrap(),
+        }
+    }
+}
 
-        // Clone locals so we can move them into the paint callback:
-        let angle = self.angle;
+impl ThreeDApp {
+    fn custom_painting(
+        &self,
+        info: egui::PaintCallbackInfo,
+        painter: &egui_glow::Painter,
+        angle: f32,
+    ) {
+        #[cfg(not(target_arch = "wasm32"))]
+        #[allow(unsafe_code)]
+        unsafe {
+            use glow::HasContext as _;
+            self.context.disable(glow::FRAMEBUFFER_SRGB);
+        }
 
-        let callback = egui::PaintCallback {
-            rect,
-            callback: std::sync::Arc::new(egui_glow::CallbackFn::new(move |info, painter| {
-                with_three_d_context(painter.gl(), |three_d| {
-                    use three_d::*;
-                    let screen = painter
-                        .intermediate_fbo()
-                        .map(|fbo| {
-                            RenderTarget::from_framebuffer(
-                                three_d,
-                                info.viewport.width() as u32,
-                                info.viewport.height() as u32,
-                                fbo,
-                            )
-                        })
-                        .unwrap_or(RenderTarget::screen(
-                            three_d,
-                            info.viewport.width() as u32,
-                            info.viewport.height() as u32,
-                        ));
+        let screen = painter
+            .intermediate_fbo()
+            .map(|fbo| {
+                RenderTarget::from_framebuffer(
+                    &self.context,
+                    info.viewport.width() as u32,
+                    info.viewport.height() as u32,
+                    fbo,
+                )
+            })
+            .unwrap_or(RenderTarget::screen(
+                &self.context,
+                info.viewport.width() as u32,
+                info.viewport.height() as u32,
+            ));
 
-                    // Set where to paint
-                    let viewport = info.viewport_in_pixels();
-                    let viewport = Viewport {
-                        x: viewport.left_px.round() as _,
-                        y: viewport.from_bottom_px.round() as _,
-                        width: viewport.width_px.round() as _,
-                        height: viewport.height_px.round() as _,
-                    };
-
-                    // Respect the egui clip region (e.g. if we are inside an `egui::ScrollArea`).
-                    let clip_rect = info.clip_rect_in_pixels();
-                    let scissor_box = ScissorBox {
-                        x: clip_rect.left_px.round() as _,
-                        y: clip_rect.from_bottom_px.round() as _,
-                        width: clip_rect.width_px.round() as _,
-                        height: clip_rect.height_px.round() as _,
-                    };
-
-                    paint_with_three_d(three_d, &screen, viewport, scissor_box, angle);
-                    screen.into_framebuffer(); // Take back the screen fbo, we will continue to use it.
-                });
-            })),
+        // Set where to paint
+        let viewport = info.viewport_in_pixels();
+        let viewport = Viewport {
+            x: viewport.left_px.round() as _,
+            y: viewport.from_bottom_px.round() as _,
+            width: viewport.width_px.round() as _,
+            height: viewport.height_px.round() as _,
         };
-        ui.painter().add(callback);
+
+        // Respect the egui clip region (e.g. if we are inside an `egui::ScrollArea`).
+        let clip_rect = info.clip_rect_in_pixels();
+        let scissor_box = ScissorBox {
+            x: clip_rect.left_px.round() as _,
+            y: clip_rect.from_bottom_px.round() as _,
+            width: clip_rect.width_px.round() as _,
+            height: clip_rect.height_px.round() as _,
+        };
+
+        self.render(&screen, viewport, scissor_box, angle);
+        screen.into_framebuffer(); // Take back the screen fbo, we will continue to use it.
+    }
+
+    fn render(
+        &self,
+        screen: &three_d::RenderTarget,
+        viewport: three_d::Viewport,
+        scissor_box: three_d::ScissorBox,
+        angle: f32,
+    ) {
+        // Based on https://github.com/asny/three-d/blob/master/examples/triangle/src/main.rs
+
+        // Create a camera
+        let camera = Camera::new_perspective(
+            viewport,
+            vec3(0.0, 0.0, 2.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.0, 1.0, 0.0),
+            degrees(45.0),
+            0.1,
+            10.0,
+        );
+
+        // Create a CPU-side mesh consisting of a single colored triangle
+        let positions = vec![
+            vec3(0.5, -0.5, 0.0),  // bottom right
+            vec3(-0.5, -0.5, 0.0), // bottom left
+            vec3(0.0, 0.5, 0.0),   // top
+        ];
+        let colors = vec![
+            Color::new(255, 0, 0, 255), // bottom right
+            Color::new(0, 255, 0, 255), // bottom left
+            Color::new(0, 0, 255, 255), // top
+        ];
+        let cpu_mesh = CpuMesh {
+            positions: Positions::F32(positions),
+            colors: Some(colors),
+            ..Default::default()
+        };
+
+        // Construct a model, with a default color material, thereby transferring the mesh data to the GPU
+        let mut model = Gm::new(
+            Mesh::new(&self.context, &cpu_mesh),
+            ColorMaterial::default(),
+        );
+
+        // Set the current transformation of the triangle
+        model.set_transformation(Mat4::from_angle_y(radians(angle)));
+
+        // Get the screen render target to be able to render something on the screen
+        screen
+            // Clear the color and depth of the screen render target
+            .clear_partially(scissor_box, ClearState::depth(1.0))
+            // Render the triangle with the color material which uses the per vertex colors defined at construction
+            .render_partially(scissor_box, &camera, &[&model], &[]);
     }
 }
 
@@ -115,77 +195,16 @@ impl MyApp {
 /// [`egui::PaintCallback`] is.
 fn with_three_d_context<R>(
     gl: &std::sync::Arc<glow::Context>,
-    f: impl FnOnce(&three_d::Context) -> R,
+    f: impl FnOnce(&ThreeDApp) -> R,
 ) -> R {
     use std::cell::RefCell;
     thread_local! {
-        pub static THREE_D: RefCell<Option<three_d::Context>> = RefCell::new(None);
-    }
-
-    // If you are using the depth buffer you need to do this:
-    #[cfg(not(target_arch = "wasm32"))]
-    #[allow(unsafe_code)]
-    unsafe {
-        use glow::HasContext as _;
-        gl.disable(glow::FRAMEBUFFER_SRGB);
+        pub static THREE_D: RefCell<Option<ThreeDApp>> = RefCell::new(None);
     }
 
     THREE_D.with(|three_d| {
         let mut three_d = three_d.borrow_mut();
-        let three_d =
-            three_d.get_or_insert_with(|| three_d::Context::from_gl_context(gl.clone()).unwrap());
+        let three_d = three_d.get_or_insert_with(|| ThreeDApp::new(gl.clone()));
         f(three_d)
     })
-}
-
-fn paint_with_three_d(
-    context: &three_d::Context,
-    screen: &three_d::RenderTarget,
-    viewport: three_d::Viewport,
-    scissor_box: three_d::ScissorBox,
-    angle: f32,
-) {
-    // Based on https://github.com/asny/three-d/blob/master/examples/triangle/src/main.rs
-    use three_d::*;
-
-    // Create a camera
-    let camera = Camera::new_perspective(
-        viewport,
-        vec3(0.0, 0.0, 2.0),
-        vec3(0.0, 0.0, 0.0),
-        vec3(0.0, 1.0, 0.0),
-        degrees(45.0),
-        0.1,
-        10.0,
-    );
-
-    // Create a CPU-side mesh consisting of a single colored triangle
-    let positions = vec![
-        vec3(0.5, -0.5, 0.0),  // bottom right
-        vec3(-0.5, -0.5, 0.0), // bottom left
-        vec3(0.0, 0.5, 0.0),   // top
-    ];
-    let colors = vec![
-        Color::new(255, 0, 0, 255), // bottom right
-        Color::new(0, 255, 0, 255), // bottom left
-        Color::new(0, 0, 255, 255), // top
-    ];
-    let cpu_mesh = CpuMesh {
-        positions: Positions::F32(positions),
-        colors: Some(colors),
-        ..Default::default()
-    };
-
-    // Construct a model, with a default color material, thereby transferring the mesh data to the GPU
-    let mut model = Gm::new(Mesh::new(&context, &cpu_mesh), ColorMaterial::default());
-
-    // Set the current transformation of the triangle
-    model.set_transformation(Mat4::from_angle_y(radians(angle)));
-
-    // Get the screen render target to be able to render something on the screen
-    screen
-        // Clear the color and depth of the screen render target
-        .clear_partially(scissor_box, ClearState::depth(1.0))
-        // Render the triangle with the color material which uses the per vertex colors defined at construction
-        .render_partially(scissor_box, &camera, &[&model], &[]);
 }

--- a/examples/custom_3d_three-d/src/main.rs
+++ b/examples/custom_3d_three-d/src/main.rs
@@ -2,6 +2,7 @@
 
 use eframe::egui;
 
+#[cfg(not(target_arch = "wasm32"))]
 fn main() {
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(550.0, 610.0)),
@@ -17,12 +18,12 @@ fn main() {
     );
 }
 
-struct MyApp {
+pub struct MyApp {
     angle: f32,
 }
 
 impl MyApp {
-    fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+    pub fn new(_cc: &eframe::CreationContext<'_>) -> Self {
         Self { angle: 0.2 }
     }
 }


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Improve the `custom_3d_three-d` example by:

- Render the `three-d` stuff into the correct frame buffer (see #1744 and a827c3e0333438c1f6afa8f709c66bbdb79b1c65 )
- Update to latest version of `three-d`
- Made it easy to build the example to web
- Only create the data (camera and model) once at startup and not every frame which is what you usually want
- Restructured the example into structs to separate the functionality (`egui`, `three-d` and the interface between them)