### PR TITLE
Use WidgetText for the slider's text

### DIFF
--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -76,8 +76,7 @@ pub struct Slider<'a> {
     orientation: SliderOrientation,
     prefix: String,
     suffix: String,
-    text: String,
-    text_color: Option<Color32>,
+    text: WidgetText,
     /// Sets the minimal step of the widget value
     step: Option<f64>,
     min_decimals: usize,
@@ -123,7 +122,6 @@ impl<'a> Slider<'a> {
             prefix: Default::default(),
             suffix: Default::default(),
             text: Default::default(),
-            text_color: None,
             step: None,
             min_decimals: 0,
             max_decimals: None,
@@ -152,13 +150,13 @@ impl<'a> Slider<'a> {
     }
 
     /// Show a text next to the slider (e.g. explaining what the slider controls).
-    pub fn text(mut self, text: impl ToString) -> Self {
-        self.text = text.to_string();
+    pub fn text(mut self, text: impl Into<WidgetText>) -> Self {
+        self.text = text.into();
         self
     }
 
     pub fn text_color(mut self, text_color: Color32) -> Self {
-        self.text_color = Some(text_color);
+        self.text = self.text.color(text_color);
         self
     }
 
@@ -730,9 +728,7 @@ impl<'a> Slider<'a> {
         }
 
         if !self.text.is_empty() {
-            let text_color = self.text_color.unwrap_or_else(|| ui.visuals().text_color());
-            let text = RichText::new(&self.text).color(text_color);
-            ui.add(Label::new(text).wrap(false));
+            ui.add(Label::new(self.text.clone()).wrap(false));
         }
 
         response
@@ -751,7 +747,7 @@ impl<'a> Widget for Slider<'a> {
         let mut response = inner_response.inner | inner_response.response;
         let value = self.get_value();
         response.changed = value != old_value;
-        response.widget_info(|| WidgetInfo::slider(value, &self.text));
+        response.widget_info(|| WidgetInfo::slider(value, self.text.text()));
         response
     }
 }


### PR DESCRIPTION
**Summary**
Allow to use a custom `RichText` as the label of a slider.

**Rationale**
Currently, the label of a `Slider` is constructed from text only (`impl ToString`). It cannot be customized/styled except for its color (through the `text_color()` function). Sometimes, users might want to use `italics`, `underline`, `strikethrough` or change the size.

By taking a `Into<WidgetText>` instead, the previous behavior is maintained, but users can also provide their own custom `RichText`:

```rust
let text = RichText::new(&self.text).italics();
let slider = Slider::new(value, min..=max).text(text);
```

Checklist
- [x] `cargo fmt`
- [x] `cargo clippy`
- [x] `./sh/check.sh`
   all green until `+ ./sh/wasm_bindgen_check.sh`
   >    Compiling wasm-bindgen-cli v0.2.83
   > error[E0425]: cannot find function `match_assets` in crate `rouille`
