### PR TITLE
Fixed `Table` growing beyond its limit ([#2098])

### DIFF
--- a/crates/egui/src/layout.rs
+++ b/crates/egui/src/layout.rs
@@ -118,28 +118,28 @@ impl Direction {
 // #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Layout {
     /// Main axis direction
-    main_dir: Direction,
+    pub main_dir: Direction,
 
     /// If true, wrap around when reading the end of the main direction.
     /// For instance, for `main_dir == Direction::LeftToRight` this will
     /// wrap to a new row when we reach the right side of the `max_rect`.
-    main_wrap: bool,
+    pub main_wrap: bool,
 
     /// How to align things on the main axis.
-    main_align: Align,
+    pub main_align: Align,
 
     /// Justify the main axis?
-    main_justify: bool,
+    pub main_justify: bool,
 
     /// How to align things on the cross axis.
     /// For vertical layouts: put things to left, center or right?
     /// For horizontal layouts: put things to top, center or bottom?
-    cross_align: Align,
+    pub cross_align: Align,
 
     /// Justify the cross axis?
     /// For vertical layouts justify mean all widgets get maximum width.
     /// For horizontal layouts justify mean all widgets get maximum height.
-    cross_justify: bool,
+    pub cross_justify: bool,
 }
 
 impl Default for Layout {

--- a/crates/egui_extras/CHANGELOG.md
+++ b/crates/egui_extras/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the `egui_extras` integration will be noted in this file.
 
 ## Unreleased
 * Added `TableBuilder::vertical_scroll_offset`: method to set vertical scroll offset position for a table ([#1946](https://github.com/emilk/egui/pull/1946)).
+* Fixed `Table` growing beyond its limit ([#2098](https://github.com/emilk/egui/issues/2098)).
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -101,9 +101,12 @@ impl<'l> StripLayout<'l> {
         let rect = self.cell_rect(&width, &height);
         let used_rect = self.cell(rect, add_contents);
         self.set_pos(rect);
-        // Make sure the content does not exceed the bounds of the parent rect
+        // Make sure the content does not exceed the width of the parent rect
         let rect = if !rect.contains_rect(used_rect) {
-            self.ui.available_rect_before_wrap()
+            Rect {
+                min: rect.min,
+                max: Pos2::new(self.ui.available_rect_before_wrap().max.x, rect.max.y)
+            }
         } else {
             used_rect
         };

--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -101,8 +101,9 @@ impl<'l> StripLayout<'l> {
         let rect = self.cell_rect(&width, &height);
         let used_rect = self.cell(rect, add_contents);
         self.set_pos(rect);
+        // Make sure the content does not exceed the bounds of the parent rect
         let rect = if !rect.contains_rect(used_rect) {
-            rect.union(self.ui.available_rect_before_wrap())
+            self.ui.available_rect_before_wrap()
         } else {
             used_rect
         };

--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -101,7 +101,13 @@ impl<'l> StripLayout<'l> {
         let rect = self.cell_rect(&width, &height);
         let used_rect = self.cell(rect, add_contents);
         self.set_pos(rect);
-        self.ui.allocate_rect(rect.union(used_rect), Sense::hover())
+        let rect = if !rect.contains_rect(used_rect) {
+            rect.union(self.ui.available_rect_before_wrap())
+        } else {
+            used_rect
+        };
+
+        self.ui.allocate_rect(rect, Sense::hover())
     }
 
     pub(crate) fn add_striped(

--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -105,7 +105,7 @@ impl<'l> StripLayout<'l> {
         let rect = if !rect.contains_rect(used_rect) {
             Rect {
                 min: rect.min,
-                max: Pos2::new(self.ui.available_rect_before_wrap().max.x, rect.max.y)
+                max: Pos2::new(self.ui.available_rect_before_wrap().max.x, rect.max.y),
             }
         } else {
             used_rect


### PR DESCRIPTION
Closes https://github.com/emilk/egui/issues/2098.

![image](https://user-images.githubusercontent.com/2380253/193451955-a1bc6913-c417-4094-b1fe-727c4c98a928.png)

I checked the Strip and the Table Demo, they are still working fine:
![image](https://user-images.githubusercontent.com/2380253/193451997-cc67e565-e922-4095-94f5-23456ca20d89.png)
