### PR TITLE
wgpu renderer now always requires a RenderPass being passed in, pass command encoder to prepare callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 ## Unreleased
 * ⚠️ BREAKING: Fix text being too small ([#2069](https://github.com/emilk/egui/pull/2069)).
 * ⚠️ BREAKING: egui now expects integrations to do all color blending in gamma space ([#2071](https://github.com/emilk/egui/pull/2071)).
+* ⚠️ BREAKING: wgpu-renderer no longer handles pass creation ([#2136](https://github.com/emilk/egui/pull/2136))
+* ⚠️ BREAKING: wgpu-renderer prepare callback now passes `wgpu::CommandEncoder` ([#2136](https://github.com/emilk/egui/pull/2136))
+
+### Added
+* eframe now supports wgpu on the web ([#2107](https://github.com/emilk/egui/pull/2107)
 
 ### Fixed 🐛
 * Improved text rendering ([#2071](https://github.com/emilk/egui/pull/2071)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 ## Unreleased
 * ⚠️ BREAKING: Fix text being too small ([#2069](https://github.com/emilk/egui/pull/2069)).
 * ⚠️ BREAKING: egui now expects integrations to do all color blending in gamma space ([#2071](https://github.com/emilk/egui/pull/2071)).
-* ⚠️ BREAKING: wgpu-renderer no longer handles pass creation ([#2136](https://github.com/emilk/egui/pull/2136))
-* ⚠️ BREAKING: wgpu-renderer prepare callback now passes `wgpu::CommandEncoder` ([#2136](https://github.com/emilk/egui/pull/2136))
-
-### Added
-* eframe now supports wgpu on the web ([#2107](https://github.com/emilk/egui/pull/2107)
 
 ### Fixed 🐛
 * Improved text rendering ([#2071](https://github.com/emilk/egui/pull/2071)).

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -16,6 +16,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 * Web: You can now use WebGL on top of `wgpu` by enabling the `wgpu` feature (and disabling `glow` via disabling default features) ([#2107](https://github.com/emilk/egui/pull/2107)).
 
 
+
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).
 * Added `wgpu` rendering backed ([#1564](https://github.com/emilk/egui/pull/1564)):

--- a/crates/eframe/src/web/web_painter_wgpu.rs
+++ b/crates/eframe/src/web/web_painter_wgpu.rs
@@ -153,6 +153,7 @@ impl WebPainter for WebPainterWgpu {
             renderer.update_buffers(
                 &render_state.device,
                 &render_state.queue,
+                &mut encoder,
                 clipped_primitives,
                 &screen_descriptor,
             );

--- a/crates/egui-wgpu/CHANGELOG.md
+++ b/crates/egui-wgpu/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to the `egui-wgpu` integration will be noted in this file.
 ## Unreleased
 * Renamed `RenderPass` to `Renderer`.
 * Renamed `RenderPass::execute` to `RenderPass::render`.
-* Renamed `RenderPass::execute_with_renderpass` to `Renderer::render_onto_renderpass`.
+* Renamed `RenderPass::execute_with_renderpass` to `Renderer::render` (replacing existing `Renderer::render`)
 * Reexported `Renderer`.
+* `Renderer` no longer handles pass creation and depth buffer creation ([#2136](https://github.com/emilk/egui/pull/2136))
+* `PrepareCallback` now passes `wgpu::CommandEncoder` ([#2136](https://github.com/emilk/egui/pull/2136))
 
 
 ## 0.19.0 - 2022-08-20

--- a/crates/egui-wgpu/src/renderer.rs
+++ b/crates/egui-wgpu/src/renderer.rs
@@ -148,11 +148,11 @@ pub struct Renderer {
 impl Renderer {
     /// Creates a renderer for a egui UI.
     ///
-    /// `output_format` should preferably be [`wgpu::TextureFormat::Rgba8Unorm`] or
+    /// `output_color_format` should preferably be [`wgpu::TextureFormat::Rgba8Unorm`] or
     /// [`wgpu::TextureFormat::Bgra8Unorm`], i.e. in gamma-space.
     pub fn new(
         device: &wgpu::Device,
-        output_format: wgpu::TextureFormat,
+        output_color_format: wgpu::TextureFormat,
         output_depth_format: Option<wgpu::TextureFormat>,
         msaa_samples: u32,
     ) -> Self {
@@ -273,14 +273,14 @@ impl Renderer {
 
             fragment: Some(wgpu::FragmentState {
                 module: &module,
-                entry_point: if output_format.describe().srgb {
-                    tracing::warn!("Detected a linear (sRGBA aware) framebuffer {:?}. egui prefers Rgba8Unorm or Bgra8Unorm", output_format);
+                entry_point: if output_color_format.describe().srgb {
+                    tracing::warn!("Detected a linear (sRGBA aware) framebuffer {:?}. egui prefers Rgba8Unorm or Bgra8Unorm", output_color_format);
                     "fs_main_linear_framebuffer"
                 } else {
                     "fs_main_gamma_framebuffer" // this is what we prefer
                 },
                 targets: &[Some(wgpu::ColorTargetState {
-                    format: output_format,
+                    format: output_color_format,
                     blend: Some(wgpu::BlendState {
                         color: wgpu::BlendComponent {
                             src_factor: wgpu::BlendFactor::One,

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -287,6 +287,7 @@ impl<'a> Painter<'a> {
             renderer.update_buffers(
                 &render_state.device,
                 &render_state.queue,
+                &mut encoder,
                 clipped_primitives,
                 &screen_descriptor,
             );

--- a/crates/egui_demo_app/src/apps/custom3d_wgpu.rs
+++ b/crates/egui_demo_app/src/apps/custom3d_wgpu.rs
@@ -138,7 +138,7 @@ impl Custom3d {
         // The paint callback is called after prepare and is given access to the render pass, which
         // can be used to issue draw commands.
         let cb = egui_wgpu::CallbackFn::new()
-            .prepare(move |device, queue, paint_callback_resources| {
+            .prepare(move |device, queue, _encoder, paint_callback_resources| {
                 let resources: &TriangleRenderResources = paint_callback_resources.get().unwrap();
                 resources.prepare(device, queue, angle);
             })


### PR DESCRIPTION
This also implies that it no longer owns the depth buffer! (why would it anyways!)

Closes #2083
Closes most of #2022 - I'd argue there should be a separate ticket for the "move winit integration elsewhere" bit
Closes half of #2084 - we get the command encoder, but haven't gone as far as removing the queue (which I also kinda don't want to right now because where else would one get it from if a `prepare` needs the queue's data uploading functionality 🤔 )

cc: @kvark