### PR TITLE
Change several methods from pub(crate) to pub

### DIFF
--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -586,11 +586,11 @@ impl Ui {
         self.id.with(&id_source)
     }
 
-    pub(crate) fn next_auto_id(&self) -> Id {
+    pub fn next_auto_id(&self) -> Id {
         Id::new(self.next_auto_id_source)
     }
 
-    pub(crate) fn auto_id_with<IdSource>(&self, id_source: IdSource) -> Id
+    pub fn auto_id_with<IdSource>(&self, id_source: IdSource) -> Id
     where
         IdSource: Hash + std::fmt::Debug,
     {

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -586,6 +586,7 @@ impl Ui {
         self.id.with(&id_source)
     }
 
+    /// This is the `Id` that will be assigned to the next widget added to this `Ui`.
     pub fn next_auto_id(&self) -> Id {
         Id::new(self.next_auto_id_source)
     }

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -116,7 +116,7 @@ impl Button {
         self
     }
 
-    pub(crate) fn min_size(mut self, min_size: Vec2) -> Self {
+    pub fn min_size(mut self, min_size: Vec2) -> Self {
         self.min_size = min_size;
         self
     }


### PR DESCRIPTION
I'm working on custom widgets, and I realized most of the core widgets use the "auto_id" mechanism. I think having that available would let custom widget authors provide the same level of ergonomics as every other core widget that makes use of this feature.

The functionality is marked as `pub(crate)`, but I couldn't find any good reason for that, so this PR makes that be `pub` and available to everyone.

I found the same issue with `Button`'s `min_size`. I'm trying to implement my own `DragValue`, so I find myself in the need of using the same workaround that was used there and call the `min_size` method of the underlying button. There, too, I could not find any rationale for `pub(crate)`.
