### PR TITLE
Simplify, clean up and speed up CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,7 +108,7 @@ jobs:
         uses: jetli/wasm-bindgen-action@v0.1.0
         with:
           version: "0.2.82"
-        run: ./scripts/wasm_bindgen_check.sh --skip-setup
+      - run: ./scripts/wasm_bindgen_check.sh --skip-setup
 
   cargo-deny:
     name: cargo deny

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -130,6 +130,7 @@ jobs:
           toolchain: 1.61.0
           target: aarch64-linux-android
           override: true
-
+      - name: Set up cargo cache
+        uses: Swatinem/rust-cache@v2
       - run: cargo check --features wgpu --target aarch64-linux-android
         working-directory: crates/eframe

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,11 +34,6 @@ jobs:
         uses: baptiste0928/cargo-install@v1
         with:
           crate: cargo-cranky
-      - name: Cranky
-        uses: actions-rs/cargo@v1
-        with:
-          command: cranky
-          args: --all-targets --all-features --  -D warnings
       - name: Check all features
         uses: actions-rs/cargo@v1
         with:
@@ -74,6 +69,11 @@ jobs:
         with:
           command: test
           args: --all-features
+      - name: Cranky
+        uses: actions-rs/cargo@v1
+        with:
+          command: cranky
+          args: --all-targets --all-features --  -D warnings
 
   check_wasm:
     name: Check wasm32 + wasm-bindgen

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -111,24 +111,13 @@ jobs:
         run: ./scripts/wasm_bindgen_check.sh --skip-setup
 
   cargo-deny:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: EmbarkStudios/cargo-deny-action@v1
-
-  wasm_bindgen:
-    name: wasm-bindgen
+    name: cargo deny
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: EmbarkStudios/cargo-deny-action@v1
         with:
-          profile: minimal
-          toolchain: 1.61.0
-          target: wasm32-unknown-unknown
-          override: true
-      - run: ./sh/setup_web.sh
-      - run: ./sh/wasm_bindgen_check.sh
+          rust-version: "1.61.0"
 
   android:
     name: android

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,10 +17,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
+          profile: default
           toolchain: 1.63.0
           override: true
-          components: clippy rustfmt
       - name: Install packages (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libgtk-3-dev # libgtk-3-dev is used by rfd

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,51 +75,40 @@ jobs:
           command: test
           args: --all-features
 
-  check_web_default:
-    name: cargo check web (default features)
+  check_wasm:
+    name: Check wasm32 + wasm-bindgen
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.61.0
+          toolchain: 1.63.0
           target: wasm32-unknown-unknown
           override: true
-      - uses: actions-rs/cargo@v1
+      - run: sudo apt-get update && sudo apt-get install libgtk-3-dev
+      - name: Set up cargo cache
+        uses: Swatinem/rust-cache@v2
+      - name: Check wasm32 egui_demo_app
+        uses: actions-rs/cargo@v1
         with:
           command: check
           args: -p egui_demo_app --lib --target wasm32-unknown-unknown
-
-  check_wasm_eframe_with_features:
-    name: cargo check wasm eframe
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.61.0
-          target: wasm32-unknown-unknown
-          override: true
-      - name: check
-        run: cargo check -p eframe --lib --no-default-features --features glow,persistence --target wasm32-unknown-unknown
-
-  check_web_all_features:
-    name: cargo check web --all-features
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.61.0
-          target: wasm32-unknown-unknown
-          override: true
-      - uses: actions-rs/cargo@v1
+      - name: Check wasm32 egui_demo_app --all-features
+        uses: actions-rs/cargo@v1
         with:
           command: check
           args: -p egui_demo_app --lib --target wasm32-unknown-unknown --all-features
+      - name: Check wasm32 eframe
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: -p eframe --lib --no-default-features --features glow,persistence --target wasm32-unknown-unknown
+      - name: wasm-bindgen
+        uses: jetli/wasm-bindgen-action@v0.1.0
+        with:
+          version: "0.2.82"
+        run: ./scripts/wasm_bindgen_check.sh --skip-setup
 
   cargo-deny:
     runs-on: ubuntu-20.04

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
           profile: minimal
           toolchain: 1.63.0
           override: true
-          components: rustfmt
+          components: clippy rustfmt
       - name: Install packages (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libgtk-3-dev # libgtk-3-dev is used by rfd

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,7 +108,7 @@ jobs:
         uses: jetli/wasm-bindgen-action@v0.1.0
         with:
           version: "0.2.82"
-      - run: ./scripts/wasm_bindgen_check.sh --skip-setup
+      - run: ./sh/wasm_bindgen_check.sh --skip-setup
 
   cargo-deny:
     name: cargo deny

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,50 +3,77 @@ on: [push, pull_request]
 name: CI
 
 env:
-  # This is required to enable the web_sys clipboard API which eframe web uses
+  # web_sys_unstable_apis is required to enable the web_sys clipboard API which eframe web uses
   # https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Clipboard.html
   # https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html
   RUSTFLAGS: --cfg=web_sys_unstable_apis -D warnings
   RUSTDOCFLAGS: -D warnings
 
 jobs:
-  check_default:
-    name: cargo check (default features)
+  fmt-crank-check-test:
+    name: Format + check + test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.61.0
+          toolchain: 1.63.0
           override: true
+          components: rustfmt
       - name: Install packages (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install libspeechd-dev libgtk-3-dev
-      - uses: actions-rs/cargo@v1
+        run: sudo apt-get update && sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libgtk-3-dev # libgtk-3-dev is used by rfd
+      - name: Set up cargo cache
+        uses: Swatinem/rust-cache@v2
+      - name: Rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+      - name: Install cargo-cranky
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-cranky
+      - name: Cranky
+        uses: actions-rs/cargo@v1
+        with:
+          command: cranky
+          args: --all-targets --all-features --  -D warnings
+      - name: Check all features
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --locked --all-features
+      - name: Check default features
+        uses: actions-rs/cargo@v1
         with:
           command: check
           args: --locked
-
-  check_all_features:
-    name: cargo check --all-features
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, windows-latest, macOS-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.61.0
-          override: true
-      - name: Install packages (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install libspeechd-dev libgtk-3-dev
-      - uses: actions-rs/cargo@v1
+      - name: Check no default features
+        uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --locked --no-default-features --lib
+      - name: Test doc-tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --doc --all-features
+      - name: cargo doc --lib
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --lib --no-deps --all-features
+      - name: cargo doc --document-private-items
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --document-private-items --no-deps --all-features
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
           args: --all-features
 
   check_web_default:
@@ -64,19 +91,6 @@ jobs:
         with:
           command: check
           args: -p egui_demo_app --lib --target wasm32-unknown-unknown
-
-  check_egui_demo_app:
-    name: cargo check -p egui_demo_app
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.61.0
-          override: true
-      - name: check
-        run: cargo check -p egui_demo_app
 
   check_wasm_eframe_with_features:
     name: cargo check wasm eframe
@@ -107,74 +121,6 @@ jobs:
         with:
           command: check
           args: -p egui_demo_app --lib --target wasm32-unknown-unknown --all-features
-
-  test:
-    name: cargo test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.61.0
-          override: true
-      - name: Install packages (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libgtk-3-dev # libgtk-3-dev is used by rfd
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
-
-  fmt:
-    name: cargo fmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.61.0
-          override: true
-          components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-  cranky:
-    name: cargo cranky
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.61.0
-          override: true
-      - run: cargo install cargo-cranky
-      - name: Install packages (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install libspeechd-dev libgtk-3-dev # libgtk-3-dev is used by rfd
-      - uses: actions-rs/cargo@v1
-        with:
-          command: cranky
-          args: --workspace --all-targets --all-features --  -D warnings
-
-  doc:
-    name: cargo doc
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.61.0
-          override: true
-      - name: Install packages (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install libspeechd-dev
-      - run: cargo doc --lib --no-deps --all-features
 
   cargo-deny:
     runs-on: ubuntu-20.04

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: 1.63.0
+          toolchain: 1.61.0
           override: true
       - name: Install packages (Linux)
         if: runner.os == 'Linux'
@@ -83,7 +83,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.63.0
+          toolchain: 1.61.0
           target: wasm32-unknown-unknown
           override: true
       - run: sudo apt-get update && sudo apt-get install libgtk-3-dev

--- a/sh/check.sh
+++ b/sh/check.sh
@@ -1,26 +1,29 @@
 #!/usr/bin/env bash
+# This scripts runs various CI-like checks in a convenient way.
+
+set -eu
 script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 cd "$script_path/.."
-set -eux
+set -x
 
 # Checks all tests, lints etc.
 # Basically does what the CI does.
 
 cargo install cargo-cranky # Uses lints defined in Cranky.toml. See https://github.com/ericseppanen/cargo-cranky
 
-RUSTFLAGS="-D warnings"
-RUSTDOCFLAGS="-D warnings" # https://github.com/emilk/egui/pull/1454
+export RUSTFLAGS="-D warnings"
+export RUSTDOCFLAGS="-D warnings" # https://github.com/emilk/egui/pull/1454
 
-cargo check --workspace --all-targets
-cargo check --workspace --all-targets --all-features
+cargo check --all-targets
+cargo check --all-targets --all-features
 cargo check -p egui_demo_app --lib --target wasm32-unknown-unknown
 cargo check -p egui_demo_app --lib --target wasm32-unknown-unknown --all-features
-cargo cranky --workspace --all-targets --all-features -- -D warnings
-cargo test --workspace --all-targets --all-features
-cargo test --workspace --doc # slow - checks all doc-tests
+cargo cranky --all-targets --all-features -- -D warnings
+cargo test --all-targets --all-features
+cargo test --doc # slow - checks all doc-tests
 cargo fmt --all -- --check
 
-cargo doc -p eframe -p egui -p egui_demo_lib -p egui_extras -p egui_glium -p egui_glow -p egui-winit -p emath -p epaint --lib --no-deps --all-features
+cargo doc --lib --no-deps --all-features
 cargo doc --document-private-items --no-deps --all-features
 
 (cd crates/eframe && cargo check --no-default-features --features "glow")

--- a/sh/wasm_bindgen_check.sh
+++ b/sh/wasm_bindgen_check.sh
@@ -3,7 +3,13 @@ set -eu
 script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 cd "$script_path/.."
 
-./sh/setup_web.sh
+if [[ $* == --skip-setup ]]
+then
+  echo "Skipping setup_web.sh"
+else
+  echo "Running setup_web.sh"
+  ./sh/setup_web.sh
+fi
 
 CRATE_NAME="egui_demo_app"
 FEATURES="glow,http,persistence,screen_reader"


### PR DESCRIPTION
Simplify and speed up the CI. It takes it from ~11 minutes to ~7 minutes.

This PR combined a lot of small steps to one big one. This would be slower, except we get a lot of speedup thanks to https://github.com/Swatinem/rust-cache by @Swatinem. Perhaps it should be split into two steps though to allow for more parallelization, but this is a good start.