### PR TITLE
Add a way to provide custom scaling to SVG rasterization

### DIFF
--- a/crates/egui_extras/CHANGELOG.md
+++ b/crates/egui_extras/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the `egui_extras` integration will be noted in this file.
 
 ## Unreleased
 * Added `TableBuilder::vertical_scroll_offset`: method to set vertical scroll offset position for a table ([#1946](https://github.com/emilk/egui/pull/1946)).
+* Added `RetainedImage::from_svg_bytes_with_size` to be able to specify a size for SVGs to be rasterized at.
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -25,9 +25,10 @@ struct MyApp {
 impl Default for MyApp {
     fn default() -> Self {
         Self {
-            svg_image: egui_extras::RetainedImage::from_svg_bytes(
+            svg_image: egui_extras::RetainedImage::from_svg_bytes_with_size(
                 "rustacean-flat-happy.svg",
                 include_bytes!("rustacean-flat-happy.svg"),
+                egui_extras::image::FitTo::Original,
             )
             .unwrap(),
         }
@@ -43,7 +44,7 @@ impl eframe::App for MyApp {
             ui.separator();
 
             let max_size = ui.available_size();
-            self.svg_image.show_max_size(ui, max_size);
+            self.svg_image.show_size(ui, max_size);
         });
     }
 }


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

This provides a way to select a custom size at which SVGs get rasterized.

This should make it easier for users to render SVGs at the proper resolution without aliasing, and possibly provide a way to rasterize dynamically in the future (although I would like to first explore enabling mipmapping for RetainedImages because it would be a more efficient solution)