### PR TITLE
eframe: Mouse-passthrough option

### DIFF
--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -270,6 +270,10 @@ pub struct NativeOptions {
     /// You should avoid having a [`egui::CentralPanel`], or make sure its frame is also transparent.
     pub transparent: bool,
 
+    /// On desktop: mouse clicks pass through the window, used for non-interactable overlays
+    /// Generally you would use this in conjunction with always_on_top
+    pub mouse_passthrough: bool,
+
     /// Turn on vertical syncing, limiting the FPS to the display refresh rate.
     ///
     /// The default is `true`.
@@ -389,6 +393,7 @@ impl Default for NativeOptions {
             max_window_size: None,
             resizable: true,
             transparent: false,
+            mouse_passthrough: false,
             vsync: true,
             multisampling: 0,
             depth_buffer: 0,

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -383,6 +383,9 @@ mod glow_integration {
             integration.egui_ctx.set_visuals(theme.egui_visuals());
 
             gl_window.window().set_ime_allowed(true);
+            if self.native_options.mouse_passthrough {
+                gl_window.window().set_cursor_hittest(false).unwrap();
+            }
 
             {
                 let event_loop_proxy = self.repaint_proxy.clone();


### PR DESCRIPTION
Now for a native app you can set `mouse_passthrough` as a `NativeOption`  
This will allow all mouse clicks to pass through the window.  
This is useful for apps that are overlays.  
You'll typically use it in conjunction with `always_on_top`

Closes https://github.com/emilk/egui/issues/1677

