### PR TITLE
Update arboard, fixing copy-paste on X11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "arboard"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e8af4eff708b72e371acd4625ad3d01a88c946b9e8d6868cb5bb6e4d0d923c"
+checksum = "d6041616acea41d67c4a984709ddab1587fd0b10efe5cc563fee954d2f011854"
 dependencies = [
  "clipboard-win",
  "log",

--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -46,7 +46,9 @@ wayland = ["winit/wayland"]
 egui = { version = "0.19.0", path = "../egui", default-features = false, features = [
   "tracing",
 ] }
-instant = { version = "0.1", features = ["wasm-bindgen"] } # We use instant so we can (maybe) compile for web
+instant = { version = "0.1", features = [
+  "wasm-bindgen",
+] } # We use instant so we can (maybe) compile for web
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 winit = { version = "0.27.2", default-features = false }
 
@@ -67,4 +69,4 @@ webbrowser = { version = "0.8", optional = true }
 smithay-clipboard = { version = "0.6.3", optional = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-arboard = { version = "3.0", optional = true, default-features = false }
+arboard = { version = "3.2", optional = true, default-features = false }

--- a/crates/egui-winit/src/clipboard.rs
+++ b/crates/egui-winit/src/clipboard.rs
@@ -5,6 +5,9 @@ use std::os::raw::c_void;
 /// If the "clipboard" feature is off, or we cannot connect to the OS clipboard,
 /// then a fallback clipboard that just works works within the same app is used instead.
 pub struct Clipboard {
+    #[cfg(all(feature = "arboard", not(target_os = "android")))]
+    arboard: Option<arboard::Clipboard>,
+
     #[cfg(all(
         any(
             target_os = "linux",
@@ -25,6 +28,8 @@ impl Clipboard {
     #[allow(unused_variables)]
     pub fn new(#[allow(unused_variables)] wayland_display: Option<*mut c_void>) -> Self {
         Self {
+            #[cfg(all(feature = "arboard", not(target_os = "android")))]
+            arboard: init_arboard(),
             #[cfg(all(
                 any(
                     target_os = "linux",
@@ -62,7 +67,7 @@ impl Clipboard {
         }
 
         #[cfg(all(feature = "arboard", not(target_os = "android")))]
-        if let Some(mut clipboard) = init_arboard() {
+        if let Some(clipboard) = &mut self.arboard {
             return match clipboard.get_text() {
                 Ok(text) => Some(text),
                 Err(err) => {
@@ -92,7 +97,7 @@ impl Clipboard {
         }
 
         #[cfg(all(feature = "arboard", not(target_os = "android")))]
-        if let Some(mut clipboard) = init_arboard() {
+        if let Some(clipboard) = &mut self.arboard {
             if let Err(err) = clipboard.set_text(text) {
                 tracing::error!("Copy/Cut error: {}", err);
             }


### PR DESCRIPTION
https://github.com/emilk/egui/pull/2067 broke copy-paste on Windows.
https://github.com/emilk/egui/pull/2120 fixed windows, but broke X11.

This PR should hopefully fix both.

See https://github.com/1Password/arboard/pull/89