### PR TITLE
`Painter` extend accepts `IntoIter`

### DIFF
--- a/crates/egui/src/layers.rs
+++ b/crates/egui/src/layers.rs
@@ -130,9 +130,12 @@ impl PaintList {
         idx
     }
 
-    pub fn extend(&mut self, clip_rect: Rect, mut shapes: Vec<Shape>) {
-        self.0
-            .extend(shapes.drain(..).map(|shape| ClippedShape(clip_rect, shape)));
+    pub fn extend<I: IntoIterator<Item = Shape>>(&mut self, clip_rect: Rect, shapes: I) {
+        self.0.extend(
+            shapes
+                .into_iter()
+                .map(|shape| ClippedShape(clip_rect, shape)),
+        );
     }
 
     /// Modify an existing [`Shape`].

--- a/crates/egui/src/painter.rs
+++ b/crates/egui/src/painter.rs
@@ -187,9 +187,9 @@ impl Painter {
                 self.transform_shape(&mut shape);
                 shape
             });
-            self.paint_list().extend(self.clip_rect, shapes)
+            self.paint_list().extend(self.clip_rect, shapes);
         } else {
-            self.paint_list().extend(self.clip_rect, shapes)
+            self.paint_list().extend(self.clip_rect, shapes);
         };
     }
 

--- a/crates/egui/src/painter.rs
+++ b/crates/egui/src/painter.rs
@@ -178,19 +178,19 @@ impl Painter {
     /// Add many shapes at once.
     ///
     /// Calling this once is generally faster than calling [`Self::add`] multiple times.
-    pub fn extend(&self, mut shapes: Vec<Shape>) {
+    pub fn extend<I: IntoIterator<Item = Shape>>(&self, shapes: I) {
         if self.fade_to_color == Some(Color32::TRANSPARENT) {
             return;
         }
-        if !shapes.is_empty() {
-            if self.fade_to_color.is_some() {
-                for shape in &mut shapes {
-                    self.transform_shape(shape);
-                }
-            }
-
-            self.paint_list().extend(self.clip_rect, shapes);
-        }
+        if self.fade_to_color.is_some() {
+            let shapes = shapes.into_iter().map(|mut shape| {
+                self.transform_shape(&mut shape);
+                shape
+            });
+            self.paint_list().extend(self.clip_rect, shapes)
+        } else {
+            self.paint_list().extend(self.clip_rect, shapes)
+        };
     }
 
     /// Modify an existing [`Shape`].

--- a/crates/egui_demo_lib/src/demo/painting.rs
+++ b/crates/egui_demo_lib/src/demo/painting.rs
@@ -56,13 +56,15 @@ impl Painting {
             response.mark_changed();
         }
 
-        let mut shapes = vec![];
-        for line in &self.lines {
-            if line.len() >= 2 {
+        let shapes = self
+            .lines
+            .iter()
+            .filter(|line| line.len() >= 2)
+            .map(|line| {
                 let points: Vec<Pos2> = line.iter().map(|p| to_screen * *p).collect();
-                shapes.push(egui::Shape::line(points, self.stroke));
-            }
-        }
+                egui::Shape::line(points, self.stroke)
+            });
+
         painter.extend(shapes);
 
         response


### PR DESCRIPTION
Non-breaking interface improvement for `Painter` and `PaintList` `extend` methods.