### PR TITLE
MacOS: Support fullsize content (no titlebar, but window controls)

### DIFF
--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -5,6 +5,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 
 
 ## Unreleased
+* Added `NativeOptions::fullsize_content` option on Mac to build titlebar-less windows with floating window controls.
 * Added `NativeOptions::event_loop_builder` hook for apps to change platform specific event loop options ([#1952](https://github.com/emilk/egui/pull/1952)).
 * Enabled deferred render state initialization to support Android ([#1952](https://github.com/emilk/egui/pull/1952)).
 * Allow empty textures with the glow renderer.

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -5,7 +5,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 
 
 ## Unreleased
-* Added `NativeOptions::fullsize_content` option on Mac to build titlebar-less windows with floating window controls.
+* Added `NativeOptions::fullsize_content` option on Mac to build titlebar-less windows with floating window controls ([#2049](https://github.com/emilk/egui/pull/2049)).
 * Added `NativeOptions::event_loop_builder` hook for apps to change platform specific event loop options ([#1952](https://github.com/emilk/egui/pull/1952)).
 * Enabled deferred render state initialization to support Android ([#1952](https://github.com/emilk/egui/pull/1952)).
 * Allow empty textures with the glow renderer.

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -223,6 +223,13 @@ pub struct NativeOptions {
     /// Default: `false`.
     pub fullscreen: bool,
 
+    /// On Mac: the window doesn't have a titlebar, but floating window buttons.
+    ///
+    /// See [winit's documentation][with_fullsize_content_view] for information on Mac-specific options.
+    ///
+    /// [with_fullsize_content_view]: https://docs.rs/winit/latest/x86_64-apple-darwin/winit/platform/macos/trait.WindowBuilderExtMacOS.html#tymethod.with_fullsize_content_view
+    pub fullsize_content: bool,
+
     /// On Windows: enable drag and drop support. Drag and drop can
     /// not be disabled on other platforms.
     ///
@@ -361,6 +368,7 @@ impl Default for NativeOptions {
             maximized: false,
             decorated: true,
             fullscreen: false,
+            fullsize_content: false,
             drag_and_drop_support: true,
             icon_data: None,
             initial_window_pos: None,

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -225,9 +225,7 @@ pub struct NativeOptions {
 
     /// On Mac: the window doesn't have a titlebar, but floating window buttons.
     ///
-    /// See [winit's documentation][with_fullsize_content_view] for information on Mac-specific options.
-    ///
-    /// [with_fullsize_content_view]: https://docs.rs/winit/latest/x86_64-apple-darwin/winit/platform/macos/trait.WindowBuilderExtMacOS.html#tymethod.with_fullsize_content_view
+    /// See [`winit::platform::macos::WindowBuilderExtMacOS`] for more information about Mac-specific options.
     pub fullsize_content: bool,
 
     /// On Windows: enable drag and drop support. Drag and drop can

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -225,7 +225,9 @@ pub struct NativeOptions {
 
     /// On Mac: the window doesn't have a titlebar, but floating window buttons.
     ///
-    /// See [`winit::platform::macos::WindowBuilderExtMacOS`] for more information about Mac-specific options.
+    /// See [winit's documentation][with_fullsize_content_view] for information on Mac-specific options.
+    ///
+    /// [with_fullsize_content_view]: https://docs.rs/winit/latest/x86_64-apple-darwin/winit/platform/macos/trait.WindowBuilderExtMacOS.html#tymethod.with_fullsize_content_view
     pub fullsize_content: bool,
 
     /// On Windows: enable drag and drop support. Drag and drop can

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -1,5 +1,8 @@
 use winit::event_loop::EventLoopWindowTarget;
 
+#[cfg(target_os = "macos")]
+use winit::platform::macos::WindowBuilderExtMacOS;
+
 use egui_winit::{native_pixels_per_point, EventResponse, WindowSettings};
 
 use crate::{epi, Theme, WindowInfo};
@@ -41,6 +44,8 @@ pub fn window_builder(
         maximized,
         decorated,
         fullscreen,
+        #[cfg(target_os = "macos")]
+        fullsize_content,
         drag_and_drop_support,
         icon_data,
         initial_window_pos,
@@ -62,6 +67,14 @@ pub fn window_builder(
         .with_resizable(*resizable)
         .with_transparent(*transparent)
         .with_window_icon(window_icon);
+
+    #[cfg(target_os = "macos")]
+    if *fullsize_content {
+        window_builder = window_builder
+            .with_title_hidden(true)
+            .with_titlebar_transparent(true)
+            .with_fullsize_content_view(true);
+    }
 
     if let Some(min_size) = *min_window_size {
         window_builder = window_builder.with_min_inner_size(points_to_size(min_size));

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -1,7 +1,7 @@
 use winit::event_loop::EventLoopWindowTarget;
 
 #[cfg(target_os = "macos")]
-use winit::platform::macos::WindowBuilderExtMacOS;
+use winit::platform::macos::WindowBuilderExtMacOS as _;
 
 use egui_winit::{native_pixels_per_point, EventResponse, WindowSettings};
 


### PR DESCRIPTION
```rust
fullsize_content: false
```
<img width="916" alt="Screenshot 2022-09-16 at 12 53 59" src="https://user-images.githubusercontent.com/373579/190560520-250561d9-e10c-4cc4-b4fe-46faaaf5056c.png">


```rust
fullsize_content: true
```

<img width="902" alt="Screenshot 2022-09-16 at 12 51 58" src="https://user-images.githubusercontent.com/373579/190560510-70a9782e-f3e3-435a-a516-2ce8ce13dff9.png">

