### PR TITLE
Fix false positives wrt `RwLock` deadlock detection

### DIFF
--- a/crates/epaint/src/mutex.rs
+++ b/crates/epaint/src/mutex.rs
@@ -178,8 +178,11 @@ mod rw_lock_impl {
             if let Some(last_tid) = last_tid {
                 assert!(
                     last_tid != tid || !self.lock.is_locked_exclusive(),
-                    "{} DEAD-LOCK DETECTED! Previous lock held at:\n{}\n\n",
+                    "{} DEAD-LOCK DETECTED!\n
+                    \rTrying to grab lock at:\n{}\n
+                    \rwhich is already held by the same thread at:\n{}\n\n",
                     std::any::type_name::<Self>(),
+                    format_backtrace(&mut make_backtrace()),
                     format_backtrace(&mut self.last_lock.lock().1)
                 );
             }
@@ -200,8 +203,11 @@ mod rw_lock_impl {
             if let Some(last_tid) = last_tid {
                 assert!(
                     last_tid != tid || !self.lock.is_locked(),
-                    "{} DEAD-LOCK DETECTED! Previous lock held at:\n{}\n\n",
+                    "{} DEAD-LOCK DETECTED!\n
+                    \rTrying to grab lock at:\n{}\n
+                    \rwhich is already held by the same thread at:\n{}\n\n",
                     std::any::type_name::<Self>(),
+                    format_backtrace(&mut make_backtrace()),
                     format_backtrace(&mut self.last_lock.lock().1)
                 );
             }


### PR DESCRIPTION
The current implementation doesn't keep track of which thread owns what, so any kind of lock contention will end up being reported as a deadlock.

This PR:
1. adds a test suite to demonstrate the faulty behaviour
2. fixes the faulty behaviour by keeping track of thread IDs
3. improves the output a little

<details>
  <summary>Example output</summary>

```
thread 'mutex::tests_rwlock::rwlock_reentry_single_thread' panicked at 'epaint::mutex::rw_lock_impl::RwLock<()> DEAD-LOCK DETECTED!

Trying to grab lock at:
             at src/mutex.rs:226:9
   1: epaint::mutex::rw_lock_impl::RwLock<T>::read
             at src/mutex.rs:185:43
   2: epaint::mutex::tests_rwlock::rwlock_reentry_single_thread
             at src/mutex.rs:387:19
   3: epaint::mutex::tests_rwlock::rwlock_reentry_single_thread::{{closure}}
             at src/mutex.rs:384:5
   4: core::ops::function::FnOnce::call_once
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/ops/function.rs:227:5
   5: core::ops::function::FnOnce::call_once
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/ops/function.rs:227:5
      test::__rust_begin_short_backtrace
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/test/src/lib.rs:574:5
   6: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/alloc/src/boxed.rs:1861:9
      <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/panic/unwind_safe.rs:271:9
      std::panicking::try::do_call
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:492:40
      std::panicking::try
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:456:19
      std::panic::catch_unwind
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panic.rs:137:14
      test::run_test_in_process
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/test/src/lib.rs:597:18
      test::run_test::run_test_inner::{{closure}}
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/test/src/lib.rs:491:39
   7: test::run_test::run_test_inner::{{closure}}
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/test/src/lib.rs:518:37


which is already held by the same thread at:
             at src/mutex.rs:226:9
   1: epaint::mutex::rw_lock_impl::RwLock<T>::write
             at src/mutex.rs:218:31
   2: epaint::mutex::tests_rwlock::rwlock_reentry_single_thread
             at src/mutex.rs:386:18
   3: epaint::mutex::tests_rwlock::rwlock_reentry_single_thread::{{closure}}
             at src/mutex.rs:384:5
   4: core::ops::function::FnOnce::call_once
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/ops/function.rs:227:5
   5: core::ops::function::FnOnce::call_once
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/ops/function.rs:227:5
      test::__rust_begin_short_backtrace
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/test/src/lib.rs:574:5
   6: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/alloc/src/boxed.rs:1861:9
      <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/panic/unwind_safe.rs:271:9
      std::panicking::try::do_call
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:492:40
      std::panicking::try
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:456:19
      std::panic::catch_unwind
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panic.rs:137:14
      test::run_test_in_process
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/test/src/lib.rs:597:18
      test::run_test::run_test_inner::{{closure}}
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/test/src/lib.rs:491:39
   7: test::run_test::run_test_inner::{{closure}}
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/test/src/lib.rs:518:37
```

  
</details>