### PR TITLE
Android support for EFrame

### DIFF
--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -5,7 +5,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 
 
 ## Unreleased
-
+* Added `NativeOptions::event_loop_builder` hook for apps to change platform specific event loop options ([#1952](https://github.com/emilk/egui/pull/1952)).
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -6,6 +6,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 
 ## Unreleased
 * Added `NativeOptions::event_loop_builder` hook for apps to change platform specific event loop options ([#1952](https://github.com/emilk/egui/pull/1952)).
+* Enabled deferred render state initialization to support Android ([#1952](https://github.com/emilk/egui/pull/1952)).
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -6,6 +6,18 @@
 
 #![warn(missing_docs)] // Let's keep `epi` well-documented.
 
+#[cfg(not(target_arch = "wasm32"))]
+pub use crate::native::run::RequestRepaintEvent;
+#[cfg(not(target_arch = "wasm32"))]
+pub use winit::event_loop::EventLoopBuilder;
+
+/// Hook into the building of an event loop before it is run
+///
+/// You can configure any platform specific details required on top of the default configuration
+/// done by `EFrame`.
+#[cfg(not(target_arch = "wasm32"))]
+pub type EventLoopBuilderHook = Box<dyn FnOnce(&mut EventLoopBuilder<RequestRepaintEvent>)>;
+
 /// This is how your app is created.
 ///
 /// You can use the [`CreationContext`] to setup egui, restore state, setup OpenGL things, etc.
@@ -177,7 +189,6 @@ pub enum HardwareAcceleration {
 ///
 /// Only a single native window is currently supported.
 #[cfg(not(target_arch = "wasm32"))]
-#[derive(Clone)]
 pub struct NativeOptions {
     /// Sets whether or not the window will always be on top of other windows.
     pub always_on_top: bool,
@@ -292,6 +303,25 @@ pub struct NativeOptions {
     /// When `true`, [`winit::platform::run_return::EventLoopExtRunReturn::run_return`] is used.
     /// When `false`, [`winit::event_loop::EventLoop::run`] is used.
     pub run_and_return: bool,
+
+    /// Hook into the building of an event loop before it is run.
+    ///
+    /// Specify a callback here in case you need to make platform specific changes to the
+    /// event loop before it is run.
+    ///
+    /// Note: A [`NativeOptions`] clone will not include any `event_loop_builder` hook.
+    pub event_loop_builder: Option<EventLoopBuilderHook>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Clone for NativeOptions {
+    fn clone(&self) -> Self {
+        Self {
+            icon_data: self.icon_data.clone(),
+            event_loop_builder: None, // Skip any builder callbacks if cloning
+            ..*self
+        }
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -319,6 +349,7 @@ impl Default for NativeOptions {
             follow_system_theme: cfg!(target_os = "macos") || cfg!(target_os = "windows"),
             default_theme: Theme::Dark,
             run_and_return: true,
+            event_loop_builder: None,
         }
     }
 }

--- a/crates/eframe/src/lib.rs
+++ b/crates/eframe/src/lib.rs
@@ -169,13 +169,13 @@ pub fn run_native(app_name: &str, native_options: NativeOptions, app_creator: Ap
         #[cfg(feature = "glow")]
         Renderer::Glow => {
             tracing::debug!("Using the glow renderer");
-            native::run::run_glow(app_name, &native_options, app_creator);
+            native::run::run_glow(app_name, native_options, app_creator);
         }
 
         #[cfg(feature = "wgpu")]
         Renderer::Wgpu => {
             tracing::debug!("Using the wgpu renderer");
-            native::run::run_wgpu(app_name, &native_options, app_creator);
+            native::run::run_wgpu(app_name, native_options, app_creator);
         }
     }
 }


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

This continues the work I started in https://github.com/emilk/egui/pull/1634 by updating eframe to also defer how it initializes graphics state, which ensures that on Android we wait until the application has an associated `SurfaceView`.

The first commit (which affects the `NativeOption` API) is needed for me to use the [android-activity](https://github.com/rib/android-activity) Android glue crate with Egui which was a pre-requisite for being able to create an Android test/example using eframe. Notably; the aim here was to create a general mechanism that allows customizing the event loop so it's not necessary for Egui/EFrame to have a direct dependency on the `android-activity` glue crate (since Winit will generally handle the Android platform integration).

The minimal example [here](https://github.com/rib/android-activity/tree/eframe/examples/agdk-eframe) can be used to test this - and that will hopefully be updated soon to use demo lib.

The main issue hit while making this change was realizing that it was only really possible to support Android fully with Wgpu currently, not with Glow/Glutin.

The difficulty with Glutin is that it currently tightly couples a GL context with a window which means you can't destroy and recreate just the window surface when an Android app is suspended - you're forced to also destroy the full GL context, at which point you're basically forced to tear everything down. There is work in progress to improve the Glutin API so suspend and resume will be possible to support in the future, but I'm not sure what the eta is currently for [this work](https://github.com/rust-windowing/glutin/pull/1435).

For now though I have still updated the Glow integration in-line with the Wgpu changes - so it would be possible to launch an Glow based application on Android and it should work until the application is suspended - which is at least an incremental improvement and hopefully it will just be another incremental change to support suspend and resume once the `Surface` API lands for Glutin.

Closes #1951