### PR TITLE
Add CollapsingHeader::show_unindented

### DIFF
--- a/crates/egui/src/containers/collapsing_header.rs
+++ b/crates/egui/src/containers/collapsing_header.rs
@@ -599,13 +599,23 @@ impl CollapsingHeader {
         ui: &mut Ui,
         add_body: impl FnOnce(&mut Ui) -> R,
     ) -> CollapsingResponse<R> {
-        self.show_dyn(ui, Box::new(add_body))
+        self.show_dyn(ui, Box::new(add_body), true)
+    }
+
+    #[inline]
+    pub fn show_unindented<R>(
+        self,
+        ui: &mut Ui,
+        add_body: impl FnOnce(&mut Ui) -> R,
+    ) -> CollapsingResponse<R> {
+        self.show_dyn(ui, Box::new(add_body), false)
     }
 
     fn show_dyn<'c, R>(
         self,
         ui: &mut Ui,
         add_body: Box<dyn FnOnce(&mut Ui) -> R + 'c>,
+        indented: bool,
     ) -> CollapsingResponse<R> {
         // Make sure body is bellow header,
         // and make sure it is one unit (necessary for putting a [`CollapsingHeader`] in a grid).
@@ -618,7 +628,11 @@ impl CollapsingHeader {
                 openness,
             } = self.begin(ui); // show the header
 
-            let ret_response = state.show_body_indented(&header_response, ui, add_body);
+            let ret_response = if indented {
+                state.show_body_indented(&header_response, ui, add_body)
+            } else {
+                state.show_body_unindented(ui, add_body)
+            };
 
             if let Some(ret_response) = ret_response {
                 CollapsingResponse {


### PR DESCRIPTION
This is a fairly minimal PR that adds a function to `CollapsingHeader` (`show_unindented`) and modifies the signature of `show_dyn`.

When using `show_unindented` `CollapsingHeader` will use `CollapsingState::show_body_unindented` instead of `show_body_indented`.

This doesn't fix any one issue- but it's a nice feature to have and I'm surprised it doesn't exist yet.