### PR TITLE
using a shared vertex & index buffer in wgpu renderer

### DIFF
--- a/crates/egui-wgpu/CHANGELOG.md
+++ b/crates/egui-wgpu/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to the `egui-wgpu` integration will be noted in this file.
 * Reexported `Renderer`.
 * `Renderer` no longer handles pass creation and depth buffer creation ([#2136](https://github.com/emilk/egui/pull/2136))
 * `PrepareCallback` now passes `wgpu::CommandEncoder` ([#2136](https://github.com/emilk/egui/pull/2136))
-
+* Only a single vertex & index buffer is now created and resized when necessary (previously, vertex/index buffers were allocated for every mesh)
 
 ## 0.19.0 - 2022-08-20
 * Enables deferred render + surface state initialization for Android ([#1634](https://github.com/emilk/egui/pull/1634)).

--- a/crates/egui-wgpu/CHANGELOG.md
+++ b/crates/egui-wgpu/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to the `egui-wgpu` integration will be noted in this file.
 * Reexported `Renderer`.
 * `Renderer` no longer handles pass creation and depth buffer creation ([#2136](https://github.com/emilk/egui/pull/2136))
 * `PrepareCallback` now passes `wgpu::CommandEncoder` ([#2136](https://github.com/emilk/egui/pull/2136))
-* Only a single vertex & index buffer is now created and resized when necessary (previously, vertex/index buffers were allocated for every mesh)
+* Only a single vertex & index buffer is now created and resized when necessary (previously, vertex/index buffers were allocated for every mesh) ([#2148](https://github.com/emilk/egui/pull/2148)).
 
 ## 0.19.0 - 2022-08-20
 * Enables deferred render + surface state initialization for Android ([#1634](https://github.com/emilk/egui/pull/1634)).

--- a/crates/egui-wgpu/src/renderer.rs
+++ b/crates/egui-wgpu/src/renderer.rs
@@ -291,9 +291,9 @@ impl Renderer {
         });
 
         const VERTEX_BUFFER_START_CAPACITY: wgpu::BufferAddress =
-            std::mem::size_of::<Vertex>() as wgpu::BufferAddress * 1024;
+            (std::mem::size_of::<Vertex>() * 1024) as _;
         const INDEX_BUFFER_START_CAPACITY: wgpu::BufferAddress =
-            std::mem::size_of::<u32>() as wgpu::BufferAddress * 1024 * 3;
+            (std::mem::size_of::<u32>() * 1024 * 3) as _;
 
         Self {
             pipeline,

--- a/crates/egui-wgpu/src/renderer.rs
+++ b/crates/egui-wgpu/src/renderer.rs
@@ -733,7 +733,7 @@ impl Renderer {
                     Primitive::Mesh(mesh) => {
                         (acc.0 + mesh.vertices.len(), acc.1 + mesh.indices.len())
                     }
-                    _ => acc,
+                    Primitive::Callback(_) => acc,
                 }
             });
         // Resize index buffer if needed.


### PR DESCRIPTION
capacity each doubles when exceeded.
This change means a lot less allocation during egui's lifetime.
