### PR TITLE
Allows creating a `ColorImage` struct without an alpha channel

### DIFF
--- a/crates/epaint/src/image.rs
+++ b/crates/epaint/src/image.rs
@@ -107,7 +107,7 @@ impl ColorImage {
     /// you are ignoring the alpha channel - considering it to always be 0xff)
     ///
     /// Panics if `size[0] * size[1] * 3 != rgba.len()`.
-    pub fn from_rgb_unmultiplied(size: [usize; 2], rgb: &[u8]) -> Self {
+    pub fn from_rgb(size: [usize; 2], rgb: &[u8]) -> Self {
         assert_eq!(size[0] * size[1] * 3, rgb.len());
         let pixels = rgb
             .chunks_exact(3)

--- a/crates/epaint/src/image.rs
+++ b/crates/epaint/src/image.rs
@@ -101,6 +101,21 @@ impl ColorImage {
         Self { size, pixels }
     }
 
+    /// Create a [`ColorImage`] from flat un-multiplied RGB data.
+    ///
+    /// This is what you want to use after having loaded an image file (and if
+    /// you are ignoring the alpha channel - considering it to always be 0xff)
+    ///
+    /// Panics if `size[0] * size[1] * 3 != rgba.len()`.
+    pub fn from_rgb_unmultiplied(size: [usize; 2], rgb: &[u8]) -> Self {
+        assert_eq!(size[0] * size[1] * 3, rgb.len());
+        let pixels = rgb
+            .chunks_exact(3)
+            .map(|p| Color32::from_rgb(p[0], p[1], p[2]))
+            .collect();
+        Self { size, pixels }
+    }
+
     /// An example color image, useful for tests.
     pub fn example() -> Self {
         let width = 128;

--- a/crates/epaint/src/image.rs
+++ b/crates/epaint/src/image.rs
@@ -106,7 +106,7 @@ impl ColorImage {
     /// This is what you want to use after having loaded an image file (and if
     /// you are ignoring the alpha channel - considering it to always be 0xff)
     ///
-    /// Panics if `size[0] * size[1] * 3 != rgba.len()`.
+    /// Panics if `size[0] * size[1] * 3 != rgb.len()`.
     pub fn from_rgb(size: [usize; 2], rgb: &[u8]) -> Self {
         assert_eq!(size[0] * size[1] * 3, rgb.len());
         let pixels = rgb

--- a/crates/epaint/src/image.rs
+++ b/crates/epaint/src/image.rs
@@ -101,7 +101,7 @@ impl ColorImage {
         Self { size, pixels }
     }
 
-    /// Create a [`ColorImage`] from flat un-multiplied RGB data.
+    /// Create a [`ColorImage`] from flat RGB data.
     ///
     /// This is what you want to use after having loaded an image file (and if
     /// you are ignoring the alpha channel - considering it to always be 0xff)


### PR DESCRIPTION
Allows creating a `ColorImage` struct without an alpha channel.

- [X] ran `cargo test`
- [X] ran `cargo fmt` 
- [X] ran `cargo clippy`
- [X] ran `./sh/check.sh`

**Background:**
I'm a student working on an image processing library in rust. As a base we are required to implement our own IO / image manipulation centered around the [PPM image format](https://netpbm.sourceforge.net/doc/ppm.html). The PPM image format does not use an alpha channel. 

In order to get `epaint` to play nice with this concept, I have to design my data structures with an extra `0xff` alpha channel. With this change, folk can create a `ColorImage` struct without an alpha channel, which lets me save like, a few bytes in my data structure. But... it feels like the *right* way to do it so 🤷 