### PR TITLE
WIP suggestion: Simplify context lock lifetimes with lambdas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,6 +2171,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "hello_world_par"
+version = "0.1.0"
+dependencies = [
+ "eframe",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## feature spec:
+1) need to remove feature spec from README
+2) methods documentation may be little outdated, since changes where made by "change api and fix all everything that failed to build"
+3) not all libs are currently ready or even can be built, especialy integration and web code
+4) changes are easy but breaking, will be great to write some migration guide
+
+
 # 🖌 egui: an easy-to-use GUI in pure Rust
 
 [<img alt="github" src="https://img.shields.io/badge/github-emilk/egui-8da0cb?logo=github" height="20">](https://github.com/emilk/egui)
@@ -369,6 +376,9 @@ All colors have premultiplied alpha.
 egui uses the builder pattern for construction widgets. For instance: `ui.add(Label::new("Hello").text_color(RED));` I am not a big fan of the builder pattern (it is quite verbose both in implementation and in use) but until Rust has named, default arguments it is the best we can do. To alleviate some of the verbosity there are common-case helper functions, like `ui.label("Hello");`.
 
 Instead of using matching `begin/end` style function calls (which can be error prone) egui prefers to use `FnOnce` closures passed to a wrapping function. Lambdas are a bit ugly though, so I'd like to find a nicer solution to this. More discussion of this at <https://github.com/emilk/egui/issues/1004#issuecomment-1001650754>.
+
+egui uses single RWLock for short time locks on each access to Context data. Single lock is to leave implementation simple and transactional. Short time locks is to allow users to run their UI logic in parallel almost without waiting on locks.
+Also, instead of creating mutex guards egui::Context uses `FnOnce` closures passed to a wrapping function. Reason for this is to make it harder to implement double locking from the same thread (can lead to deadlock) or long locking.
 
 ### Inspiration
 

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -229,7 +229,8 @@ impl EpiIntegration {
     ) -> Self {
         let egui_ctx = egui::Context::default();
 
-        *egui_ctx.memory() = load_egui_memory(storage.as_deref()).unwrap_or_default();
+        let memory = load_egui_memory(storage.as_deref()).unwrap_or_default();
+        egui_ctx.memory_mut(|mem| *mem = memory);
 
         let native_pixels_per_point = window.scale_factor() as f32;
 
@@ -287,11 +288,12 @@ impl EpiIntegration {
 
     pub fn warm_up(&mut self, app: &mut dyn epi::App, window: &winit::window::Window) {
         crate::profile_function!();
-        let saved_memory: egui::Memory = self.egui_ctx.memory().clone();
-        self.egui_ctx.memory().set_everything_is_visible(true);
+        let saved_memory: egui::Memory = self.egui_ctx.memory(|mem| mem.clone());
+        self.egui_ctx
+            .memory_mut(|mem| mem.set_everything_is_visible(true));
         let full_output = self.update(app, window);
         self.pending_full_output.append(full_output); // Handle it next frame
-        *self.egui_ctx.memory() = saved_memory; // We don't want to remember that windows were huge.
+        self.egui_ctx.memory_mut(|mem| *mem = saved_memory); // We don't want to remember that windows were huge.
         self.egui_ctx.clear_animations();
     }
 
@@ -410,7 +412,8 @@ impl EpiIntegration {
             }
             if _app.persist_egui_memory() {
                 crate::profile_scope!("egui_memory");
-                epi::set_value(storage, STORAGE_EGUI_MEMORY_KEY, &*self.egui_ctx.memory());
+                self.egui_ctx
+                    .memory(|mem| epi::set_value(storage, STORAGE_EGUI_MEMORY_KEY, mem));
             }
             {
                 crate::profile_scope!("App::save");

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -614,7 +614,7 @@ impl State {
         egui_ctx: &egui::Context,
         platform_output: egui::PlatformOutput,
     ) {
-        if egui_ctx.options().screen_reader {
+        if egui_ctx.options(|o| o.screen_reader) {
             self.screen_reader
                 .speak(&platform_output.events_description());
         }

--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -231,7 +231,7 @@ impl Area {
 
         let layer_id = LayerId::new(order, id);
 
-        let state = ctx.memory().areas.get(id).copied();
+        let state = ctx.memory(|mem| mem.areas.get(id).copied());
         let is_new = state.is_none();
         if is_new {
             ctx.request_repaint(); // if we don't know the previous size we are likely drawing the area in the wrong place
@@ -278,7 +278,7 @@ impl Area {
             // Important check - don't try to move e.g. a combobox popup!
             if movable {
                 if move_response.dragged() {
-                    state.pos += ctx.input().pointer.delta();
+                    state.pos += ctx.input(|i| i.pointer.delta());
                 }
 
                 state.pos = ctx
@@ -288,9 +288,9 @@ impl Area {
 
             if (move_response.dragged() || move_response.clicked())
                 || pointer_pressed_on_area(ctx, layer_id)
-                || !ctx.memory().areas.visible_last_frame(&layer_id)
+                || !ctx.memory(|m| m.areas.visible_last_frame(&layer_id))
             {
-                ctx.memory().areas.move_to_top(layer_id);
+                ctx.memory_mut(|m| m.areas.move_to_top(layer_id));
                 ctx.request_repaint();
             }
 
@@ -329,7 +329,7 @@ impl Area {
         }
 
         let layer_id = LayerId::new(self.order, self.id);
-        let area_rect = ctx.memory().areas.get(self.id).map(|area| area.rect());
+        let area_rect = ctx.memory(|mem| mem.areas.get(self.id).map(|area| area.rect()));
         if let Some(area_rect) = area_rect {
             let clip_rect = ctx.available_rect();
             let painter = Painter::new(ctx.clone(), layer_id, clip_rect);
@@ -358,7 +358,7 @@ impl Prepared {
     }
 
     pub(crate) fn content_ui(&self, ctx: &Context) -> Ui {
-        let screen_rect = ctx.input().screen_rect();
+        let screen_rect = ctx.input(|i| i.screen_rect());
 
         let bounds = if let Some(bounds) = self.drag_bounds {
             bounds.intersect(screen_rect) // protect against infinite bounds
@@ -410,7 +410,7 @@ impl Prepared {
 
         state.size = content_ui.min_rect().size();
 
-        ctx.memory().areas.set_state(layer_id, state);
+        ctx.memory_mut(|m| m.areas.set_state(layer_id, state));
 
         move_response
     }
@@ -418,7 +418,7 @@ impl Prepared {
 
 fn pointer_pressed_on_area(ctx: &Context, layer_id: LayerId) -> bool {
     if let Some(pointer_pos) = ctx.pointer_interact_pos() {
-        let any_pressed = ctx.input().pointer.any_pressed();
+        let any_pressed = ctx.input(|i| i.pointer.any_pressed());
         any_pressed && ctx.layer_id_at(pointer_pos) == Some(layer_id)
     } else {
         false
@@ -426,13 +426,13 @@ fn pointer_pressed_on_area(ctx: &Context, layer_id: LayerId) -> bool {
 }
 
 fn automatic_area_position(ctx: &Context) -> Pos2 {
-    let mut existing: Vec<Rect> = ctx
-        .memory()
-        .areas
-        .visible_windows()
-        .into_iter()
-        .map(State::rect)
-        .collect();
+    let mut existing: Vec<Rect> = ctx.memory(|mem| {
+        mem.areas
+            .visible_windows()
+            .into_iter()
+            .map(State::rect)
+            .collect()
+    });
     existing.sort_by_key(|r| r.left().round() as i32);
 
     let available_rect = ctx.available_rect();

--- a/crates/egui/src/containers/collapsing_header.rs
+++ b/crates/egui/src/containers/collapsing_header.rs
@@ -26,13 +26,14 @@ pub struct CollapsingState {
 
 impl CollapsingState {
     pub fn load(ctx: &Context, id: Id) -> Option<Self> {
-        ctx.data()
-            .get_persisted::<InnerState>(id)
-            .map(|state| Self { id, state })
+        ctx.data_mut(|d| {
+            d.get_persisted::<InnerState>(id)
+                .map(|state| Self { id, state })
+        })
     }
 
     pub fn store(&self, ctx: &Context) {
-        ctx.data().insert_persisted(self.id, self.state);
+        ctx.data_mut(|d| d.insert_persisted(self.id, self.state));
     }
 
     pub fn id(&self) -> Id {
@@ -64,7 +65,7 @@ impl CollapsingState {
 
     /// 0 for closed, 1 for open, with tweening
     pub fn openness(&self, ctx: &Context) -> f32 {
-        if ctx.memory().everything_is_visible() {
+        if ctx.memory(|mem| mem.everything_is_visible()) {
             1.0
         } else {
             ctx.animate_bool(self.id, self.state.open)

--- a/crates/egui/src/containers/combo_box.rs
+++ b/crates/egui/src/containers/combo_box.rs
@@ -243,18 +243,13 @@ fn combo_box_dyn<'c, R>(
 ) -> InnerResponse<Option<R>> {
     let popup_id = button_id.with("popup");
 
-    let is_popup_open = ui.memory().is_popup_open(popup_id);
+    let is_popup_open = ui.memory(|m| m.is_popup_open(popup_id));
 
-    let popup_height = ui
-        .ctx()
-        .memory()
-        .areas
-        .get(popup_id)
-        .map_or(100.0, |state| state.size.y);
+    let popup_height = ui.memory(|m| m.areas.get(popup_id).map_or(100.0, |state| state.size.y));
 
     let above_or_below =
         if ui.next_widget_position().y + ui.spacing().interact_size.y + popup_height
-            < ui.ctx().input().screen_rect().bottom()
+            < ui.input(|i| i.screen_rect().bottom())
         {
             AboveOrBelow::Below
         } else {
@@ -314,7 +309,7 @@ fn combo_box_dyn<'c, R>(
     });
 
     if button_response.clicked() {
-        ui.memory().toggle_popup(popup_id);
+        ui.memory_mut(|mem| mem.toggle_popup(popup_id));
     }
     let inner = crate::popup::popup_above_or_below_widget(
         ui,

--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -28,7 +28,7 @@ pub struct PanelState {
 
 impl PanelState {
     pub fn load(ctx: &Context, bar_id: Id) -> Option<Self> {
-        ctx.data().get_persisted(bar_id)
+        ctx.data_mut(|d| d.get_persisted(bar_id))
     }
 
     /// The size of the panel (from previous frame).
@@ -37,7 +37,7 @@ impl PanelState {
     }
 
     fn store(self, ctx: &Context, bar_id: Id) {
-        ctx.data().insert_persisted(bar_id, self);
+        ctx.data_mut(|d| d.insert_persisted(bar_id, self));
     }
 }
 
@@ -245,11 +245,12 @@ impl SidePanel {
                     && (resize_x - pointer.x).abs()
                         <= ui.style().interaction.resize_grab_radius_side;
 
-                let any_pressed = ui.input().pointer.any_pressed(); // avoid deadlocks
-                if any_pressed && ui.input().pointer.any_down() && mouse_over_resize_line {
-                    ui.memory().set_dragged_id(resize_id);
+                if ui.input(|i| i.pointer.any_pressed() && i.pointer.any_down())
+                    && mouse_over_resize_line
+                {
+                    ui.memory_mut(|mem| mem.set_dragged_id(resize_id));
                 }
-                is_resizing = ui.memory().is_being_dragged(resize_id);
+                is_resizing = ui.memory(|mem| mem.is_being_dragged(resize_id));
                 if is_resizing {
                     let width = (pointer.x - side.side_x(panel_rect)).abs();
                     let width =
@@ -257,12 +258,12 @@ impl SidePanel {
                     side.set_rect_width(&mut panel_rect, width);
                 }
 
-                let any_down = ui.input().pointer.any_down(); // avoid deadlocks
-                let dragging_something_else = any_down || ui.input().pointer.any_pressed();
+                let dragging_something_else =
+                    ui.input(|i| i.pointer.any_down() || i.pointer.any_pressed());
                 resize_hover = mouse_over_resize_line && !dragging_something_else;
 
                 if resize_hover || is_resizing {
-                    ui.output().cursor_icon = CursorIcon::ResizeHorizontal;
+                    ui.output_mut(|o| o.cursor_icon = CursorIcon::ResizeHorizontal);
                 }
             }
         }
@@ -331,19 +332,19 @@ impl SidePanel {
         let layer_id = LayerId::background();
         let side = self.side;
         let available_rect = ctx.available_rect();
-        let clip_rect = ctx.input().screen_rect();
+        let clip_rect = ctx.input(|i| i.screen_rect());
         let mut panel_ui = Ui::new(ctx.clone(), layer_id, self.id, available_rect, clip_rect);
 
         let inner_response = self.show_inside_dyn(&mut panel_ui, add_contents);
         let rect = inner_response.response.rect;
 
         match side {
-            Side::Left => ctx
-                .frame_state()
-                .allocate_left_panel(Rect::from_min_max(available_rect.min, rect.max)),
-            Side::Right => ctx
-                .frame_state()
-                .allocate_right_panel(Rect::from_min_max(rect.min, available_rect.max)),
+            Side::Left => ctx.frame_state_mut(|state| {
+                state.allocate_left_panel(Rect::from_min_max(available_rect.min, rect.max))
+            }),
+            Side::Right => ctx.frame_state_mut(|state| {
+                state.allocate_right_panel(Rect::from_min_max(rect.min, available_rect.max))
+            }),
         }
         inner_response
     }
@@ -679,7 +680,7 @@ impl TopBottomPanel {
         let mut is_resizing = false;
         if resizable {
             let resize_id = id.with("__resize");
-            let latest_pos = ui.input().pointer.latest_pos();
+            let latest_pos = ui.input(|i| i.pointer.latest_pos());
             if let Some(pointer) = latest_pos {
                 let we_are_on_top = ui
                     .ctx()
@@ -692,13 +693,12 @@ impl TopBottomPanel {
                     && (resize_y - pointer.y).abs()
                         <= ui.style().interaction.resize_grab_radius_side;
 
-                if ui.input().pointer.any_pressed()
-                    && ui.input().pointer.any_down()
+                if ui.input(|i| i.pointer.any_pressed() && i.pointer.any_down())
                     && mouse_over_resize_line
                 {
-                    ui.memory().interaction.drag_id = Some(resize_id);
+                    ui.memory_mut(|mem| mem.interaction.drag_id = Some(resize_id));
                 }
-                is_resizing = ui.memory().interaction.drag_id == Some(resize_id);
+                is_resizing = ui.memory(|mem| mem.interaction.drag_id == Some(resize_id));
                 if is_resizing {
                     let height = (pointer.y - side.side_y(panel_rect)).abs();
                     let height = clamp_to_range(height, height_range.clone())
@@ -706,12 +706,12 @@ impl TopBottomPanel {
                     side.set_rect_height(&mut panel_rect, height);
                 }
 
-                let any_down = ui.input().pointer.any_down(); // avoid deadlocks
-                let dragging_something_else = any_down || ui.input().pointer.any_pressed();
+                let dragging_something_else =
+                    ui.input(|i| i.pointer.any_down() || i.pointer.any_pressed());
                 resize_hover = mouse_over_resize_line && !dragging_something_else;
 
                 if resize_hover || is_resizing {
-                    ui.output().cursor_icon = CursorIcon::ResizeVertical;
+                    ui.output_mut(|o| o.cursor_icon = CursorIcon::ResizeVertical);
                 }
             }
         }
@@ -781,7 +781,7 @@ impl TopBottomPanel {
         let available_rect = ctx.available_rect();
         let side = self.side;
 
-        let clip_rect = ctx.input().screen_rect();
+        let clip_rect = ctx.input(|i| i.screen_rect());
         let mut panel_ui = Ui::new(ctx.clone(), layer_id, self.id, available_rect, clip_rect);
 
         let inner_response = self.show_inside_dyn(&mut panel_ui, add_contents);
@@ -789,12 +789,14 @@ impl TopBottomPanel {
 
         match side {
             TopBottomSide::Top => {
-                ctx.frame_state()
-                    .allocate_top_panel(Rect::from_min_max(available_rect.min, rect.max));
+                ctx.frame_state_mut(|state| {
+                    state.allocate_top_panel(Rect::from_min_max(available_rect.min, rect.max))
+                });
             }
             TopBottomSide::Bottom => {
-                ctx.frame_state()
-                    .allocate_bottom_panel(Rect::from_min_max(rect.min, available_rect.max));
+                ctx.frame_state_mut(|state| {
+                    state.allocate_bottom_panel(Rect::from_min_max(rect.min, available_rect.max))
+                });
             }
         }
 
@@ -1036,14 +1038,13 @@ impl CentralPanel {
         let layer_id = LayerId::background();
         let id = Id::new("central_panel");
 
-        let clip_rect = ctx.input().screen_rect();
+        let clip_rect = ctx.input(|i| i.screen_rect());
         let mut panel_ui = Ui::new(ctx.clone(), layer_id, id, available_rect, clip_rect);
 
         let inner_response = self.show_inside_dyn(&mut panel_ui, add_contents);
 
         // Only inform ctx about what we actually used, so we can shrink the native window to fit.
-        ctx.frame_state()
-            .allocate_central_panel(inner_response.response.rect);
+        ctx.frame_state_mut(|state| state.allocate_central_panel(inner_response.response.rect));
 
         inner_response
     }

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -13,11 +13,11 @@ pub(crate) struct TooltipState {
 
 impl TooltipState {
     pub fn load(ctx: &Context) -> Option<Self> {
-        ctx.data().get_temp(Id::null())
+        ctx.data_mut(|d| d.get_temp(Id::null()))
     }
 
     fn store(self, ctx: &Context) {
-        ctx.data().insert_temp(Id::null(), self);
+        ctx.data_mut(|d| d.insert_temp(Id::null(), self));
     }
 
     fn individual_tooltip_size(&self, common_id: Id, index: usize) -> Option<Vec2> {
@@ -95,9 +95,7 @@ pub fn show_tooltip_at_pointer<R>(
     add_contents: impl FnOnce(&mut Ui) -> R,
 ) -> Option<R> {
     let suggested_pos = ctx
-        .input()
-        .pointer
-        .hover_pos()
+        .input(|i| i.pointer.hover_pos())
         .map(|pointer_pos| pointer_pos + vec2(16.0, 16.0));
     show_tooltip_at(ctx, id, suggested_pos, add_contents)
 }
@@ -112,7 +110,7 @@ pub fn show_tooltip_for<R>(
     add_contents: impl FnOnce(&mut Ui) -> R,
 ) -> Option<R> {
     let expanded_rect = rect.expand2(vec2(2.0, 4.0));
-    let (above, position) = if ctx.input().any_touches() {
+    let (above, position) = if ctx.input(|i| i.any_touches()) {
         (true, expanded_rect.left_top())
     } else {
         (false, expanded_rect.left_bottom())
@@ -158,14 +156,14 @@ fn show_tooltip_at_avoid_dyn<'c, R>(
     let spacing = 4.0;
 
     // if there are multiple tooltips open they should use the same common_id for the `tooltip_size` caching to work.
-    let mut frame_state =
-        ctx.frame_state()
-            .tooltip_state
+    let mut frame_state = ctx.frame_state(|fs| {
+        fs.tooltip_state
             .unwrap_or(crate::frame_state::TooltipFrameState {
                 common_id: individual_id,
                 rect: Rect::NOTHING,
                 count: 0,
-            });
+            })
+    });
 
     let mut position = if frame_state.rect.is_positive() {
         avoid_rect = avoid_rect.union(frame_state.rect);
@@ -176,7 +174,7 @@ fn show_tooltip_at_avoid_dyn<'c, R>(
         }
     } else if let Some(position) = suggested_position {
         position
-    } else if ctx.memory().everything_is_visible() {
+    } else if ctx.memory(|mem| mem.everything_is_visible()) {
         Pos2::ZERO
     } else {
         return None; // No good place for a tooltip :(
@@ -191,7 +189,7 @@ fn show_tooltip_at_avoid_dyn<'c, R>(
         position.y -= expected_size.y;
     }
 
-    position = position.at_most(ctx.input().screen_rect().max - expected_size);
+    position = position.at_most(ctx.input(|i| i.screen_rect().max) - expected_size);
 
     // check if we intersect the avoid_rect
     {
@@ -209,7 +207,7 @@ fn show_tooltip_at_avoid_dyn<'c, R>(
         }
     }
 
-    let position = position.at_least(ctx.input().screen_rect().min);
+    let position = position.at_least(ctx.input(|i| i.screen_rect().min));
 
     let area_id = frame_state.common_id.with(frame_state.count);
 
@@ -226,7 +224,7 @@ fn show_tooltip_at_avoid_dyn<'c, R>(
 
     frame_state.count += 1;
     frame_state.rect = frame_state.rect.union(response.rect);
-    ctx.frame_state().tooltip_state = Some(frame_state);
+    ctx.frame_state_mut(|fs| fs.tooltip_state = Some(frame_state));
 
     Some(inner)
 }
@@ -283,7 +281,7 @@ pub fn was_tooltip_open_last_frame(ctx: &Context, tooltip_id: Id) -> bool {
                 if *individual_id == tooltip_id {
                     let area_id = common_id.with(count);
                     let layer_id = LayerId::new(Order::Tooltip, area_id);
-                    if ctx.memory().areas.visible_last_frame(&layer_id) {
+                    if ctx.memory(|mem| mem.areas.visible_last_frame(&layer_id)) {
                         return true;
                     }
                 }
@@ -323,7 +321,7 @@ pub fn popup_below_widget<R>(
 /// let response = ui.button("Open popup");
 /// let popup_id = ui.make_persistent_id("my_unique_id");
 /// if response.clicked() {
-///     ui.memory().toggle_popup(popup_id);
+///     ui.memory_mut(|mem| mem.toggle_popup(popup_id));
 /// }
 /// let below = egui::AboveOrBelow::Below;
 /// egui::popup::popup_above_or_below_widget(ui, popup_id, &response, below, |ui| {
@@ -340,7 +338,7 @@ pub fn popup_above_or_below_widget<R>(
     above_or_below: AboveOrBelow,
     add_contents: impl FnOnce(&mut Ui) -> R,
 ) -> Option<R> {
-    if ui.memory().is_popup_open(popup_id) {
+    if ui.memory(|mem| mem.is_popup_open(popup_id)) {
         let (pos, pivot) = match above_or_below {
             AboveOrBelow::Above => (widget_response.rect.left_top(), Align2::LEFT_BOTTOM),
             AboveOrBelow::Below => (widget_response.rect.left_bottom(), Align2::LEFT_TOP),
@@ -368,8 +366,8 @@ pub fn popup_above_or_below_widget<R>(
             })
             .inner;
 
-        if ui.input().key_pressed(Key::Escape) || widget_response.clicked_elsewhere() {
-            ui.memory().close_popup();
+        if ui.input(|i| i.key_pressed(Key::Escape)) || widget_response.clicked_elsewhere() {
+            ui.memory_mut(|mem| mem.close_popup());
         }
         Some(inner)
     } else {

--- a/crates/egui/src/containers/resize.rs
+++ b/crates/egui/src/containers/resize.rs
@@ -18,11 +18,11 @@ pub(crate) struct State {
 
 impl State {
     pub fn load(ctx: &Context, id: Id) -> Option<Self> {
-        ctx.data().get_persisted(id)
+        ctx.data_mut(|d| d.get_persisted(id))
     }
 
     pub fn store(self, ctx: &Context, id: Id) {
-        ctx.data().insert_persisted(id, self);
+        ctx.data_mut(|d| d.insert_persisted(id, self));
     }
 }
 
@@ -180,7 +180,7 @@ impl Resize {
                 .at_least(self.min_size)
                 .at_most(self.max_size)
                 .at_most(
-                    ui.input().screen_rect().size() - ui.spacing().window_margin.sum(), // hack for windows
+                    ui.input(|i| i.screen_rect().size()) - ui.spacing().window_margin.sum(), // hack for windows
                 );
 
             State {
@@ -305,7 +305,8 @@ impl Resize {
             paint_resize_corner(ui, &corner_response);
 
             if corner_response.hovered() || corner_response.dragged() {
-                ui.ctx().output().cursor_icon = CursorIcon::ResizeNwSe;
+                ui.ctx()
+                    .output_mut(|o| o.cursor_icon = CursorIcon::ResizeNwSe);
             }
         }
 

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -48,11 +48,11 @@ impl Default for State {
 
 impl State {
     pub fn load(ctx: &Context, id: Id) -> Option<Self> {
-        ctx.data().get_persisted(id)
+        ctx.data_mut(|d| d.get_persisted(id))
     }
 
     pub fn store(self, ctx: &Context, id: Id) {
-        ctx.data().insert_persisted(id, self);
+        ctx.data_mut(|d| d.insert_persisted(id, self));
     }
 }
 
@@ -431,8 +431,10 @@ impl ScrollArea {
             if content_response.dragged() {
                 for d in 0..2 {
                     if has_bar[d] {
-                        state.offset[d] -= ui.input().pointer.delta()[d];
-                        state.vel[d] = ui.input().pointer.velocity()[d];
+                        let (delta, velocity) =
+                            ui.input(|i| (i.pointer.delta()[d], i.pointer.velocity()[d]));
+                        state.offset[d] -= delta;
+                        state.vel[d] = velocity;
                         state.scroll_stuck_to_end[d] = false;
                     } else {
                         state.vel[d] = 0.0;
@@ -441,7 +443,7 @@ impl ScrollArea {
             } else {
                 let stop_speed = 20.0; // Pixels per second.
                 let friction_coeff = 1000.0; // Pixels per second squared.
-                let dt = ui.input().unstable_dt;
+                let dt = ui.input(|i| i.unstable_dt);
 
                 let friction = friction_coeff * dt;
                 if friction > state.vel.length() || state.vel.length() < stop_speed {
@@ -585,7 +587,9 @@ impl Prepared {
         for d in 0..2 {
             if has_bar[d] {
                 // We take the scroll target so only this ScrollArea will use it:
-                let scroll_target = content_ui.ctx().frame_state().scroll_target[d].take();
+                let scroll_target = content_ui
+                    .ctx()
+                    .frame_state_mut(|state| state.scroll_target[d].take());
                 if let Some((scroll, align)) = scroll_target {
                     let min = content_ui.min_rect().min[d];
                     let clip_rect = content_ui.clip_rect();
@@ -650,8 +654,7 @@ impl Prepared {
         if scrolling_enabled && ui.rect_contains_pointer(outer_rect) {
             for d in 0..2 {
                 if has_bar[d] {
-                    let mut frame_state = ui.ctx().frame_state();
-                    let scroll_delta = frame_state.scroll_delta;
+                    let scroll_delta = ui.ctx().frame_state(|fs| fs.scroll_delta);
 
                     let scrolling_up = state.offset[d] > 0.0 && scroll_delta[d] > 0.0;
                     let scrolling_down = state.offset[d] < max_offset[d] && scroll_delta[d] < 0.0;
@@ -659,7 +662,7 @@ impl Prepared {
                     if scrolling_up || scrolling_down {
                         state.offset[d] -= scroll_delta[d];
                         // Clear scroll delta so no parent scroll will use it.
-                        frame_state.scroll_delta[d] = 0.0;
+                        ui.ctx().frame_state_mut(|fs| fs.scroll_delta[d] = 0.0);
                         state.scroll_stuck_to_end[d] = false;
                     }
                 }

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -280,7 +280,7 @@ impl<'open> Window<'open> {
 
         let frame = frame.unwrap_or_else(|| Frame::window(&ctx.style()));
 
-        let is_open = !matches!(open, Some(false)) || ctx.memory().everything_is_visible();
+        let is_open = !matches!(open, Some(false)) || ctx.memory(|mem| mem.everything_is_visible());
         area.show_open_close_animation(ctx, &frame, is_open);
 
         if !is_open {
@@ -318,7 +318,7 @@ impl<'open> Window<'open> {
                 // Calculate roughly how much larger the window size is compared to the inner rect
                 let title_bar_height = if with_title_bar {
                     let style = ctx.style();
-                    title.font_height(&ctx.fonts(), &style) + title_content_spacing
+                    ctx.fonts(|f| title.font_height(f, &style)) + title_content_spacing
                 } else {
                     0.0
                 };
@@ -404,7 +404,7 @@ impl<'open> Window<'open> {
                     ctx.style().visuals.widgets.active,
                 );
             } else if let Some(hover_interaction) = hover_interaction {
-                if ctx.input().pointer.has_pointer() {
+                if ctx.input(|i| i.pointer.has_pointer()) {
                     paint_frame_interaction(
                         &mut area_content_ui,
                         outer_rect,
@@ -499,13 +499,13 @@ pub(crate) struct WindowInteraction {
 impl WindowInteraction {
     pub fn set_cursor(&self, ctx: &Context) {
         if (self.left && self.top) || (self.right && self.bottom) {
-            ctx.output().cursor_icon = CursorIcon::ResizeNwSe;
+            ctx.output_mut(|o| o.cursor_icon = CursorIcon::ResizeNwSe);
         } else if (self.right && self.top) || (self.left && self.bottom) {
-            ctx.output().cursor_icon = CursorIcon::ResizeNeSw;
+            ctx.output_mut(|o| o.cursor_icon = CursorIcon::ResizeNeSw);
         } else if self.left || self.right {
-            ctx.output().cursor_icon = CursorIcon::ResizeHorizontal;
+            ctx.output_mut(|o| o.cursor_icon = CursorIcon::ResizeHorizontal);
         } else if self.bottom || self.top {
-            ctx.output().cursor_icon = CursorIcon::ResizeVertical;
+            ctx.output_mut(|o| o.cursor_icon = CursorIcon::ResizeVertical);
         }
     }
 
@@ -537,7 +537,7 @@ fn interact(
         }
     }
 
-    ctx.memory().areas.move_to_top(area_layer_id);
+    ctx.memory_mut(|mem| mem.areas.move_to_top(area_layer_id));
     Some(window_interaction)
 }
 
@@ -545,11 +545,11 @@ fn move_and_resize_window(ctx: &Context, window_interaction: &WindowInteraction)
     window_interaction.set_cursor(ctx);
 
     // Only move/resize windows with primary mouse button:
-    if !ctx.input().pointer.primary_down() {
+    if !ctx.input(|i| i.pointer.primary_down()) {
         return None;
     }
 
-    let pointer_pos = ctx.input().pointer.interact_pos()?;
+    let pointer_pos = ctx.input(|i| i.pointer.interact_pos())?;
     let mut rect = window_interaction.start_rect; // prevent drift
 
     if window_interaction.is_resize() {
@@ -571,8 +571,8 @@ fn move_and_resize_window(ctx: &Context, window_interaction: &WindowInteraction)
         // but we want anything interactive in the window (e.g. slider) to steal
         // the drag from us. It is therefor important not to move the window the first frame,
         // but instead let other widgets to the steal. HACK.
-        if !ctx.input().pointer.any_pressed() {
-            let press_origin = ctx.input().pointer.press_origin()?;
+        if !ctx.input(|i| i.pointer.any_pressed()) {
+            let press_origin = ctx.input(|i| i.pointer.press_origin())?;
             let delta = pointer_pos - press_origin;
             rect = rect.translate(delta);
         }
@@ -590,30 +590,31 @@ fn window_interaction(
     rect: Rect,
 ) -> Option<WindowInteraction> {
     {
-        let drag_id = ctx.memory().interaction.drag_id;
+        let drag_id = ctx.memory(|mem| mem.interaction.drag_id);
 
         if drag_id.is_some() && drag_id != Some(id) {
             return None;
         }
     }
 
-    let mut window_interaction = { ctx.memory().window_interaction };
+    let mut window_interaction = ctx.memory(|mem| mem.window_interaction);
 
     if window_interaction.is_none() {
         if let Some(hover_window_interaction) = resize_hover(ctx, possible, area_layer_id, rect) {
             hover_window_interaction.set_cursor(ctx);
-            let any_pressed = ctx.input().pointer.any_pressed(); // avoid deadlocks
-            if any_pressed && ctx.input().pointer.primary_down() {
-                ctx.memory().interaction.drag_id = Some(id);
-                ctx.memory().interaction.drag_is_window = true;
-                window_interaction = Some(hover_window_interaction);
-                ctx.memory().window_interaction = window_interaction;
+            if ctx.input(|i| i.pointer.any_pressed() && i.pointer.primary_down()) {
+                ctx.memory_mut(|mem| {
+                    mem.interaction.drag_id = Some(id);
+                    mem.interaction.drag_is_window = true;
+                    window_interaction = Some(hover_window_interaction);
+                    mem.window_interaction = window_interaction;
+                });
             }
         }
     }
 
     if let Some(window_interaction) = window_interaction {
-        let is_active = ctx.memory().interaction.drag_id == Some(id);
+        let is_active = ctx.memory_mut(|mem| mem.interaction.drag_id == Some(id));
 
         if is_active && window_interaction.area_layer_id == area_layer_id {
             return Some(window_interaction);
@@ -629,10 +630,9 @@ fn resize_hover(
     area_layer_id: LayerId,
     rect: Rect,
 ) -> Option<WindowInteraction> {
-    let pointer = ctx.input().pointer.interact_pos()?;
+    let pointer = ctx.input(|i| i.pointer.interact_pos())?;
 
-    let any_down = ctx.input().pointer.any_down(); // avoid deadlocks
-    if any_down && !ctx.input().pointer.any_pressed() {
+    if ctx.input(|i| i.pointer.any_down() && !i.pointer.any_pressed()) {
         return None; // already dragging (something)
     }
 
@@ -642,7 +642,7 @@ fn resize_hover(
         }
     }
 
-    if ctx.memory().interaction.drag_interest {
+    if ctx.memory(|mem| mem.interaction.drag_interest) {
         // Another widget will become active if we drag here
         return None;
     }
@@ -804,8 +804,8 @@ fn show_title_bar(
     collapsible: bool,
 ) -> TitleBar {
     let inner_response = ui.horizontal(|ui| {
-        let height = title
-            .font_height(&ui.fonts(), ui.style())
+        let height = ui
+            .fonts(|fonts| title.font_height(fonts, ui.style()))
             .max(ui.spacing().interact_size.y);
         ui.set_min_height(height);
 

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -179,7 +179,7 @@ impl ContextImpl {
 /// [`Context`] is cheap to clone, and any clones refers to the same mutable data
 /// ([`Context`] uses refcounting internally).
 ///
-/// All methods are marked `&self`; [`Context`] has interior mutability (protected by a mutex).
+/// All methods are marked `&self`; [`Context`] has interior mutability (protected by a `RwLock`).
 ///
 ///
 /// You can store
@@ -208,7 +208,25 @@ impl ContextImpl {
 /// }
 /// ```
 #[derive(Clone)]
-pub struct Context(Arc<RwLock<ContextImpl>>);
+pub struct Context(Arc<ShortRwLockHelper<ContextImpl>>);
+
+// helper struct to enforce users to lock their data more careful
+// todo: is it required? should it be here?
+struct ShortRwLockHelper<T>(RwLock<T>);
+
+impl<T> ShortRwLockHelper<T> {
+    fn new(data: T) -> Self {
+        Self(RwLock::new(data))
+    }
+
+    fn read<R>(&self, reader: impl FnOnce(&T) -> R) -> R {
+        reader(&*self.0.read())
+    }
+
+    fn write<R>(&self, writer: impl FnOnce(&mut T) -> R) -> R {
+        writer(&mut *self.0.write())
+    }
+}
 
 impl std::fmt::Debug for Context {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -224,7 +242,7 @@ impl std::cmp::PartialEq for Context {
 
 impl Default for Context {
     fn default() -> Self {
-        Self(Arc::new(RwLock::new(ContextImpl {
+        Self(Arc::new(ShortRwLockHelper::new(ContextImpl {
             // Start with painting an extra frame to compensate for some widgets
             // that take two frames before they "settle":
             repaint_requests: 1,
@@ -234,12 +252,14 @@ impl Default for Context {
 }
 
 impl Context {
-    fn read(&self) -> RwLockReadGuard<'_, ContextImpl> {
-        self.0.read()
+    // Do read-only (shared access) transaction on Context
+    fn read<R>(&self, reader: impl FnOnce(&ContextImpl) -> R) -> R {
+        self.0.read(reader)
     }
 
-    fn write(&self) -> RwLockWriteGuard<'_, ContextImpl> {
-        self.0.write()
+    // Do read-write (exclusive access) transaction on Context
+    fn write<R>(&self, writer: impl FnOnce(&mut ContextImpl) -> R) -> R {
+        self.0.write(writer)
     }
 
     /// Run the ui code for one frame.
@@ -289,7 +309,7 @@ impl Context {
     /// // handle full_output
     /// ```
     pub fn begin_frame(&self, new_input: RawInput) {
-        self.write().begin_frame_mut(new_input);
+        self.write(|ctx| ctx.begin_frame_mut(new_input));
     }
 
     // ---------------------------------------------------------------------
@@ -304,7 +324,7 @@ impl Context {
     /// The most important thing is that [`Rect::min`] is approximately correct,
     /// because that's where the warning will be painted. If you don't know what size to pick, just pick [`Vec2::ZERO`].
     pub fn check_for_id_clash(&self, id: Id, new_rect: Rect, what: &str) {
-        let prev_rect = self.frame_state().used_ids.insert(id, new_rect);
+        let prev_rect = self.frame_state_mut(move |state| state.used_ids.insert(id, new_rect));
         if let Some(prev_rect) = prev_rect {
             // it is ok to reuse the same ID for e.g. a frame around a widget,
             // or to check for interaction with the same widget twice:
@@ -320,7 +340,7 @@ impl Context {
                 let painter = self.debug_painter();
                 painter.rect_stroke(widget_rect, 0.0, (1.0, color));
 
-                let below = widget_rect.bottom() + 32.0 < self.input().screen_rect.bottom();
+                let below = widget_rect.bottom() + 32.0 < self.input(|i| i.screen_rect.bottom());
 
                 let text_rect = if below {
                     painter.debug_text(
@@ -408,46 +428,46 @@ impl Context {
                 );
             }
 
-            let mut slf = self.write();
+            self.write(|ctx| {
+                ctx.layer_rects_this_frame
+                    .entry(layer_id)
+                    .or_default()
+                    .push((id, interact_rect));
 
-            slf.layer_rects_this_frame
-                .entry(layer_id)
-                .or_default()
-                .push((id, interact_rect));
-
-            if hovered {
-                let pointer_pos = slf.input.pointer.interact_pos();
-                if let Some(pointer_pos) = pointer_pos {
-                    if let Some(rects) = slf.layer_rects_prev_frame.get(&layer_id) {
-                        for &(prev_id, prev_rect) in rects.iter().rev() {
-                            if prev_id == id {
-                                break; // there is no other interactive widget covering us at the pointer position.
-                            }
-                            if prev_rect.contains(pointer_pos) {
-                                // Another interactive widget is covering us at the pointer position,
-                                // so we aren't hovered.
-
-                                if slf.memory.options.style.debug.show_blocking_widget {
-                                    drop(slf);
-                                    Self::layer_painter(self, LayerId::debug()).debug_rect(
-                                        interact_rect,
-                                        Color32::GREEN,
-                                        "Covered",
-                                    );
-                                    Self::layer_painter(self, LayerId::debug()).debug_rect(
-                                        prev_rect,
-                                        Color32::LIGHT_BLUE,
-                                        "On top",
-                                    );
+                if hovered {
+                    let pointer_pos = ctx.input.pointer.interact_pos();
+                    if let Some(pointer_pos) = pointer_pos {
+                        if let Some(rects) = ctx.layer_rects_prev_frame.get(&layer_id) {
+                            for &(prev_id, prev_rect) in rects.iter().rev() {
+                                if prev_id == id {
+                                    break; // there is no other interactive widget covering us at the pointer position.
                                 }
+                                if prev_rect.contains(pointer_pos) {
+                                    // Another interactive widget is covering us at the pointer position,
+                                    // so we aren't hovered.
 
-                                hovered = false;
-                                break;
+                                    if ctx.memory.options.style.debug.show_blocking_widget {
+                                        drop(ctx);
+                                        Self::layer_painter(self, LayerId::debug()).debug_rect(
+                                            interact_rect,
+                                            Color32::GREEN,
+                                            "Covered",
+                                        );
+                                        Self::layer_painter(self, LayerId::debug()).debug_rect(
+                                            prev_rect,
+                                            Color32::LIGHT_BLUE,
+                                            "On top",
+                                        );
+                                    }
+
+                                    hovered = false;
+                                    break;
+                                }
                             }
                         }
                     }
                 }
-            }
+            })
         }
 
         self.interact_with_hovered(layer_id, id, rect, sense, enabled, hovered)
@@ -485,7 +505,7 @@ impl Context {
 
         if !enabled || !sense.focusable || !layer_id.allow_interaction() {
             // Not interested or allowed input:
-            self.memory().surrender_focus(id);
+            self.memory_mut(|mem| mem.surrender_focus(id));
             return response;
         }
 
@@ -496,116 +516,115 @@ impl Context {
             // Make sure anything that can receive focus has an AccessKit node.
             // TODO(mwcampbell): For nodes that are filled from widget info,
             // some information is written to the node twice.
-            if let Some(mut node) = self.accesskit_node(id) {
-                response.fill_accesskit_node_common(&mut node);
-            }
+            self.accesskit_node_if_some(id, |node| response.fill_accesskit_node_common(node));
         }
 
         let clicked_elsewhere = response.clicked_elsewhere();
-        let ctx_impl = &mut *self.write();
-        let memory = &mut ctx_impl.memory;
-        let input = &mut ctx_impl.input;
+        self.write(|ctx| {
+            let memory = &mut ctx.memory;
+            let input = &mut ctx.input;
 
-        if sense.focusable {
-            memory.interested_in_focus(id);
-        }
+            if sense.focusable {
+                memory.interested_in_focus(id);
+            }
 
-        if sense.click
-            && memory.has_focus(response.id)
-            && (input.key_pressed(Key::Space) || input.key_pressed(Key::Enter))
-        {
-            // Space/enter works like a primary click for e.g. selected buttons
-            response.clicked[PointerButton::Primary as usize] = true;
-        }
-
-        #[cfg(feature = "accesskit")]
-        {
             if sense.click
-                && input.has_accesskit_action_request(response.id, accesskit::Action::Default)
+                && memory.has_focus(response.id)
+                && (input.key_pressed(Key::Space) || input.key_pressed(Key::Enter))
             {
+                // Space/enter works like a primary click for e.g. selected buttons
                 response.clicked[PointerButton::Primary as usize] = true;
             }
-        }
 
-        if sense.click || sense.drag {
-            memory.interaction.click_interest |= hovered && sense.click;
-            memory.interaction.drag_interest |= hovered && sense.drag;
+            #[cfg(feature = "accesskit")]
+            {
+                if sense.click
+                    && input.has_accesskit_action_request(response.id, accesskit::Action::Default)
+                {
+                    response.clicked[PointerButton::Primary as usize] = true;
+                }
+            }
 
-            response.dragged = memory.interaction.drag_id == Some(id);
-            response.is_pointer_button_down_on =
-                memory.interaction.click_id == Some(id) || response.dragged;
+            if sense.click || sense.drag {
+                memory.interaction.click_interest |= hovered && sense.click;
+                memory.interaction.drag_interest |= hovered && sense.drag;
 
-            for pointer_event in &input.pointer.pointer_events {
-                match pointer_event {
-                    PointerEvent::Moved(_) => {}
-                    PointerEvent::Pressed { .. } => {
-                        if hovered {
-                            if sense.click && memory.interaction.click_id.is_none() {
-                                // potential start of a click
-                                memory.interaction.click_id = Some(id);
-                                response.is_pointer_button_down_on = true;
-                            }
+                response.dragged = memory.interaction.drag_id == Some(id);
+                response.is_pointer_button_down_on =
+                    memory.interaction.click_id == Some(id) || response.dragged;
 
-                            // HACK: windows have low priority on dragging.
-                            // This is so that if you drag a slider in a window,
-                            // the slider will steal the drag away from the window.
-                            // This is needed because we do window interaction first (to prevent frame delay),
-                            // and then do content layout.
-                            if sense.drag
-                                && (memory.interaction.drag_id.is_none()
-                                    || memory.interaction.drag_is_window)
-                            {
-                                // potential start of a drag
-                                memory.interaction.drag_id = Some(id);
-                                memory.interaction.drag_is_window = false;
-                                memory.window_interaction = None; // HACK: stop moving windows (if any)
-                                response.is_pointer_button_down_on = true;
-                                response.dragged = true;
+                for pointer_event in &input.pointer.pointer_events {
+                    match pointer_event {
+                        PointerEvent::Moved(_) => {}
+                        PointerEvent::Pressed { .. } => {
+                            if hovered {
+                                if sense.click && memory.interaction.click_id.is_none() {
+                                    // potential start of a click
+                                    memory.interaction.click_id = Some(id);
+                                    response.is_pointer_button_down_on = true;
+                                }
+
+                                // HACK: windows have low priority on dragging.
+                                // This is so that if you drag a slider in a window,
+                                // the slider will steal the drag away from the window.
+                                // This is needed because we do window interaction first (to prevent frame delay),
+                                // and then do content layout.
+                                if sense.drag
+                                    && (memory.interaction.drag_id.is_none()
+                                        || memory.interaction.drag_is_window)
+                                {
+                                    // potential start of a drag
+                                    memory.interaction.drag_id = Some(id);
+                                    memory.interaction.drag_is_window = false;
+                                    memory.window_interaction = None; // HACK: stop moving windows (if any)
+                                    response.is_pointer_button_down_on = true;
+                                    response.dragged = true;
+                                }
                             }
                         }
-                    }
-                    PointerEvent::Released(click) => {
-                        response.drag_released = response.dragged;
-                        response.dragged = false;
+                        PointerEvent::Released(click) => {
+                            response.drag_released = response.dragged;
+                            response.dragged = false;
 
-                        if hovered && response.is_pointer_button_down_on {
-                            if let Some(click) = click {
-                                let clicked = hovered && response.is_pointer_button_down_on;
-                                response.clicked[click.button as usize] = clicked;
-                                response.double_clicked[click.button as usize] =
-                                    clicked && click.is_double();
-                                response.triple_clicked[click.button as usize] =
-                                    clicked && click.is_triple();
+                            if hovered && response.is_pointer_button_down_on {
+                                if let Some(click) = click {
+                                    let clicked = hovered && response.is_pointer_button_down_on;
+                                    response.clicked[click.button as usize] = clicked;
+                                    response.double_clicked[click.button as usize] =
+                                        clicked && click.is_double();
+                                    response.triple_clicked[click.button as usize] =
+                                        clicked && click.is_triple();
+                                }
                             }
                         }
                     }
                 }
             }
-        }
 
-        if response.is_pointer_button_down_on {
-            response.interact_pointer_pos = input.pointer.interact_pos();
-        }
+            if response.is_pointer_button_down_on {
+                response.interact_pointer_pos = input.pointer.interact_pos();
+            }
 
-        if input.pointer.any_down() {
-            response.hovered &= response.is_pointer_button_down_on; // we don't hover widgets while interacting with *other* widgets
-        }
+            if input.pointer.any_down() {
+                response.hovered &= response.is_pointer_button_down_on; // we don't hover widgets while interacting with *other* widgets
+            }
 
-        if memory.has_focus(response.id) && clicked_elsewhere {
-            memory.surrender_focus(id);
-        }
+            if memory.has_focus(response.id) && clicked_elsewhere {
+                memory.surrender_focus(id);
+            }
 
-        if response.dragged() && !memory.has_focus(response.id) {
-            // e.g.: remove focus from a widget when you drag something else
-            memory.stop_text_input();
-        }
+            if response.dragged() && !memory.has_focus(response.id) {
+                // e.g.: remove focus from a widget when you drag something else
+                memory.stop_text_input();
+            }
+        });
 
         response
     }
 
     /// Get a full-screen painter for a new or existing layer
     pub fn layer_painter(&self, layer_id: LayerId) -> Painter {
-        let screen_rect = self.input().screen_rect();
+        let screen_rect = self.input(|i| i.screen_rect());
         Painter::new(self.clone(), layer_id, screen_rect)
     }
 
@@ -618,7 +637,7 @@ impl Context {
     /// This is the "background" area, what egui doesn't cover with panels (but may cover with windows).
     /// This is also the area to which windows are constrained.
     pub fn available_rect(&self) -> Rect {
-        self.frame_state().available_rect()
+        self.frame_state(|s| s.available_rect())
     }
 }
 
@@ -628,91 +647,115 @@ impl Context {
     ///
     /// If you want to store/restore egui, serialize this.
     #[inline]
-    pub fn memory(&self) -> RwLockWriteGuard<'_, Memory> {
-        RwLockWriteGuard::map(self.write(), |c| &mut c.memory)
+    pub fn memory<R>(&self, reader: impl FnOnce(&Memory) -> R) -> R {
+        self.read(move |ctx| reader(&ctx.memory))
+    }
+
+    #[inline]
+    pub fn memory_mut<R>(&self, writer: impl FnOnce(&mut Memory) -> R) -> R {
+        self.write(move |ctx| writer(&mut ctx.memory))
     }
 
     /// Stores superficial widget state.
     #[inline]
-    pub fn data(&self) -> RwLockWriteGuard<'_, crate::util::IdTypeMap> {
-        RwLockWriteGuard::map(self.write(), |c| &mut c.memory.data)
+    pub fn data<R>(&self, reader: impl FnOnce(&crate::util::IdTypeMap) -> R) -> R {
+        self.read(move |ctx| reader(&ctx.memory.data))
+    }
+    #[inline]
+    pub fn data_mut<R>(&self, writer: impl FnOnce(&mut crate::util::IdTypeMap) -> R) -> R {
+        self.write(move |ctx| writer(&mut ctx.memory.data))
     }
 
     #[inline]
-    pub(crate) fn graphics(&self) -> RwLockWriteGuard<'_, GraphicLayers> {
-        RwLockWriteGuard::map(self.write(), |c| &mut c.graphics)
+    pub(crate) fn graphics_mut<R>(&self, writer: impl FnOnce(&mut GraphicLayers) -> R) -> R {
+        self.write(move |ctx| writer(&mut ctx.graphics))
     }
 
     /// What egui outputs each frame.
     ///
     /// ```
     /// # let mut ctx = egui::Context::default();
-    /// ctx.output().cursor_icon = egui::CursorIcon::Progress;
+    /// ctx.output_mut(|o| o.cursor_icon = egui::CursorIcon::Progress);
     /// ```
     #[inline]
-    pub fn output(&self) -> RwLockWriteGuard<'_, PlatformOutput> {
-        RwLockWriteGuard::map(self.write(), |c| &mut c.output)
+    pub fn output<R>(&self, reader: impl FnOnce(&PlatformOutput) -> R) -> R {
+        self.read(move |ctx| reader(&ctx.output))
+    }
+    #[inline]
+    pub fn output_mut<R>(&self, writer: impl FnOnce(&mut PlatformOutput) -> R) -> R {
+        self.write(move |ctx| writer(&mut ctx.output))
     }
 
     #[inline]
-    pub(crate) fn frame_state(&self) -> RwLockWriteGuard<'_, FrameState> {
-        RwLockWriteGuard::map(self.write(), |c| &mut c.frame_state)
+    pub(crate) fn frame_state<R>(&self, reader: impl FnOnce(&FrameState) -> R) -> R {
+        self.read(move |ctx| reader(&ctx.frame_state))
+    }
+    #[inline]
+    pub(crate) fn frame_state_mut<R>(&self, writer: impl FnOnce(&mut FrameState) -> R) -> R {
+        self.write(move |ctx| writer(&mut ctx.frame_state))
     }
 
     /// Access the [`InputState`].
     ///
-    /// Note that this locks the [`Context`], so be careful with if-let bindings:
+    /// Note that this locks the [`Context`]
     ///
     /// ```
     /// # let mut ctx = egui::Context::default();
-    /// if let Some(pos) = ctx.input().pointer.hover_pos() {
-    ///     // ⚠️ Using `ctx` again here will lead to a dead-lock!
-    /// }
+    /// ctx.input(|i| {
+    ///     // ⚠️ Using `ctx` (even from other `Arc` reference) again here will lead to a dead-lock!
+    /// })
     ///
-    /// if let Some(pos) = { ctx.input().pointer.hover_pos() } {
-    ///     // This is fine!
-    /// }
-    ///
-    /// let pos = ctx.input().pointer.hover_pos();
-    /// if let Some(pos) = pos {
+    /// if let Some(pos) = ctx.input(|i| i.pointer.hover_pos()) {
     ///     // This is fine!
     /// }
     /// ```
     #[inline]
-    pub fn input(&self) -> RwLockReadGuard<'_, InputState> {
-        RwLockReadGuard::map(self.read(), |c| &c.input)
+    pub fn input<R>(&self, reader: impl FnOnce(&InputState) -> R) -> R {
+        self.read(move |ctx| reader(&ctx.input))
     }
 
     #[inline]
-    pub fn input_mut(&self) -> RwLockWriteGuard<'_, InputState> {
-        RwLockWriteGuard::map(self.write(), |c| &mut c.input)
+    pub fn input_mut<R>(&self, writer: impl FnOnce(&mut InputState) -> R) -> R {
+        self.write(move |ctx| writer(&mut ctx.input))
     }
 
     /// Not valid until first call to [`Context::run()`].
     /// That's because since we don't know the proper `pixels_per_point` until then.
     #[inline]
-    pub fn fonts(&self) -> RwLockReadGuard<'_, Fonts> {
-        RwLockReadGuard::map(self.read(), |c| {
-            c.fonts
-                .as_ref()
-                .expect("No fonts available until first call to Context::run()")
+    pub fn fonts<R>(&self, reader: impl FnOnce(&Fonts) -> R) -> R {
+        self.read(move |ctx| {
+            reader(
+                ctx.fonts
+                    .as_ref()
+                    .expect("No fonts available until first call to Context::run()"),
+            )
         })
     }
-
     #[inline]
-    fn fonts_mut(&self) -> RwLockWriteGuard<'_, Option<Fonts>> {
-        RwLockWriteGuard::map(self.write(), |c| &mut c.fonts)
+    pub fn fonts_mut<R>(&self, writer: impl FnOnce(&mut Option<Fonts>) -> R) -> R {
+        self.write(move |ctx| writer(&mut ctx.fonts))
     }
 
     #[inline]
-    pub fn options(&self) -> RwLockWriteGuard<'_, Options> {
-        RwLockWriteGuard::map(self.write(), |c| &mut c.memory.options)
+    pub fn options<R>(&self, reader: impl FnOnce(&Options) -> R) -> R {
+        self.read(move |ctx| reader(&ctx.memory.options))
+    }
+    #[inline]
+    pub fn options_mut<R>(&self, writer: impl FnOnce(&mut Options) -> R) -> R {
+        self.write(move |ctx| writer(&mut ctx.memory.options))
     }
 
     /// Change the options used by the tessellator.
     #[inline]
-    pub fn tessellation_options(&self) -> RwLockWriteGuard<'_, TessellationOptions> {
-        RwLockWriteGuard::map(self.write(), |c| &mut c.memory.options.tessellation_options)
+    pub fn tessellation_options<R>(&self, reader: impl FnOnce(&TessellationOptions) -> R) -> R {
+        self.read(move |ctx| reader(&ctx.memory.options.tessellation_options))
+    }
+    #[inline]
+    pub fn tessellation_options_mut<R>(
+        &self,
+        writer: impl FnOnce(&mut TessellationOptions) -> R,
+    ) -> R {
+        self.write(move |ctx| writer(&mut ctx.memory.options.tessellation_options))
     }
 
     /// What operating system are we running on?
@@ -723,7 +766,7 @@ impl Context {
     /// For web, this can be figured out from the user-agent,
     /// and is done so by [`eframe`](https://github.com/emilk/egui/tree/master/crates/eframe).
     pub fn os(&self) -> OperatingSystem {
-        self.read().os
+        self.read(|ctx| ctx.os)
     }
 
     /// Set the operating system we are running on.
@@ -731,7 +774,7 @@ impl Context {
     /// If you are writing wasm-based integration for egui you
     /// may want to set this based on e.g. the user-agent.
     pub fn set_os(&self, os: OperatingSystem) {
-        self.write().os = os;
+        self.write(|ctx| ctx.os = os);
     }
 
     /// Format the given shortcut in a human-readable way (e.g. `Ctrl+Shift+X`).
@@ -752,13 +795,14 @@ impl Context {
             } = ModifierNames::SYMBOLS;
 
             let font_id = TextStyle::Body.resolve(&self.style());
-            let fonts = self.fonts();
-            let mut fonts = fonts.lock();
-            let font = fonts.fonts.font(&font_id);
-            font.has_glyphs(alt)
-                && font.has_glyphs(ctrl)
-                && font.has_glyphs(shift)
-                && font.has_glyphs(mac_cmd)
+            self.fonts(|f| {
+                let mut lock = f.lock();
+                let font = lock.fonts.font(&font_id);
+                font.has_glyphs(alt)
+                    && font.has_glyphs(ctrl)
+                    && font.has_glyphs(shift)
+                    && font.has_glyphs(mac_cmd)
+            })
         };
 
         if is_mac && can_show_symbols() {
@@ -780,14 +824,15 @@ impl Context {
     /// (this will work on `eframe`).
     pub fn request_repaint(&self) {
         // request two frames of repaint, just to cover some corner cases (frame delays):
-        let mut ctx = self.write();
-        ctx.repaint_requests = 2;
-        if let Some(callback) = &ctx.request_repaint_callback {
-            if !ctx.has_requested_repaint_this_frame {
-                (callback)();
-                ctx.has_requested_repaint_this_frame = true;
+        self.write(|ctx| {
+            ctx.repaint_requests = 2;
+            if let Some(callback) = &ctx.request_repaint_callback {
+                if !ctx.has_requested_repaint_this_frame {
+                    (callback)();
+                    ctx.has_requested_repaint_this_frame = true;
+                }
             }
-        }
+        })
     }
 
     /// Request repaint after the specified duration elapses in the case of no new input
@@ -819,8 +864,7 @@ impl Context {
     /// during app idle time where we are not receiving any new input events.
     pub fn request_repaint_after(&self, duration: std::time::Duration) {
         // Maybe we can check if duration is ZERO, and call self.request_repaint()?
-        let mut ctx = self.write();
-        ctx.repaint_after = ctx.repaint_after.min(duration);
+        self.write(|ctx| ctx.repaint_after = ctx.repaint_after.min(duration))
     }
 
     /// For integrations: this callback will be called when an egui user calls [`Self::request_repaint`].
@@ -830,7 +874,7 @@ impl Context {
     /// Note that only one callback can be set. Any new call overrides the previous callback.
     pub fn set_request_repaint_callback(&self, callback: impl Fn() + Send + Sync + 'static) {
         let callback = Box::new(callback);
-        self.write().request_repaint_callback = Some(callback);
+        self.write(|ctx| ctx.request_repaint_callback = Some(callback))
     }
 
     /// Tell `egui` which fonts to use.
@@ -840,19 +884,21 @@ impl Context {
     ///
     /// The new fonts will become active at the start of the next frame.
     pub fn set_fonts(&self, font_definitions: FontDefinitions) {
-        if let Some(current_fonts) = &*self.fonts_mut() {
-            // NOTE: this comparison is expensive since it checks TTF data for equality
-            if current_fonts.lock().fonts.definitions() == &font_definitions {
-                return; // no change - save us from reloading font textures
+        self.fonts_mut(|fonts| {
+            if let Some(current_fonts) = fonts {
+                // NOTE: this comparison is expensive since it checks TTF data for equality
+                if current_fonts.lock().fonts.definitions() == &font_definitions {
+                    return; // no change - save us from reloading font textures
+                }
             }
-        }
+        });
 
-        self.memory().new_font_definitions = Some(font_definitions);
+        self.memory_mut(|mem| mem.new_font_definitions = Some(font_definitions));
     }
 
     /// The [`Style`] used by all subsequent windows, panels etc.
     pub fn style(&self) -> Arc<Style> {
-        self.options().style.clone()
+        self.options(|opt| opt.style.clone())
     }
 
     /// The [`Style`] used by all new windows, panels etc.
@@ -867,7 +913,7 @@ impl Context {
     /// ctx.set_style(style);
     /// ```
     pub fn set_style(&self, style: impl Into<Arc<Style>>) {
-        self.options().style = style.into();
+        self.options_mut(|opt| opt.style = style.into());
     }
 
     /// The [`Visuals`] used by all subsequent windows, panels etc.
@@ -880,13 +926,13 @@ impl Context {
     /// ctx.set_visuals(egui::Visuals::light()); // Switch to light mode
     /// ```
     pub fn set_visuals(&self, visuals: crate::Visuals) {
-        std::sync::Arc::make_mut(&mut self.options().style).visuals = visuals;
+        self.options_mut(|opt| std::sync::Arc::make_mut(&mut opt.style).visuals = visuals);
     }
 
     /// The number of physical pixels for each logical point.
     #[inline(always)]
     pub fn pixels_per_point(&self) -> f32 {
-        self.input().pixels_per_point()
+        self.input(|i| i.pixels_per_point())
     }
 
     /// Set the number of physical pixels for each logical point.
@@ -897,7 +943,7 @@ impl Context {
     pub fn set_pixels_per_point(&self, pixels_per_point: f32) {
         if pixels_per_point != self.pixels_per_point() {
             self.request_repaint();
-            self.memory().new_pixels_per_point = Some(pixels_per_point);
+            self.memory_mut(|mem| mem.new_pixels_per_point = Some(pixels_per_point));
         }
     }
 
@@ -966,7 +1012,7 @@ impl Context {
     ) -> TextureHandle {
         let name = name.into();
         let image = image.into();
-        let max_texture_side = self.input().max_texture_side;
+        let max_texture_side = self.input(|i| i.max_texture_side);
         crate::egui_assert!(
             image.width() <= max_texture_side && image.height() <= max_texture_side,
             "Texture {:?} has size {}x{}, but the maximum texture side is {}",
@@ -986,7 +1032,7 @@ impl Context {
     ///
     /// You can show stats about the allocated textures using [`Self::texture_ui`].
     pub fn tex_manager(&self) -> Arc<RwLock<epaint::textures::TextureManager>> {
-        self.read().tex_manager.0.clone()
+        self.read(|ctx| ctx.tex_manager.0.clone())
     }
 
     // ---------------------------------------------------------------------
@@ -1000,13 +1046,13 @@ impl Context {
         if window.width() > area.width() {
             // Allow overlapping side bars.
             // This is important for small screens, e.g. mobiles running the web demo.
-            area.max.x = self.input().screen_rect().max.x;
-            area.min.x = self.input().screen_rect().min.x;
+            (area.min.x, area.max.x) =
+                self.input(|i| (i.screen_rect().min.x, i.screen_rect().max.x));
         }
         if window.height() > area.height() {
             // Allow overlapping top/bottom bars:
-            area.max.y = self.input().screen_rect().max.y;
-            area.min.y = self.input().screen_rect().min.y;
+            (area.min.y, area.max.y) =
+                self.input(|i| (i.screen_rect().min.y, i.screen_rect().max.y));
         }
 
         let mut pos = window.min;
@@ -1030,37 +1076,32 @@ impl Context {
     /// Call at the end of each frame.
     #[must_use]
     pub fn end_frame(&self) -> FullOutput {
-        if self.input().wants_repaint() {
+        if self.input(|i| i.wants_repaint()) {
             self.request_repaint();
         }
 
-        let textures_delta;
-        {
-            let ctx_impl = &mut *self.write();
-            ctx_impl
-                .memory
-                .end_frame(&ctx_impl.input, &ctx_impl.frame_state.used_ids);
+        let textures_delta = self.write(|ctx| {
+            ctx.memory.end_frame(&ctx.input, &ctx.frame_state.used_ids);
 
-            let font_image_delta = ctx_impl.fonts.as_ref().unwrap().font_image_delta();
+            let font_image_delta = ctx.fonts.as_ref().unwrap().font_image_delta();
             if let Some(font_image_delta) = font_image_delta {
-                ctx_impl
-                    .tex_manager
+                ctx.tex_manager
                     .0
                     .write()
                     .set(TextureId::default(), font_image_delta);
             }
 
-            textures_delta = ctx_impl.tex_manager.0.write().take_delta();
-        };
+            ctx.tex_manager.0.write().take_delta()
+        });
 
         #[cfg_attr(not(feature = "accesskit"), allow(unused_mut))]
-        let mut platform_output: PlatformOutput = std::mem::take(&mut self.output());
+        let mut platform_output: PlatformOutput = self.output_mut(|o| std::mem::take(o));
 
         #[cfg(feature = "accesskit")]
         {
-            let state = self.frame_state().accesskit_state.take();
+            let state = self.frame_state_mut(|fs| fs.accesskit_state.take());
             if let Some(state) = state {
-                let has_focus = self.input().raw.has_focus;
+                let has_focus = self.input(|i| i.raw.has_focus);
                 let root_id = crate::accesskit_root_id().accesskit_id();
                 platform_output.accesskit_update = Some(accesskit::TreeUpdate {
                     nodes: state
@@ -1070,7 +1111,7 @@ impl Context {
                         .collect(),
                     tree: Some(accesskit::Tree::new(root_id)),
                     focus: has_focus.then(|| {
-                        let focus_id = self.memory().interaction.focus.id;
+                        let focus_id = self.memory(|mem| mem.interaction.focus.id);
                         focus_id.map_or(root_id, |id| id.accesskit_id())
                     }),
                 });
@@ -1079,25 +1120,26 @@ impl Context {
 
         // if repaint_requests is greater than zero. just set the duration to zero for immediate
         // repaint. if there's no repaint requests, then we can use the actual repaint_after instead.
-        let repaint_after = if self.read().repaint_requests > 0 {
-            self.write().repaint_requests -= 1;
-            std::time::Duration::ZERO
-        } else {
-            self.read().repaint_after
-        };
+        let repaint_after = self.write(|ctx| {
+            if ctx.repaint_requests > 0 {
+                ctx.repaint_requests -= 1;
+                std::time::Duration::ZERO
+            } else {
+                ctx.repaint_after
+            }
+        });
 
-        {
-            let ctx_impl = &mut *self.write();
-            ctx_impl.requested_repaint_last_frame = repaint_after.is_zero();
+        self.write(|ctx| {
+            ctx.requested_repaint_last_frame = repaint_after.is_zero();
 
-            ctx_impl.has_requested_repaint_this_frame = false; // allow new calls between frames
+            ctx.has_requested_repaint_this_frame = false; // allow new calls between frames
 
             // make sure we reset the repaint_after duration.
             // otherwise, if repaint_after is low, then any widget setting repaint_after next frame,
             // will fail to overwrite the previous lower value. and thus, repaints will never
             // go back to higher values.
-            ctx_impl.repaint_after = std::time::Duration::MAX;
-        }
+            ctx.repaint_after = std::time::Duration::MAX;
+        });
         let shapes = self.drain_paint_lists();
 
         FullOutput {
@@ -1109,11 +1151,7 @@ impl Context {
     }
 
     fn drain_paint_lists(&self) -> Vec<ClippedShape> {
-        let ctx_impl = &mut *self.write();
-        ctx_impl
-            .graphics
-            .drain(ctx_impl.memory.areas.order())
-            .collect()
+        self.write(|ctx| ctx.graphics.drain(ctx.memory.areas.order()).collect())
     }
 
     /// Tessellate the given shapes into triangle meshes.
@@ -1122,33 +1160,44 @@ impl Context {
         // shapes are the same, but just comparing the shapes takes about 50% of the time
         // it takes to tessellate them, so it is not a worth optimization.
 
-        let pixels_per_point = self.pixels_per_point();
-        let tessellation_options = *self.tessellation_options();
-        let texture_atlas = self.fonts().texture_atlas();
-        let font_tex_size = texture_atlas.lock().size();
-        let prepared_discs = texture_atlas.lock().prepared_discs();
+        // here we expect that we are the only user of context, since frame is ended
+        self.write(|ctx| {
+            let pixels_per_point = ctx.input.pixels_per_point();
+            let tessellation_options = ctx.memory.options.tessellation_options;
+            let texture_atlas = ctx
+                .fonts
+                .as_ref()
+                .expect("tessellate called before first call to Context::run()")
+                .texture_atlas();
+            let (font_tex_size, prepared_discs) = {
+                let atlas = texture_atlas.lock();
+                (atlas.size(), atlas.prepared_discs())
+            };
 
-        let paint_stats = PaintStats::from_shapes(&shapes);
-        let clipped_primitives = tessellator::tessellate_shapes(
-            pixels_per_point,
-            tessellation_options,
-            font_tex_size,
-            prepared_discs,
-            shapes,
-        );
-        self.write().paint_stats = paint_stats.with_clipped_primitives(&clipped_primitives);
-        clipped_primitives
+            let paint_stats = PaintStats::from_shapes(&shapes);
+            let clipped_primitives = tessellator::tessellate_shapes(
+                pixels_per_point,
+                tessellation_options,
+                font_tex_size,
+                prepared_discs,
+                shapes,
+            );
+            ctx.paint_stats = paint_stats.with_clipped_primitives(&clipped_primitives);
+            clipped_primitives
+        })
     }
 
     // ---------------------------------------------------------------------
 
     /// How much space is used by panels and windows.
     pub fn used_rect(&self) -> Rect {
-        let mut used = self.frame_state().used_by_panels;
-        for window in self.memory().areas.visible_windows() {
-            used = used.union(window.rect());
-        }
-        used
+        self.read(|ctx| {
+            let mut used = ctx.frame_state.used_by_panels;
+            for window in ctx.memory.areas.visible_windows() {
+                used = used.union(window.rect());
+            }
+            used
+        })
     }
 
     /// How much space is used by panels and windows.
@@ -1161,11 +1210,11 @@ impl Context {
 
     /// Is the pointer (mouse/touch) over any egui area?
     pub fn is_pointer_over_area(&self) -> bool {
-        let pointer_pos = self.input().pointer.interact_pos();
+        let pointer_pos = self.input(|i| i.pointer.interact_pos());
         if let Some(pointer_pos) = pointer_pos {
             if let Some(layer) = self.layer_id_at(pointer_pos) {
                 if layer.order == Order::Background {
-                    !self.frame_state().unused_rect.contains(pointer_pos)
+                    !self.frame_state(|state| state.unused_rect.contains(pointer_pos))
                 } else {
                     true
                 }
@@ -1183,18 +1232,19 @@ impl Context {
     /// you may be interested in what it is doing (e.g. controlling your game).
     /// Returns `false` if a drag started outside of egui and then moved over an egui area.
     pub fn wants_pointer_input(&self) -> bool {
-        self.is_using_pointer() || (self.is_pointer_over_area() && !self.input().pointer.any_down())
+        self.is_using_pointer()
+            || (self.is_pointer_over_area() && !self.input(|i| i.pointer.any_down()))
     }
 
     /// Is egui currently using the pointer position (e.g. dragging a slider).
     /// NOTE: this will return `false` if the pointer is just hovering over an egui area.
     pub fn is_using_pointer(&self) -> bool {
-        self.memory().interaction.is_using_pointer()
+        self.memory(|m| m.interaction.is_using_pointer())
     }
 
     /// If `true`, egui is currently listening on text input (e.g. typing text in a [`TextEdit`]).
     pub fn wants_keyboard_input(&self) -> bool {
-        self.memory().interaction.focus.focused().is_some()
+        self.memory(|m| m.interaction.focus.focused().is_some())
     }
 }
 
@@ -1204,13 +1254,13 @@ impl Context {
     /// When tapping a touch screen, this will be `None`.
     #[inline(always)]
     pub fn pointer_latest_pos(&self) -> Option<Pos2> {
-        self.input().pointer.latest_pos()
+        self.input(|i| i.pointer.latest_pos())
     }
 
     /// If it is a good idea to show a tooltip, where is pointer?
     #[inline(always)]
     pub fn pointer_hover_pos(&self) -> Option<Pos2> {
-        self.input().pointer.hover_pos()
+        self.input(|i| i.pointer.hover_pos())
     }
 
     /// If you detect a click or drag and wants to know where it happened, use this.
@@ -1220,12 +1270,12 @@ impl Context {
     /// When tapping a touch screen, this will be the location of the touch.
     #[inline(always)]
     pub fn pointer_interact_pos(&self) -> Option<Pos2> {
-        self.input().pointer.interact_pos()
+        self.input(|i| i.pointer.interact_pos())
     }
 
     /// Calls [`InputState::multi_touch`].
     pub fn multi_touch(&self) -> Option<MultiTouchInfo> {
-        self.input().multi_touch()
+        self.input(|i| i.multi_touch())
     }
 }
 
@@ -1234,25 +1284,26 @@ impl Context {
     /// Can be used to implement drag-and-drop (see relevant demo).
     pub fn translate_layer(&self, layer_id: LayerId, delta: Vec2) {
         if delta != Vec2::ZERO {
-            self.graphics().list(layer_id).translate(delta);
+            self.graphics_mut(|g| g.list(layer_id).translate(delta));
         }
     }
 
     /// Top-most layer at the given position.
     pub fn layer_id_at(&self, pos: Pos2) -> Option<LayerId> {
-        let resize_grab_radius_side = self.style().interaction.resize_grab_radius_side;
-        self.memory().layer_id_at(pos, resize_grab_radius_side)
+        self.memory(|mem| {
+            mem.layer_id_at(pos, mem.options.style.interaction.resize_grab_radius_side)
+        })
     }
 
     /// Moves the given area to the top in its [`Order`].
     /// [`Area`]:s and [`Window`]:s also do this automatically when being clicked on or interacted with.
     pub fn move_to_top(&self, layer_id: LayerId) {
-        self.memory().areas.move_to_top(layer_id);
+        self.memory_mut(|mem| mem.areas.move_to_top(layer_id));
     }
 
     pub(crate) fn rect_contains_pointer(&self, layer_id: LayerId, rect: Rect) -> bool {
         rect.is_positive() && {
-            let pointer_pos = self.input().pointer.interact_pos();
+            let pointer_pos = self.input(|i| i.pointer.interact_pos());
             if let Some(pointer_pos) = pointer_pos {
                 rect.contains(pointer_pos) && self.layer_id_at(pointer_pos) == Some(layer_id)
             } else {
@@ -1265,12 +1316,12 @@ impl Context {
 
     /// Whether or not to debug widget layout on hover.
     pub fn debug_on_hover(&self) -> bool {
-        self.options().style.debug.debug_on_hover
+        self.options(|opt| opt.style.debug.debug_on_hover)
     }
 
     /// Turn on/off whether or not to debug widget layout on hover.
     pub fn set_debug_on_hover(&self, debug_on_hover: bool) {
-        let mut style = (*self.options().style).clone();
+        let mut style = self.options(|opt| (*opt.style).clone());
         style.debug.debug_on_hover = debug_on_hover;
         self.set_style(style);
     }
@@ -1294,15 +1345,10 @@ impl Context {
 
     /// Like [`Self::animate_bool`] but allows you to control the animation time.
     pub fn animate_bool_with_time(&self, id: Id, target_value: bool, animation_time: f32) -> f32 {
-        let animated_value = {
-            let ctx_impl = &mut *self.write();
-            ctx_impl.animation_manager.animate_bool(
-                &ctx_impl.input,
-                animation_time,
-                id,
-                target_value,
-            )
-        };
+        let animated_value = self.write(|ctx| {
+            ctx.animation_manager
+                .animate_bool(&ctx.input, animation_time, id, target_value)
+        });
         let animation_in_progress = 0.0 < animated_value && animated_value < 1.0;
         if animation_in_progress {
             self.request_repaint();
@@ -1314,15 +1360,10 @@ impl Context {
     /// At the first call the value is written to memory.
     /// When it is called with a new value, it linearly interpolates to it in the given time.
     pub fn animate_value_with_time(&self, id: Id, target_value: f32, animation_time: f32) -> f32 {
-        let animated_value = {
-            let ctx_impl = &mut *self.write();
-            ctx_impl.animation_manager.animate_value(
-                &ctx_impl.input,
-                animation_time,
-                id,
-                target_value,
-            )
-        };
+        let animated_value = self.write(|ctx| {
+            ctx.animation_manager
+                .animate_value(&ctx.input, animation_time, id, target_value)
+        });
         let animation_in_progress = animated_value != target_value;
         if animation_in_progress {
             self.request_repaint();
@@ -1333,7 +1374,7 @@ impl Context {
 
     /// Clear memory of any animations.
     pub fn clear_animations(&self) {
-        self.write().animation_manager = Default::default();
+        self.write(|ctx| ctx.animation_manager = Default::default());
     }
 }
 
@@ -1350,10 +1391,13 @@ impl Context {
         CollapsingHeader::new("✒ Painting")
             .default_open(true)
             .show(ui, |ui| {
-                let mut tessellation_options = self.options().tessellation_options;
+                let prev_tessellation_options = self.tessellation_options(|o| *o);
+                let mut tessellation_options = prev_tessellation_options;
                 tessellation_options.ui(ui);
                 ui.vertical_centered(|ui| reset_button(ui, &mut tessellation_options));
-                *self.tessellation_options() = tessellation_options;
+                if tessellation_options != prev_tessellation_options {
+                    self.tessellation_options_mut(move |o| *o = tessellation_options);
+                }
             });
     }
 
@@ -1374,10 +1418,7 @@ impl Context {
         .on_hover_text("Is egui currently listening for text input?");
         ui.label(format!(
             "Keyboard focus widget: {}",
-            self.memory()
-                .interaction
-                .focus
-                .focused()
+            self.memory(|m| m.interaction.focus.focused())
                 .as_ref()
                 .map(Id::short_debug_format)
                 .unwrap_or_default()
@@ -1399,7 +1440,7 @@ impl Context {
 
         ui.label(format!(
             "There are {} text galleys in the layout cache",
-            self.fonts().num_galleys_in_cache()
+            self.fonts(|f| f.num_galleys_in_cache())
         ))
         .on_hover_text("This is approximately the number of text strings on screen");
         ui.add_space(16.0);
@@ -1407,14 +1448,14 @@ impl Context {
         CollapsingHeader::new("📥 Input")
             .default_open(false)
             .show(ui, |ui| {
-                let input = ui.input().clone();
+                let input = ui.input(|i| i.clone());
                 input.ui(ui);
             });
 
         CollapsingHeader::new("📊 Paint stats")
             .default_open(false)
             .show(ui, |ui| {
-                let paint_stats = self.write().paint_stats;
+                let paint_stats = self.read(|ctx| ctx.paint_stats);
                 paint_stats.ui(ui);
             });
 
@@ -1427,7 +1468,7 @@ impl Context {
         CollapsingHeader::new("🔠 Font texture")
             .default_open(false)
             .show(ui, |ui| {
-                let font_image_size = self.fonts().font_image_size();
+                let font_image_size = self.fonts(|f| f.font_image_size());
                 crate::introspection::font_texture_ui(ui, font_image_size);
             });
     }
@@ -1472,7 +1513,7 @@ impl Context {
                                 size *= (max_preview_size.y / size.y).min(1.0);
                                 ui.image(texture_id, size).on_hover_ui(|ui| {
                                     // show larger on hover
-                                    let max_size = 0.5 * ui.ctx().input().screen_rect().size();
+                                    let max_size = 0.5 * ui.ctx().input(|i| i.screen_rect().size());
                                     let mut size = vec2(w as f32, h as f32);
                                     size *= max_size.x / size.x.max(max_size.x);
                                     size *= max_size.y / size.y.max(max_size.y);
@@ -1495,11 +1536,10 @@ impl Context {
             .on_hover_text("Reset all egui state")
             .clicked()
         {
-            *self.memory() = Default::default();
+            self.memory_mut(|mem| *mem = Default::default());
         }
 
-        let num_state = self.data().len();
-        let num_serialized = self.data().count_serialized();
+        let (num_state, num_serialized) = self.data(|d| (d.len(), d.count_serialized()));
         ui.label(format!(
             "{} widget states stored (of which {} are serialized).",
             num_state, num_serialized
@@ -1508,20 +1548,20 @@ impl Context {
         ui.horizontal(|ui| {
             ui.label(format!(
                 "{} areas (panels, windows, popups, …)",
-                self.memory().areas.count()
+                self.memory(|mem| mem.areas.count())
             ));
             if ui.button("Reset").clicked() {
-                self.memory().areas = Default::default();
+                self.memory_mut(|mem| mem.areas = Default::default());
             }
         });
         ui.indent("areas", |ui| {
             ui.label("Visible areas, ordered back to front.");
             ui.label("Hover to highlight");
-            let layers_ids: Vec<LayerId> = self.memory().areas.order().to_vec();
+            let layers_ids: Vec<LayerId> = self.memory(|mem| mem.areas.order().to_vec());
             for layer_id in layers_ids {
-                let area = self.memory().areas.get(layer_id.id).copied();
+                let area = self.memory(|mem| mem.areas.get(layer_id.id).copied());
                 if let Some(area) = area {
-                    let is_visible = self.memory().areas.is_visible(&layer_id);
+                    let is_visible = self.memory(|mem| mem.areas.is_visible(&layer_id));
                     if !is_visible {
                         continue;
                     }
@@ -1543,42 +1583,40 @@ impl Context {
         ui.horizontal(|ui| {
             ui.label(format!(
                 "{} collapsing headers",
-                self.data()
-                    .count::<containers::collapsing_header::InnerState>()
+                self.data(|d| d.count::<containers::collapsing_header::InnerState>())
             ));
             if ui.button("Reset").clicked() {
-                self.data()
-                    .remove_by_type::<containers::collapsing_header::InnerState>();
+                self.data_mut(|d| d.remove_by_type::<containers::collapsing_header::InnerState>());
             }
         });
 
         ui.horizontal(|ui| {
             ui.label(format!(
                 "{} menu bars",
-                self.data().count::<menu::BarState>()
+                self.data(|d| d.count::<menu::BarState>())
             ));
             if ui.button("Reset").clicked() {
-                self.data().remove_by_type::<menu::BarState>();
+                self.data_mut(|d| d.remove_by_type::<menu::BarState>());
             }
         });
 
         ui.horizontal(|ui| {
             ui.label(format!(
                 "{} scroll areas",
-                self.data().count::<scroll_area::State>()
+                self.data(|d| d.count::<scroll_area::State>())
             ));
             if ui.button("Reset").clicked() {
-                self.data().remove_by_type::<scroll_area::State>();
+                self.data_mut(|d| d.remove_by_type::<scroll_area::State>());
             }
         });
 
         ui.horizontal(|ui| {
             ui.label(format!(
                 "{} resize areas",
-                self.data().count::<resize::State>()
+                self.data(|d| d.count::<resize::State>())
             ));
             if ui.button("Reset").clicked() {
-                self.data().remove_by_type::<resize::State>();
+                self.data_mut(|d| d.remove_by_type::<resize::State>());
             }
         });
 
@@ -1586,7 +1624,7 @@ impl Context {
         ui.label("NOTE: the position of this window cannot be reset from within itself.");
 
         ui.collapsing("Interaction", |ui| {
-            let interaction = self.memory().interaction.clone();
+            let interaction = self.memory(|mem| mem.interaction.clone());
             interaction.ui(ui);
         });
     }
@@ -1609,10 +1647,11 @@ impl Context {
     pub fn with_accessibility_parent(&self, id: Id, f: impl FnOnce()) {
         #[cfg(feature = "accesskit")]
         {
-            let mut frame_state = self.frame_state();
-            if let Some(state) = frame_state.accesskit_state.as_mut() {
-                state.parent_stack.push(id);
-            }
+            self.frame_state_mut(|fs| {
+                if let Some(state) = fs.accesskit_state.as_mut() {
+                    state.parent_stack.push(id);
+                }
+            })
         }
         #[cfg(not(feature = "accesskit"))]
         {
@@ -1621,10 +1660,11 @@ impl Context {
         f();
         #[cfg(feature = "accesskit")]
         {
-            let mut frame_state = self.frame_state();
-            if let Some(state) = frame_state.accesskit_state.as_mut() {
-                assert_eq!(state.parent_stack.pop(), Some(id));
-            }
+            self.frame_state_mut(|fs| {
+                if let Some(state) = fs.accesskit_state.as_mut() {
+                    assert_eq!(state.parent_stack.pop(), Some(id));
+                }
+            })
         }
     }
 
@@ -1632,13 +1672,31 @@ impl Context {
     /// a node with the specified ID and return a mutable reference to it.
     /// For newly crated nodes, the parent is the node with the ID at the top
     /// of the stack managed by [`Context::with_accessibility_parent`].
+    /// TODO: consider making both RO and RW versions
     #[cfg(feature = "accesskit")]
-    pub fn accesskit_node(&self, id: Id) -> Option<RwLockWriteGuard<'_, accesskit::Node>> {
-        let ctx = self.write();
-        ctx.frame_state
-            .accesskit_state
-            .is_some()
-            .then(move || RwLockWriteGuard::map(ctx, |c| c.accesskit_node(id)))
+    pub fn accesskit_node<R>(
+        &self,
+        id: Id,
+        writer: impl FnOnce(Option<&mut accesskit::Node>) -> R,
+    ) -> R {
+        self.write(|ctx| {
+            writer(
+                ctx.frame_state
+                    .accesskit_state
+                    .is_some()
+                    .then(|| ctx.accesskit_node(id)),
+            )
+        })
+    }
+
+    /// TODO: explicit enough?
+    #[cfg(feature = "accesskit")]
+    pub fn accesskit_node_if_some<R>(
+        &self,
+        id: Id,
+        writer: impl FnOnce(&mut accesskit::Node) -> R,
+    ) -> Option<R> {
+        self.accesskit_node(id, move |node| node.map(writer))
     }
 
     /// Enable generation of AccessKit tree updates in all future frames.
@@ -1652,7 +1710,7 @@ impl Context {
     /// in the meantime.
     #[cfg(feature = "accesskit")]
     pub fn enable_accesskit(&self) {
-        self.write().is_accesskit_enabled = true;
+        self.write(|ctx| ctx.is_accesskit_enabled = true);
     }
 }
 

--- a/crates/egui/src/grid.rs
+++ b/crates/egui/src/grid.rs
@@ -8,14 +8,14 @@ pub(crate) struct State {
 
 impl State {
     pub fn load(ctx: &Context, id: Id) -> Option<Self> {
-        ctx.data().get_temp(id)
+        ctx.data_mut(|d| d.get_temp(id))
     }
 
     pub fn store(self, ctx: &Context, id: Id) {
         // We don't persist Grids, because
         // A) there are potentially a lot of them, using up a lot of space (and therefore serialization time)
         // B) if the code changes, the grid _should_ change, and not remember old sizes
-        ctx.data().insert_temp(id, self);
+        ctx.data_mut(|d| d.insert_temp(id, self));
     }
 
     fn set_min_col_width(&mut self, col: usize, width: f32) {

--- a/crates/egui/src/gui_zoom.rs
+++ b/crates/egui/src/gui_zoom.rs
@@ -26,15 +26,15 @@ pub mod kb_shortcuts {
 /// }
 /// ```
 pub fn zoom_with_keyboard_shortcuts(ctx: &Context, native_pixels_per_point: Option<f32>) {
-    if ctx.input_mut().consume_shortcut(&kb_shortcuts::ZOOM_RESET) {
+    if ctx.input_mut(|i| i.consume_shortcut(&kb_shortcuts::ZOOM_RESET)) {
         if let Some(native_pixels_per_point) = native_pixels_per_point {
             ctx.set_pixels_per_point(native_pixels_per_point);
         }
     } else {
-        if ctx.input_mut().consume_shortcut(&kb_shortcuts::ZOOM_IN) {
+        if ctx.input_mut(|i| i.consume_shortcut(&kb_shortcuts::ZOOM_IN)) {
             zoom_in(ctx);
         }
-        if ctx.input_mut().consume_shortcut(&kb_shortcuts::ZOOM_OUT) {
+        if ctx.input_mut(|i| i.consume_shortcut(&kb_shortcuts::ZOOM_OUT)) {
             zoom_out(ctx);
         }
     }

--- a/crates/egui/src/introspection.rs
+++ b/crates/egui/src/introspection.rs
@@ -2,7 +2,7 @@
 use crate::*;
 
 pub fn font_family_ui(ui: &mut Ui, font_family: &mut FontFamily) {
-    let families = ui.fonts().families();
+    let families = ui.fonts(|f| f.families());
     ui.horizontal(|ui| {
         for alternative in families {
             let text = alternative.to_string();
@@ -12,7 +12,7 @@ pub fn font_family_ui(ui: &mut Ui, font_family: &mut FontFamily) {
 }
 
 pub fn font_id_ui(ui: &mut Ui, font_id: &mut FontId) {
-    let families = ui.fonts().families();
+    let families = ui.fonts(|f| f.families());
     ui.horizontal(|ui| {
         ui.add(Slider::new(&mut font_id.size, 4.0..=40.0).max_decimals(1));
         for alternative in families {

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -403,7 +403,7 @@ impl Memory {
     }
 
     /// Is the keyboard focus locked on this widget? If so the focus won't move even if the user presses the tab key.
-    pub fn has_lock_focus(&mut self, id: Id) -> bool {
+    pub fn has_lock_focus(&self, id: Id) -> bool {
         if self.had_focus_last_frame(id) && self.has_focus(id) {
             self.interaction.focus.is_focus_locked
         } else {

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -31,11 +31,11 @@ pub(crate) struct BarState {
 
 impl BarState {
     fn load(ctx: &Context, bar_id: Id) -> Self {
-        ctx.data().get_temp::<Self>(bar_id).unwrap_or_default()
+        ctx.data_mut(|d| d.get_temp::<Self>(bar_id).unwrap_or_default())
     }
 
     fn store(self, ctx: &Context, bar_id: Id) {
-        ctx.data().insert_temp(bar_id, self);
+        ctx.data_mut(|d| d.insert_temp(bar_id, self));
     }
 
     /// Show a menu at pointer if primary-clicked response.
@@ -277,10 +277,9 @@ impl MenuRoot {
         root: &mut MenuRootManager,
         id: Id,
     ) -> MenuResponse {
-        // Lock the input once for the whole function call (see https://github.com/emilk/egui/pull/1380).
-        let input = response.ctx.input();
-
-        if (response.clicked() && root.is_menu_open(id)) || input.key_pressed(Key::Escape) {
+        if (response.clicked() && root.is_menu_open(id))
+            || response.ctx.input(|i| i.key_pressed(Key::Escape))
+        {
             // menu open and button clicked or esc pressed
             return MenuResponse::Close;
         } else if (response.clicked() && !root.is_menu_open(id))
@@ -288,12 +287,10 @@ impl MenuRoot {
         {
             // menu not open and button clicked
             // or button hovered while other menu is open
-            drop(input);
-
             let mut pos = response.rect.left_bottom();
             if let Some(root) = root.inner.as_mut() {
                 let menu_rect = root.menu_state.read().rect;
-                let screen_rect = response.ctx.input().screen_rect;
+                let screen_rect = response.ctx.input(|i| i.screen_rect);
 
                 if pos.y + menu_rect.height() > screen_rect.max.y {
                     pos.y = screen_rect.max.y - menu_rect.height() - response.rect.height();
@@ -305,8 +302,11 @@ impl MenuRoot {
             }
 
             return MenuResponse::Create(pos, id);
-        } else if input.pointer.any_pressed() && input.pointer.primary_down() {
-            if let Some(pos) = input.pointer.interact_pos() {
+        } else if response
+            .ctx
+            .input(|i| i.pointer.any_pressed() && i.pointer.primary_down())
+        {
+            if let Some(pos) = response.ctx.input(|i| i.pointer.interact_pos()) {
                 if let Some(root) = root.inner.as_mut() {
                     if root.id == id {
                         // pressed somewhere while this menu is open
@@ -329,26 +329,28 @@ impl MenuRoot {
         id: Id,
     ) -> MenuResponse {
         let response = response.interact(Sense::click());
-        let pointer = &response.ctx.input().pointer;
-        if pointer.any_pressed() {
-            if let Some(pos) = pointer.interact_pos() {
-                let mut destroy = false;
-                let mut in_old_menu = false;
-                if let Some(root) = root {
-                    let menu_state = root.menu_state.read();
-                    in_old_menu = menu_state.area_contains(pos);
-                    destroy = root.id == response.id;
-                }
-                if !in_old_menu {
-                    if response.hovered() && pointer.secondary_down() {
-                        return MenuResponse::Create(pos, id);
-                    } else if (response.hovered() && pointer.primary_down()) || destroy {
-                        return MenuResponse::Close;
+        response.ctx.input(|input| {
+            let pointer = &input.pointer;
+            if pointer.any_pressed() {
+                if let Some(pos) = pointer.interact_pos() {
+                    let mut destroy = false;
+                    let mut in_old_menu = false;
+                    if let Some(root) = root {
+                        let menu_state = root.menu_state.read();
+                        in_old_menu = menu_state.area_contains(pos);
+                        destroy = root.id == response.id;
+                    }
+                    if !in_old_menu {
+                        if response.hovered() && pointer.secondary_down() {
+                            return MenuResponse::Create(pos, id);
+                        } else if (response.hovered() && pointer.primary_down()) || destroy {
+                            return MenuResponse::Close;
+                        }
                     }
                 }
             }
-        }
-        MenuResponse::Stay
+            MenuResponse::Stay
+        })
     }
 
     fn handle_menu_response(root: &mut MenuRootManager, menu_response: MenuResponse) {
@@ -571,15 +573,15 @@ impl MenuState {
 
     /// Sense button interaction opening and closing submenu.
     fn submenu_button_interaction(&mut self, ui: &mut Ui, sub_id: Id, button: &Response) {
-        let pointer = &ui.input().pointer.clone();
+        let pointer = ui.input(|i| i.pointer.clone());
         let open = self.is_open(sub_id);
-        if self.moving_towards_current_submenu(pointer) {
+        if self.moving_towards_current_submenu(&pointer) {
             // ensure to repaint once even when pointer is not moving
             ui.ctx().request_repaint();
         } else if !open && button.hovered() {
             let pos = button.rect.right_top();
             self.open_submenu(sub_id, pos);
-        } else if open && !button.hovered() && !self.hovering_current_submenu(pointer) {
+        } else if open && !button.hovered() && !self.hovering_current_submenu(&pointer) {
             self.close_submenu();
         }
     }

--- a/crates/egui/src/painter.rs
+++ b/crates/egui/src/painter.rs
@@ -7,7 +7,6 @@ use crate::{
     Color32, Context, FontId,
 };
 use epaint::{
-    mutex::{RwLockReadGuard, RwLockWriteGuard},
     text::{Fonts, Galley},
     CircleShape, RectShape, Rounding, Shape, Stroke,
 };
@@ -107,8 +106,8 @@ impl Painter {
 
     /// Available fonts.
     #[inline(always)]
-    pub fn fonts(&self) -> RwLockReadGuard<'_, Fonts> {
-        self.ctx.fonts()
+    pub fn fonts<R>(&self, reader: impl FnOnce(&Fonts) -> R) -> R {
+        self.ctx.fonts(reader)
     }
 
     /// Where we paint
@@ -152,8 +151,9 @@ impl Painter {
 
 /// ## Low level
 impl Painter {
-    fn paint_list(&self) -> RwLockWriteGuard<'_, PaintList> {
-        RwLockWriteGuard::map(self.ctx.graphics(), |g| g.list(self.layer_id))
+    #[inline]
+    fn paint_list<R>(&self, writer: impl FnOnce(&mut PaintList) -> R) -> R {
+        self.ctx.graphics_mut(|g| writer(g.list(self.layer_id)))
     }
 
     fn transform_shape(&self, shape: &mut Shape) {
@@ -167,11 +167,11 @@ impl Painter {
     /// NOTE: all coordinates are screen coordinates!
     pub fn add(&self, shape: impl Into<Shape>) -> ShapeIdx {
         if self.fade_to_color == Some(Color32::TRANSPARENT) {
-            self.paint_list().add(self.clip_rect, Shape::Noop)
+            self.paint_list(|l| l.add(self.clip_rect, Shape::Noop))
         } else {
             let mut shape = shape.into();
             self.transform_shape(&mut shape);
-            self.paint_list().add(self.clip_rect, shape)
+            self.paint_list(|l| l.add(self.clip_rect, shape))
         }
     }
 
@@ -187,9 +187,9 @@ impl Painter {
                 self.transform_shape(&mut shape);
                 shape
             });
-            self.paint_list().extend(self.clip_rect, shapes);
+            self.paint_list(|l| l.extend(self.clip_rect, shapes));
         } else {
-            self.paint_list().extend(self.clip_rect, shapes);
+            self.paint_list(|l| l.extend(self.clip_rect, shapes));
         };
     }
 
@@ -200,7 +200,7 @@ impl Painter {
         }
         let mut shape = shape.into();
         self.transform_shape(&mut shape);
-        self.paint_list().set(idx, self.clip_rect, shape);
+        self.paint_list(|l| l.set(idx, self.clip_rect, shape));
     }
 }
 
@@ -405,7 +405,7 @@ impl Painter {
         color: crate::Color32,
         wrap_width: f32,
     ) -> Arc<Galley> {
-        self.fonts().layout(text, font_id, color, wrap_width)
+        self.fonts(|f| f.layout(text, font_id, color, wrap_width))
     }
 
     /// Will line break at `\n`.
@@ -418,7 +418,7 @@ impl Painter {
         font_id: FontId,
         color: crate::Color32,
     ) -> Arc<Galley> {
-        self.fonts().layout(text, font_id, color, f32::INFINITY)
+        self.fonts(|f| f.layout(text, font_id, color, f32::INFINITY))
     }
 
     /// Paint text that has already been layed out in a [`Galley`].

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -173,23 +173,25 @@ impl Response {
         // We do not use self.clicked(), because we want to catch all clicks within our frame,
         // even if we aren't clickable (or even enabled).
         // This is important for windows and such that should close then the user clicks elsewhere.
-        let pointer = &self.ctx.input().pointer;
+        self.ctx.input(|i| {
+            let pointer = &i.pointer;
 
-        if pointer.any_click() {
-            // We detect clicks/hover on a "interact_rect" that is slightly larger than
-            // self.rect. See Context::interact.
-            // This means we can be hovered and clicked even though `!self.rect.contains(pos)` is true,
-            // hence the extra complexity here.
-            if self.hovered() {
-                false
-            } else if let Some(pos) = pointer.interact_pos() {
-                !self.rect.contains(pos)
+            if pointer.any_click() {
+                // We detect clicks/hover on a "interact_rect" that is slightly larger than
+                // self.rect. See Context::interact.
+                // This means we can be hovered and clicked even though `!self.rect.contains(pos)` is true,
+                // hence the extra complexity here.
+                if self.hovered() {
+                    false
+                } else if let Some(pos) = pointer.interact_pos() {
+                    !self.rect.contains(pos)
+                } else {
+                    false // clicked without a pointer, weird
+                }
             } else {
-                false // clicked without a pointer, weird
+                false
             }
-        } else {
-            false
-        }
+        })
     }
 
     /// Was the widget enabled?
@@ -217,14 +219,12 @@ impl Response {
     /// also has the keyboard focus. That makes this function suitable
     /// for style choices, e.g. a thicker border around focused widgets.
     pub fn has_focus(&self) -> bool {
-        // Access input and memory in separate statements to prevent deadlock.
-        let has_global_focus = self.ctx.input().raw.has_focus;
-        has_global_focus && self.ctx.memory().has_focus(self.id)
+        self.ctx.input(|i| i.raw.has_focus) && self.ctx.memory(|mem| mem.has_focus(self.id))
     }
 
     /// True if this widget has keyboard focus this frame, but didn't last frame.
     pub fn gained_focus(&self) -> bool {
-        self.ctx.memory().gained_focus(self.id)
+        self.ctx.memory(|mem| mem.gained_focus(self.id))
     }
 
     /// The widget had keyboard focus and lost it,
@@ -242,17 +242,17 @@ impl Response {
     /// # });
     /// ```
     pub fn lost_focus(&self) -> bool {
-        self.ctx.memory().lost_focus(self.id)
+        self.ctx.memory(|mem| mem.lost_focus(self.id))
     }
 
     /// Request that this widget get keyboard focus.
     pub fn request_focus(&self) {
-        self.ctx.memory().request_focus(self.id);
+        self.ctx.memory_mut(|mem| mem.request_focus(self.id));
     }
 
     /// Surrender keyboard focus for this widget.
     pub fn surrender_focus(&self) {
-        self.ctx.memory().surrender_focus(self.id);
+        self.ctx.memory_mut(|mem| mem.surrender_focus(self.id));
     }
 
     /// The widgets is being dragged.
@@ -270,12 +270,12 @@ impl Response {
     }
 
     pub fn dragged_by(&self, button: PointerButton) -> bool {
-        self.dragged() && self.ctx.input().pointer.button_down(button)
+        self.dragged() && self.ctx.input(|i| i.pointer.button_down(button))
     }
 
     /// Did a drag on this widgets begin this frame?
     pub fn drag_started(&self) -> bool {
-        self.dragged && self.ctx.input().pointer.any_pressed()
+        self.dragged && self.ctx.input(|i| i.pointer.any_pressed())
     }
 
     /// The widget was being dragged, but now it has been released.
@@ -286,7 +286,7 @@ impl Response {
     /// If dragged, how many points were we dragged and in what direction?
     pub fn drag_delta(&self) -> Vec2 {
         if self.dragged() {
-            self.ctx.input().pointer.delta()
+            self.ctx.input(|i| i.pointer.delta())
         } else {
             Vec2::ZERO
         }
@@ -302,7 +302,7 @@ impl Response {
     /// None if the pointer is outside the response area.
     pub fn hover_pos(&self) -> Option<Pos2> {
         if self.hovered() {
-            self.ctx.input().pointer.hover_pos()
+            self.ctx.input(|i| i.pointer.hover_pos())
         } else {
             None
         }
@@ -392,11 +392,11 @@ impl Response {
     }
 
     fn should_show_hover_ui(&self) -> bool {
-        if self.ctx.memory().everything_is_visible() {
+        if self.ctx.memory(|mem| mem.everything_is_visible()) {
             return true;
         }
 
-        if !self.hovered || !self.ctx.input().pointer.has_pointer() {
+        if !self.hovered || !self.ctx.input(|i| i.pointer.has_pointer()) {
             return false;
         }
 
@@ -404,8 +404,7 @@ impl Response {
             // We only show the tooltip when the mouse pointer is still,
             // but once shown we keep showing it until the mouse leaves the parent.
 
-            let is_pointer_still = self.ctx.input().pointer.is_still();
-            if !is_pointer_still && !self.is_tooltip_open() {
+            if !self.ctx.input(|i| i.pointer.is_still()) && !self.is_tooltip_open() {
                 // wait for mouse to stop
                 self.ctx.request_repaint();
                 return false;
@@ -414,8 +413,9 @@ impl Response {
 
         // We don't want tooltips of things while we are dragging them,
         // but we do want tooltips while holding down on an item on a touch screen.
-        if self.ctx.input().pointer.any_down()
-            && self.ctx.input().pointer.has_moved_too_much_for_a_click
+        if self
+            .ctx
+            .input(|i| i.pointer.any_down() && i.pointer.has_moved_too_much_for_a_click)
         {
             return false;
         }
@@ -454,7 +454,7 @@ impl Response {
     /// When hovered, use this icon for the mouse cursor.
     pub fn on_hover_cursor(self, cursor: CursorIcon) -> Self {
         if self.hovered() {
-            self.ctx.output().cursor_icon = cursor;
+            self.ctx.output_mut(|o| o.cursor_icon = cursor);
         }
         self
     }
@@ -503,8 +503,10 @@ impl Response {
     /// # });
     /// ```
     pub fn scroll_to_me(&self, align: Option<Align>) {
-        self.ctx.frame_state().scroll_target[0] = Some((self.rect.x_range(), align));
-        self.ctx.frame_state().scroll_target[1] = Some((self.rect.y_range(), align));
+        self.ctx.frame_state_mut(|state| {
+            state.scroll_target[0] = Some((self.rect.x_range(), align));
+            state.scroll_target[1] = Some((self.rect.y_range(), align));
+        })
     }
 
     /// For accessibility.
@@ -529,18 +531,18 @@ impl Response {
             self.output_event(event);
         } else {
             #[cfg(feature = "accesskit")]
-            if let Some(mut node) = self.ctx.accesskit_node(self.id) {
-                self.fill_accesskit_node_from_widget_info(&mut node, make_info());
-            }
+            self.ctx.accesskit_node_if_some(self.id, |node| {
+                self.fill_accesskit_node_from_widget_info(node, make_info())
+            });
         }
     }
 
     pub fn output_event(&self, event: crate::output::OutputEvent) {
         #[cfg(feature = "accesskit")]
-        if let Some(mut node) = self.ctx.accesskit_node(self.id) {
-            self.fill_accesskit_node_from_widget_info(&mut node, event.widget_info().clone());
-        }
-        self.ctx.output().events.push(event);
+        self.ctx.accesskit_node_if_some(self.id, |node| {
+            self.fill_accesskit_node_from_widget_info(node, event.widget_info().clone())
+        });
+        self.ctx.output_mut(|o| o.events.push(event));
     }
 
     #[cfg(feature = "accesskit")]
@@ -618,9 +620,8 @@ impl Response {
     /// ```
     pub fn labelled_by(self, id: Id) -> Self {
         #[cfg(feature = "accesskit")]
-        if let Some(mut node) = self.ctx.accesskit_node(self.id) {
-            node.labelled_by.push(id.accesskit_id());
-        }
+        self.ctx
+            .accesskit_node_if_some(self.id, |node| node.labelled_by.push(id.accesskit_id()));
         #[cfg(not(feature = "accesskit"))]
         {
             let _ = id;

--- a/crates/egui/src/util/id_type_map.rs
+++ b/crates/egui/src/util/id_type_map.rs
@@ -460,18 +460,18 @@ impl IdTypeMap {
     }
 
     #[inline]
-    pub fn is_empty(&mut self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
     #[inline]
-    pub fn len(&mut self) -> usize {
+    pub fn len(&self) -> usize {
         self.0.len()
     }
 
     /// Count how many values are stored but not yet deserialized.
     #[inline]
-    pub fn count_serialized(&mut self) -> usize {
+    pub fn count_serialized(&self) -> usize {
         self.0
             .values()
             .filter(|e| matches!(e, Element::Serialized { .. }))
@@ -479,7 +479,7 @@ impl IdTypeMap {
     }
 
     /// Count the number of values are stored with the given type.
-    pub fn count<T: 'static>(&mut self) -> usize {
+    pub fn count<T: 'static>(&self) -> usize {
         let key = TypeId::of::<T>();
         self.0
             .iter()

--- a/crates/egui/src/widget_text.rs
+++ b/crates/egui/src/widget_text.rs
@@ -573,14 +573,14 @@ impl WidgetText {
                 let mut text_job = text.into_text_job(ui.style(), fallback_font.into(), valign);
                 text_job.job.wrap.max_width = wrap_width;
                 WidgetTextGalley {
-                    galley: ui.fonts().layout_job(text_job.job),
+                    galley: ui.fonts(|f| f.layout_job(text_job.job)),
                     galley_has_color: text_job.job_has_color,
                 }
             }
             Self::LayoutJob(mut job) => {
                 job.wrap.max_width = wrap_width;
                 WidgetTextGalley {
-                    galley: ui.fonts().layout_job(job),
+                    galley: ui.fonts(|f| f.layout_job(job)),
                     galley_has_color: true,
                 }
             }

--- a/crates/egui/src/widgets/color_picker.rs
+++ b/crates/egui/src/widgets/color_picker.rs
@@ -228,9 +228,9 @@ fn color_text_ui(ui: &mut Ui, color: impl Into<Color32>, alpha: Alpha) {
 
         if ui.button("📋").on_hover_text("Click to copy").clicked() {
             if alpha == Alpha::Opaque {
-                ui.output().copied_text = format!("{}, {}, {}", r, g, b);
+                ui.output_mut(|o| o.copied_text = format!("{}, {}, {}", r, g, b));
             } else {
-                ui.output().copied_text = format!("{}, {}, {}, {}", r, g, b, a);
+                ui.output_mut(|o| o.copied_text = format!("{}, {}, {}, {}", r, g, b, a));
             }
         }
 
@@ -341,20 +341,20 @@ pub fn color_picker_color32(ui: &mut Ui, srgba: &mut Color32, alpha: Alpha) -> b
 
 pub fn color_edit_button_hsva(ui: &mut Ui, hsva: &mut Hsva, alpha: Alpha) -> Response {
     let popup_id = ui.auto_id_with("popup");
-    let open = ui.memory().is_popup_open(popup_id);
+    let open = ui.memory(|mem| mem.is_popup_open(popup_id));
     let mut button_response = color_button(ui, (*hsva).into(), open);
     if ui.style().explanation_tooltips {
         button_response = button_response.on_hover_text("Click to edit color");
     }
 
     if button_response.clicked() {
-        ui.memory().toggle_popup(popup_id);
+        ui.memory_mut(|mem| mem.toggle_popup(popup_id));
     }
 
     const COLOR_SLIDER_WIDTH: f32 = 210.0;
 
     // TODO(emilk): make it easier to show a temporary popup that closes when you click outside it
-    if ui.memory().is_popup_open(popup_id) {
+    if ui.memory(|mem| mem.is_popup_open(popup_id)) {
         let area_response = Area::new(popup_id)
             .order(Order::Foreground)
             .fixed_pos(button_response.rect.max)
@@ -370,9 +370,9 @@ pub fn color_edit_button_hsva(ui: &mut Ui, hsva: &mut Hsva, alpha: Alpha) -> Res
             .response;
 
         if !button_response.clicked()
-            && (ui.input().key_pressed(Key::Escape) || area_response.clicked_elsewhere())
+            && (ui.input(|i| i.key_pressed(Key::Escape)) || area_response.clicked_elsewhere())
         {
-            ui.memory().close_popup();
+            ui.memory_mut(|mem| mem.close_popup());
         }
     }
 
@@ -436,5 +436,5 @@ fn color_cache_set(ctx: &Context, rgba: impl Into<Rgba>, hsva: Hsva) {
 
 // To ensure we keep hue slider when `srgba` is gray we store the full [`Hsva`] in a cache:
 fn use_color_cache<R>(ctx: &Context, f: impl FnOnce(&mut FixedCache<Rgba, Hsva>) -> R) -> R {
-    f(ctx.data().get_temp_mut_or_default(Id::null()))
+    ctx.data_mut(|d| f(d.get_temp_mut_or_default(Id::null())))
 }

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -368,30 +368,29 @@ impl<'a> Widget for DragValue<'a> {
             custom_parser,
         } = self;
 
-        let shift = ui.input().modifiers.shift_only();
+        let shift = ui.input(|i| i.modifiers.shift_only());
         // The widget has the same ID whether it's in edit or button mode.
         let id = ui.next_auto_id();
-        let is_slow_speed = shift && ui.memory().is_being_dragged(id);
+        let is_slow_speed = shift && ui.memory(|mem| mem.is_being_dragged(id));
 
         // The following call ensures that when a `DragValue` receives focus,
         // it is immediately rendered in edit mode, rather than being rendered
         // in button mode for just one frame. This is important for
         // screen readers.
-        ui.memory().interested_in_focus(id);
-        let is_kb_editing = ui.memory().has_focus(id);
+        ui.memory_mut(|mem| mem.interested_in_focus(id));
+        let is_kb_editing = ui.memory(|mem| mem.has_focus(id));
 
         let old_value = get(&mut get_set_value);
         let mut value = old_value;
-        let aim_rad = ui.input().aim_radius() as f64;
+        let aim_rad = ui.input(|i| i.aim_radius() as f64);
 
         let auto_decimals = (aim_rad / speed.abs()).log10().ceil().clamp(0.0, 15.0) as usize;
         let auto_decimals = auto_decimals + is_slow_speed as usize;
         let max_decimals = max_decimals.unwrap_or(auto_decimals + 2);
         let auto_decimals = auto_decimals.clamp(min_decimals, max_decimals);
 
-        let change = {
+        let change = ui.input_mut(|input| {
             let mut change = 0.0;
-            let mut input = ui.input_mut();
 
             if is_kb_editing {
                 // This deliberately doesn't listen for left and right arrow keys,
@@ -415,16 +414,18 @@ impl<'a> Widget for DragValue<'a> {
             }
 
             change
-        };
+        });
 
         #[cfg(feature = "accesskit")]
         {
             use accesskit::{Action, ActionData};
-            for request in ui.input().accesskit_action_requests(id, Action::SetValue) {
-                if let Some(ActionData::NumericValue(new_value)) = request.data {
-                    value = new_value;
+            ui.input(|i| {
+                for request in i.accesskit_action_requests(id, Action::SetValue) {
+                    if let Some(ActionData::NumericValue(new_value)) = request.data {
+                        value = new_value;
+                    }
                 }
-            }
+            });
         }
 
         if change != 0.0 {
@@ -435,7 +436,7 @@ impl<'a> Widget for DragValue<'a> {
         value = clamp_to_range(value, clamp_range.clone());
         if old_value != value {
             set(&mut get_set_value, value);
-            ui.memory().drag_value.edit_string = None;
+            ui.memory_mut(|mem| mem.drag_value.edit_string = None);
         }
 
         let value_text = match custom_formatter {
@@ -454,10 +455,7 @@ impl<'a> Widget for DragValue<'a> {
         let mut response = if is_kb_editing {
             let button_width = ui.spacing().interact_size.x;
             let mut value_text = ui
-                .memory()
-                .drag_value
-                .edit_string
-                .take()
+                .memory_mut(|mem| mem.drag_value.edit_string.take())
                 .unwrap_or_else(|| value_text.clone());
             let response = ui.add(
                 TextEdit::singleline(&mut value_text)
@@ -473,10 +471,10 @@ impl<'a> Widget for DragValue<'a> {
                 let parsed_value = clamp_to_range(parsed_value, clamp_range.clone());
                 set(&mut get_set_value, parsed_value);
             }
-            ui.memory().drag_value.edit_string = Some(value_text);
+            ui.memory_mut(|mem| mem.drag_value.edit_string = Some(value_text));
             response
         } else {
-            ui.memory().drag_value.edit_string = None;
+            ui.memory_mut(|mem| mem.drag_value.edit_string = None);
             let button = Button::new(
                 RichText::new(format!("{}{}{}", prefix, value_text.clone(), suffix)).monospace(),
             )
@@ -497,9 +495,9 @@ impl<'a> Widget for DragValue<'a> {
             }
 
             if response.clicked() {
-                ui.memory().request_focus(id);
+                ui.memory_mut(|mem| mem.request_focus(id));
             } else if response.dragged() {
-                ui.output().cursor_icon = CursorIcon::ResizeHorizontal;
+                ui.output_mut(|o| o.cursor_icon = CursorIcon::ResizeHorizontal);
 
                 let mdelta = response.drag_delta();
                 let delta_points = mdelta.x - mdelta.y; // Increase to the right and up
@@ -509,7 +507,7 @@ impl<'a> Widget for DragValue<'a> {
                 let delta_value = delta_points as f64 * speed;
 
                 if delta_value != 0.0 {
-                    let mut drag_state = std::mem::take(&mut ui.memory().drag_value);
+                    let mut drag_state = ui.memory_mut(|mem| std::mem::take(&mut mem.drag_value));
 
                     // Since we round the value being dragged, we need to store the full precision value in memory:
                     let stored_value = (drag_state.last_dragged_id == Some(response.id))
@@ -530,7 +528,7 @@ impl<'a> Widget for DragValue<'a> {
 
                     drag_state.last_dragged_id = Some(response.id);
                     drag_state.last_dragged_value = Some(stored_value);
-                    ui.memory().drag_value = drag_state;
+                    ui.memory_mut(|mem| mem.drag_value = drag_state);
                 }
             }
 
@@ -542,7 +540,7 @@ impl<'a> Widget for DragValue<'a> {
         response.widget_info(|| WidgetInfo::drag_value(value));
 
         #[cfg(feature = "accesskit")]
-        if let Some(mut node) = ui.ctx().accesskit_node(response.id) {
+        ui.ctx().accesskit_node_if_some(response.id, |node| {
             use accesskit::Action;
             // If either end of the range is unbounded, it's better
             // to leave the corresponding AccessKit field set to None,
@@ -586,7 +584,7 @@ impl<'a> Widget for DragValue<'a> {
                 let value_text = format!("{}{}{}", prefix, value_text, suffix);
                 node.value = Some(value_text.into());
             }
-        }
+        });
 
         response
     }

--- a/crates/egui/src/widgets/hyperlink.rs
+++ b/crates/egui/src/widgets/hyperlink.rs
@@ -38,7 +38,8 @@ impl Widget for Link {
         response.widget_info(|| WidgetInfo::labeled(WidgetType::Link, text_galley.text()));
 
         if response.hovered() {
-            ui.ctx().output().cursor_icon = CursorIcon::PointingHand;
+            ui.ctx()
+                .output_mut(|o| o.cursor_icon = CursorIcon::PointingHand);
         }
 
         if ui.is_rect_visible(response.rect) {
@@ -110,16 +111,20 @@ impl Widget for Hyperlink {
 
         let response = ui.add(Link::new(text));
         if response.clicked() {
-            let modifiers = ui.ctx().input().modifiers;
-            ui.ctx().output().open_url = Some(crate::output::OpenUrl {
-                url: url.clone(),
-                new_tab: modifiers.any(),
+            let modifiers = ui.ctx().input(|i| i.modifiers);
+            ui.ctx().output_mut(|o| {
+                o.open_url = Some(crate::output::OpenUrl {
+                    url: url.clone(),
+                    new_tab: modifiers.any(),
+                })
             });
         }
         if response.middle_clicked() {
-            ui.ctx().output().open_url = Some(crate::output::OpenUrl {
-                url: url.clone(),
-                new_tab: true,
+            ui.ctx().output_mut(|o| {
+                o.open_url = Some(crate::output::OpenUrl {
+                    url: url.clone(),
+                    new_tab: true,
+                })
             });
         }
         response.on_hover_text(url)

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -72,7 +72,7 @@ impl Label {
     pub fn layout_in_ui(self, ui: &mut Ui) -> (Pos2, WidgetTextGalley, Response) {
         let sense = self.sense.unwrap_or_else(|| {
             // We only want to focus labels if the screen reader is on.
-            if ui.memory().options.screen_reader {
+            if ui.memory(|mem| mem.options.screen_reader) {
                 Sense::focusable_noninteractive()
             } else {
                 Sense::hover()
@@ -120,7 +120,7 @@ impl Label {
             if let Some(first_section) = text_job.job.sections.first_mut() {
                 first_section.leading_space = first_row_indentation;
             }
-            let text_galley = text_job.into_galley(&ui.fonts());
+            let text_galley = ui.fonts(|f| text_job.into_galley(f));
 
             let pos = pos2(ui.max_rect().left(), ui.cursor().top());
             assert!(
@@ -153,7 +153,7 @@ impl Label {
                 text_job.job.justify = ui.layout().horizontal_justify();
             };
 
-            let text_galley = text_job.into_galley(&ui.fonts());
+            let text_galley = ui.fonts(|f| text_job.into_galley(f));
             let (rect, response) = ui.allocate_exact_size(text_galley.size(), sense);
             let pos = match text_galley.galley.job.halign {
                 Align::LEFT => rect.left_top(),

--- a/crates/egui/src/widgets/plot/items/mod.rs
+++ b/crates/egui/src/widgets/plot/items/mod.rs
@@ -1656,14 +1656,16 @@ fn add_rulers_and_text(
     let font_id = TextStyle::Body.resolve(plot.ui.style());
 
     let corner_value = elem.corner_value();
-    shapes.push(Shape::text(
-        &plot.ui.fonts(),
-        plot.transform.position_from_point(&corner_value) + vec2(3.0, -2.0),
-        Align2::LEFT_BOTTOM,
-        text,
-        font_id,
-        plot.ui.visuals().text_color(),
-    ));
+    plot.ui.fonts(|f| {
+        shapes.push(Shape::text(
+            &f,
+            plot.transform.position_from_point(&corner_value) + vec2(3.0, -2.0),
+            Align2::LEFT_BOTTOM,
+            text,
+            font_id,
+            plot.ui.visuals().text_color(),
+        ))
+    });
 }
 
 /// Draws a cross of horizontal and vertical ruler at the `pointer` position.
@@ -1712,15 +1714,16 @@ pub(super) fn rulers_at_value(
     };
 
     let font_id = TextStyle::Body.resolve(plot.ui.style());
-
-    shapes.push(Shape::text(
-        &plot.ui.fonts(),
-        pointer + vec2(3.0, -2.0),
-        Align2::LEFT_BOTTOM,
-        text,
-        font_id,
-        plot.ui.visuals().text_color(),
-    ));
+    plot.ui.fonts(|f| {
+        shapes.push(Shape::text(
+            &f,
+            pointer + vec2(3.0, -2.0),
+            Align2::LEFT_BOTTOM,
+            text,
+            font_id,
+            plot.ui.visuals().text_color(),
+        ))
+    });
 }
 
 fn find_closest_rect<'a, T>(

--- a/crates/egui/src/widgets/plot/legend.rs
+++ b/crates/egui/src/widgets/plot/legend.rs
@@ -89,9 +89,7 @@ impl LegendEntry {
 
         let font_id = text_style.resolve(ui.style());
 
-        let galley = ui
-            .fonts()
-            .layout_delayed_color(text, font_id, f32::INFINITY);
+        let galley = ui.fonts(|f| f.layout_delayed_color(text, font_id, f32::INFINITY));
 
         let icon_size = galley.size().y;
         let icon_spacing = icon_size / 5.0;

--- a/crates/egui/src/widgets/plot/mod.rs
+++ b/crates/egui/src/widgets/plot/mod.rs
@@ -108,11 +108,11 @@ struct PlotMemory {
 
 impl PlotMemory {
     pub fn load(ctx: &Context, id: Id) -> Option<Self> {
-        ctx.data().get_persisted(id)
+        ctx.data_mut(|d| d.get_persisted(id))
     }
 
     pub fn store(self, ctx: &Context, id: Id) {
-        ctx.data().insert_persisted(id, self);
+        ctx.data_mut(|d| d.insert_persisted(id, self));
     }
 }
 
@@ -929,9 +929,9 @@ impl Plot {
         if let Some(hover_pos) = response.hover_pos() {
             if allow_zoom {
                 let zoom_factor = if data_aspect.is_some() {
-                    Vec2::splat(ui.input().zoom_delta())
+                    Vec2::splat(ui.input(|i| i.zoom_delta()))
                 } else {
-                    ui.input().zoom_delta_2d()
+                    ui.input(|i| i.zoom_delta_2d())
                 };
                 if zoom_factor != Vec2::splat(1.0) {
                     transform.zoom(zoom_factor, hover_pos);
@@ -939,7 +939,7 @@ impl Plot {
                 }
             }
             if allow_scroll {
-                let scroll_delta = ui.input().scroll_delta;
+                let scroll_delta = ui.input(|i| i.scroll_delta);
                 if scroll_delta != Vec2::ZERO {
                     transform.translate_bounds(-scroll_delta);
                     bounds_modified = true.into();
@@ -1068,7 +1068,7 @@ impl PlotUi {
     /// The pointer position in plot coordinates. Independent of whether the pointer is in the plot area.
     pub fn pointer_coordinate(&self) -> Option<PlotPoint> {
         // We need to subtract the drag delta to keep in sync with the frame-delayed screen transform:
-        let last_pos = self.ctx().input().pointer.latest_pos()? - self.response.drag_delta();
+        let last_pos = self.ctx().input(|i| i.pointer.latest_pos())? - self.response.drag_delta();
         let value = self.plot_from_screen(last_pos);
         Some(value)
     }

--- a/crates/egui/src/widgets/progress_bar.rs
+++ b/crates/egui/src/widgets/progress_bar.rs
@@ -90,7 +90,7 @@ impl Widget for ProgressBar {
 
             let (dark, bright) = (0.7, 1.0);
             let color_factor = if animate {
-                lerp(dark..=bright, ui.input().time.cos().abs())
+                lerp(dark..=bright, ui.input(|i| i.time).cos().abs())
             } else {
                 bright
             };
@@ -104,8 +104,9 @@ impl Widget for ProgressBar {
 
             if animate {
                 let n_points = 20;
-                let start_angle = ui.input().time * std::f64::consts::TAU;
-                let end_angle = start_angle + 240f64.to_radians() * ui.input().time.sin();
+                let input_time = ui.input(|i| i.time);
+                let start_angle = input_time * std::f64::consts::TAU;
+                let end_angle = start_angle + 240f64.to_radians() * input_time.sin();
                 let circle_radius = rounding - 2.0;
                 let points: Vec<Pos2> = (0..n_points)
                     .map(|i| {

--- a/crates/egui/src/widgets/spinner.rs
+++ b/crates/egui/src/widgets/spinner.rs
@@ -48,8 +48,9 @@ impl Widget for Spinner {
 
             let radius = (rect.height() / 2.0) - 2.0;
             let n_points = 20;
-            let start_angle = ui.input().time * std::f64::consts::TAU;
-            let end_angle = start_angle + 240f64.to_radians() * ui.input().time.sin();
+            let input_time = ui.input(|i| i.time);
+            let start_angle = input_time * std::f64::consts::TAU;
+            let end_angle = start_angle + 240f64.to_radians() * input_time.sin();
             let points: Vec<Pos2> = (0..n_points)
                 .map(|i| {
                     let angle = lerp(start_angle..=end_angle, i as f64 / n_points as f64);

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -312,7 +312,7 @@ impl<'t> TextEdit<'t> {
             output.response |= ui.interact(frame_rect, id, Sense::click());
         }
         if output.response.clicked() && !output.response.lost_focus() {
-            ui.memory().request_focus(output.response.id);
+            ui.memory_mut(|mem| mem.request_focus(output.response.id));
         }
 
         if frame {
@@ -381,7 +381,7 @@ impl<'t> TextEdit<'t> {
         let prev_text = text.as_str().to_owned();
 
         let font_id = font_selection.resolve(ui.style());
-        let row_height = ui.fonts().row_height(&font_id);
+        let row_height = ui.fonts(|f| f.row_height(&font_id));
         const MIN_WIDTH: f32 = 24.0; // Never make a [`TextEdit`] more narrow than this.
         let available_width = ui.available_width().at_least(MIN_WIDTH);
         let desired_width = desired_width.unwrap_or_else(|| ui.spacing().text_edit_width);
@@ -394,11 +394,12 @@ impl<'t> TextEdit<'t> {
         let font_id_clone = font_id.clone();
         let mut default_layouter = move |ui: &Ui, text: &str, wrap_width: f32| {
             let text = mask_if_password(password, text);
-            ui.fonts().layout_job(if multiline {
+            let layout_job = if multiline {
                 LayoutJob::simple(text, font_id_clone.clone(), text_color, wrap_width)
             } else {
                 LayoutJob::simple_singleline(text, font_id_clone.clone(), text_color)
-            })
+            };
+            ui.fonts(|f| f.layout_job(layout_job))
         };
 
         let layouter = layouter.unwrap_or(&mut default_layouter);
@@ -428,8 +429,8 @@ impl<'t> TextEdit<'t> {
         // dragging select text, or scroll the enclosing [`ScrollArea`] (if any)?
         // Since currently copying selected text in not supported on `eframe` web,
         // we prioritize touch-scrolling:
-        let any_touches = ui.input().any_touches(); // separate line to avoid double-locking the same mutex
-        let allow_drag_to_select = !any_touches || ui.memory().has_focus(id);
+        let allow_drag_to_select =
+            ui.input(|i| !i.any_touches()) || ui.memory(|mem| mem.has_focus(id));
 
         let sense = if interactive {
             if allow_drag_to_select {
@@ -447,7 +448,7 @@ impl<'t> TextEdit<'t> {
         if interactive {
             if let Some(pointer_pos) = ui.ctx().pointer_interact_pos() {
                 if response.hovered() && text.is_mutable() {
-                    ui.output().mutable_text_under_cursor = true;
+                    ui.output_mut(|o| o.mutable_text_under_cursor = true);
                 }
 
                 // TODO(emilk): drag selected text to either move or clone (ctrl on windows, alt on mac)
@@ -457,7 +458,7 @@ impl<'t> TextEdit<'t> {
 
                 if ui.visuals().text_cursor_preview
                     && response.hovered()
-                    && ui.input().pointer.is_moving()
+                    && ui.input(|i| i.pointer.is_moving())
                 {
                     // preview:
                     paint_cursor_end(
@@ -487,9 +488,9 @@ impl<'t> TextEdit<'t> {
                         secondary: galley.from_ccursor(ccursor_range.secondary),
                     }));
                 } else if allow_drag_to_select {
-                    if response.hovered() && ui.input().pointer.any_pressed() {
-                        ui.memory().request_focus(id);
-                        if ui.input().modifiers.shift {
+                    if response.hovered() && ui.input(|i| i.pointer.any_pressed()) {
+                        ui.memory_mut(|mem| mem.request_focus(id));
+                        if ui.input(|i| i.modifiers.shift) {
                             if let Some(mut cursor_range) = state.cursor_range(&galley) {
                                 cursor_range.primary = cursor_at_pointer;
                                 state.set_cursor_range(Some(cursor_range));
@@ -499,7 +500,8 @@ impl<'t> TextEdit<'t> {
                         } else {
                             state.set_cursor_range(Some(CursorRange::one(cursor_at_pointer)));
                         }
-                    } else if ui.input().pointer.any_down() && response.is_pointer_button_down_on()
+                    } else if ui.input(|i| i.pointer.any_down())
+                        && response.is_pointer_button_down_on()
                     {
                         // drag to select text:
                         if let Some(mut cursor_range) = state.cursor_range(&galley) {
@@ -511,14 +513,14 @@ impl<'t> TextEdit<'t> {
             }
         }
 
-        if response.hovered() && interactive {
-            ui.output().cursor_icon = CursorIcon::Text;
+        if interactive && response.hovered() {
+            ui.output_mut(|o| o.cursor_icon = CursorIcon::Text);
         }
 
         let mut cursor_range = None;
         let prev_cursor_range = state.cursor_range(&galley);
-        if ui.memory().has_focus(id) && interactive {
-            ui.memory().lock_focus(id, lock_focus);
+        if interactive && ui.memory(|mem| mem.has_focus(id)) {
+            ui.memory_mut(|mem| mem.lock_focus(id, lock_focus));
 
             let default_cursor_range = if cursor_at_end {
                 CursorRange::one(galley.end())
@@ -549,7 +551,7 @@ impl<'t> TextEdit<'t> {
 
         // Visual clipping for singleline text editor with text larger than width
         if !multiline {
-            let cursor_pos = match (cursor_range, ui.memory().has_focus(id)) {
+            let cursor_pos = match (cursor_range, ui.memory(|mem| mem.has_focus(id))) {
                 (Some(cursor_range), true) => galley.pos_from_cursor(&cursor_range.primary).min.x,
                 _ => 0.0,
             };
@@ -594,7 +596,7 @@ impl<'t> TextEdit<'t> {
                 galley.paint_with_fallback_color(&painter, response.rect.min, hint_text_color);
             }
 
-            if ui.memory().has_focus(id) {
+            if ui.memory(|mem| mem.has_focus(id)) {
                 if let Some(cursor_range) = state.cursor_range(&galley) {
                     // We paint the cursor on top of the text, in case
                     // the text galley has backgrounds (as e.g. `code` snippets in markup do).
@@ -621,9 +623,13 @@ impl<'t> TextEdit<'t> {
                             // But `winit` and `egui_web` differs in how to set the
                             // position of IME.
                             if cfg!(target_arch = "wasm32") {
-                                ui.ctx().output().text_cursor_pos = Some(cursor_pos.left_top());
+                                ui.ctx().output_mut(|o| {
+                                    o.text_cursor_pos = Some(cursor_pos.left_top())
+                                });
                             } else {
-                                ui.ctx().output().text_cursor_pos = Some(cursor_pos.left_bottom());
+                                ui.ctx().output_mut(|o| {
+                                    o.text_cursor_pos = Some(cursor_pos.left_bottom())
+                                });
                             }
                         }
                     }
@@ -659,89 +665,97 @@ impl<'t> TextEdit<'t> {
         }
 
         #[cfg(feature = "accesskit")]
-        if let Some(mut node) = ui.ctx().accesskit_node(response.id) {
-            use accesskit::{Role, TextDirection, TextPosition, TextSelection};
+        ui.ctx()
+            .accesskit_node_if_some(response.id, |node| {
+                use accesskit::{TextPosition, TextSelection};
 
-            let parent_id = response.id;
+                let parent_id = response.id;
 
-            if let Some(cursor_range) = &cursor_range {
-                let anchor = &cursor_range.secondary.rcursor;
-                let focus = &cursor_range.primary.rcursor;
-                node.text_selection = Some(TextSelection {
-                    anchor: TextPosition {
-                        node: parent_id.with(anchor.row).accesskit_id(),
-                        character_index: anchor.column,
-                    },
-                    focus: TextPosition {
-                        node: parent_id.with(focus.row).accesskit_id(),
-                        character_index: focus.column,
-                    },
-                });
-            }
-
-            node.default_action_verb = Some(accesskit::DefaultActionVerb::Focus);
-
-            drop(node);
-
-            ui.ctx().with_accessibility_parent(parent_id, || {
-                for (i, row) in galley.rows.iter().enumerate() {
-                    let id = parent_id.with(i);
-                    let mut node = ui.ctx().accesskit_node(id).unwrap();
-                    node.role = Role::InlineTextBox;
-                    let rect = row.rect.translate(text_draw_pos.to_vec2());
-                    node.bounds = Some(accesskit::kurbo::Rect {
-                        x0: rect.min.x.into(),
-                        y0: rect.min.y.into(),
-                        x1: rect.max.x.into(),
-                        y1: rect.max.y.into(),
+                if let Some(cursor_range) = &cursor_range {
+                    let anchor = &cursor_range.secondary.rcursor;
+                    let focus = &cursor_range.primary.rcursor;
+                    node.text_selection = Some(TextSelection {
+                        anchor: TextPosition {
+                            node: parent_id.with(anchor.row).accesskit_id(),
+                            character_index: anchor.column,
+                        },
+                        focus: TextPosition {
+                            node: parent_id.with(focus.row).accesskit_id(),
+                            character_index: focus.column,
+                        },
                     });
-                    node.text_direction = Some(TextDirection::LeftToRight);
-                    // TODO(mwcampbell): Set more node fields for the row
-                    // once AccessKit adapters expose text formatting info.
-
-                    let glyph_count = row.glyphs.len();
-                    let mut value = String::new();
-                    value.reserve(glyph_count);
-                    let mut character_lengths = Vec::<u8>::new();
-                    character_lengths.reserve(glyph_count);
-                    let mut character_positions = Vec::<f32>::new();
-                    character_positions.reserve(glyph_count);
-                    let mut character_widths = Vec::<f32>::new();
-                    character_widths.reserve(glyph_count);
-                    let mut word_lengths = Vec::<u8>::new();
-                    let mut was_at_word_end = false;
-                    let mut last_word_start = 0usize;
-
-                    for glyph in &row.glyphs {
-                        let is_word_char = is_word_char(glyph.chr);
-                        if is_word_char && was_at_word_end {
-                            word_lengths.push((character_lengths.len() - last_word_start) as _);
-                            last_word_start = character_lengths.len();
-                        }
-                        was_at_word_end = !is_word_char;
-                        let old_len = value.len();
-                        value.push(glyph.chr);
-                        character_lengths.push((value.len() - old_len) as _);
-                        character_positions.push(glyph.pos.x - row.rect.min.x);
-                        character_widths.push(glyph.size.x);
-                    }
-
-                    if row.ends_with_newline {
-                        value.push('\n');
-                        character_lengths.push(1);
-                        character_positions.push(row.rect.max.x - row.rect.min.x);
-                        character_widths.push(0.0);
-                    }
-                    word_lengths.push((character_lengths.len() - last_word_start) as _);
-
-                    node.value = Some(value.into());
-                    node.character_lengths = character_lengths.into();
-                    node.character_positions = Some(character_positions.into());
-                    node.character_widths = Some(character_widths.into());
-                    node.word_lengths = word_lengths.into();
                 }
+
+                node.default_action_verb = Some(accesskit::DefaultActionVerb::Focus);
+
+                parent_id
+            })
+            .map(|parent_id| {
+                // drop ctx lock before further processing
+                use accesskit::{Role, TextDirection};
+
+                ui.ctx().with_accessibility_parent(parent_id, || {
+                    for (i, row) in galley.rows.iter().enumerate() {
+                        let id = parent_id.with(i);
+                        ui.ctx().accesskit_node(id, |node| {
+                            let node = node.unwrap();
+                            node.role = Role::InlineTextBox;
+                            let rect = row.rect.translate(text_draw_pos.to_vec2());
+                            node.bounds = Some(accesskit::kurbo::Rect {
+                                x0: rect.min.x.into(),
+                                y0: rect.min.y.into(),
+                                x1: rect.max.x.into(),
+                                y1: rect.max.y.into(),
+                            });
+                            node.text_direction = Some(TextDirection::LeftToRight);
+                            // TODO(mwcampbell): Set more node fields for the row
+                            // once AccessKit adapters expose text formatting info.
+
+                            let glyph_count = row.glyphs.len();
+                            let mut value = String::new();
+                            value.reserve(glyph_count);
+                            let mut character_lengths = Vec::<u8>::new();
+                            character_lengths.reserve(glyph_count);
+                            let mut character_positions = Vec::<f32>::new();
+                            character_positions.reserve(glyph_count);
+                            let mut character_widths = Vec::<f32>::new();
+                            character_widths.reserve(glyph_count);
+                            let mut word_lengths = Vec::<u8>::new();
+                            let mut was_at_word_end = false;
+                            let mut last_word_start = 0usize;
+
+                            for glyph in &row.glyphs {
+                                let is_word_char = is_word_char(glyph.chr);
+                                if is_word_char && was_at_word_end {
+                                    word_lengths
+                                        .push((character_lengths.len() - last_word_start) as _);
+                                    last_word_start = character_lengths.len();
+                                }
+                                was_at_word_end = !is_word_char;
+                                let old_len = value.len();
+                                value.push(glyph.chr);
+                                character_lengths.push((value.len() - old_len) as _);
+                                character_positions.push(glyph.pos.x - row.rect.min.x);
+                                character_widths.push(glyph.size.x);
+                            }
+
+                            if row.ends_with_newline {
+                                value.push('\n');
+                                character_lengths.push(1);
+                                character_positions.push(row.rect.max.x - row.rect.min.x);
+                                character_widths.push(0.0);
+                            }
+                            word_lengths.push((character_lengths.len() - last_word_start) as _);
+
+                            node.value = Some(value.into());
+                            node.character_lengths = character_lengths.into();
+                            node.character_positions = Some(character_positions.into());
+                            node.character_widths = Some(character_widths.into());
+                            node.word_lengths = word_lengths.into();
+                        });
+                    }
+                });
             });
-        }
 
         TextEditOutput {
             response,
@@ -811,19 +825,19 @@ fn events(
     // We feed state to the undoer both before and after handling input
     // so that the undoer creates automatic saves even when there are no events for a while.
     state.undoer.lock().feed_state(
-        ui.input().time,
+        ui.input(|i| i.time),
         &(cursor_range.as_ccursor_range(), text.as_str().to_owned()),
     );
 
     let copy_if_not_password = |ui: &Ui, text: String| {
         if !password {
-            ui.ctx().output().copied_text = text;
+            ui.ctx().output_mut(|o| o.copied_text = text);
         }
     };
 
     let mut any_change = false;
 
-    let events = ui.input().events.clone(); // avoid dead-lock by cloning. TODO(emilk): optimize
+    let events = ui.input(|i| i.events.clone()); // avoid dead-lock by cloning. TODO(emilk): optimize
     for event in &events {
         let did_mutate_text = match event {
             Event::Copy => {
@@ -867,7 +881,7 @@ fn events(
                 pressed: true,
                 modifiers,
             } => {
-                if multiline && ui.memory().has_lock_focus(id) {
+                if multiline && ui.memory(|mem| mem.has_lock_focus(id)) {
                     let mut ccursor = delete_selected(text, &cursor_range);
                     if modifiers.shift {
                         // TODO(emilk): support removing indentation over a selection?
@@ -891,7 +905,7 @@ fn events(
                     // TODO(emilk): if code editor, auto-indent by same leading tabs, + one if the lines end on an opening bracket
                     Some(CCursorRange::one(ccursor))
                 } else {
-                    ui.memory().surrender_focus(id); // End input with enter
+                    ui.memory_mut(|mem| mem.surrender_focus(id)); // End input with enter
                     break;
                 }
             }
@@ -993,7 +1007,7 @@ fn events(
     state.set_cursor_range(Some(cursor_range));
 
     state.undoer.lock().feed_state(
-        ui.input().time,
+        ui.input(|i| i.time),
         &(cursor_range.as_ccursor_range(), text.as_str().to_owned()),
     );
 

--- a/crates/egui/src/widgets/text_edit/state.rs
+++ b/crates/egui/src/widgets/text_edit/state.rs
@@ -34,11 +34,11 @@ pub struct TextEditState {
 
 impl TextEditState {
     pub fn load(ctx: &Context, id: Id) -> Option<Self> {
-        ctx.data().get_persisted(id)
+        ctx.data_mut(|d| d.get_persisted(id))
     }
 
     pub fn store(self, ctx: &Context, id: Id) {
-        ctx.data().insert_persisted(id, self);
+        ctx.data_mut(|d| d.insert_persisted(id, self));
     }
 
     /// The the currently selected range of characters.

--- a/crates/egui_demo_app/src/apps/fractal_clock.rs
+++ b/crates/egui_demo_app/src/apps/fractal_clock.rs
@@ -35,7 +35,7 @@ impl Default for FractalClock {
 impl FractalClock {
     pub fn ui(&mut self, ui: &mut Ui, seconds_since_midnight: Option<f64>) {
         if !self.paused {
-            self.time = seconds_since_midnight.unwrap_or_else(|| ui.input().time);
+            self.time = seconds_since_midnight.unwrap_or_else(|| ui.input(|i| i.time));
             ui.ctx().request_repaint();
         }
 

--- a/crates/egui_demo_app/src/backend_panel.rs
+++ b/crates/egui_demo_app/src/backend_panel.rs
@@ -81,7 +81,7 @@ impl Default for BackendPanel {
 impl BackendPanel {
     pub fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
         self.frame_history
-            .on_new_frame(ctx.input().time, frame.info().cpu_usage);
+            .on_new_frame(ctx.input(|i| i.time), frame.info().cpu_usage);
 
         match self.run_mode {
             RunMode::Continuous => {
@@ -131,9 +131,9 @@ impl BackendPanel {
         ui.separator();
 
         {
-            let mut screen_reader = ui.ctx().options().screen_reader;
+            let mut screen_reader = ui.ctx().options(|o| o.screen_reader);
             ui.checkbox(&mut screen_reader, "🔈 Screen reader").on_hover_text("Experimental feature: checking this will turn on the screen reader on supported platforms");
-            ui.ctx().options().screen_reader = screen_reader;
+            ui.ctx().options_mut(|o| o.screen_reader = screen_reader);
         }
 
         #[cfg(not(target_arch = "wasm32"))]
@@ -335,9 +335,11 @@ impl EguiWindows {
             output_event_history,
         } = self;
 
-        for event in &ctx.output().events {
-            output_event_history.push_back(event.clone());
-        }
+        ctx.output(|o| {
+            for event in &o.events {
+                output_event_history.push_back(event.clone());
+            }
+        });
         while output_event_history.len() > 1000 {
             output_event_history.pop_front();
         }

--- a/crates/egui_demo_app/src/frame_history.rs
+++ b/crates/egui_demo_app/src/frame_history.rs
@@ -95,19 +95,21 @@ impl FrameHistory {
             ));
             let cpu_usage = to_screen.inverse().transform_pos(pointer_pos).y;
             let text = format!("{:.1} ms", 1e3 * cpu_usage);
-            shapes.push(Shape::text(
-                &ui.fonts(),
-                pos2(rect.left(), y),
-                egui::Align2::LEFT_BOTTOM,
-                text,
-                TextStyle::Monospace.resolve(ui.style()),
-                color,
-            ));
+            ui.fonts(|f| {
+                shapes.push(Shape::text(
+                    &f,
+                    pos2(rect.left(), y),
+                    egui::Align2::LEFT_BOTTOM,
+                    text,
+                    TextStyle::Monospace.resolve(ui.style()),
+                    color,
+                ))
+            });
         }
 
         let circle_color = color;
         let radius = 2.0;
-        let right_side_time = ui.input().time; // Time at right side of screen
+        let right_side_time = ui.input(|i| i.time); // Time at right side of screen
 
         for (time, cpu_usage) in history.iter() {
             let age = (right_side_time - time) as f32;

--- a/crates/egui_demo_app/src/wrap_app.rs
+++ b/crates/egui_demo_app/src/wrap_app.rs
@@ -233,7 +233,8 @@ impl WrapApp {
     fn backend_panel(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
         // The backend-panel can be toggled on/off.
         // We show a little animation when the user switches it.
-        let is_open = self.state.backend_panel.open || ctx.memory().everything_is_visible();
+        let is_open =
+            self.state.backend_panel.open || ctx.memory(|mem| mem.everything_is_visible());
 
         egui::SidePanel::left("backend_panel")
             .resizable(false)
@@ -258,13 +259,13 @@ impl WrapApp {
                 .on_hover_text("Forget scroll, positions, sizes etc")
                 .clicked()
             {
-                *ui.ctx().memory() = Default::default();
+                ui.ctx().memory_mut(|mem| *mem = Default::default());
                 ui.close_menu();
             }
 
             if ui.button("Reset everything").clicked() {
                 self.state = Default::default();
-                *ui.ctx().memory() = Default::default();
+                ui.ctx().memory_mut(|mem| *mem = Default::default());
                 ui.close_menu();
             }
         });
@@ -274,7 +275,7 @@ impl WrapApp {
         let mut found_anchor = false;
         let selected_anchor = self.state.selected_anchor.clone();
         for (_name, anchor, app) in self.apps_iter_mut() {
-            if anchor == selected_anchor || ctx.memory().everything_is_visible() {
+            if anchor == selected_anchor || ctx.memory(|mem| mem.everything_is_visible()) {
                 app.update(ctx, frame);
                 found_anchor = true;
             }
@@ -308,7 +309,7 @@ impl WrapApp {
             {
                 selected_anchor = anchor.to_owned();
                 if frame.is_web() {
-                    ui.output().open_url(format!("#{}", anchor));
+                    ui.output_mut(|o| o.open_url(format!("#{}", anchor)));
                 }
             }
         }
@@ -320,7 +321,7 @@ impl WrapApp {
                 if clock_button(ui, crate::seconds_since_midnight()).clicked() {
                     self.state.selected_anchor = "clock".to_owned();
                     if frame.is_web() {
-                        ui.output().open_url("#clock");
+                        ui.output_mut(|o| o.open_url("#clock"));
                     }
                 }
             }
@@ -334,22 +335,25 @@ impl WrapApp {
         use std::fmt::Write as _;
 
         // Preview hovering files:
-        if !ctx.input().raw.hovered_files.is_empty() {
-            let mut text = "Dropping files:\n".to_owned();
-            for file in &ctx.input().raw.hovered_files {
-                if let Some(path) = &file.path {
-                    write!(text, "\n{}", path.display()).ok();
-                } else if !file.mime.is_empty() {
-                    write!(text, "\n{}", file.mime).ok();
-                } else {
-                    text += "\n???";
+        if !ctx.input(|i| i.raw.hovered_files.is_empty()) {
+            let text = ctx.input(|i| {
+                let mut text = "Dropping files:\n".to_owned();
+                for file in &i.raw.hovered_files {
+                    if let Some(path) = &file.path {
+                        write!(text, "\n{}", path.display()).ok();
+                    } else if !file.mime.is_empty() {
+                        write!(text, "\n{}", file.mime).ok();
+                    } else {
+                        text += "\n???";
+                    }
                 }
-            }
+                text
+            });
 
             let painter =
                 ctx.layer_painter(LayerId::new(Order::Foreground, Id::new("file_drop_target")));
 
-            let screen_rect = ctx.input().screen_rect();
+            let screen_rect = ctx.input(|i| i.screen_rect());
             painter.rect_filled(screen_rect, 0.0, Color32::from_black_alpha(192));
             painter.text(
                 screen_rect.center(),
@@ -361,9 +365,11 @@ impl WrapApp {
         }
 
         // Collect dropped files:
-        if !ctx.input().raw.dropped_files.is_empty() {
-            self.dropped_files = ctx.input().raw.dropped_files.clone();
-        }
+        ctx.input(|i| {
+            if !i.raw.dropped_files.is_empty() {
+                self.dropped_files = i.raw.dropped_files.clone();
+            }
+        });
 
         // Show dropped files (if any):
         if !self.dropped_files.is_empty() {

--- a/crates/egui_demo_lib/src/demo/code_editor.rs
+++ b/crates/egui_demo_lib/src/demo/code_editor.rs
@@ -79,7 +79,7 @@ impl super::View for CodeEditor {
             let mut layout_job =
                 crate::syntax_highlighting::highlight(ui.ctx(), &theme, string, language);
             layout_job.wrap.max_width = wrap_width;
-            ui.fonts().layout_job(layout_job)
+            ui.fonts(|f| f.layout_job(layout_job))
         };
 
         egui::ScrollArea::vertical().show(ui, |ui| {

--- a/crates/egui_demo_lib/src/demo/code_example.rs
+++ b/crates/egui_demo_lib/src/demo/code_example.rs
@@ -103,7 +103,7 @@ impl CodeExample {
 
         ui.horizontal(|ui| {
             let font_id = egui::TextStyle::Monospace.resolve(ui.style());
-            let indentation = 8.0 * ui.fonts().glyph_width(&font_id, ' ');
+            let indentation = 8.0 * ui.fonts(|f| f.glyph_width(&font_id, ' '));
             let item_spacing = ui.spacing_mut().item_spacing;
             ui.add_space(indentation - item_spacing.x);
 

--- a/crates/egui_demo_lib/src/demo/dancing_strings.rs
+++ b/crates/egui_demo_lib/src/demo/dancing_strings.rs
@@ -30,7 +30,7 @@ impl super::View for DancingStrings {
 
         Frame::canvas(ui.style()).show(ui, |ui| {
             ui.ctx().request_repaint();
-            let time = ui.input().time;
+            let time = ui.input(|i| i.time);
 
             let desired_size = ui.available_width() * vec2(1.0, 0.35);
             let (_id, rect) = ui.allocate_space(desired_size);

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -177,7 +177,7 @@ impl DemoWindows {
 
     fn mobile_ui(&mut self, ctx: &Context) {
         if self.about_is_open {
-            let screen_size = ctx.input().screen_rect.size();
+            let screen_size = ctx.input(|i| i.screen_rect.size());
             let default_width = (screen_size.x - 20.0).min(400.0);
 
             let mut close = false;
@@ -216,7 +216,7 @@ impl DemoWindows {
                 ui.menu_button(egui::RichText::new("⏷ demos").size(font_size), |ui| {
                     ui.set_style(ui.ctx().style()); // ignore the "menu" style set by `menu_button`.
                     self.demo_list_ui(ui);
-                    if ui.ui_contains_pointer() && ui.input().pointer.any_click() {
+                    if ui.ui_contains_pointer() && ui.input(|i| i.pointer.any_click()) {
                         ui.close_menu();
                     }
                 });
@@ -291,7 +291,7 @@ impl DemoWindows {
                 ui.separator();
 
                 if ui.button("Organize windows").clicked() {
-                    ui.ctx().memory().reset_areas();
+                    ui.ctx().memory_mut(|mem| mem.reset_areas());
                 }
             });
         });
@@ -309,12 +309,12 @@ fn file_menu_button(ui: &mut Ui) {
     // NOTE: we must check the shortcuts OUTSIDE of the actual "File" menu,
     // or else they would only be checked if the "File" menu was actually open!
 
-    if ui.input_mut().consume_shortcut(&organize_shortcut) {
-        ui.ctx().memory().reset_areas();
+    if ui.input_mut(|i| i.consume_shortcut(&organize_shortcut)) {
+        ui.ctx().memory_mut(|mem| mem.reset_areas());
     }
 
-    if ui.input_mut().consume_shortcut(&reset_shortcut) {
-        *ui.ctx().memory() = Default::default();
+    if ui.input_mut(|i| i.consume_shortcut(&reset_shortcut)) {
+        ui.ctx().memory_mut(|mem| *mem = Default::default());
     }
 
     ui.menu_button("File", |ui| {
@@ -335,7 +335,7 @@ fn file_menu_button(ui: &mut Ui) {
             )
             .clicked()
         {
-            ui.ctx().memory().reset_areas();
+            ui.ctx().memory_mut(|mem| mem.reset_areas());
             ui.close_menu();
         }
 
@@ -347,7 +347,7 @@ fn file_menu_button(ui: &mut Ui) {
             .on_hover_text("Forget scroll, positions, sizes etc")
             .clicked()
         {
-            *ui.ctx().memory() = Default::default();
+            ui.ctx().memory_mut(|mem| *mem = Default::default());
             ui.close_menu();
         }
     });

--- a/crates/egui_demo_lib/src/demo/drag_and_drop.rs
+++ b/crates/egui_demo_lib/src/demo/drag_and_drop.rs
@@ -1,7 +1,7 @@
 use egui::*;
 
 pub fn drag_source(ui: &mut Ui, id: Id, body: impl FnOnce(&mut Ui)) {
-    let is_being_dragged = ui.memory().is_being_dragged(id);
+    let is_being_dragged = ui.memory(|mem| mem.is_being_dragged(id));
 
     if !is_being_dragged {
         let response = ui.scope(body).response;
@@ -9,10 +9,10 @@ pub fn drag_source(ui: &mut Ui, id: Id, body: impl FnOnce(&mut Ui)) {
         // Check for drags:
         let response = ui.interact(response.rect, id, Sense::drag());
         if response.hovered() {
-            ui.output().cursor_icon = CursorIcon::Grab;
+            ui.output_mut(|o| o.cursor_icon = CursorIcon::Grab);
         }
     } else {
-        ui.output().cursor_icon = CursorIcon::Grabbing;
+        ui.output_mut(|o| o.cursor_icon = CursorIcon::Grabbing);
 
         // Paint the body to a new layer:
         let layer_id = LayerId::new(Order::Tooltip, id);
@@ -37,7 +37,7 @@ pub fn drop_target<R>(
     can_accept_what_is_being_dragged: bool,
     body: impl FnOnce(&mut Ui) -> R,
 ) -> InnerResponse<R> {
-    let is_being_dragged = ui.memory().is_anything_being_dragged();
+    let is_being_dragged = ui.memory(|mem| mem.is_anything_being_dragged());
 
     let margin = Vec2::splat(4.0);
 
@@ -140,7 +140,7 @@ impl super::View for DragAndDropDemo {
                             });
                         });
 
-                        if ui.memory().is_being_dragged(item_id) {
+                        if ui.memory(|mem| mem.is_being_dragged(item_id)) {
                             source_col_row = Some((col_idx, row_idx));
                         }
                     }
@@ -154,7 +154,7 @@ impl super::View for DragAndDropDemo {
                     }
                 });
 
-                let is_being_dragged = ui.memory().is_anything_being_dragged();
+                let is_being_dragged = ui.memory(|mem| mem.is_anything_being_dragged());
                 if is_being_dragged && can_accept_what_is_being_dragged && response.hovered() {
                     drop_col = Some(col_idx);
                 }
@@ -163,7 +163,7 @@ impl super::View for DragAndDropDemo {
 
         if let Some((source_col, source_row)) = source_col_row {
             if let Some(drop_col) = drop_col {
-                if ui.input().pointer.any_released() {
+                if ui.input(|i| i.pointer.any_released()) {
                     // do the drop:
                     let item = self.columns[source_col].remove(source_row);
                     self.columns[drop_col].push(item);

--- a/crates/egui_demo_lib/src/demo/font_book.rs
+++ b/crates/egui_demo_lib/src/demo/font_book.rs
@@ -93,7 +93,7 @@ impl super::View for FontBook {
                         };
 
                         if ui.add(button).on_hover_ui(tooltip_ui).clicked() {
-                            ui.output().copied_text = chr.to_string();
+                            ui.output_mut(|o| o.copied_text = chr.to_string());
                         }
                     }
                 }
@@ -103,15 +103,16 @@ impl super::View for FontBook {
 }
 
 fn available_characters(ui: &egui::Ui, family: egui::FontFamily) -> BTreeMap<char, String> {
-    ui.fonts()
-        .lock()
-        .fonts
-        .font(&egui::FontId::new(10.0, family)) // size is arbitrary for getting the characters
-        .characters()
-        .iter()
-        .filter(|chr| !chr.is_whitespace() && !chr.is_ascii_control())
-        .map(|&chr| (chr, char_name(chr)))
-        .collect()
+    ui.fonts(|f| {
+        f.lock()
+            .fonts
+            .font(&egui::FontId::new(10.0, family)) // size is arbitrary for getting the characters
+            .characters()
+            .iter()
+            .filter(|chr| !chr.is_whitespace() && !chr.is_ascii_control())
+            .map(|&chr| (chr, char_name(chr)))
+            .collect()
+    })
 }
 
 fn char_name(chr: char) -> String {

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -202,7 +202,7 @@ impl Widgets {
 
         ui.horizontal_wrapped(|ui| {
             // Trick so we don't have to add spaces in the text below:
-            let width = ui.fonts().glyph_width(&TextStyle::Body.resolve(ui.style()), ' ');
+            let width = ui.fonts(|f|f.glyph_width(&TextStyle::Body.resolve(ui.style()), ' '));
             ui.spacing_mut().item_spacing.x = width;
 
             ui.label(RichText::new("Text can have").color(Color32::from_rgb(110, 255, 110)));

--- a/crates/egui_demo_lib/src/demo/multi_touch.rs
+++ b/crates/egui_demo_lib/src/demo/multi_touch.rs
@@ -49,7 +49,7 @@ impl super::View for MultiTouch {
         ui.separator();
         ui.label("Try touch gestures Pinch/Stretch, Rotation, and Pressure with 2+ fingers.");
 
-        let num_touches = ui.input().multi_touch().map_or(0, |mt| mt.num_touches);
+        let num_touches = ui.input(|i| i.multi_touch().map_or(0, |mt| mt.num_touches));
         ui.label(format!("Current touches: {}", num_touches));
 
         let color = if ui.visuals().dark_mode {
@@ -93,7 +93,7 @@ impl super::View for MultiTouch {
                 // touch pressure will make the arrow thicker (not all touch devices support this):
                 stroke_width += 10. * multi_touch.force;
 
-                self.last_touch_time = ui.input().time;
+                self.last_touch_time = ui.input(|i| i.time);
             } else {
                 self.slowly_reset(ui);
             }
@@ -118,7 +118,7 @@ impl MultiTouch {
         // This has nothing to do with the touch gesture. It just smoothly brings the
         // painted arrow back into its original position, for a nice visual effect:
 
-        let time_since_last_touch = (ui.input().time - self.last_touch_time) as f32;
+        let time_since_last_touch = (ui.input(|i| i.time) - self.last_touch_time) as f32;
 
         let delay = 0.5;
         if time_since_last_touch < delay {
@@ -133,7 +133,7 @@ impl MultiTouch {
                 self.rotation = 0.0;
                 self.translation = Vec2::ZERO;
             } else {
-                let dt = ui.input().unstable_dt;
+                let dt = ui.input(|i| i.unstable_dt);
                 let half_life_factor = (-(2_f32.ln()) / half_life * dt).exp();
                 self.zoom = 1. + ((self.zoom - 1.) * half_life_factor);
                 self.rotation *= half_life_factor;

--- a/crates/egui_demo_lib/src/demo/paint_bezier.rs
+++ b/crates/egui_demo_lib/src/demo/paint_bezier.rs
@@ -53,11 +53,10 @@ impl PaintBezier {
         });
 
         ui.collapsing("Global tessellation options", |ui| {
-            let mut tessellation_options = *(ui.ctx().tessellation_options());
-            let tessellation_options = &mut tessellation_options;
+            let mut tessellation_options = ui.ctx().tessellation_options(|to| to.clone());
             tessellation_options.ui(ui);
-            let mut new_tessellation_options = ui.ctx().tessellation_options();
-            *new_tessellation_options = *tessellation_options;
+            ui.ctx()
+                .tessellation_options_mut(|to| *to = tessellation_options);
         });
 
         ui.radio_value(&mut self.degree, 3, "Quadratic Bézier");

--- a/crates/egui_demo_lib/src/demo/password.rs
+++ b/crates/egui_demo_lib/src/demo/password.rs
@@ -20,7 +20,7 @@ pub fn password_ui(ui: &mut egui::Ui, password: &mut String) -> egui::Response {
 
     // Get state for this widget.
     // You should get state by value, not by reference to avoid borrowing of [`Memory`].
-    let mut show_plaintext = ui.data().get_temp::<bool>(state_id).unwrap_or(false);
+    let mut show_plaintext = ui.data_mut(|d| d.get_temp::<bool>(state_id).unwrap_or(false));
 
     // Process ui, change a local copy of the state
     // We want TextEdit to fill entire space, and have button after that, so in that case we can
@@ -43,7 +43,7 @@ pub fn password_ui(ui: &mut egui::Ui, password: &mut String) -> egui::Response {
     });
 
     // Store the (possibly changed) state:
-    ui.data().insert_temp(state_id, show_plaintext);
+    ui.data_mut(|d| d.insert_temp(state_id, show_plaintext));
 
     // All done! Return the interaction response so the user can check what happened
     // (hovered, clicked, …) and maybe show a tooltip:

--- a/crates/egui_demo_lib/src/demo/plot_demo.rs
+++ b/crates/egui_demo_lib/src/demo/plot_demo.rs
@@ -152,7 +152,7 @@ impl LineDemo {
         self.options_ui(ui);
         if self.animate {
             ui.ctx().request_repaint();
-            self.time += ui.input().unstable_dt.at_most(1.0 / 30.0) as f64;
+            self.time += ui.input(|i| i.unstable_dt).at_most(1.0 / 30.0) as f64;
         };
         let mut plot = Plot::new("lines_demo").legend(Legend::default());
         if self.square {

--- a/crates/egui_demo_lib/src/demo/scrolling.rs
+++ b/crates/egui_demo_lib/src/demo/scrolling.rs
@@ -112,7 +112,7 @@ fn huge_content_painter(ui: &mut egui::Ui) {
     ui.add_space(4.0);
 
     let font_id = TextStyle::Body.resolve(ui.style());
-    let row_height = ui.fonts().row_height(&font_id) + ui.spacing().item_spacing.y;
+    let row_height = ui.fonts(|f| f.row_height(&font_id)) + ui.spacing().item_spacing.y;
     let num_rows = 10_000;
 
     ScrollArea::vertical()

--- a/crates/egui_demo_lib/src/demo/text_edit.rs
+++ b/crates/egui_demo_lib/src/demo/text_edit.rs
@@ -65,10 +65,7 @@ impl super::View for TextEdit {
             egui::Label::new("Press ctrl+Y to toggle the case of selected text (cmd+Y on Mac)"),
         );
 
-        if ui
-            .input_mut()
-            .consume_key(egui::Modifiers::COMMAND, egui::Key::Y)
-        {
+        if ui.input_mut(|i| i.consume_key(egui::Modifiers::COMMAND, egui::Key::Y)) {
             if let Some(text_cursor_range) = output.cursor_range {
                 use egui::TextBuffer as _;
                 let selected_chars = text_cursor_range.as_sorted_char_range();
@@ -93,7 +90,7 @@ impl super::View for TextEdit {
                     let ccursor = egui::text::CCursor::new(0);
                     state.set_ccursor_range(Some(egui::text::CCursorRange::one(ccursor)));
                     state.store(ui.ctx(), text_edit_id);
-                    ui.ctx().memory().request_focus(text_edit_id); // give focus back to the [`TextEdit`].
+                    ui.ctx().memory_mut(|mem| mem.request_focus(text_edit_id)); // give focus back to the [`TextEdit`].
                 }
             }
 
@@ -103,7 +100,7 @@ impl super::View for TextEdit {
                     let ccursor = egui::text::CCursor::new(text.chars().count());
                     state.set_ccursor_range(Some(egui::text::CCursorRange::one(ccursor)));
                     state.store(ui.ctx(), text_edit_id);
-                    ui.ctx().memory().request_focus(text_edit_id); // give focus back to the [`TextEdit`].
+                    ui.ctx().memory_mut(|mem| mem.request_focus(text_edit_id)); // give focus back to the [`TextEdit`].
                 }
             }
         });

--- a/crates/egui_demo_lib/src/demo/window_options.rs
+++ b/crates/egui_demo_lib/src/demo/window_options.rs
@@ -50,7 +50,7 @@ impl super::Demo for WindowOptions {
             anchor_offset,
         } = self.clone();
 
-        let enabled = ctx.input().time - disabled_time > 2.0;
+        let enabled = ctx.input(|i| i.time) - disabled_time > 2.0;
         if !enabled {
             ctx.request_repaint();
         }
@@ -132,7 +132,7 @@ impl super::View for WindowOptions {
 
         ui.horizontal(|ui| {
             if ui.button("Disable for 2 seconds").clicked() {
-                self.disabled_time = ui.input().time;
+                self.disabled_time = ui.input(|i| i.time);
             }
             egui::reset_button(ui, self);
             ui.add(crate::egui_github_link_file!());

--- a/crates/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/crates/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -81,7 +81,7 @@ impl EasyMarkEditor {
             let mut layouter = |ui: &egui::Ui, easymark: &str, wrap_width: f32| {
                 let mut layout_job = highlighter.highlight(ui.style(), easymark);
                 layout_job.wrap.max_width = wrap_width;
-                ui.fonts().layout_job(layout_job)
+                ui.fonts(|f| f.layout_job(layout_job))
             };
 
             ui.add(
@@ -141,7 +141,7 @@ fn nested_hotkeys_ui(ui: &mut egui::Ui) {
 fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRange) -> bool {
     let mut any_change = false;
 
-    if ui.input_mut().consume_shortcut(&SHORTCUT_INDENT) {
+    if ui.input_mut(|i| i.consume_shortcut(&SHORTCUT_INDENT)) {
         // This is a placeholder till we can indent the active line
         any_change = true;
         let [primary, _secondary] = ccursor_range.sorted();
@@ -160,7 +160,7 @@ fn shortcuts(ui: &Ui, code: &mut dyn TextBuffer, ccursor_range: &mut CCursorRang
         (SHORTCUT_STRIKETHROUGH, "~"),
         (SHORTCUT_UNDERLINE, "_"),
     ] {
-        if ui.input_mut().consume_shortcut(&shortcut) {
+        if ui.input_mut(|i| i.consume_shortcut(&shortcut)) {
             any_change = true;
             toggle_surrounding(code, ccursor_range, surrounding);
         };

--- a/crates/egui_demo_lib/src/easy_mark/easy_mark_viewer.rs
+++ b/crates/egui_demo_lib/src/easy_mark/easy_mark_viewer.rs
@@ -144,7 +144,7 @@ fn bullet_point(ui: &mut Ui, width: f32) -> Response {
 
 fn numbered_point(ui: &mut Ui, width: f32, number: &str) -> Response {
     let font_id = TextStyle::Body.resolve(ui.style());
-    let row_height = ui.fonts().row_height(&font_id);
+    let row_height = ui.fonts(|f| f.row_height(&font_id));
     let (rect, response) = ui.allocate_exact_size(vec2(width, row_height), Sense::hover());
     let text = format!("{}.", number);
     let text_color = ui.visuals().strong_text_color();

--- a/crates/egui_demo_lib/src/lib.rs
+++ b/crates/egui_demo_lib/src/lib.rs
@@ -102,6 +102,6 @@ fn test_egui_zero_window_size() {
 /// Detect narrow screens. This is used to show a simpler UI on mobile devices,
 /// especially for the web demo at <https://egui.rs>.
 pub fn is_mobile(ctx: &egui::Context) -> bool {
-    let screen_size = ctx.input().screen_rect().size();
+    let screen_size = ctx.input(|i| i.screen_rect().size());
     screen_size.x < 550.0
 }

--- a/crates/egui_demo_lib/src/syntax_highlighting.rs
+++ b/crates/egui_demo_lib/src/syntax_highlighting.rs
@@ -8,7 +8,7 @@ pub fn code_view_ui(ui: &mut egui::Ui, mut code: &str) {
     let mut layouter = |ui: &egui::Ui, string: &str, _wrap_width: f32| {
         let layout_job = highlight(ui.ctx(), &theme, string, language);
         // layout_job.wrap.max_width = wrap_width; // no wrapping
-        ui.fonts().layout_job(layout_job)
+        ui.fonts(|f| f.layout_job(layout_job))
     };
 
     ui.add(
@@ -31,9 +31,11 @@ pub fn highlight(ctx: &egui::Context, theme: &CodeTheme, code: &str, language: &
 
     type HighlightCache = egui::util::cache::FrameCache<LayoutJob, Highlighter>;
 
-    let mut memory = ctx.memory();
-    let highlight_cache = memory.caches.cache::<HighlightCache>();
-    highlight_cache.get((theme, code, language))
+    ctx.memory_mut(|mem| {
+        mem.caches
+            .cache::<HighlightCache>()
+            .get((theme, code, language))
+    })
 }
 
 // ----------------------------------------------------------------------------
@@ -146,21 +148,23 @@ impl CodeTheme {
 
     pub fn from_memory(ctx: &egui::Context) -> Self {
         if ctx.style().visuals.dark_mode {
-            ctx.data()
-                .get_persisted(egui::Id::new("dark"))
-                .unwrap_or_else(CodeTheme::dark)
+            ctx.data_mut(|d| {
+                d.get_persisted(egui::Id::new("dark"))
+                    .unwrap_or_else(CodeTheme::dark)
+            })
         } else {
-            ctx.data()
-                .get_persisted(egui::Id::new("light"))
-                .unwrap_or_else(CodeTheme::light)
+            ctx.data_mut(|d| {
+                d.get_persisted(egui::Id::new("light"))
+                    .unwrap_or_else(CodeTheme::light)
+            })
         }
     }
 
     pub fn store_in_memory(self, ctx: &egui::Context) {
         if self.dark_mode {
-            ctx.data().insert_persisted(egui::Id::new("dark"), self);
+            ctx.data_mut(|d| d.insert_persisted(egui::Id::new("dark"), self));
         } else {
-            ctx.data().insert_persisted(egui::Id::new("light"), self);
+            ctx.data_mut(|d| d.insert_persisted(egui::Id::new("light"), self));
         }
     }
 }
@@ -230,9 +234,8 @@ impl CodeTheme {
     pub fn ui(&mut self, ui: &mut egui::Ui) {
         ui.horizontal_top(|ui| {
             let selected_id = egui::Id::null();
-            let mut selected_tt: TokenType = *ui
-                .data()
-                .get_persisted_mut_or(selected_id, TokenType::Comment);
+            let mut selected_tt: TokenType =
+                ui.data_mut(|d| *d.get_persisted_mut_or(selected_id, TokenType::Comment));
 
             ui.vertical(|ui| {
                 ui.set_width(150.0);
@@ -274,7 +277,7 @@ impl CodeTheme {
 
             ui.add_space(16.0);
 
-            ui.data().insert_persisted(selected_id, selected_tt);
+            ui.data_mut(|d| d.insert_persisted(selected_id, selected_tt));
 
             egui::Frame::group(ui.style())
                 .inner_margin(egui::Vec2::splat(2.0))

--- a/crates/egui_extras/src/datepicker/button.rs
+++ b/crates/egui_extras/src/datepicker/button.rs
@@ -64,9 +64,7 @@ impl<'a> Widget for DatePickerButton<'a> {
     fn ui(self, ui: &mut Ui) -> egui::Response {
         let id = ui.make_persistent_id(self.id_source);
         let mut button_state = ui
-            .memory()
-            .data
-            .get_persisted::<DatePickerButtonState>(id)
+            .memory_mut(|mem| mem.data.get_persisted::<DatePickerButtonState>(id))
             .unwrap_or_default();
 
         let mut text = RichText::new(format!("{} 📆", self.selection.format("%Y-%m-%d")));
@@ -81,7 +79,7 @@ impl<'a> Widget for DatePickerButton<'a> {
         let mut button_response = ui.add(button);
         if button_response.clicked() {
             button_state.picker_visible = true;
-            ui.memory().data.insert_persisted(id, button_state.clone());
+            ui.memory_mut(|mem| mem.data.insert_persisted(id, button_state.clone()));
         }
 
         if button_state.picker_visible {
@@ -131,10 +129,10 @@ impl<'a> Widget for DatePickerButton<'a> {
             }
 
             if !button_response.clicked()
-                && (ui.input().key_pressed(Key::Escape) || area_response.clicked_elsewhere())
+                && (ui.input(|i| i.key_pressed(Key::Escape)) || area_response.clicked_elsewhere())
             {
                 button_state.picker_visible = false;
-                ui.memory().data.insert_persisted(id, button_state);
+                ui.memory_mut(|mem| mem.data.insert_persisted(id, button_state));
             }
         }
 

--- a/crates/egui_extras/src/datepicker/popup.rs
+++ b/crates/egui_extras/src/datepicker/popup.rs
@@ -41,16 +41,14 @@ impl<'a> DatePickerPopup<'a> {
         let id = ui.make_persistent_id("date_picker");
         let today = chrono::offset::Utc::now().date_naive();
         let mut popup_state = ui
-            .memory()
-            .data
-            .get_persisted::<DatePickerPopupState>(id)
+            .memory_mut(|mem| mem.data.get_persisted::<DatePickerPopupState>(id))
             .unwrap_or_default();
         if !popup_state.setup {
             popup_state.year = self.selection.year();
             popup_state.month = self.selection.month();
             popup_state.day = self.selection.day();
             popup_state.setup = true;
-            ui.memory().data.insert_persisted(id, popup_state.clone());
+            ui.memory_mut(|mem| mem.data.insert_persisted(id, popup_state.clone()));
         }
 
         let weeks = month_data(popup_state.year, popup_state.month);
@@ -93,9 +91,10 @@ impl<'a> DatePickerPopup<'a> {
                                                 popup_state.day = popup_state
                                                     .day
                                                     .min(popup_state.last_day_of_month());
-                                                ui.memory()
-                                                    .data
-                                                    .insert_persisted(id, popup_state.clone());
+                                                ui.memory_mut(|mem| {
+                                                    mem.data
+                                                        .insert_persisted(id, popup_state.clone())
+                                                });
                                             }
                                         }
                                     });
@@ -116,9 +115,10 @@ impl<'a> DatePickerPopup<'a> {
                                                 popup_state.day = popup_state
                                                     .day
                                                     .min(popup_state.last_day_of_month());
-                                                ui.memory()
-                                                    .data
-                                                    .insert_persisted(id, popup_state.clone());
+                                                ui.memory_mut(|mem| {
+                                                    mem.data
+                                                        .insert_persisted(id, popup_state.clone())
+                                                });
                                             }
                                         }
                                     });
@@ -136,9 +136,10 @@ impl<'a> DatePickerPopup<'a> {
                                                 )
                                                 .changed()
                                             {
-                                                ui.memory()
-                                                    .data
-                                                    .insert_persisted(id, popup_state.clone());
+                                                ui.memory_mut(|mem| {
+                                                    mem.data
+                                                        .insert_persisted(id, popup_state.clone())
+                                                });
                                             }
                                         }
                                     });
@@ -160,7 +161,9 @@ impl<'a> DatePickerPopup<'a> {
                                         popup_state.year -= 1;
                                         popup_state.day =
                                             popup_state.day.min(popup_state.last_day_of_month());
-                                        ui.memory().data.insert_persisted(id, popup_state.clone());
+                                        ui.memory_mut(|mem| {
+                                            mem.data.insert_persisted(id, popup_state.clone())
+                                        });
                                     }
                                 });
                             });
@@ -178,7 +181,9 @@ impl<'a> DatePickerPopup<'a> {
                                         }
                                         popup_state.day =
                                             popup_state.day.min(popup_state.last_day_of_month());
-                                        ui.memory().data.insert_persisted(id, popup_state.clone());
+                                        ui.memory_mut(|mem| {
+                                            mem.data.insert_persisted(id, popup_state.clone())
+                                        });
                                     }
                                 });
                             });
@@ -194,7 +199,9 @@ impl<'a> DatePickerPopup<'a> {
                                             }
                                             popup_state.day = popup_state.last_day_of_month();
                                         }
-                                        ui.memory().data.insert_persisted(id, popup_state.clone());
+                                        ui.memory_mut(|mem| {
+                                            mem.data.insert_persisted(id, popup_state.clone())
+                                        });
                                     }
                                 });
                             });
@@ -210,7 +217,9 @@ impl<'a> DatePickerPopup<'a> {
                                                 popup_state.year += 1;
                                             }
                                         }
-                                        ui.memory().data.insert_persisted(id, popup_state.clone());
+                                        ui.memory_mut(|mem| {
+                                            mem.data.insert_persisted(id, popup_state.clone())
+                                        });
                                     }
                                 });
                             });
@@ -224,7 +233,9 @@ impl<'a> DatePickerPopup<'a> {
                                         }
                                         popup_state.day =
                                             popup_state.day.min(popup_state.last_day_of_month());
-                                        ui.memory().data.insert_persisted(id, popup_state.clone());
+                                        ui.memory_mut(|mem| {
+                                            mem.data.insert_persisted(id, popup_state.clone())
+                                        });
                                     }
                                 });
                             });
@@ -234,7 +245,9 @@ impl<'a> DatePickerPopup<'a> {
                                         popup_state.year += 1;
                                         popup_state.day =
                                             popup_state.day.min(popup_state.last_day_of_month());
-                                        ui.memory().data.insert_persisted(id, popup_state.clone());
+                                        ui.memory_mut(|mem| {
+                                            mem.data.insert_persisted(id, popup_state.clone())
+                                        });
                                     }
                                 });
                             });
@@ -342,10 +355,12 @@ impl<'a> DatePickerPopup<'a> {
                                                             popup_state.year = day.year();
                                                             popup_state.month = day.month();
                                                             popup_state.day = day.day();
-                                                            ui.memory().data.insert_persisted(
-                                                                id,
-                                                                popup_state.clone(),
-                                                            );
+                                                            ui.memory_mut(|mem| {
+                                                                mem.data.insert_persisted(
+                                                                    id,
+                                                                    popup_state.clone(),
+                                                                )
+                                                            });
                                                         }
                                                     },
                                                 );
@@ -387,12 +402,12 @@ impl<'a> DatePickerPopup<'a> {
 
         if close {
             popup_state.setup = false;
-            ui.memory().data.insert_persisted(id, popup_state);
-
-            ui.memory()
-                .data
-                .get_persisted_mut_or_default::<DatePickerButtonState>(self.button_id)
-                .picker_visible = false;
+            ui.memory_mut(|mem| {
+                mem.data.insert_persisted(id, popup_state);
+                mem.data
+                    .get_persisted_mut_or_default::<DatePickerButtonState>(self.button_id)
+                    .picker_visible = false;
+            });
         }
 
         saved && close

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -473,7 +473,7 @@ impl TableState {
         let rect = Rect::from_min_size(ui.available_rect_before_wrap().min, Vec2::ZERO);
         ui.ctx().check_for_id_clash(state_id, rect, "Table");
 
-        if let Some(state) = ui.data().get_persisted::<Self>(state_id) {
+        if let Some(state) = ui.data_mut(|d| d.get_persisted::<Self>(state_id)) {
             // make sure that the stored widths aren't out-dated
             if state.column_widths.len() == default_widths.len() {
                 return (true, state);
@@ -489,7 +489,7 @@ impl TableState {
     }
 
     fn store(self, ui: &egui::Ui, state_id: egui::Id) {
-        ui.data().insert_persisted(state_id, self);
+        ui.data_mut(|d| d.insert_persisted(state_id, self));
     }
 }
 
@@ -667,14 +667,12 @@ impl<'a> Table<'a> {
                     }
                 }
 
-                let dragging_something_else = {
-                    let pointer = &ui.input().pointer;
-                    pointer.any_down() || pointer.any_pressed()
-                };
+                let dragging_something_else =
+                    ui.input(|i| i.pointer.any_down() || i.pointer.any_pressed());
                 let resize_hover = resize_response.hovered() && !dragging_something_else;
 
                 if resize_hover || resize_response.dragged() {
-                    ui.output().cursor_icon = egui::CursorIcon::ResizeColumn;
+                    ui.output_mut(|o| o.cursor_icon = egui::CursorIcon::ResizeColumn);
                 }
 
                 let stroke = if resize_response.dragged() {

--- a/examples/file_dialog/src/main.rs
+++ b/examples/file_dialog/src/main.rs
@@ -65,9 +65,11 @@ impl eframe::App for MyApp {
         preview_files_being_dropped(ctx);
 
         // Collect dropped files:
-        if !ctx.input().raw.dropped_files.is_empty() {
-            self.dropped_files = ctx.input().raw.dropped_files.clone();
-        }
+        ctx.input(|i| {
+            if !i.raw.dropped_files.is_empty() {
+                self.dropped_files = i.raw.dropped_files.clone();
+            }
+        });
     }
 }
 
@@ -76,22 +78,25 @@ fn preview_files_being_dropped(ctx: &egui::Context) {
     use egui::*;
     use std::fmt::Write as _;
 
-    if !ctx.input().raw.hovered_files.is_empty() {
-        let mut text = "Dropping files:\n".to_owned();
-        for file in &ctx.input().raw.hovered_files {
-            if let Some(path) = &file.path {
-                write!(text, "\n{}", path.display()).ok();
-            } else if !file.mime.is_empty() {
-                write!(text, "\n{}", file.mime).ok();
-            } else {
-                text += "\n???";
+    if !ctx.input(|i| i.raw.hovered_files.is_empty()) {
+        let text = ctx.input(|i| {
+            let mut text = "Dropping files:\n".to_owned();
+            for file in &i.raw.hovered_files {
+                if let Some(path) = &file.path {
+                    write!(text, "\n{}", path.display()).ok();
+                } else if !file.mime.is_empty() {
+                    write!(text, "\n{}", file.mime).ok();
+                } else {
+                    text += "\n???";
+                }
             }
-        }
+            text
+        });
 
         let painter =
             ctx.layer_painter(LayerId::new(Order::Foreground, Id::new("file_drop_target")));
 
-        let screen_rect = ctx.input().screen_rect();
+        let screen_rect = ctx.input(|i| i.screen_rect());
         painter.rect_filled(screen_rect, 0.0, Color32::from_black_alpha(192));
         painter.text(
             screen_rect.center(),

--- a/examples/hello_world_par/Cargo.toml
+++ b/examples/hello_world_par/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "hello_world_par"
+version = "0.1.0"
+authors = ["Maxim Osipenko <maxim1999max@gmail.com>"]
+license = "MIT OR Apache-2.0"
+edition = "2021"
+rust-version = "1.61"
+publish = false
+
+[dependencies]
+eframe = { path = "../../crates/eframe" }

--- a/examples/hello_world_par/README.md
+++ b/examples/hello_world_par/README.md
@@ -1,0 +1,3 @@
+```sh
+cargo run -p hello_world_par
+```

--- a/examples/hello_world_par/src/main.rs
+++ b/examples/hello_world_par/src/main.rs
@@ -1,0 +1,115 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
+use eframe::egui;
+use std::sync::mpsc;
+use std::thread::JoinHandle;
+
+fn main() {
+    let options = eframe::NativeOptions::default();
+    eframe::run_native(
+        "My egui App",
+        options,
+        Box::new(|_cc| Box::new(MyApp::new())),
+    );
+}
+
+struct TestPanel {
+    title: String,
+    name: String,
+    age: u32,
+}
+
+impl TestPanel {
+    fn show(&mut self, ctx: &egui::Context) {
+        egui::Window::new(&self.title).show(ctx, |ui| {
+            ui.heading("My egui Application");
+            ui.horizontal(|ui| {
+                ui.label("Your name: ");
+                ui.text_edit_singleline(&mut self.name);
+            });
+            ui.add(egui::Slider::new(&mut self.age, 0..=120).text("age"));
+            if ui.button("Click each year").clicked() {
+                self.age += 1;
+            }
+            ui.label(format!("Hello '{}', age {}", self.name, self.age));
+        });
+    }
+
+    fn new(name: &str, age: u32, id: usize) -> Self {
+        let name = name.into();
+        let title = format!("{}'s test panel {}", name, id);
+        Self { title, name, age }
+    }
+}
+
+fn new_worker(
+    id: usize,
+    on_done_tx: mpsc::SyncSender<()>,
+) -> (JoinHandle<()>, mpsc::SyncSender<egui::Context>) {
+    let (show_tx, show_rc) = mpsc::sync_channel(0);
+    let handle = std::thread::Builder::new()
+        .name(format!("EguiPanelWorker {}", id))
+        .spawn(move || {
+            let mut panels = [
+                TestPanel::new("Bob", 42 + id as u32, id),
+                TestPanel::new("Alice", 15 - id as u32, id),
+                TestPanel::new("Cris", 10 * id as u32, id),
+            ];
+
+            while let Ok(ctx) = show_rc.recv() {
+                for panel in &mut panels {
+                    panel.show(&ctx)
+                }
+
+                let _ = on_done_tx.send(());
+            }
+        })
+        .expect("failed to spawn thread");
+    (handle, show_tx)
+}
+
+struct MyApp {
+    workers: Vec<(JoinHandle<()>, mpsc::SyncSender<egui::Context>)>,
+    on_done_tx: mpsc::SyncSender<()>,
+    on_done_rc: mpsc::Receiver<()>,
+}
+
+impl MyApp {
+    fn new() -> Self {
+        let workers = Vec::with_capacity(3);
+        let (on_done_tx, on_done_rc) = mpsc::sync_channel(0);
+
+        Self {
+            workers,
+            on_done_tx,
+            on_done_rc,
+        }
+    }
+}
+
+impl std::ops::Drop for MyApp {
+    fn drop(&mut self) {
+        for (handle, show_tx) in self.workers.drain(..) {
+            std::mem::drop(show_tx);
+            handle.join().unwrap();
+        }
+    }
+}
+
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            if ui.button("add worker").clicked() {
+                let id = self.workers.len();
+                self.workers.push(new_worker(id, self.on_done_tx.clone()))
+            }
+        });
+
+        for (_handle, show_tx) in &self.workers {
+            let _ = show_tx.send(ctx.clone());
+        }
+
+        for _ in 0..self.workers.len() {
+            let _ = self.on_done_rc.recv();
+        }
+    }
+}

--- a/examples/keyboard_events/src/main.rs
+++ b/examples/keyboard_events/src/main.rs
@@ -33,14 +33,14 @@ impl eframe::App for Content {
                     ui.label(&self.text);
                 });
 
-            if ctx.input().key_pressed(Key::A) {
+            if ctx.input(|i| i.key_pressed(Key::A)) {
                 self.text.push_str("\nPressed");
             }
-            if ctx.input().key_down(Key::A) {
+            if ctx.input(|i| i.key_down(Key::A)) {
                 self.text.push_str("\nHeld");
                 ui.ctx().request_repaint(); // make sure we note the holding.
             }
-            if ctx.input().key_released(Key::A) {
+            if ctx.input(|i| i.key_released(Key::A)) {
                 self.text.push_str("\nReleased");
             }
         });

--- a/examples/puffin_profiler/src/main.rs
+++ b/examples/puffin_profiler/src/main.rs
@@ -28,7 +28,7 @@ impl eframe::App for MyApp {
             ui.horizontal(|ui| {
                 ui.monospace(cmd);
                 if ui.small_button("📋").clicked() {
-                    ui.output().copied_text = cmd.into();
+                    ui.output_mut(|o| o.copied_text = cmd.into());
                 }
             });
 


### PR DESCRIPTION
My suggestion on how to prevent double-read caused deadlocks in new/user code (and also fixes of existing ones).
The main change internally is that Context now holds `Arc<Helper<Impl>>` instead of `Arc<RwLock<Impl>>`, and `Helper` API consumes "transaction functors" instead of returning lock-guards. Speaking by example, `ctx.input().screen_rect()` now will be implemented as `ctx.input(|i| i.screen_rect())`.

Pros:
1) Now it's way more clear when the Context is actually locked (only in lambda body), there is syntactically no way to extend its lock time.
2) Now it's safe to use: locks in if-let statement, multiple locks in the same expression.
3) Now it's little easier to read/write multiple fields under the same lock, instead of using multiple locks in the same expression.

Cons:
1) Lambda syntax is kind of ugly for this purpose.
2) Changes are trivial, but big and breaking the api.
3) TBA

Notes:
1) It's now harder to lock multiple fields at once, but that's a way to deadlock anyway.

Couple more words about feature state and motivation are placed in README.md.

Also, this PR features new "hello_world_par" example, which heavily uses Context in parallel (was used for smoke testing the branch).

Currently the code is a little bit dirty, not everything can compile, but I hope it's enough to get the idea and decide is the it worth it to develop these changes.
I expect the possibility of early rejection so I hope to get some feedback from contributors about how useful will it be before continuing development.