### PR TITLE
Only require something GLES 3 compatible from wgpu

### DIFF
--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -507,7 +507,7 @@ mod wgpu_integration {
                     wgpu::DeviceDescriptor {
                         label: None,
                         features: wgpu::Features::default(),
-                        limits: wgpu::Limits::default(),
+                        limits: wgpu::Limits::downlevel_webgl2_defaults(),
                     },
                     wgpu::PresentMode::Fifo,
                     native_options.multisampling.max(1) as _,


### PR DESCRIPTION
This allows the wgpu backend to be used on older devices and is required by the Android emulator. There should probably be a way to request higher limits for applications doing their own rendering however.