### PR TITLE
eframe/egui-winit: Fix copy-paste on Windows

### DIFF
--- a/crates/egui-winit/src/clipboard.rs
+++ b/crates/egui-winit/src/clipboard.rs
@@ -5,9 +5,6 @@ use std::os::raw::c_void;
 /// If the "clipboard" feature is off, or we cannot connect to the OS clipboard,
 /// then a fallback clipboard that just works works within the same app is used instead.
 pub struct Clipboard {
-    #[cfg(all(feature = "arboard", not(target_os = "android")))]
-    arboard: Option<arboard::Clipboard>,
-
     #[cfg(all(
         any(
             target_os = "linux",
@@ -28,8 +25,6 @@ impl Clipboard {
     #[allow(unused_variables)]
     pub fn new(#[allow(unused_variables)] wayland_display: Option<*mut c_void>) -> Self {
         Self {
-            #[cfg(all(feature = "arboard", not(target_os = "android")))]
-            arboard: init_arboard(),
             #[cfg(all(
                 any(
                     target_os = "linux",
@@ -67,7 +62,7 @@ impl Clipboard {
         }
 
         #[cfg(all(feature = "arboard", not(target_os = "android")))]
-        if let Some(clipboard) = &mut self.arboard {
+        if let Some(mut clipboard) = init_arboard() {
             return match clipboard.get_text() {
                 Ok(text) => Some(text),
                 Err(err) => {
@@ -97,7 +92,7 @@ impl Clipboard {
         }
 
         #[cfg(all(feature = "arboard", not(target_os = "android")))]
-        if let Some(clipboard) = &mut self.arboard {
+        if let Some(mut clipboard) = init_arboard() {
             if let Err(err) = clipboard.set_text(text) {
                 tracing::error!("Copy/Cut error: {}", err);
             }


### PR DESCRIPTION
Closes https://github.com/emilk/egui/issues/2109
Broken since https://github.com/emilk/egui/pull/2067

Since arboard 3.0 you must absolutely not hold onto `arboard::Clipbaord` longer than you are using it.

See https://github.com/1Password/arboard/issues/84

PTAL @apexys