### PR TITLE
egui_glow: default to RGBA8 if sRGB not supported

### DIFF
--- a/crates/egui_glow/src/painter.rs
+++ b/crates/egui_glow/src/painter.rs
@@ -117,6 +117,7 @@ impl Painter {
         let header = shader_version.version_declaration();
         tracing::debug!("Shader header: {:?}.", header);
         let srgb_support = gl.supported_extensions().contains("EXT_sRGB");
+        tracing::debug!("SRGB Support: {:?}.", srgb_support);
 
         let (post_process, srgb_support_define) = match (shader_version, srgb_support) {
             // WebGL2 support sRGB default
@@ -591,6 +592,8 @@ impl Painter {
                     glow::RGBA
                 };
                 (format, format)
+            } else if !self.srgb_support {
+                (glow::RGBA8, glow::RGBA)
             } else {
                 (glow::SRGB8_ALPHA8, glow::RGBA)
             };

--- a/crates/egui_glow/src/vao.rs
+++ b/crates/egui_glow/src/vao.rs
@@ -147,6 +147,7 @@ fn supports_vao(gl: &glow::Context) -> bool {
             let supported_extensions = gl.supported_extensions();
             tracing::debug!("Supported OpenGL extensions: {:?}", supported_extensions);
             supported_extensions.contains("ARB_vertex_array_object")
+                || supported_extensions.contains("GL_ARB_vertex_array_object")
         } else {
             true
         }


### PR DESCRIPTION
The Vivante GPU on many STM32MP1 based boards does not support sRGB as an internal format.

Introduce a check for sRGB support and default to `RGBA8` internal format if not supported.

Additionally the STM32MP1 needs to be checked for `GL_ARB_vertex_array_object`

Closes #1991

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->
