### PR TITLE
Typo in egui, layout: alignmen => alignment

### DIFF
--- a/crates/egui/src/layout.rs
+++ b/crates/egui/src/layout.rs
@@ -183,7 +183,7 @@ impl Layout {
 
     /// Place elements vertically, top to bottom.
     ///
-    /// Use the provided horizontal alignmen.
+    /// Use the provided horizontal alignment.
     #[inline(always)]
     pub fn top_down(halign: Align) -> Self {
         Self {
@@ -204,7 +204,7 @@ impl Layout {
 
     /// Place elements vertically, bottom up.
     ///
-    /// Use the provided horizontal alignmen.
+    /// Use the provided horizontal alignment.
     #[inline(always)]
     pub fn bottom_up(halign: Align) -> Self {
         Self {


### PR DESCRIPTION
crates/egui/src/layout.rs had a typo due to a missing "t". 