### PR TITLE
Allow overlapping interactive widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 
 ## Unreleased
 * ⚠️ BREAKING: egui now expects integrations to do all color blending in gamma space ([#2071](https://github.com/emilk/egui/pull/2071)).
+* ⚠️ BREAKING: if you have overlapping interactive widgets, only the top widget (last added) will be interactive ([#2244](https://github.com/emilk/egui/pull/2244)).
 
 ### Added ⭐
 * Added helper functions for animating panels that collapse/expand ([#2190](https://github.com/emilk/egui/pull/2190)).
@@ -15,6 +16,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 * Texture loading now takes a `TexureOptions` with minification and magnification filters ([#2224](https://github.com/emilk/egui/pull/2224)).
 * Added `Key::Minus` and `Key::Equals` ([#2239](https://github.com/emilk/egui/pull/2239)).
 * Added `egui::gui_zoom` module with helpers for scaling the whole GUI of an app ([#2239](https://github.com/emilk/egui/pull/2239)).
+* You can now put one interactive widget on top of another, and only one will get interaction at a time ([#2244](https://github.com/emilk/egui/pull/2244)).
 
 ### Fixed 🐛
 * ⚠️ BREAKING: Fix text being too small ([#2069](https://github.com/emilk/egui/pull/2069)).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ opt-level = 2 # fast and small wasm, basically same as `opt-level = 's'`
 
 [profile.dev]
 split-debuginfo = "unpacked" # faster debug builds on mac
-opt-level = 1                # Make debug builds run faster
+# opt-level = 1                # Make debug builds run faster
 
 # Optimize all dependencies even in debug builds (does not affect workspace packages):
 [profile.dev.package."*"]

--- a/crates/egui/src/containers/frame.rs
+++ b/crates/egui/src/containers/frame.rs
@@ -119,38 +119,45 @@ impl Frame {
 }
 
 impl Frame {
+    #[inline]
     pub fn fill(mut self, fill: Color32) -> Self {
         self.fill = fill;
         self
     }
 
+    #[inline]
     pub fn stroke(mut self, stroke: Stroke) -> Self {
         self.stroke = stroke;
         self
     }
 
+    #[inline]
     pub fn rounding(mut self, rounding: impl Into<Rounding>) -> Self {
         self.rounding = rounding.into();
         self
     }
 
     /// Margin within the painted frame.
+    #[inline]
     pub fn inner_margin(mut self, inner_margin: impl Into<Margin>) -> Self {
         self.inner_margin = inner_margin.into();
         self
     }
 
     /// Margin outside the painted frame.
+    #[inline]
     pub fn outer_margin(mut self, outer_margin: impl Into<Margin>) -> Self {
         self.outer_margin = outer_margin.into();
         self
     }
 
     #[deprecated = "Renamed inner_margin in egui 0.18"]
+    #[inline]
     pub fn margin(self, margin: impl Into<Margin>) -> Self {
         self.inner_margin(margin)
     }
 
+    #[inline]
     pub fn shadow(mut self, shadow: Shadow) -> Self {
         self.shadow = shadow;
         self
@@ -163,6 +170,16 @@ impl Frame {
         self
     }
 }
+
+impl Frame {
+    /// inner margin plus outer margin.
+    #[inline]
+    pub fn total_margin(&self) -> Margin {
+        self.inner_margin + self.outer_margin
+    }
+}
+
+// ----------------------------------------------------------------------------
 
 pub struct Prepared {
     pub frame: Frame,

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -302,7 +302,7 @@ pub fn popup_below_widget<R>(
                 // Note: we use a separate clip-rect for this area, so the popup can be outside the parent.
                 // See https://github.com/emilk/egui/issues/825
                 let frame = Frame::popup(ui.style());
-                let frame_margin = frame.inner_margin + frame.outer_margin;
+                let frame_margin = frame.total_margin();
                 frame
                     .show(ui, |ui| {
                         ui.with_layout(Layout::top_down_justified(Align::LEFT), |ui| {

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -881,8 +881,11 @@ impl TitleBar {
             ui.painter().hline(outer_rect.x_range(), y, stroke);
         }
 
+        // Don't cover the close- and collapse buttons:
+        let double_click_rect = self.rect.shrink2(vec2(32.0, 0.0));
+
         if ui
-            .interact(self.rect, self.id, Sense::click())
+            .interact(double_click_rect, self.id, Sense::click())
             .double_clicked()
             && collapsible
         {

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -344,7 +344,7 @@ impl Context {
         // This solves the problem of overlapping widgets.
         // Whichever widget is added LAST (=on top) gets the input:
         if interact_rect.is_positive() && sense.interactive() {
-            if false {
+            if self.style().debug.show_interactive_widgets {
                 Self::layer_painter(self, LayerId::debug()).rect(
                     interact_rect,
                     0.0,
@@ -372,17 +372,17 @@ impl Context {
                                 // Another interactive widget is covering us at the pointer position,
                                 // so we aren't hovered.
 
-                                if false {
+                                if slf.memory.options.style.debug.show_blocking_widget {
                                     drop(slf);
-                                    Self::layer_painter(self, LayerId::debug()).debug_rect(
-                                        prev_rect,
-                                        Color32::RED,
-                                        "On top",
-                                    );
                                     Self::layer_painter(self, LayerId::debug()).debug_rect(
                                         interact_rect,
                                         Color32::GREEN,
                                         "Covered",
+                                    );
+                                    Self::layer_painter(self, LayerId::debug()).debug_rect(
+                                        prev_rect,
+                                        Color32::LIGHT_BLUE,
+                                        "On top",
                                     );
                                 }
 

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1089,11 +1089,13 @@ impl Context {
     }
 
     pub(crate) fn rect_contains_pointer(&self, layer_id: LayerId, rect: Rect) -> bool {
-        let pointer_pos = self.input().pointer.interact_pos();
-        if let Some(pointer_pos) = pointer_pos {
-            rect.contains(pointer_pos) && self.layer_id_at(pointer_pos) == Some(layer_id)
-        } else {
-            false
+        rect.is_positive() && {
+            let pointer_pos = self.input().pointer.interact_pos();
+            if let Some(pointer_pos) = pointer_pos {
+                rect.contains(pointer_pos) && self.layer_id_at(pointer_pos) == Some(layer_id)
+            } else {
+                false
+            }
         }
     }
 

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -62,6 +62,11 @@ struct ContextImpl {
     has_requested_repaint_this_frame: bool,
 
     requested_repaint_last_frame: bool,
+
+    /// Written to during the frame.
+    layer_rects_this_frame: ahash::HashMap<LayerId, Vec<(Id, Rect)>>,
+    /// Read
+    layer_rects_prev_frame: ahash::HashMap<LayerId, Vec<(Id, Rect)>>,
 }
 
 impl ContextImpl {
@@ -78,6 +83,8 @@ impl ContextImpl {
             rect.max = (ratio * rect.max.to_vec2()).to_pos2();
             new_raw_input.screen_rect = Some(rect);
         }
+
+        self.layer_rects_prev_frame = std::mem::take(&mut self.layer_rects_this_frame);
 
         self.memory.begin_frame(&self.input, &new_raw_input);
 
@@ -322,8 +329,66 @@ impl Context {
             (0.5 * item_spacing - Vec2::splat(gap))
                 .at_least(Vec2::splat(0.0))
                 .at_most(Vec2::splat(5.0)),
-        ); // make it easier to click
-        let hovered = self.rect_contains_pointer(layer_id, clip_rect.intersect(interact_rect));
+        );
+
+        // Respect clip rectangle when interacting
+        let interact_rect = clip_rect.intersect(interact_rect);
+        let mut hovered = self.rect_contains_pointer(layer_id, interact_rect);
+
+        // This solves the problem of overlapping widgets.
+        // Whichever widget is added LAST (=on top) gets the input:
+        if interact_rect.is_positive() && sense.interactive() {
+            if false {
+                Self::layer_painter(self, LayerId::debug()).rect(
+                    interact_rect,
+                    0.0,
+                    Color32::YELLOW.additive().linear_multiply(0.005),
+                    Stroke::new(1.0, Color32::YELLOW.additive().linear_multiply(0.05)),
+                );
+            }
+
+            let mut slf = self.write();
+
+            slf.layer_rects_this_frame
+                .entry(layer_id)
+                .or_default()
+                .push((id, interact_rect));
+
+            if hovered {
+                let pointer_pos = slf.input.pointer.interact_pos();
+                if let Some(pointer_pos) = pointer_pos {
+                    if let Some(rects) = slf.layer_rects_prev_frame.get(&layer_id) {
+                        for &(prev_id, prev_rect) in rects.iter().rev() {
+                            if prev_id == id {
+                                break; // there is no other interactive widget covering us at the pointer position.
+                            }
+                            if prev_rect.contains(pointer_pos) {
+                                // Another interactive widget is covering us at the pointer position,
+                                // so we aren't hovered.
+
+                                if false {
+                                    drop(slf);
+                                    Self::layer_painter(self, LayerId::debug()).debug_rect(
+                                        prev_rect,
+                                        Color32::RED,
+                                        "On top",
+                                    );
+                                    Self::layer_painter(self, LayerId::debug()).debug_rect(
+                                        interact_rect,
+                                        Color32::GREEN,
+                                        "Covered",
+                                    );
+                                }
+
+                                hovered = false;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         self.interact_with_hovered(layer_id, id, rect, sense, enabled, hovered)
     }
 

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -592,11 +592,20 @@ impl WidgetVisuals {
 pub struct DebugOptions {
     /// However over widgets to see their rectangles
     pub debug_on_hover: bool,
+
     /// Show which widgets make their parent wider
     pub show_expand_width: bool,
+
     /// Show which widgets make their parent higher
     pub show_expand_height: bool,
+
     pub show_resize: bool,
+
+    /// Show an overlay on all interactive widgets.
+    pub show_interactive_widgets: bool,
+
+    /// Show what widget blocks the interaction of another widget.
+    pub show_blocking_widget: bool,
 }
 
 // ----------------------------------------------------------------------------
@@ -1255,21 +1264,33 @@ impl DebugOptions {
     pub fn ui(&mut self, ui: &mut crate::Ui) {
         let Self {
             debug_on_hover,
-            show_expand_width: debug_expand_width,
-            show_expand_height: debug_expand_height,
-            show_resize: debug_resize,
+            show_expand_width,
+            show_expand_height,
+            show_resize,
+            show_interactive_widgets,
+            show_blocking_widget,
         } = self;
 
         ui.checkbox(debug_on_hover, "Show debug info on hover");
         ui.checkbox(
-            debug_expand_width,
+            show_expand_width,
             "Show which widgets make their parent wider",
         );
         ui.checkbox(
-            debug_expand_height,
+            show_expand_height,
             "Show which widgets make their parent higher",
         );
-        ui.checkbox(debug_resize, "Debug Resize");
+        ui.checkbox(show_resize, "Debug Resize");
+
+        ui.checkbox(
+            show_interactive_widgets,
+            "Show an overlay on all interactive widgets",
+        );
+
+        ui.checkbox(
+            show_blocking_widget,
+            "Show wha widget blocks the interaction of another widget",
+        );
 
         ui.vertical_centered(|ui| reset_button(ui, self));
     }

--- a/crates/egui/src/widgets/color_picker.rs
+++ b/crates/egui/src/widgets/color_picker.rs
@@ -354,7 +354,7 @@ pub fn color_edit_button_hsva(ui: &mut Ui, hsva: &mut Hsva, alpha: Alpha) -> Res
     if ui.memory().is_popup_open(popup_id) {
         let area_response = Area::new(popup_id)
             .order(Order::Foreground)
-            .current_pos(button_response.rect.max)
+            .fixed_pos(button_response.rect.max)
             .show(ui.ctx(), |ui| {
                 ui.spacing_mut().slider_width = 210.0;
                 Frame::popup(ui.style()).show(ui, |ui| {


### PR DESCRIPTION
Closes https://github.com/emilk/egui/issues/980

By interactive widget, I mean any widget with `Sense::click` or `Sense::drag` (or both).

This design is based on the idea that the latest added (which usually mean the top-most) widget gets the interaction.

For instance: say you have a big interactive canvas and on top of that put some widgets. If you hover the widgets, they get all the input. If you hover the canvas outside of the widgets, the canvas gets the input.

This is done by storing where all interactive widgets are, frame-to-frame. When a new interactive widget is added, we check if there is anything interactive above it (=added later in the previous frame), and if there is, the first widget gets `hovered=false`.

This change required some changes to `ScrollArea`, `Area` and `Window` to make sure they were properly layering interaction back-to-front.

There may be other looming bugs I haven't found yet.

Most user code should be unaffected, unless the user has added layers of interaction on top of each other.

You can visualize this using `style.debug.show_blocking_widget` and `style.debug.show_interactive_widgets`.