### PR TITLE
Add depth buffer support for egui-wgpu's render pass

### DIFF
--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -259,6 +259,10 @@ pub struct NativeOptions {
     /// Sets the number of bits in the depth buffer.
     ///
     /// `egui` doesn't need the depth buffer, so the default value is 0.
+    ///
+    /// On `wgpu` backends, due to limited depth texture format options, this
+    /// will be interpreted as a boolean (non-zero = true) for whether or not
+    /// specifically a `Depth32Float` buffer is used.
     pub depth_buffer: u8,
 
     /// Sets the number of bits in the stencil buffer.
@@ -266,7 +270,7 @@ pub struct NativeOptions {
     /// `egui` doesn't need the stencil buffer, so the default value is 0.
     pub stencil_buffer: u8,
 
-    /// Specify wether or not hardware acceleration is preferred, required, or not.
+    /// Specify whether or not hardware acceleration is preferred, required, or not.
     ///
     /// Default: [`HardwareAcceleration::Preferred`].
     pub hardware_acceleration: HardwareAcceleration,

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -690,7 +690,10 @@ mod wgpu_integration {
                     wgpu::DeviceDescriptor {
                         label: None,
                         features: wgpu::Features::default(),
-                        limits: wgpu::Limits::downlevel_webgl2_defaults(),
+                        limits: wgpu::Limits {
+                            max_texture_dimension_2d: 4096,
+                            ..wgpu::Limits::downlevel_webgl2_defaults()
+                        },
                     },
                     wgpu::PresentMode::Fifo,
                     self.native_options.multisampling.max(1) as _,

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -682,6 +682,12 @@ mod wgpu_integration {
             storage: Option<Box<dyn epi::Storage>>,
             window: winit::window::Window,
         ) {
+            let mut limits = wgpu::Limits::downlevel_webgl2_defaults();
+            if self.native_options.depth_buffer > 0 {
+                // When using a depth buffer, we have to be able to create a texture large enough for the entire surface.
+                limits.max_texture_dimension_2d = 8192;
+            }
+
             #[allow(unsafe_code, unused_mut, unused_unsafe)]
             let painter = unsafe {
                 let mut painter = egui_wgpu::winit::Painter::new(
@@ -690,13 +696,11 @@ mod wgpu_integration {
                     wgpu::DeviceDescriptor {
                         label: None,
                         features: wgpu::Features::default(),
-                        limits: wgpu::Limits {
-                            max_texture_dimension_2d: 4096,
-                            ..wgpu::Limits::downlevel_webgl2_defaults()
-                        },
+                        limits,
                     },
                     wgpu::PresentMode::Fifo,
                     self.native_options.multisampling.max(1) as _,
+                    self.native_options.depth_buffer,
                 );
                 painter.set_window(Some(&window));
                 painter

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -145,6 +145,8 @@ impl<'a> Painter<'a> {
             .configure(&render_state.device, &config);
         surface_state.width = width_in_pixels;
         surface_state.height = height_in_pixels;
+
+        render_state.egui_rpass.write().update_depth_texture(&render_state.device, width_in_pixels, height_in_pixels);
     }
 
     /// Updates (or clears) the [`winit::window::Window`] associated with the [`Painter`]


### PR DESCRIPTION
`depth_buffer` in `NativeOptions` is currently completely unused when using eframe with the wgpu backend, making it a bit tedious to use render callbacks. This PR uses a 32-bit float depth buffer when `depth_buffer` is non-zero. It also conditionally raises the 2d texture size limit, which very quickly became an issue due to the low webgl2 compatibility defaults.