### PR TITLE
Make private types related to ScrollArea public

### DIFF
--- a/crates/egui/src/containers/mod.rs
+++ b/crates/egui/src/containers/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod frame;
 pub mod panel;
 pub mod popup;
 pub(crate) mod resize;
-pub(crate) mod scroll_area;
+pub mod scroll_area;
 pub(crate) mod window;
 
 pub use {


### PR DESCRIPTION
The ScrollAreaOutput that show()ing a ScrollArea returns is a private. It cannot be used as a parameter, a return type or a type hint. It doesn't even have documentation page. Same with the State struct of the scroll_area module (Prepared remains private).