### PR TITLE
Add custom shader_version on glow renderer

### DIFF
--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -8,7 +8,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 * Added `NativeOptions::event_loop_builder` hook for apps to change platform specific event loop options ([#1952](https://github.com/emilk/egui/pull/1952)).
 * Enabled deferred render state initialization to support Android ([#1952](https://github.com/emilk/egui/pull/1952)).
 * Allow empty textures with the glow renderer.
-* Added `custom_shader_version` to `NativeOptions` for cross compilling support on different target OpenGL | ES versions (on native `glow` renderer only).
+* Added `custom_shader_version` to `NativeOptions` for cross compilling support on different target OpenGL | ES versions (on native `glow` renderer only) ([#1993](https://github.com/emilk/egui/pull/1993))..
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -8,7 +8,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 * Added `NativeOptions::event_loop_builder` hook for apps to change platform specific event loop options ([#1952](https://github.com/emilk/egui/pull/1952)).
 * Enabled deferred render state initialization to support Android ([#1952](https://github.com/emilk/egui/pull/1952)).
 * Allow empty textures with the glow renderer.
-* Added `custom_shader_version` to `NativeOptions` for cross compilling support on different target OpenGL | ES versions (on native `glow` renderer only) ([#1993](https://github.com/emilk/egui/pull/1993))..
+* Added `shader_version` to `NativeOptions` for cross compilling support on different target OpenGL | ES versions (on native `glow` renderer only) ([#1993](https://github.com/emilk/egui/pull/1993))..
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -8,7 +8,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 * Added `NativeOptions::event_loop_builder` hook for apps to change platform specific event loop options ([#1952](https://github.com/emilk/egui/pull/1952)).
 * Enabled deferred render state initialization to support Android ([#1952](https://github.com/emilk/egui/pull/1952)).
 * Allow empty textures with the glow renderer.
-
+* Added `custom_shader_version` to `NativeOptions` for cross compilling support on different target OpenGL | ES versions (on native `glow` renderer only).
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -311,6 +311,14 @@ pub struct NativeOptions {
     ///
     /// Note: A [`NativeOptions`] clone will not include any `event_loop_builder` hook.
     pub event_loop_builder: Option<EventLoopBuilderHook>,
+
+    #[cfg(feature = "glow")]
+    /// A helper when cross compiling for different target OpenGL | ES versions.
+    ///
+    /// cross compiling for VirtualBox VMSVGA driver with OpenGL 2.1 but doesn't support SRGB texture.
+    ///
+    /// the OpenGL ES 2.0 shader: ShaderVersion::Es100 can be used to solve blank texture problem (fallback shader).
+    pub custom_shader_version: Option<egui_glow::ShaderVersion>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -350,6 +358,8 @@ impl Default for NativeOptions {
             default_theme: Theme::Dark,
             run_and_return: true,
             event_loop_builder: None,
+            #[cfg(feature = "glow")]
+            custom_shader_version: None,
         }
     }
 }

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -313,13 +313,11 @@ pub struct NativeOptions {
     pub event_loop_builder: Option<EventLoopBuilderHook>,
 
     #[cfg(feature = "glow")]
-    /// A helper when cross compiling for different target OpenGL | ES versions.
-    ///
-    /// Needed fo cross compiling for VirtualBox VMSVGA driver with OpenGL 2.1 which doesn't support SRGB texture.
+    /// Needed for cross compiling for VirtualBox VMSVGA driver with OpenGL ES 2.0 and OpenGL 2.1 which doesn't support SRGB texture.
     /// See <https://github.com//pull/1993>.
     ///
-    /// For OpenGL ES 2.0: set this to [`ShaderVersion::Es100`] to solve blank texture problem (by using the "fallback shader").
-    pub custom_shader_version: Option<egui_glow::ShaderVersion>,
+    /// For OpenGL ES 2.0: set this to [`egui_glow::ShaderVersion::Es100`] to solve blank texture problem (by using the "fallback shader").
+    pub shader_version: Option<egui_glow::ShaderVersion>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -360,7 +358,7 @@ impl Default for NativeOptions {
             run_and_return: true,
             event_loop_builder: None,
             #[cfg(feature = "glow")]
-            custom_shader_version: None,
+            shader_version: None,
         }
     }
 }

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -314,7 +314,7 @@ pub struct NativeOptions {
 
     #[cfg(feature = "glow")]
     /// Needed for cross compiling for VirtualBox VMSVGA driver with OpenGL ES 2.0 and OpenGL 2.1 which doesn't support SRGB texture.
-    /// See <https://github.com//pull/1993>.
+    /// See <https://github.com/emilk/egui/pull/1993>.
     ///
     /// For OpenGL ES 2.0: set this to [`egui_glow::ShaderVersion::Es100`] to solve blank texture problem (by using the "fallback shader").
     pub shader_version: Option<egui_glow::ShaderVersion>,

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -315,7 +315,8 @@ pub struct NativeOptions {
     #[cfg(feature = "glow")]
     /// A helper when cross compiling for different target OpenGL | ES versions.
     ///
-    /// cross compiling for VirtualBox VMSVGA driver with OpenGL 2.1 but doesn't support SRGB texture.
+    /// Needed fo cross compiling for VirtualBox VMSVGA driver with OpenGL 2.1 which doesn't support SRGB texture.
+    /// See <https://github.com//pull/1993>.
     ///
     /// For OpenGL ES 2.0: set this to [`ShaderVersion::Es100`] to solve blank texture problem (by using the "fallback shader").
     pub custom_shader_version: Option<egui_glow::ShaderVersion>,

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -317,7 +317,7 @@ pub struct NativeOptions {
     ///
     /// cross compiling for VirtualBox VMSVGA driver with OpenGL 2.1 but doesn't support SRGB texture.
     ///
-    /// the OpenGL ES 2.0 shader: ShaderVersion::Es100 can be used to solve blank texture problem (fallback shader).
+    /// For OpenGL ES 2.0: set this to [`ShaderVersion::Es100`] to solve blank texture problem (by using the "fallback shader").
     pub custom_shader_version: Option<egui_glow::ShaderVersion>,
 }
 

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -337,8 +337,13 @@ mod glow_integration {
             );
             let gl = Arc::new(gl);
 
-            let painter = egui_glow::Painter::new(gl.clone(), None, "")
-                .unwrap_or_else(|error| panic!("some OpenGL error occurred {}\n", error));
+            let painter = egui_glow::Painter::new(
+                gl.clone(),
+                None,
+                "",
+                self.native_options.custom_shader_version,
+            )
+            .unwrap_or_else(|error| panic!("some OpenGL error occurred {}\n", error));
 
             let system_theme = self.native_options.system_theme();
             let mut integration = epi_integration::EpiIntegration::new(

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -337,13 +337,9 @@ mod glow_integration {
             );
             let gl = Arc::new(gl);
 
-            let painter = egui_glow::Painter::new(
-                gl.clone(),
-                None,
-                "",
-                self.native_options.custom_shader_version,
-            )
-            .unwrap_or_else(|error| panic!("some OpenGL error occurred {}\n", error));
+            let painter =
+                egui_glow::Painter::new(gl.clone(), None, "", self.native_options.shader_version)
+                    .unwrap_or_else(|error| panic!("some OpenGL error occurred {}\n", error));
 
             let system_theme = self.native_options.system_theme();
             let mut integration = epi_integration::EpiIntegration::new(

--- a/crates/eframe/src/web/web_glow_painter.rs
+++ b/crates/eframe/src/web/web_glow_painter.rs
@@ -23,7 +23,7 @@ impl WebPainter {
         let gl = std::sync::Arc::new(gl);
 
         let dimension = [canvas.width() as i32, canvas.height() as i32];
-        let painter = egui_glow::Painter::new(gl, Some(dimension), shader_prefix. None)
+        let painter = egui_glow::Painter::new(gl, Some(dimension), shader_prefix.None)
             .map_err(|error| format!("Error starting glow painter: {}", error))?;
 
         Ok(Self {

--- a/crates/eframe/src/web/web_glow_painter.rs
+++ b/crates/eframe/src/web/web_glow_painter.rs
@@ -23,7 +23,7 @@ impl WebPainter {
         let gl = std::sync::Arc::new(gl);
 
         let dimension = [canvas.width() as i32, canvas.height() as i32];
-        let painter = egui_glow::Painter::new(gl, Some(dimension), shader_prefix.None)
+        let painter = egui_glow::Painter::new(gl, Some(dimension), shader_prefix, None)
             .map_err(|error| format!("Error starting glow painter: {}", error))?;
 
         Ok(Self {

--- a/crates/eframe/src/web/web_glow_painter.rs
+++ b/crates/eframe/src/web/web_glow_painter.rs
@@ -23,7 +23,7 @@ impl WebPainter {
         let gl = std::sync::Arc::new(gl);
 
         let dimension = [canvas.width() as i32, canvas.height() as i32];
-        let painter = egui_glow::Painter::new(gl, Some(dimension), shader_prefix)
+        let painter = egui_glow::Painter::new(gl, Some(dimension), shader_prefix. None)
             .map_err(|error| format!("Error starting glow painter: {}", error))?;
 
         Ok(Self {

--- a/crates/egui_glow/CHANGELOG.md
+++ b/crates/egui_glow/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the `egui_glow` integration will be noted in this file.
 
 ## Unreleased
 * Allow empty textures.
-* small BREAKING change: Added `custom_shader_version` variable on `EguiGlow::new` for easier cross compilling on different OpenGL | ES targets.
+* Added `custom_shader_version` variable on `EguiGlow::new` for easier cross compilling on different OpenGL | ES targets ([#1993](https://github.com/emilk/egui/pull/1993)).
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/egui_glow/CHANGELOG.md
+++ b/crates/egui_glow/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the `egui_glow` integration will be noted in this file.
 
 ## Unreleased
 * Allow empty textures.
-* Added `custom_shader_version` variable on `EguiGlow::new` for easier cross compilling on different OpenGL | ES targets ([#1993](https://github.com/emilk/egui/pull/1993)).
+* Added `shader_version` variable on `EguiGlow::new` for easier cross compilling on different OpenGL | ES targets ([#1993](https://github.com/emilk/egui/pull/1993)).
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/egui_glow/CHANGELOG.md
+++ b/crates/egui_glow/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the `egui_glow` integration will be noted in this file.
 
 ## Unreleased
 * Allow empty textures.
-
+* Add a variable custom_shader_version on EguiGlow::new 
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/egui_glow/CHANGELOG.md
+++ b/crates/egui_glow/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the `egui_glow` integration will be noted in this file.
 
 ## Unreleased
 * Allow empty textures.
-* Add a variable custom_shader_version on EguiGlow::new 
+* small BREAKING change: Added `custom_shader_version` variable on `EguiGlow::new` for easier cross compilling on different OpenGL | ES targets.
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/egui_glow/examples/pure_glow.rs
+++ b/crates/egui_glow/examples/pure_glow.rs
@@ -10,7 +10,7 @@ fn main() {
     let (gl_window, gl) = create_display(&event_loop);
     let gl = std::sync::Arc::new(gl);
 
-    let mut egui_glow = egui_glow::EguiGlow::new(&event_loop, gl.clone());
+    let mut egui_glow = egui_glow::EguiGlow::new(&event_loop, gl.clone(), None);
 
     event_loop.run(move |event, _, control_flow| {
         let mut redraw = || {

--- a/crates/egui_glow/src/painter.rs
+++ b/crates/egui_glow/src/painter.rs
@@ -106,13 +106,16 @@ impl Painter {
         gl: Arc<glow::Context>,
         pp_fb_extent: Option<[i32; 2]>,
         shader_prefix: &str,
+        custom_shader_version: Option<ShaderVersion>,
     ) -> Result<Painter, String> {
         crate::profile_function!();
         crate::check_for_gl_error_even_in_release!(&gl, "before Painter::new");
 
         let max_texture_side = unsafe { gl.get_parameter_i32(glow::MAX_TEXTURE_SIZE) } as usize;
-
-        let shader_version = ShaderVersion::get(&gl);
+        let shader_version = match custom_shader_version {
+            Some(version) => version,
+            _ => ShaderVersion::get(&gl),
+        };
         let is_webgl_1 = shader_version == ShaderVersion::Es100;
         let header = shader_version.version_declaration();
         tracing::debug!("Shader header: {:?}.", header);

--- a/crates/egui_glow/src/painter.rs
+++ b/crates/egui_glow/src/painter.rs
@@ -112,10 +112,7 @@ impl Painter {
         crate::check_for_gl_error_even_in_release!(&gl, "before Painter::new");
 
         let max_texture_side = unsafe { gl.get_parameter_i32(glow::MAX_TEXTURE_SIZE) } as usize;
-        let shader_version = match custom_shader_version {
-            Some(version) => version,
-            _ => ShaderVersion::get(&gl),
-        };
+        let shader_version = custom_shader_version.uwrap_or_else(|| ShaderVersion::get(&gl));
         let is_webgl_1 = shader_version == ShaderVersion::Es100;
         let header = shader_version.version_declaration();
         tracing::debug!("Shader header: {:?}.", header);

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -14,11 +14,13 @@ pub struct EguiGlow {
 }
 
 impl EguiGlow {
+    /// for automatic shader version detection set custom_shader_version to None
     pub fn new<E>(
         event_loop: &winit::event_loop::EventLoopWindowTarget<E>,
         gl: std::sync::Arc<glow::Context>,
+        custom_shader_version: Option<egui_glow::ShaderVersion>,
     ) -> Self {
-        let painter = crate::Painter::new(gl, None, "")
+        let painter = crate::Painter::new(gl, None, "", custom_shader_version)
             .map_err(|error| {
                 tracing::error!("error occurred in initializing painter:\n{}", error);
             })

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -1,7 +1,7 @@
-pub use egui_winit;
-pub use egui_winit::EventResponse;
 use crate::shader_version::ShaderVersion;
+pub use egui_winit;
 use egui_winit::winit;
+pub use egui_winit::EventResponse;
 
 /// Use [`egui`] from a [`glow`] app based on [`winit`].
 pub struct EguiGlow {

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -14,7 +14,7 @@ pub struct EguiGlow {
 }
 
 impl EguiGlow {
-    /// for automatic shader version detection set `custom_shader_version` to None
+    /// For automatic shader version detection set `custom_shader_version` to `None`.
     pub fn new<E>(
         event_loop: &winit::event_loop::EventLoopWindowTarget<E>,
         gl: std::sync::Arc<glow::Context>,

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -14,7 +14,7 @@ pub struct EguiGlow {
 }
 
 impl EguiGlow {
-    /// for automatic shader version detection set custom_shader_version to None
+    /// for automatic shader version detection set `custom_shader_version` to None
     pub fn new<E>(
         event_loop: &winit::event_loop::EventLoopWindowTarget<E>,
         gl: std::sync::Arc<glow::Context>,

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -1,6 +1,6 @@
 pub use egui_winit;
 pub use egui_winit::EventResponse;
-
+use crate::shader_version::ShaderVersion;
 use egui_winit::winit;
 
 /// Use [`egui`] from a [`glow`] app based on [`winit`].
@@ -18,7 +18,7 @@ impl EguiGlow {
     pub fn new<E>(
         event_loop: &winit::event_loop::EventLoopWindowTarget<E>,
         gl: std::sync::Arc<glow::Context>,
-        custom_shader_version: Option<egui_glow::ShaderVersion>,
+        custom_shader_version: Option<ShaderVersion>,
     ) -> Self {
         let painter = crate::Painter::new(gl, None, "", custom_shader_version)
             .map_err(|error| {

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -14,13 +14,13 @@ pub struct EguiGlow {
 }
 
 impl EguiGlow {
-    /// For automatic shader version detection set `custom_shader_version` to `None`.
+    /// For automatic shader version detection set `shader_version` to `None`.
     pub fn new<E>(
         event_loop: &winit::event_loop::EventLoopWindowTarget<E>,
         gl: std::sync::Arc<glow::Context>,
-        custom_shader_version: Option<ShaderVersion>,
+        shader_version: Option<ShaderVersion>,
     ) -> Self {
-        let painter = crate::Painter::new(gl, None, "", custom_shader_version)
+        let painter = crate::Painter::new(gl, None, "", shader_version)
             .map_err(|error| {
                 tracing::error!("error occurred in initializing painter:\n{}", error);
             })

--- a/examples/retained_image/src/main.rs
+++ b/examples/retained_image/src/main.rs
@@ -8,6 +8,7 @@ fn main() {
         initial_window_size: Some(egui::vec2(500.0, 900.0)),
         ..Default::default()
     };
+
     eframe::run_native(
         "Show an image with eframe/egui",
         options,


### PR DESCRIPTION
* Fix black screen by changing shader_version to OpenGL ES 2.0 shader (ES100) on VirtualBox VMSVGA driver with OpenGL ES 2.0 and OpenGL 2.1 with no srgb support.
* More easier cross compiling for different targets.