### PR TITLE
eframe: Add `center` to `NativeOptions` and `monitor_size` to `WindowInfo`

### DIFF
--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -10,7 +10,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 * Allow empty textures with the glow renderer.
 * Added `shader_version` to `NativeOptions` for cross compiling support on different target OpenGL | ES versions (on native `glow` renderer only) ([#1993](https://github.com/emilk/egui/pull/1993)).
 * Fix: app state is now saved when user presses Cmd-Q on Mac ([#2013](https://github.com/emilk/egui/pull/2013)).
-* Added `center` to `NativeOptions`and `monitor_size` to `WindowInfo` on Desktop ([#2035](https://github.com/emilk/egui/pull/2035))
+* Added `center` to `NativeOptions` and `monitor_size` to `WindowInfo` on desktop ([#2035](https://github.com/emilk/egui/pull/2035)).
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -10,7 +10,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 * Allow empty textures with the glow renderer.
 * Added `shader_version` to `NativeOptions` for cross compiling support on different target OpenGL | ES versions (on native `glow` renderer only) ([#1993](https://github.com/emilk/egui/pull/1993)).
 * Fix: app state is now saved when user presses Cmd-Q on Mac ([#2013](https://github.com/emilk/egui/pull/2013)).
-* Added `center` to `NativeOptions`, `monitor_size` to `WindowInfo` on Desktop.
+* Added `center` to `NativeOptions`and `monitor_size` to `WindowInfo` on Desktop ([#2035](https://github.com/emilk/egui/pull/2035))
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -9,8 +9,8 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 * Enabled deferred render state initialization to support Android ([#1952](https://github.com/emilk/egui/pull/1952)).
 * Allow empty textures with the glow renderer.
 * Added `shader_version` to `NativeOptions` for cross compiling support on different target OpenGL | ES versions (on native `glow` renderer only) ([#1993](https://github.com/emilk/egui/pull/1993)).
-* Fix: app state is now saved when user presses Cmd-Q on Mac ([#1993](https://github.com/emilk/egui/pull/1993)).
-
+* Fix: app state is now saved when user presses Cmd-Q on Mac ([#2013](https://github.com/emilk/egui/pull/2013)).
+* Added `center` to `NativeOptions`, `monitor_size` to `WindowInfo` on Desktop.
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -706,18 +706,18 @@ impl Frame {
         self.output.visible = Some(visible);
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
-    /// On desktop: Set the window always on top at runtime.
+    /// On desktop: Set the window always on top.
     ///
     /// (Wayland desktop currently aren't supported)
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn set_always_on_top(&mut self, always_on_top: bool) {
         self.output.always_on_top = Some(always_on_top);
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
-    /// On desktop: Set the window to be centered at runtime.
+    /// On desktop: Set the window to be centered.
     ///
     /// (Wayland desktop currently aren't supported)
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn set_centered(&mut self) {
         if let Some(monitor_size) = self.info.window_info.monitor_size {
             let inner_size = self.info.window_info.size;

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -723,7 +723,7 @@ impl Frame {
             let inner_size = self.info.window_info.size;
             if monitor_size.x > 1.0 && monitor_size.y > 1.0 {
                 let x = (monitor_size.x - inner_size.x) / 2.0;
-                let y = (monitor_size.y - inner_size.y) / 2.0
+                let y = (monitor_size.y - inner_size.y) / 2.0;
                 self.set_window_pos(egui::Pos2 { x, y });
             }
         }

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -339,7 +339,7 @@ pub struct NativeOptions {
     ///
     /// Platform specific:
     ///
-    /// Wayland desktop currently aren't supported.
+    /// Wayland desktop currently not supported.
     pub centered: bool,
 }
 
@@ -708,7 +708,7 @@ impl Frame {
 
     /// On desktop: Set the window always on top.
     ///
-    /// (Wayland desktop currently aren't supported)
+    /// (Wayland desktop currently not supported)
     #[cfg(not(target_arch = "wasm32"))]
     pub fn set_always_on_top(&mut self, always_on_top: bool) {
         self.output.always_on_top = Some(always_on_top);
@@ -716,7 +716,7 @@ impl Frame {
 
     /// On desktop: Set the window to be centered.
     ///
-    /// (Wayland desktop currently aren't supported)
+    /// (Wayland desktop currently not supported)
     #[cfg(not(target_arch = "wasm32"))]
     pub fn set_centered(&mut self) {
         if let Some(monitor_size) = self.info.window_info.monitor_size {

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -721,11 +721,9 @@ impl Frame {
     pub fn set_centered(&mut self) {
         if let Some(monitor_size) = self.info.window_info.monitor_size {
             let inner_size = self.info.window_info.size;
-            let logical_one = 1.0;
-            if monitor_size.x > logical_one && monitor_size.y > logical_one {
-                let logical_two = 2.0;
-                let x = (monitor_size.x - inner_size.x) / logical_two;
-                let y = (monitor_size.y - inner_size.y) / logical_two;
+            if monitor_size.x > 1.0 && monitor_size.y > 1.0 {
+                let x = (monitor_size.x - inner_size.x) / 2.0;
+                let y = (monitor_size.y - inner_size.y) / 2.0
                 self.set_window_pos(egui::Pos2 { x, y });
             }
         }

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -18,6 +18,14 @@ pub fn read_window_info(window: &winit::window::Window, pixels_per_point: f32) -
         .map(|pos| pos.to_logical::<f32>(pixels_per_point.into()))
         .map(|pos| egui::Pos2 { x: pos.x, y: pos.y });
 
+    let monitor = window.current_monitor().is_some();
+    let monitor_size = if monitor {
+        let size = window.current_monitor().unwrap().size();
+        Some(egui::vec2(size.width as _, size.height as _))
+    } else {
+        None
+    };
+
     let size = window
         .inner_size()
         .to_logical::<f32>(pixels_per_point.into());
@@ -29,6 +37,7 @@ pub fn read_window_info(window: &winit::window::Window, pixels_per_point: f32) -
             x: size.width,
             y: size.height,
         },
+        monitor_size,
     }
 }
 
@@ -125,6 +134,7 @@ pub fn handle_app_output(
         drag_window,
         window_pos,
         visible,
+        ..
     } = app_output;
 
     if let Some(decorated) = decorated {
@@ -162,6 +172,11 @@ pub fn handle_app_output(
 
     if let Some(visible) = visible {
         window.set_visible(visible);
+    }
+
+    #[cfg(not(any(target_os = "ios", target_os = "android", target_arch = "wasm32")))]
+    if let Some(always_on_top) = app_output.always_on_top {
+        window.set_always_on_top(always_on_top);
     }
 }
 

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -174,7 +174,6 @@ pub fn handle_app_output(
         window.set_visible(visible);
     }
 
-    #[cfg(not(any(target_os = "ios", target_os = "android", target_arch = "wasm32")))]
     if let Some(always_on_top) = app_output.always_on_top {
         window.set_always_on_top(always_on_top);
     }

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -134,7 +134,7 @@ pub fn handle_app_output(
         drag_window,
         window_pos,
         visible,
-        ..
+        always_on_top,
     } = app_output;
 
     if let Some(decorated) = decorated {
@@ -174,7 +174,7 @@ pub fn handle_app_output(
         window.set_visible(visible);
     }
 
-    if let Some(always_on_top) = app_output.always_on_top {
+    if let Some(always_on_top) = always_on_top {
         window.set_always_on_top(always_on_top);
     }
 }

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -223,12 +223,11 @@ fn run_and_exit(
     })
 }
 
-fn centere_window_pos<T: 'static>(
-    event_loop: &EventLoop<T>,
+fn centere_window_pos(
+    monitor: Option<winit::monitor::MonitorHandle>,
     native_options: &mut epi::NativeOptions,
 ) {
     // Get the current_monitor.
-    let monitor = event_loop.available_monitors().next();
     if let Some(monitor) = monitor {
         let monitor_size = monitor.size();
         let inner_size = native_options
@@ -610,7 +609,7 @@ mod glow_integration {
         if native_options.run_and_return {
             with_event_loop(native_options, |event_loop, mut native_options| {
                 if native_options.centered {
-                    centere_window_pos(&event_loop, &mut native_options);
+                    centere_window_pos(event_loop.available_monitors().next(), &mut native_options);
                 }
 
                 let glow_eframe =
@@ -621,7 +620,7 @@ mod glow_integration {
             let event_loop = create_event_loop_builder(&mut native_options).build();
 
             if native_options.centered {
-                centere_window_pos(&event_loop, &mut native_options);
+                centere_window_pos(event_loop.available_monitors().next(), &mut native_options);
             }
 
             let glow_eframe = GlowWinitApp::new(&event_loop, app_name, native_options, app_creator);
@@ -988,7 +987,7 @@ mod wgpu_integration {
         if native_options.run_and_return {
             with_event_loop(native_options, |event_loop, mut native_options| {
                 if native_options.centered {
-                    centere_window_pos(&event_loop, &mut native_options);
+                    centere_window_pos(event_loop.available_monitors().next(), &mut native_options);
                 }
 
                 let wgpu_eframe =
@@ -999,7 +998,7 @@ mod wgpu_integration {
             let event_loop = create_event_loop_builder(&mut native_options).build();
 
             if native_options.centered {
-                centere_window_pos(&event_loop, &mut native_options);
+                centere_window_pos(event_loop.available_monitors().next(), &mut native_options);
             }
 
             let wgpu_eframe = WgpuWinitApp::new(&event_loop, app_name, native_options, app_creator);

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -229,11 +229,11 @@ fn centere_window_pos<T: 'static>(
 ) {
     // Get the current_monitor.
     let monitor = event_loop.available_monitors().next();
-    if monitor.is_some() {
-        let monitor_size = monitor.unwrap().size();
+    if let Some(monitor) = monitor {
+        let monitor_size = monitor.size();
         let inner_size = native_options
             .initial_window_size
-            .unwrap_or_else(|| egui::Vec2 { x: 800.0, y: 600.0 });
+            .unwrap_or(egui::Vec2 { x: 800.0, y: 600.0 });
         if monitor_size.width > 0 && monitor_size.height > 0 {
             let x = (monitor_size.width - inner_size.x as u32) / 2;
             let y = (monitor_size.height - inner_size.y as u32) / 2;
@@ -610,7 +610,7 @@ mod glow_integration {
         if native_options.run_and_return {
             with_event_loop(native_options, |event_loop, mut native_options| {
                 if native_options.centered {
-                    centere_window_pos(&event_loop, &mut native_options)
+                    centere_window_pos(&event_loop, &mut native_options);
                 }
 
                 let glow_eframe =
@@ -621,7 +621,7 @@ mod glow_integration {
             let event_loop = create_event_loop_builder(&mut native_options).build();
 
             if native_options.centered {
-                centere_window_pos(&event_loop, &mut native_options)
+                centere_window_pos(&event_loop, &mut native_options);
             }
 
             let glow_eframe = GlowWinitApp::new(&event_loop, app_name, native_options, app_creator);
@@ -988,7 +988,7 @@ mod wgpu_integration {
         if native_options.run_and_return {
             with_event_loop(native_options, |event_loop, mut native_options| {
                 if native_options.centered {
-                    centere_window_pos(&event_loop, &mut native_options)
+                    centere_window_pos(&event_loop, &mut native_options);
                 }
 
                 let wgpu_eframe =
@@ -999,7 +999,7 @@ mod wgpu_integration {
             let event_loop = create_event_loop_builder(&mut native_options).build();
 
             if native_options.centered {
-                centere_window_pos(&event_loop, &mut native_options)
+                centere_window_pos(&event_loop, &mut native_options);
             }
 
             let wgpu_eframe = WgpuWinitApp::new(&event_loop, app_name, native_options, app_creator);


### PR DESCRIPTION
- Make window always on top and center positioning to be configured both at runtime and initialization.
-  Centering the window position at initialization it will fix the window being shown at different positions twice as if centering the window at runtime (which is doesn't seem right).