### PR TITLE
eframe: make sure we save app state on Cmd-Q

### DIFF
--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -8,7 +8,9 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 * Added `NativeOptions::event_loop_builder` hook for apps to change platform specific event loop options ([#1952](https://github.com/emilk/egui/pull/1952)).
 * Enabled deferred render state initialization to support Android ([#1952](https://github.com/emilk/egui/pull/1952)).
 * Allow empty textures with the glow renderer.
-* Added `shader_version` to `NativeOptions` for cross compilling support on different target OpenGL | ES versions (on native `glow` renderer only) ([#1993](https://github.com/emilk/egui/pull/1993))..
+* Added `shader_version` to `NativeOptions` for cross compiling support on different target OpenGL | ES versions (on native `glow` renderer only) ([#1993](https://github.com/emilk/egui/pull/1993)).
+* Fix: app state is now saved when user presses Cmd-Q on Mac ([#1993](https://github.com/emilk/egui/pull/1993)).
+
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -83,7 +83,10 @@ fn run_and_return(event_loop: &mut EventLoop<RequestRepaintEvent>, mut winit_app
 
     event_loop.run_return(|event, event_loop, control_flow| {
         let event_result = match &event {
-            winit::event::Event::LoopDestroyed => EventResult::Exit,
+            winit::event::Event::LoopDestroyed => {
+                tracing::debug!("winit::event::Event::LoopDestroyed");
+                EventResult::Exit
+            }
 
             // Platform-dependent event handlers to workaround a winit bug
             // See: https://github.com/rust-windowing/winit/issues/987
@@ -124,6 +127,10 @@ fn run_and_return(event_loop: &mut EventLoop<RequestRepaintEvent>, mut winit_app
                 next_repaint_time = next_repaint_time.min(repaint_time);
             }
             EventResult::Exit => {
+                // On Cmd-Q we get here and then `run_return` doesn't return,
+                // so we need to save state now:
+                tracing::debug!("Exiting event loop - saving app state…");
+                winit_app.save_and_destroy();
                 *control_flow = ControlFlow::Exit;
                 return;
             }
@@ -145,11 +152,10 @@ fn run_and_return(event_loop: &mut EventLoop<RequestRepaintEvent>, mut winit_app
 
     tracing::debug!("eframe window closed");
 
-    winit_app.save_and_destroy();
-
     drop(winit_app);
 
-    // Needed to clean the event_loop:
+    // On Windows this clears out events so that we can later create another window.
+    // See https://github.com/emilk/egui/pull/1889 for details.
     event_loop.run_return(|_, _, control_flow| {
         control_flow.set_exit();
     });


### PR DESCRIPTION
Cmd-Q emits a `winit::event::Event::LoopDestroyed` and then the app closes, without `run_return` returning (despite its name). Reported by @vincev in https://github.com/emilk/egui/pull/1889#issuecomment-1237194215
