### PR TITLE
egui_extras: Add Table::vertical_scroll_offset

### DIFF
--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -81,11 +81,12 @@ impl super::View for TableDemo {
                 ui.add(
                     egui::Slider::new(&mut self.row_to_scroll_to, 0..=self.num_rows as i32)
                         .logarithmic(true)
-                        .text("Row to scroll to")
+                        .text("Row to scroll to"),
                 );
 
                 if ui.button("Scroll to row").clicked() {
-                    self.vertical_scroll_offset.replace(scroll_offset_for_row(ui, self.row_to_scroll_to));
+                    self.vertical_scroll_offset
+                        .replace(scroll_offset_for_row(ui, self.row_to_scroll_to));
                 }
             }
         });
@@ -124,11 +125,12 @@ impl TableDemo {
             .column(Size::remainder().at_least(60.0))
             .resizable(self.resizable);
 
-            if let Some(y_scroll) = self.vertical_scroll_offset.take() {
-                table = table.vertical_scroll_offset(y_scroll);
-            }
+        if let Some(y_scroll) = self.vertical_scroll_offset.take() {
+            table = table.vertical_scroll_offset(y_scroll);
+        }
 
-            table.header(20.0, |mut header| {
+        table
+            .header(20.0, |mut header| {
                 header.col(|ui| {
                     ui.heading("Row");
                 });

--- a/crates/egui_extras/CHANGELOG.md
+++ b/crates/egui_extras/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to the `egui_extras` integration will be noted in this file.
 
 
 ## Unreleased
-* Added `TableBuilder::vertical_scroll_offset`: method to set vertical scroll offset position for a table.
+* Added `TableBuilder::vertical_scroll_offset`: method to set vertical scroll offset position for a table ([#1946](https://github.com/emilk/egui/pull/1946)).
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/egui_extras/CHANGELOG.md
+++ b/crates/egui_extras/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to the `egui_extras` integration will be noted in this file.
 
 
 ## Unreleased
-
+* Added `TableBuilder::vertical_scroll_offset`: method to set vertical scroll offset position for a table.
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -57,6 +57,7 @@ pub struct TableBuilder<'a> {
     resizable: bool,
     clip: bool,
     stick_to_bottom: bool,
+    scroll_offset_y: Option<f32>,
     cell_layout: egui::Layout,
 }
 
@@ -71,6 +72,7 @@ impl<'a> TableBuilder<'a> {
             resizable: false,
             clip: true,
             stick_to_bottom: false,
+            scroll_offset_y: None,
             cell_layout,
         }
     }
@@ -115,6 +117,12 @@ impl<'a> TableBuilder<'a> {
         self
     }
 
+    /// Set the vertical scroll offset position.
+    pub fn vertical_scroll_offset(mut self, offset: f32) -> Self {
+        self.scroll_offset_y = Some(offset);
+        self
+    }
+
     /// What layout should we use for the individual cells?
     pub fn cell_layout(mut self, cell_layout: egui::Layout) -> Self {
         self.cell_layout = cell_layout;
@@ -156,6 +164,7 @@ impl<'a> TableBuilder<'a> {
             resizable,
             clip,
             stick_to_bottom,
+            scroll_offset_y,
             cell_layout,
         } = self;
 
@@ -189,6 +198,7 @@ impl<'a> TableBuilder<'a> {
             striped,
             clip,
             stick_to_bottom,
+            scroll_offset_y,
             cell_layout,
         }
     }
@@ -208,6 +218,7 @@ impl<'a> TableBuilder<'a> {
             resizable,
             clip,
             stick_to_bottom,
+            scroll_offset_y,
             cell_layout,
         } = self;
 
@@ -229,6 +240,7 @@ impl<'a> TableBuilder<'a> {
             striped,
             clip,
             stick_to_bottom,
+            scroll_offset_y,
             cell_layout,
         }
         .body(body);
@@ -268,6 +280,7 @@ pub struct Table<'a> {
     striped: bool,
     clip: bool,
     stick_to_bottom: bool,
+    scroll_offset_y: Option<f32>,
     cell_layout: egui::Layout,
 }
 
@@ -288,6 +301,7 @@ impl<'a> Table<'a> {
             striped,
             clip,
             stick_to_bottom,
+            scroll_offset_y,
             cell_layout,
         } = self;
 
@@ -295,9 +309,13 @@ impl<'a> Table<'a> {
 
         let mut new_widths = widths.clone();
 
-        let scroll_area = egui::ScrollArea::new([false, scroll])
+        let mut scroll_area = egui::ScrollArea::new([false, scroll])
             .auto_shrink([true; 2])
             .stick_to_bottom(stick_to_bottom);
+
+        if let Some(scroll_offset_y) = scroll_offset_y {
+            scroll_area = scroll_area.vertical_scroll_offset(scroll_offset_y);
+        }
 
         scroll_area.show(ui, move |ui| {
             let layout = StripLayout::new(ui, CellDirection::Horizontal, clip, cell_layout);


### PR DESCRIPTION
Sorry, I messed up PR #1936, so I created a new one. This PR adds the ability to scroll the table to a specific vertical scroll offset. Useful if items are not yet rendered, and therefore it cannot be scrolled to them via Response::scroll_to_me.