### PR TITLE
Example: three-d downgrade depth_buffer to 24 bit

### DIFF
--- a/examples/custom_3d_three-d/src/main.rs
+++ b/examples/custom_3d_three-d/src/main.rs
@@ -9,7 +9,7 @@ fn main() {
         initial_window_size: Some(egui::vec2(550.0, 610.0)),
         multisampling: 8,
         renderer: eframe::Renderer::Glow,
-        depth_buffer: 32,
+        depth_buffer: 24,
         ..Default::default()
     };
     eframe::run_native(


### PR DESCRIPTION
Closes: #1949 

This works on my pc. I'm not sure if there's another and better fix.