### PR TITLE
Fix bit more code that could lead to a possible deadlock.

### DIFF
--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -215,10 +215,8 @@ impl SidePanel {
                     && (resize_x - pointer.x).abs()
                         <= ui.style().interaction.resize_grab_radius_side;
 
-                if ui.input().pointer.any_pressed()
-                    && ui.input().pointer.any_down()
-                    && mouse_over_resize_line
-                {
+                let any_pressed = ui.input().pointer.any_pressed(); // avoid deadlocks
+                if any_pressed && ui.input().pointer.any_down() && mouse_over_resize_line {
                     ui.memory().set_dragged_id(resize_id);
                 }
                 is_resizing = ui.memory().is_being_dragged(resize_id);
@@ -229,8 +227,8 @@ impl SidePanel {
                     side.set_rect_width(&mut panel_rect, width);
                 }
 
-                let dragging_something_else =
-                    ui.input().pointer.any_down() || ui.input().pointer.any_pressed();
+                let any_down = ui.input().pointer.any_down(); // avoid deadlocks
+                let dragging_something_else = any_down || ui.input().pointer.any_pressed();
                 resize_hover = mouse_over_resize_line && !dragging_something_else;
 
                 if resize_hover || is_resizing {
@@ -516,8 +514,8 @@ impl TopBottomPanel {
                     side.set_rect_height(&mut panel_rect, height);
                 }
 
-                let dragging_something_else =
-                    ui.input().pointer.any_down() || ui.input().pointer.any_pressed();
+                let any_down = ui.input().pointer.any_down(); // avoid deadlocks
+                let dragging_something_else = any_down || ui.input().pointer.any_pressed();
                 resize_hover = mouse_over_resize_line && !dragging_something_else;
 
                 if resize_hover || is_resizing {

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -584,7 +584,8 @@ fn window_interaction(
     if window_interaction.is_none() {
         if let Some(hover_window_interaction) = resize_hover(ctx, possible, area_layer_id, rect) {
             hover_window_interaction.set_cursor(ctx);
-            if ctx.input().pointer.any_pressed() && ctx.input().pointer.primary_down() {
+            let any_pressed = ctx.input().pointer.any_pressed(); // avoid deadlocks
+            if any_pressed && ctx.input().pointer.primary_down() {
                 ctx.memory().interaction.drag_id = Some(id);
                 ctx.memory().interaction.drag_is_window = true;
                 window_interaction = Some(hover_window_interaction);
@@ -612,7 +613,8 @@ fn resize_hover(
 ) -> Option<WindowInteraction> {
     let pointer = ctx.input().pointer.interact_pos()?;
 
-    if ctx.input().pointer.any_down() && !ctx.input().pointer.any_pressed() {
+    let any_down = ctx.input().pointer.any_down(); // avoid deadlocks
+    if any_down && !ctx.input().pointer.any_pressed() {
         return None; // already dragging (something)
     }
 


### PR DESCRIPTION
Continuation of #1380 story. Fixed bit more code that can possibly lead to double-read caused deadlocks.
 
Some of this deadlocks were found with test panels and gdb, others are found by reading during more global solution research on how to avoid same deadlocks in the future.

First deadlock was found in attempt to integrate egui with last amethyst version, when tried to draw panels in parallel from ecs systems.