### PR TITLE
Add custom parser to `DragValue` and `Slider`, with additional support for binary, octal, and hexadecimal numbers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 * Added `custom_formatter` method for `Slider` and `DragValue` ([#1851](https://github.com/emilk/egui/issues/1851)).
 * Added `RawInput::has_focus` which backends can set to indicate whether the UI as a whole has the keyboard focus ([#1859](https://github.com/emilk/egui/pull/1859)).
 * Added `PointerState::button_double_clicked()` and `PointerState::button_triple_clicked()` ([#1906](https://github.com/emilk/egui/issues/1906)).
+* Added `custom_formatter`, `binary_u64`, `octal_u64`, and `hexadecimal_64` to `DragValue` and `Slider` ([#1953](https://github.com/emilk/egui/issues/1953))
 
 ### Changed
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 * Added `custom_formatter` method for `Slider` and `DragValue` ([#1851](https://github.com/emilk/egui/issues/1851)).
 * Added `RawInput::has_focus` which backends can set to indicate whether the UI as a whole has the keyboard focus ([#1859](https://github.com/emilk/egui/pull/1859)).
 * Added `PointerState::button_double_clicked()` and `PointerState::button_triple_clicked()` ([#1906](https://github.com/emilk/egui/issues/1906)).
-* Added `custom_formatter`, `binary_u64`, `octal_u64`, and `hexadecimal_64` to `DragValue` and `Slider` ([#1953](https://github.com/emilk/egui/issues/1953))
+* Added `custom_formatter`, `binary`, `octal`, and `hexadecimal` to `DragValue` and `Slider` ([#1953](https://github.com/emilk/egui/issues/1953))
 
 ### Changed
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -240,8 +240,8 @@ impl<'a> DragValue<'a> {
         self
     }
 
-    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary signed integers. Floating
-    /// point numbers are *not* supported.
+    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary integers. Floating point
+    /// numbers are *not* supported.
     ///
     /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
     /// prefixed with additional 0s to match `min_width`.
@@ -277,8 +277,8 @@ impl<'a> DragValue<'a> {
         .custom_parser(|s| i64::from_str_radix(s, 2).map(|n| n as f64).ok())
     }
 
-    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary signed integers. Floating
-    /// point numbers are *not* supported.
+    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary integers. Floating point
+    /// numbers are *not* supported.
     ///
     /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
     /// prefixed with additional 0s to match `min_width`.
@@ -314,8 +314,8 @@ impl<'a> DragValue<'a> {
         .custom_parser(|s| i64::from_str_radix(s, 8).map(|n| n as f64).ok())
     }
 
-    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary signed integers. Floating
-    /// point numbers are *not* supported.
+    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary integers. Floating point
+    /// numbers are *not* supported.
     ///
     /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
     /// prefixed with additional 0s to match `min_width`.

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -250,10 +250,12 @@ impl<'a> DragValue<'a> {
     ///
     /// Panics if `min_width` is 0.
     ///
+    /// ```
     /// # egui::__run_test_ui(|ui| {
     /// # let mut my_i32: i32 = 0;
     /// ui.add(egui::DragValue::new(&mut my_i32).binary_u64(64));
     /// # });
+    /// ```
     pub fn binary_u64(self, min_width: usize) -> Self {
         assert!(
             min_width > 0,
@@ -286,10 +288,12 @@ impl<'a> DragValue<'a> {
     ///
     /// Panics if `min_width` is 0.
     ///
+    /// ```
     /// # egui::__run_test_ui(|ui| {
     /// # let mut my_i32: i32 = 0;
     /// ui.add(egui::DragValue::new(&mut my_i32).octal_u64(22));
     /// # });
+    /// ```
     pub fn octal_u64(self, min_width: usize) -> Self {
         assert!(
             min_width > 0,
@@ -322,10 +326,12 @@ impl<'a> DragValue<'a> {
     ///
     /// Panics if `min_width` is 0.
     ///
+    /// ```
     /// # egui::__run_test_ui(|ui| {
     /// # let mut my_i32: i32 = 0;
-    /// ui.add(egui::DragValue::new(&mut my_i32).hexadecimal_u64(16));
+    /// ui.add(egui::DragValue::new(&mut my_i32).hexadecimal_u64(16, true));
     /// # });
+    /// ```
     pub fn hexadecimal_u64(self, min_width: usize, upper: bool) -> Self {
         assert!(
             min_width > 0,
@@ -348,7 +354,7 @@ impl<'a> DragValue<'a> {
                         if digit > 15 {
                             digit -= 6;
                         }
-                        n += (digit as u64) * 16u64.pow(i as u32)
+                        n += (digit as u64) * 16u64.pow(i as u32);
                     }
                     None => return None,
                 }

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -243,7 +243,7 @@ impl<'a> DragValue<'a> {
     /// Set `custom_formatter` and `custom_parser` to display and parse numbers in binary.
     /// Signed integers and floating point numbers are not supported.
     ///
-    /// `min_width` specifies the minimum number of displayed digits; if the number is shorten than this, it will be
+    /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
     /// prefixed with additional 0s to match `min_width`.
     ///
     /// # Panics
@@ -255,7 +255,10 @@ impl<'a> DragValue<'a> {
     /// ui.add(egui::DragValue::new(&mut my_i32).binary_u64(64));
     /// # });
     pub fn binary_u64(self, min_width: usize) -> Self {
-        assert!(min_width > 0, "DragValue::binary_u64: `min_width` must be greater than 0");
+        assert!(
+            min_width > 0,
+            "DragValue::binary_u64: `min_width` must be greater than 0"
+        );
         self.custom_formatter(move |n, _| format!("{:0>min_width$b}", n as u64))
             .custom_parser(|s| {
                 if s.is_empty() {
@@ -276,7 +279,7 @@ impl<'a> DragValue<'a> {
     /// Set `custom_formatter` and `custom_parser` to display and parse numbers in octal.
     /// Signed integers and floating point numbers are not supported.
     ///
-    /// `min_width` specifies the minimum number of displayed digits; if the number is shorten than this, it will be
+    /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
     /// prefixed with additional 0s to match `min_width`.
     ///
     /// # Panics
@@ -288,7 +291,10 @@ impl<'a> DragValue<'a> {
     /// ui.add(egui::DragValue::new(&mut my_i32).octal_u64(22));
     /// # });
     pub fn octal_u64(self, min_width: usize) -> Self {
-        assert!(min_width > 0, "DragValue::octal_u64: `min_width` must be greater than 0");
+        assert!(
+            min_width > 0,
+            "DragValue::octal_u64: `min_width` must be greater than 0"
+        );
         self.custom_formatter(move |n, _| format!("{:0>min_width$o}", n as u64))
             .custom_parser(|s| {
                 if s.is_empty() {
@@ -309,7 +315,7 @@ impl<'a> DragValue<'a> {
     /// Set `custom_formatter` and `custom_parser` to display and parse numbers in hexadecimal.
     /// Signed integers and floating point numbers are not supported.
     ///
-    /// `min_width` specifies the minimum number of displayed digits; if the number is shorten than this, it will be
+    /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
     /// prefixed with additional 0s to match `min_width`.
     ///
     /// # Panics
@@ -320,9 +326,12 @@ impl<'a> DragValue<'a> {
     /// # let mut my_i32: i32 = 0;
     /// ui.add(egui::DragValue::new(&mut my_i32).hexadecimal_u64(16));
     /// # });
-    pub fn hexadecimal_u64(self, min_width: usize, big: bool) -> Self {
-        assert!(min_width > 0, "DragValue::hexadecimal_u64: `min_width` must be greater than 0");
-        if big {
+    pub fn hexadecimal_u64(self, min_width: usize, upper: bool) -> Self {
+        assert!(
+            min_width > 0,
+            "DragValue::hexadecimal_u64: `min_width` must be greater than 0"
+        );
+        if upper {
             self.custom_formatter(move |n, _| format!("{:0>min_width$X}", n as u64))
         } else {
             self.custom_formatter(move |n, _| format!("{:0>min_width$x}", n as u64))

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -277,7 +277,7 @@ impl<'a> DragValue<'a> {
         .custom_parser(|s| i64::from_str_radix(s, 2).map(|n| n as f64).ok())
     }
 
-    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary integers. Floating point
+    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as octal integers. Floating point
     /// numbers are *not* supported.
     ///
     /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
@@ -314,7 +314,7 @@ impl<'a> DragValue<'a> {
         .custom_parser(|s| i64::from_str_radix(s, 8).map(|n| n as f64).ok())
     }
 
-    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary integers. Floating point
+    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as hexadecimal integers. Floating point
     /// numbers are *not* supported.
     ///
     /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -249,7 +249,7 @@ impl<'a> DragValue<'a> {
     /// If `twos_complement` is true, negative values will be displayed as the 2's complement representation. Otherwise
     /// they will be prefixed with a '-' sign.
     ///
-    /// See also: [`binary_uint`]
+    /// See also: [`binary`]
     ///
     /// # Panics
     ///
@@ -286,7 +286,7 @@ impl<'a> DragValue<'a> {
     /// If `twos_complement` is true, negative values will be displayed as the 2's complement representation. Otherwise
     /// they will be prefixed with a '-' sign.
     ///
-    /// See also: [`octal_uint`]
+    /// See also: [`octal`]
     ///
     /// # Panics
     ///
@@ -301,7 +301,7 @@ impl<'a> DragValue<'a> {
     pub fn octal(self, min_width: usize, twos_complement: bool) -> Self {
         assert!(
             min_width > 0,
-            "DragValue::octal_int: `min_width` must be greater than 0"
+            "DragValue::octal: `min_width` must be greater than 0"
         );
         if twos_complement {
             self.custom_formatter(move |n, _| format!("{:0>min_width$o}", n as i64))
@@ -323,7 +323,7 @@ impl<'a> DragValue<'a> {
     /// If `twos_complement` is true, negative values will be displayed as the 2's complement representation. Otherwise
     /// they will be prefixed with a '-' sign.
     ///
-    /// See also: [`hexadecinal_uint`]
+    /// See also: [`hexadecimal`]
     ///
     /// # Panics
     ///

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -249,8 +249,6 @@ impl<'a> DragValue<'a> {
     /// If `twos_complement` is true, negative values will be displayed as the 2's complement representation. Otherwise
     /// they will be prefixed with a '-' sign.
     ///
-    /// See also: [`binary`]
-    ///
     /// # Panics
     ///
     /// Panics if `min_width` is 0.
@@ -286,8 +284,6 @@ impl<'a> DragValue<'a> {
     /// If `twos_complement` is true, negative values will be displayed as the 2's complement representation. Otherwise
     /// they will be prefixed with a '-' sign.
     ///
-    /// See also: [`octal`]
-    ///
     /// # Panics
     ///
     /// Panics if `min_width` is 0.
@@ -322,8 +318,6 @@ impl<'a> DragValue<'a> {
     ///
     /// If `twos_complement` is true, negative values will be displayed as the 2's complement representation. Otherwise
     /// they will be prefixed with a '-' sign.
-    ///
-    /// See also: [`hexadecimal`]
     ///
     /// # Panics
     ///

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -179,8 +179,8 @@ impl<'a> DragValue<'a> {
     ///         if parts.len() == 3 {
     ///             parts[0].parse::<i32>().and_then(|h| {
     ///                 parts[1].parse::<i32>().and_then(|m| {
-    ///                     parts[2].parse::<i32>().and_then(|s| {
-    ///                         Ok(((h * 60 * 60) + (m * 60) + s) as f64)
+    ///                     parts[2].parse::<i32>().map(|s| {
+    ///                         ((h * 60 * 60) + (m * 60) + s) as f64
     ///                     })
     ///                 })
     ///             })
@@ -223,8 +223,8 @@ impl<'a> DragValue<'a> {
     ///         if parts.len() == 3 {
     ///             parts[0].parse::<i32>().and_then(|h| {
     ///                 parts[1].parse::<i32>().and_then(|m| {
-    ///                     parts[2].parse::<i32>().and_then(|s| {
-    ///                         Ok(((h * 60 * 60) + (m * 60) + s) as f64)
+    ///                     parts[2].parse::<i32>().map(|s| {
+    ///                         ((h * 60 * 60) + (m * 60) + s) as f64
     ///                     })
     ///                 })
     ///             })

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -372,7 +372,7 @@ impl<'a> Slider<'a> {
         .custom_parser(|s| i64::from_str_radix(s, 2).map(|n| n as f64).ok())
     }
 
-    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary integers. Floating point
+    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as octal integers. Floating point
     /// numbers are *not* supported.
     ///
     /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
@@ -409,7 +409,7 @@ impl<'a> Slider<'a> {
         .custom_parser(|s| i64::from_str_radix(s, 8).map(|n| n as f64).ok())
     }
 
-    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary integers. Floating point
+    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as hexadecimal integers. Floating point
     /// numbers are *not* supported.
     ///
     /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -262,8 +262,7 @@ impl<'a> Slider<'a> {
     /// ```
     /// # egui::__run_test_ui(|ui| {
     /// # let mut my_i32: i32 = 0;
-    /// ui.add(egui::DragValue::new(&mut my_i32)
-    ///     .clamp_range(0..=((60 * 60 * 24) - 1))
+    /// ui.add(egui::Slider::new(&mut my_i32, 0..=((60 * 60 * 24) - 1))
     ///     .custom_formatter(|n, _| {
     ///         let n = n as i32;
     ///         let hours = n / (60 * 60);
@@ -276,8 +275,8 @@ impl<'a> Slider<'a> {
     ///         if parts.len() == 3 {
     ///             parts[0].parse::<i32>().and_then(|h| {
     ///                 parts[1].parse::<i32>().and_then(|m| {
-    ///                     parts[2].parse::<i32>().and_then(|s| {
-    ///                         Ok(((h * 60 * 60) + (m * 60) + s) as f64)
+    ///                     parts[2].parse::<i32>().map(|s| {
+    ///                         ((h * 60 * 60) + (m * 60) + s) as f64
     ///                     })
     ///                 })
     ///             })
@@ -306,8 +305,7 @@ impl<'a> Slider<'a> {
     /// ```
     /// # egui::__run_test_ui(|ui| {
     /// # let mut my_i32: i32 = 0;
-    /// ui.add(egui::DragValue::new(&mut my_i32)
-    ///     .clamp_range(0..=((60 * 60 * 24) - 1))
+    /// ui.add(egui::Slider::new(&mut my_i32, 0..=((60 * 60 * 24) - 1))
     ///     .custom_formatter(|n, _| {
     ///         let n = n as i32;
     ///         let hours = n / (60 * 60);
@@ -320,8 +318,8 @@ impl<'a> Slider<'a> {
     ///         if parts.len() == 3 {
     ///             parts[0].parse::<i32>().and_then(|h| {
     ///                 parts[1].parse::<i32>().and_then(|m| {
-    ///                     parts[2].parse::<i32>().and_then(|s| {
-    ///                         Ok(((h * 60 * 60) + (m * 60) + s) as f64)
+    ///                     parts[2].parse::<i32>().map(|s| {
+    ///                         ((h * 60 * 60) + (m * 60) + s) as f64
     ///                     })
     ///                 })
     ///             })
@@ -335,6 +333,114 @@ impl<'a> Slider<'a> {
     pub fn custom_parser(mut self, parser: impl 'a + Fn(&str) -> Option<f64>) -> Self {
         self.custom_parser = Some(Box::new(parser));
         self
+    }
+
+    /// Set `custom_formatter` and `custom_parser` to display and parse numbers in binary.
+    /// Signed integers and floating point numbers are not supported.
+    ///
+    /// `min_width` specifies the minimum number of displayed digits; if the number is shorten than this, it will be
+    /// prefixed with additional 0s to match `min_width`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `min_width` is 0.
+    ///
+    /// # egui::__run_test_ui(|ui| {
+    /// # let mut my_i32: i32 = 0;
+    /// ui.add(egui::DragValue::new(&mut my_i32).binary_u64(64));
+    /// # });
+    pub fn binary_u64(self, min_width: usize) -> Self {
+        assert!(min_width > 0, "DragValue::binary_u64: `min_width` must be greater than 0");
+        self.custom_formatter(move |n, _| format!("{:0>min_width$b}", n as u64))
+            .custom_parser(|s| {
+                if s.is_empty() {
+                    return None;
+                }
+                let num_digits = s.len().min(64);
+                let mut n = 0;
+                for (i, digit) in s.chars().rev().take(num_digits).enumerate() {
+                    if digit != '0' && digit != '1' {
+                        return None;
+                    }
+                    n |= (digit as u64 - '0' as u64) << (i as u64);
+                }
+                Some(n as f64)
+            })
+    }
+
+    /// Set `custom_formatter` and `custom_parser` to display and parse numbers in octal.
+    /// Signed integers and floating point numbers are not supported.
+    ///
+    /// `min_width` specifies the minimum number of displayed digits; if the number is shorten than this, it will be
+    /// prefixed with additional 0s to match `min_width`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `min_width` is 0.
+    ///
+    /// # egui::__run_test_ui(|ui| {
+    /// # let mut my_i32: i32 = 0;
+    /// ui.add(egui::DragValue::new(&mut my_i32).octal_u64(22));
+    /// # });
+    pub fn octal_u64(self, min_width: usize) -> Self {
+        assert!(min_width > 0, "DragValue::octal_u64: `min_width` must be greater than 0");
+        self.custom_formatter(move |n, _| format!("{:0>min_width$o}", n as u64))
+            .custom_parser(|s| {
+                if s.is_empty() {
+                    return None;
+                }
+                let num_digits = s.len().min(22);
+                let mut n = 0;
+                for (i, digit) in s.chars().rev().take(num_digits).enumerate() {
+                    if !"01234567".contains(digit) {
+                        return None;
+                    }
+                    n += (digit as u64 - '0' as u64) * 8u64.pow(i as u32);
+                }
+                Some(n as f64)
+            })
+    }
+
+    /// Set `custom_formatter` and `custom_parser` to display and parse numbers in hexadecimal.
+    /// Signed integers and floating point numbers are not supported.
+    ///
+    /// `min_width` specifies the minimum number of displayed digits; if the number is shorten than this, it will be
+    /// prefixed with additional 0s to match `min_width`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `min_width` is 0.
+    ///
+    /// # egui::__run_test_ui(|ui| {
+    /// # let mut my_i32: i32 = 0;
+    /// ui.add(egui::DragValue::new(&mut my_i32).hexadecimal_u64(16));
+    /// # });
+    pub fn hexadecimal_u64(self, min_width: usize, big: bool) -> Self {
+        assert!(min_width > 0, "DragValue::hexadecimal_u64: `min_width` must be greater than 0");
+        if big {
+            self.custom_formatter(move |n, _| format!("{:0>min_width$X}", n as u64))
+        } else {
+            self.custom_formatter(move |n, _| format!("{:0>min_width$x}", n as u64))
+        }
+            .custom_parser(|s| {
+                if s.is_empty() {
+                    return None;
+                }
+                let num_digits = s.len().min(16);
+                let mut n = 0;
+                for (i, digit) in s.chars().rev().take(num_digits).enumerate() {
+                    match "0123456789ABCDEFabcdef".find(digit) {
+                        Some(mut digit) => {
+                            if digit > 15 {
+                                digit -= 6;
+                            }
+                            n += (digit as u64) * 16u64.pow(i as u32)
+                        }
+                        None => return None,
+                    }
+                }
+                Some(n as f64)
+            })
     }
 
     /// Helper: equivalent to `self.precision(0).smallest_positive(1.0)`.

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -335,8 +335,8 @@ impl<'a> Slider<'a> {
         self
     }
 
-    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary signed integers. Floating
-    /// point numbers are *not* supported.
+    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary integers. Floating point
+    /// numbers are *not* supported.
     ///
     /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
     /// prefixed with additional 0s to match `min_width`.
@@ -372,8 +372,8 @@ impl<'a> Slider<'a> {
         .custom_parser(|s| i64::from_str_radix(s, 2).map(|n| n as f64).ok())
     }
 
-    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary signed integers. Floating
-    /// point numbers are *not* supported.
+    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary integers. Floating point
+    /// numbers are *not* supported.
     ///
     /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
     /// prefixed with additional 0s to match `min_width`.
@@ -409,8 +409,8 @@ impl<'a> Slider<'a> {
         .custom_parser(|s| i64::from_str_radix(s, 8).map(|n| n as f64).ok())
     }
 
-    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary signed integers. Floating
-    /// point numbers are *not* supported.
+    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary integers. Floating point
+    /// numbers are *not* supported.
     ///
     /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
     /// prefixed with additional 0s to match `min_width`.

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -344,8 +344,6 @@ impl<'a> Slider<'a> {
     /// If `twos_complement` is true, negative values will be displayed as the 2's complement representation. Otherwise
     /// they will be prefixed with a '-' sign.
     ///
-    /// See also: [`binary`]
-    ///
     /// # Panics
     ///
     /// Panics if `min_width` is 0.
@@ -381,8 +379,6 @@ impl<'a> Slider<'a> {
     /// If `twos_complement` is true, negative values will be displayed as the 2's complement representation. Otherwise
     /// they will be prefixed with a '-' sign.
     ///
-    /// See also: [`octal`]
-    ///
     /// # Panics
     ///
     /// Panics if `min_width` is 0.
@@ -417,8 +413,6 @@ impl<'a> Slider<'a> {
     ///
     /// If `twos_complement` is true, negative values will be displayed as the 2's complement representation. Otherwise
     /// they will be prefixed with a '-' sign.
-    ///
-    /// See also: [`hexadecimal`]
     ///
     /// # Panics
     ///

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -345,10 +345,12 @@ impl<'a> Slider<'a> {
     ///
     /// Panics if `min_width` is 0.
     ///
+    /// ```
     /// # egui::__run_test_ui(|ui| {
     /// # let mut my_i32: i32 = 0;
     /// ui.add(egui::DragValue::new(&mut my_i32).binary_u64(64));
     /// # });
+    /// ```
     pub fn binary_u64(self, min_width: usize) -> Self {
         assert!(
             min_width > 0,
@@ -381,10 +383,12 @@ impl<'a> Slider<'a> {
     ///
     /// Panics if `min_width` is 0.
     ///
+    /// ```
     /// # egui::__run_test_ui(|ui| {
     /// # let mut my_i32: i32 = 0;
     /// ui.add(egui::DragValue::new(&mut my_i32).octal_u64(22));
     /// # });
+    /// ```
     pub fn octal_u64(self, min_width: usize) -> Self {
         assert!(
             min_width > 0,
@@ -417,10 +421,12 @@ impl<'a> Slider<'a> {
     ///
     /// Panics if `min_width` is 0.
     ///
+    /// ```
     /// # egui::__run_test_ui(|ui| {
     /// # let mut my_i32: i32 = 0;
-    /// ui.add(egui::DragValue::new(&mut my_i32).hexadecimal_u64(16));
+    /// ui.add(egui::DragValue::new(&mut my_i32).hexadecimal_u64(16, true));
     /// # });
+    /// ```
     pub fn hexadecimal_u64(self, min_width: usize, upper: bool) -> Self {
         assert!(
             min_width > 0,
@@ -443,7 +449,7 @@ impl<'a> Slider<'a> {
                         if digit > 15 {
                             digit -= 6;
                         }
-                        n += (digit as u64) * 16u64.pow(i as u32)
+                        n += (digit as u64) * 16u64.pow(i as u32);
                     }
                     None => return None,
                 }

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -335,11 +335,16 @@ impl<'a> Slider<'a> {
         self
     }
 
-    /// Set `custom_formatter` and `custom_parser` to display and parse numbers in binary.
-    /// Signed integers and floating point numbers are not supported.
+    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary signed integers. Floating
+    /// point numbers are *not* supported.
     ///
     /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
     /// prefixed with additional 0s to match `min_width`.
+    ///
+    /// If `twos_complement` is true, negative values will be displayed as the 2's complement representation. Otherwise
+    /// they will be prefixed with a '-' sign.
+    ///
+    /// See also: [`binary_uint`]
     ///
     /// # Panics
     ///
@@ -348,114 +353,105 @@ impl<'a> Slider<'a> {
     /// ```
     /// # egui::__run_test_ui(|ui| {
     /// # let mut my_i32: i32 = 0;
-    /// ui.add(egui::DragValue::new(&mut my_i32).binary_u64(64));
+    /// ui.add(egui::Slider::new(&mut my_i32, -100..=100).binary(64, false));
     /// # });
     /// ```
-    pub fn binary_u64(self, min_width: usize) -> Self {
+    pub fn binary(self, min_width: usize, twos_complement: bool) -> Self {
         assert!(
             min_width > 0,
-            "DragValue::binary_u64: `min_width` must be greater than 0"
+            "Slider::binary: `min_width` must be greater than 0"
         );
-        self.custom_formatter(move |n, _| format!("{:0>min_width$b}", n as u64))
-            .custom_parser(|s| {
-                if s.is_empty() {
-                    return None;
-                }
-                let num_digits = s.len().min(64);
-                let mut n = 0;
-                for (i, digit) in s.chars().rev().take(num_digits).enumerate() {
-                    if digit != '0' && digit != '1' {
-                        return None;
-                    }
-                    n |= (digit as u64 - '0' as u64) << (i as u64);
-                }
-                Some(n as f64)
-            })
-    }
-
-    /// Set `custom_formatter` and `custom_parser` to display and parse numbers in octal.
-    /// Signed integers and floating point numbers are not supported.
-    ///
-    /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
-    /// prefixed with additional 0s to match `min_width`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `min_width` is 0.
-    ///
-    /// ```
-    /// # egui::__run_test_ui(|ui| {
-    /// # let mut my_i32: i32 = 0;
-    /// ui.add(egui::DragValue::new(&mut my_i32).octal_u64(22));
-    /// # });
-    /// ```
-    pub fn octal_u64(self, min_width: usize) -> Self {
-        assert!(
-            min_width > 0,
-            "DragValue::octal_u64: `min_width` must be greater than 0"
-        );
-        self.custom_formatter(move |n, _| format!("{:0>min_width$o}", n as u64))
-            .custom_parser(|s| {
-                if s.is_empty() {
-                    return None;
-                }
-                let num_digits = s.len().min(22);
-                let mut n = 0;
-                for (i, digit) in s.chars().rev().take(num_digits).enumerate() {
-                    if !"01234567".contains(digit) {
-                        return None;
-                    }
-                    n += (digit as u64 - '0' as u64) * 8u64.pow(i as u32);
-                }
-                Some(n as f64)
-            })
-    }
-
-    /// Set `custom_formatter` and `custom_parser` to display and parse numbers in hexadecimal.
-    /// Signed integers and floating point numbers are not supported.
-    ///
-    /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
-    /// prefixed with additional 0s to match `min_width`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `min_width` is 0.
-    ///
-    /// ```
-    /// # egui::__run_test_ui(|ui| {
-    /// # let mut my_i32: i32 = 0;
-    /// ui.add(egui::DragValue::new(&mut my_i32).hexadecimal_u64(16, true));
-    /// # });
-    /// ```
-    pub fn hexadecimal_u64(self, min_width: usize, upper: bool) -> Self {
-        assert!(
-            min_width > 0,
-            "DragValue::hexadecimal_u64: `min_width` must be greater than 0"
-        );
-        if upper {
-            self.custom_formatter(move |n, _| format!("{:0>min_width$X}", n as u64))
+        if twos_complement {
+            self.custom_formatter(move |n, _| format!("{:0>min_width$b}", n as i64))
         } else {
-            self.custom_formatter(move |n, _| format!("{:0>min_width$x}", n as u64))
+            self.custom_formatter(move |n, _| {
+                let sign = if n < 0.0 { "-" } else { "" };
+                format!("{sign}{:0>min_width$b}", n.abs() as i64)
+            })
         }
-        .custom_parser(|s| {
-            if s.is_empty() {
-                return None;
+        .custom_parser(|s| i64::from_str_radix(s, 2).map(|n| n as f64).ok())
+    }
+
+    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary signed integers. Floating
+    /// point numbers are *not* supported.
+    ///
+    /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
+    /// prefixed with additional 0s to match `min_width`.
+    ///
+    /// If `twos_complement` is true, negative values will be displayed as the 2's complement representation. Otherwise
+    /// they will be prefixed with a '-' sign.
+    ///
+    /// See also: [`octal_uint`]
+    ///
+    /// # Panics
+    ///
+    /// Panics if `min_width` is 0.
+    ///
+    /// ```
+    /// # egui::__run_test_ui(|ui| {
+    /// # let mut my_i32: i32 = 0;
+    /// ui.add(egui::Slider::new(&mut my_i32, -100..=100).octal(22, false));
+    /// # });
+    /// ```
+    pub fn octal(self, min_width: usize, twos_complement: bool) -> Self {
+        assert!(
+            min_width > 0,
+            "Slider::octal_int: `min_width` must be greater than 0"
+        );
+        if twos_complement {
+            self.custom_formatter(move |n, _| format!("{:0>min_width$o}", n as i64))
+        } else {
+            self.custom_formatter(move |n, _| {
+                let sign = if n < 0.0 { "-" } else { "" };
+                format!("{sign}{:0>min_width$o}", n.abs() as i64)
+            })
+        }
+        .custom_parser(|s| i64::from_str_radix(s, 8).map(|n| n as f64).ok())
+    }
+
+    /// Set `custom_formatter` and `custom_parser` to display and parse numbers as binary signed integers. Floating
+    /// point numbers are *not* supported.
+    ///
+    /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
+    /// prefixed with additional 0s to match `min_width`.
+    ///
+    /// If `twos_complement` is true, negative values will be displayed as the 2's complement representation. Otherwise
+    /// they will be prefixed with a '-' sign.
+    ///
+    /// See also: [`hexadecinal_uint`]
+    ///
+    /// # Panics
+    ///
+    /// Panics if `min_width` is 0.
+    ///
+    /// ```
+    /// # egui::__run_test_ui(|ui| {
+    /// # let mut my_i32: i32 = 0;
+    /// ui.add(egui::Slider::new(&mut my_i32, -100..=100).hexadecimal(16, false, true));
+    /// # });
+    /// ```
+    pub fn hexadecimal(self, min_width: usize, twos_complement: bool, upper: bool) -> Self {
+        assert!(
+            min_width > 0,
+            "Slider::hexadecimal: `min_width` must be greater than 0"
+        );
+        match (twos_complement, upper) {
+            (true, true) => {
+                self.custom_formatter(move |n, _| format!("{:0>min_width$X}", n as i64))
             }
-            let num_digits = s.len().min(16);
-            let mut n = 0;
-            for (i, digit) in s.chars().rev().take(num_digits).enumerate() {
-                match "0123456789ABCDEFabcdef".find(digit) {
-                    Some(mut digit) => {
-                        if digit > 15 {
-                            digit -= 6;
-                        }
-                        n += (digit as u64) * 16u64.pow(i as u32);
-                    }
-                    None => return None,
-                }
+            (true, false) => {
+                self.custom_formatter(move |n, _| format!("{:0>min_width$x}", n as i64))
             }
-            Some(n as f64)
-        })
+            (false, true) => self.custom_formatter(move |n, _| {
+                let sign = if n < 0.0 { "-" } else { "" };
+                format!("{sign}{:0>min_width$X}", n.abs() as i64)
+            }),
+            (false, false) => self.custom_formatter(move |n, _| {
+                let sign = if n < 0.0 { "-" } else { "" };
+                format!("{sign}{:0>min_width$x}", n.abs() as i64)
+            }),
+        }
+        .custom_parser(|s| i64::from_str_radix(s, 16).map(|n| n as f64).ok())
     }
 
     /// Helper: equivalent to `self.precision(0).smallest_positive(1.0)`.

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -344,7 +344,7 @@ impl<'a> Slider<'a> {
     /// If `twos_complement` is true, negative values will be displayed as the 2's complement representation. Otherwise
     /// they will be prefixed with a '-' sign.
     ///
-    /// See also: [`binary_uint`]
+    /// See also: [`binary`]
     ///
     /// # Panics
     ///
@@ -381,7 +381,7 @@ impl<'a> Slider<'a> {
     /// If `twos_complement` is true, negative values will be displayed as the 2's complement representation. Otherwise
     /// they will be prefixed with a '-' sign.
     ///
-    /// See also: [`octal_uint`]
+    /// See also: [`octal`]
     ///
     /// # Panics
     ///
@@ -396,7 +396,7 @@ impl<'a> Slider<'a> {
     pub fn octal(self, min_width: usize, twos_complement: bool) -> Self {
         assert!(
             min_width > 0,
-            "Slider::octal_int: `min_width` must be greater than 0"
+            "Slider::octal: `min_width` must be greater than 0"
         );
         if twos_complement {
             self.custom_formatter(move |n, _| format!("{:0>min_width$o}", n as i64))
@@ -418,7 +418,7 @@ impl<'a> Slider<'a> {
     /// If `twos_complement` is true, negative values will be displayed as the 2's complement representation. Otherwise
     /// they will be prefixed with a '-' sign.
     ///
-    /// See also: [`hexadecinal_uint`]
+    /// See also: [`hexadecimal`]
     ///
     /// # Panics
     ///

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -338,7 +338,7 @@ impl<'a> Slider<'a> {
     /// Set `custom_formatter` and `custom_parser` to display and parse numbers in binary.
     /// Signed integers and floating point numbers are not supported.
     ///
-    /// `min_width` specifies the minimum number of displayed digits; if the number is shorten than this, it will be
+    /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
     /// prefixed with additional 0s to match `min_width`.
     ///
     /// # Panics
@@ -350,7 +350,10 @@ impl<'a> Slider<'a> {
     /// ui.add(egui::DragValue::new(&mut my_i32).binary_u64(64));
     /// # });
     pub fn binary_u64(self, min_width: usize) -> Self {
-        assert!(min_width > 0, "DragValue::binary_u64: `min_width` must be greater than 0");
+        assert!(
+            min_width > 0,
+            "DragValue::binary_u64: `min_width` must be greater than 0"
+        );
         self.custom_formatter(move |n, _| format!("{:0>min_width$b}", n as u64))
             .custom_parser(|s| {
                 if s.is_empty() {
@@ -371,7 +374,7 @@ impl<'a> Slider<'a> {
     /// Set `custom_formatter` and `custom_parser` to display and parse numbers in octal.
     /// Signed integers and floating point numbers are not supported.
     ///
-    /// `min_width` specifies the minimum number of displayed digits; if the number is shorten than this, it will be
+    /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
     /// prefixed with additional 0s to match `min_width`.
     ///
     /// # Panics
@@ -383,7 +386,10 @@ impl<'a> Slider<'a> {
     /// ui.add(egui::DragValue::new(&mut my_i32).octal_u64(22));
     /// # });
     pub fn octal_u64(self, min_width: usize) -> Self {
-        assert!(min_width > 0, "DragValue::octal_u64: `min_width` must be greater than 0");
+        assert!(
+            min_width > 0,
+            "DragValue::octal_u64: `min_width` must be greater than 0"
+        );
         self.custom_formatter(move |n, _| format!("{:0>min_width$o}", n as u64))
             .custom_parser(|s| {
                 if s.is_empty() {
@@ -404,7 +410,7 @@ impl<'a> Slider<'a> {
     /// Set `custom_formatter` and `custom_parser` to display and parse numbers in hexadecimal.
     /// Signed integers and floating point numbers are not supported.
     ///
-    /// `min_width` specifies the minimum number of displayed digits; if the number is shorten than this, it will be
+    /// `min_width` specifies the minimum number of displayed digits; if the number is shorter than this, it will be
     /// prefixed with additional 0s to match `min_width`.
     ///
     /// # Panics
@@ -415,32 +421,35 @@ impl<'a> Slider<'a> {
     /// # let mut my_i32: i32 = 0;
     /// ui.add(egui::DragValue::new(&mut my_i32).hexadecimal_u64(16));
     /// # });
-    pub fn hexadecimal_u64(self, min_width: usize, big: bool) -> Self {
-        assert!(min_width > 0, "DragValue::hexadecimal_u64: `min_width` must be greater than 0");
-        if big {
+    pub fn hexadecimal_u64(self, min_width: usize, upper: bool) -> Self {
+        assert!(
+            min_width > 0,
+            "DragValue::hexadecimal_u64: `min_width` must be greater than 0"
+        );
+        if upper {
             self.custom_formatter(move |n, _| format!("{:0>min_width$X}", n as u64))
         } else {
             self.custom_formatter(move |n, _| format!("{:0>min_width$x}", n as u64))
         }
-            .custom_parser(|s| {
-                if s.is_empty() {
-                    return None;
-                }
-                let num_digits = s.len().min(16);
-                let mut n = 0;
-                for (i, digit) in s.chars().rev().take(num_digits).enumerate() {
-                    match "0123456789ABCDEFabcdef".find(digit) {
-                        Some(mut digit) => {
-                            if digit > 15 {
-                                digit -= 6;
-                            }
-                            n += (digit as u64) * 16u64.pow(i as u32)
+        .custom_parser(|s| {
+            if s.is_empty() {
+                return None;
+            }
+            let num_digits = s.len().min(16);
+            let mut n = 0;
+            for (i, digit) in s.chars().rev().take(num_digits).enumerate() {
+                match "0123456789ABCDEFabcdef".find(digit) {
+                    Some(mut digit) => {
+                        if digit > 15 {
+                            digit -= 6;
                         }
-                        None => return None,
+                        n += (digit as u64) * 16u64.pow(i as u32)
                     }
+                    None => return None,
                 }
-                Some(n as f64)
-            })
+            }
+            Some(n as f64)
+        })
     }
 
     /// Helper: equivalent to `self.precision(0).smallest_positive(1.0)`.


### PR DESCRIPTION
Closes <https://github.com/emilk/egui/issues/1953>.

Adds a `custom_parser` method to `DragValue` and `Slider`, along with extra `binary_u64`, `octal_u64`, and `hexadecimal_u64` which overwrite the `custom_formatter` and `custom_parser`.

The purpose of `custom_parser` is to convert the text input from both widgets to a `f64`. A parser function returns an `Option<f64>` set to `Some` when parsing succeeds or `None` when it fails.

Additional methods for different number systems all take in a `min_width` parameter that specifies the minimum number of displayed digits. If the number is shorter than `min_width`, it will be prefixed with additional 0s to match it. `hexadecimal_u64` also takes in a `bool` which specifies if in the output text alphabetic digits should be uppercase or not.

Demo (apologies for quality):
![untitled](https://user-images.githubusercontent.com/2311185/187002217-e2f020c4-fbfa-45db-a51a-392ccc73e31d.GIF)

Code for the demo:
```rust
ui.add(
    egui::Slider::new(&mut self.age, 0..=1023)
        .text("bin")
        .binary_u64(10),
);
ui.add(
    egui::Slider::new(&mut self.age, 0..=1023)
        .text("oct")
        .octal_u64(4),
);
ui.add(
    egui::Slider::new(&mut self.age, 0..=1023)
        .text("hex")
        .hexadecimal_u64(3, false),
);
ui.add(
    egui::Slider::new(&mut self.age, 0..=1023)
        .text("HEX")
        .hexadecimal_u64(3, true),
);
ui.add(
    egui::Slider::new(&mut self.age, 0..=((60 * 60 * 24) - 1))
        .text("time")
        .custom_formatter(|n, _| {
            let n = n as i32;
            let hours = n / (60 * 60);
            let mins = (n / 60) % 60;
            let secs = n % 60;
            format!("{hours:02}:{mins:02}:{secs:02}")
        })
        .custom_parser(|s| {
            let parts: Vec<&str> = s.split(':').collect();
            if parts.len() == 3 {
                parts[0]
                    .parse::<i32>()
                    .and_then(|h| {
                        parts[1].parse::<i32>().and_then(|m| {
                            parts[2]
                                .parse::<i32>()
                                .map(|s| ((h * 60 * 60) + (m * 60) + s) as f64)
                        })
                    })
                    .ok()
            } else {
                None
            }
        }),
);
```