### PR TITLE
Fix some monospace fonts spacing being non-monospace

### DIFF
--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -122,14 +122,13 @@ fn layout_section(
 
             paragraph.glyphs.push(Glyph {
                 chr,
-                pos: pos2(paragraph.cursor_x, f32::NAN),
+                pos: pos2(font.round_to_pixel(paragraph.cursor_x), f32::NAN),
                 size: vec2(glyph_info.advance_width, font_height),
                 uv_rect: glyph_info.uv_rect,
                 section_index,
             });
 
             paragraph.cursor_x += glyph_info.advance_width;
-            paragraph.cursor_x = font.round_to_pixel(paragraph.cursor_x);
             last_glyph_id = Some(glyph_info.id);
         }
     }


### PR DESCRIPTION
On fonts like Jetbrains Mono the rounding to the closest pixel after every glyph made the spacing between the characters non-monospace. This fixes that issue by rounding the glyph location instead of the cursor x position which affects the future characters in a non-expected way.