### PR TITLE
Add option to disable mouse dragging on scroll area.

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -90,6 +90,8 @@ pub struct ScrollArea {
     offset_y: Option<f32>,
     /// If false, we ignore scroll events.
     scrolling_enabled: bool,
+    /// If false we ignore mouse drag events.
+    mouse_dragging_enabled: bool,
 
     /// If true for vertical or horizontal the scroll wheel will stick to the
     /// end position until user manually changes position. It will become true
@@ -132,6 +134,7 @@ impl ScrollArea {
             offset_x: None,
             offset_y: None,
             scrolling_enabled: true,
+            mouse_dragging_enabled: true,
             stick_to_end: [false; 2],
         }
     }
@@ -251,6 +254,19 @@ impl ScrollArea {
         self
     }
 
+    /// Control the dragging behavior
+    /// If `true` (default), the scroll area will respond to mouse dragging.
+    /// If `false`, the scroll area will not respond to mouse dragging
+    ///
+    /// This can be used, for example for code editors where
+    /// selecting and scrolling with a mouse is required.
+    ///
+    /// This controls both scrolling directions.
+    pub fn enable_mouse_dragging(mut self, enable: bool) -> Self {
+        self.mouse_dragging_enabled = enable;
+        self
+    }
+
     /// For each axis, should the containing area shrink if the content is small?
     ///
     /// If true, egui will add blank space outside the scroll area.
@@ -305,6 +321,7 @@ struct Prepared {
     /// `viewport.min == ZERO` means we scrolled to the top.
     viewport: Rect,
     scrolling_enabled: bool,
+    mouse_dragging_enabled: bool,
     stick_to_end: [bool; 2],
 }
 
@@ -320,6 +337,7 @@ impl ScrollArea {
             offset_x,
             offset_y,
             scrolling_enabled,
+            mouse_dragging_enabled,
             stick_to_end,
         } = self;
 
@@ -417,6 +435,7 @@ impl ScrollArea {
             content_ui,
             viewport,
             scrolling_enabled,
+            mouse_dragging_enabled,
             stick_to_end,
         }
     }
@@ -521,6 +540,7 @@ impl Prepared {
             content_ui,
             viewport: _,
             scrolling_enabled,
+            mouse_dragging_enabled,
             stick_to_end,
         } = self;
 
@@ -608,7 +628,7 @@ impl Prepared {
 
         if content_is_too_large[0] || content_is_too_large[1] {
             // Drag contents to scroll (for touch screens mostly):
-            let sense = if self.scrolling_enabled {
+            let sense = if self.mouse_dragging_enabled {
                 Sense::drag()
             } else {
                 Sense::hover()

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -254,7 +254,8 @@ impl ScrollArea {
         self
     }
 
-    /// Control the dragging behavior
+    /// Control the dragging behavior.
+    ///
     /// If `true` (default), the scroll area will respond to mouse dragging.
     /// If `false`, the scroll area will not respond to mouse dragging
     ///

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -91,7 +91,7 @@ pub struct ScrollArea {
     /// If false, we ignore scroll events.
     scrolling_enabled: bool,
     /// If false we ignore mouse drag events.
-    mouse_dragging_enabled: bool,
+    drag_to_scroll_enabled: bool,
 
     /// If true for vertical or horizontal the scroll wheel will stick to the
     /// end position until user manually changes position. It will become true
@@ -134,7 +134,7 @@ impl ScrollArea {
             offset_x: None,
             offset_y: None,
             scrolling_enabled: true,
-            mouse_dragging_enabled: true,
+            drag_to_scroll_enabled: true,
             stick_to_end: [false; 2],
         }
     }
@@ -254,7 +254,7 @@ impl ScrollArea {
         self
     }
 
-    /// Control the dragging behavior.
+    /// Control the mouse dragging behavior.
     ///
     /// If `true` (default), the scroll area will respond to mouse dragging.
     /// If `false`, the scroll area will not respond to mouse dragging
@@ -263,8 +263,8 @@ impl ScrollArea {
     /// selecting and scrolling with a mouse is required.
     ///
     /// This controls both scrolling directions.
-    pub fn enable_mouse_dragging(mut self, enable: bool) -> Self {
-        self.mouse_dragging_enabled = enable;
+    pub fn enable_drag_to_scroll(mut self, enable: bool) -> Self {
+        self.drag_to_scroll_enabled = enable;
         self
     }
 
@@ -322,7 +322,7 @@ struct Prepared {
     /// `viewport.min == ZERO` means we scrolled to the top.
     viewport: Rect,
     scrolling_enabled: bool,
-    mouse_dragging_enabled: bool,
+    drag_to_scroll_enabled: bool,
     stick_to_end: [bool; 2],
 }
 
@@ -338,7 +338,7 @@ impl ScrollArea {
             offset_x,
             offset_y,
             scrolling_enabled,
-            mouse_dragging_enabled,
+            drag_to_scroll_enabled,
             stick_to_end,
         } = self;
 
@@ -436,7 +436,7 @@ impl ScrollArea {
             content_ui,
             viewport,
             scrolling_enabled,
-            mouse_dragging_enabled,
+            drag_to_scroll_enabled,
             stick_to_end,
         }
     }
@@ -541,7 +541,7 @@ impl Prepared {
             content_ui,
             viewport: _,
             scrolling_enabled,
-            mouse_dragging_enabled,
+            drag_to_scroll_enabled: mouse_dragging_enabled,
             stick_to_end,
         } = self;
 
@@ -629,7 +629,7 @@ impl Prepared {
 
         if content_is_too_large[0] || content_is_too_large[1] {
             // Drag contents to scroll (for touch screens mostly):
-            let sense = if self.mouse_dragging_enabled {
+            let sense = if self.drag_to_scroll_enabled {
                 Sense::drag()
             } else {
                 Sense::hover()

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -122,13 +122,14 @@ fn layout_section(
 
             paragraph.glyphs.push(Glyph {
                 chr,
-                pos: pos2(font.round_to_pixel(paragraph.cursor_x), f32::NAN),
+                pos: pos2(paragraph.cursor_x, f32::NAN),
                 size: vec2(glyph_info.advance_width, font_height),
                 uv_rect: glyph_info.uv_rect,
                 section_index,
             });
 
             paragraph.cursor_x += glyph_info.advance_width;
+            paragraph.cursor_x = font.round_to_pixel(paragraph.cursor_x);
             last_glyph_id = Some(glyph_info.id);
         }
     }

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -122,14 +122,13 @@ fn layout_section(
 
             paragraph.glyphs.push(Glyph {
                 chr,
-                pos: pos2(paragraph.cursor_x, f32::NAN),
+                pos: pos2(font.round_to_pixel(paragraph.cursor_x), f32::NAN),
                 size: vec2(glyph_info.advance_width, font_height),
                 uv_rect: glyph_info.uv_rect,
                 section_index,
             });
 
             paragraph.cursor_x += glyph_info.advance_width;
-            paragraph.cursor_x = font.round_to_pixel(paragraph.cursor_x);
             last_glyph_id = Some(glyph_info.id);
         }
     }


### PR DESCRIPTION
Adds an option in scrollarea to disable dragging with the mouse seperatley from the option to disable scrolling entirely.
There is not much more to this commit and i am unsure if it is a trivial change.