### PR TITLE
fix comment for WebOptions follow_system_theme

### DIFF
--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -454,7 +454,7 @@ pub struct WebOptions {
     ///
     /// See also [`Self::default_theme`].
     ///
-    /// Default: `false`.
+    /// Default: `true`.
     pub follow_system_theme: bool,
 
     /// Which theme to use in case [`Self::follow_system_theme`] is `false`


### PR DESCRIPTION
it took me a while to figure out why the theme doesn't change :)
```
impl Default for WebOptions {
    fn default() -> Self {
        Self {
            follow_system_theme: true,
```