### PR TITLE
Update ahash to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
+checksum = "464b3811b747f8f7ebc8849c9c728c39f6ac98a055edad93baf9eb330e3f8f9d"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -1138,7 +1138,6 @@ dependencies = [
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
- "getrandom",
  "glow",
  "glutin",
  "js-sys",
@@ -1159,7 +1158,7 @@ dependencies = [
 name = "egui"
 version = "0.19.0"
 dependencies = [
- "ahash 0.8.0",
+ "ahash 0.8.1",
  "document-features",
  "epaint",
  "nohash-hasher",
@@ -1255,7 +1254,7 @@ dependencies = [
 name = "egui_glium"
 version = "0.19.0"
 dependencies = [
- "ahash 0.8.0",
+ "ahash 0.8.1",
  "bytemuck",
  "document-features",
  "egui",
@@ -1371,7 +1370,7 @@ name = "epaint"
 version = "0.19.0"
 dependencies = [
  "ab_glyph",
- "ahash 0.8.0",
+ "ahash 0.8.1",
  "atomic_refcell",
  "backtrace",
  "bytemuck",

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -50,10 +50,7 @@ persistence = [
 puffin = ["dep:puffin", "egui_glow?/puffin"]
 
 ## Enable screen reader support (requires `ctx.options().screen_reader = true;`)
-screen_reader = [
-  "egui-winit/screen_reader",
-  "tts",
-]
+screen_reader = ["egui-winit/screen_reader", "tts"]
 
 ## Use [`wgpu`](https://docs.rs/wgpu) for painting (via [`egui-wgpu`](https://github.com/emilk/egui/tree/master/crates/egui-wgpu)).
 ## This overrides the `glow` feature.
@@ -79,14 +76,19 @@ serde = { version = "1", optional = true, features = ["derive"] }
 # -------------------------------------------
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-egui-winit = { version = "0.19.0", path = "../egui-winit", default-features = false, features = ["clipboard", "links"] }
+egui-winit = { version = "0.19.0", path = "../egui-winit", default-features = false, features = [
+  "clipboard",
+  "links",
+] }
 glutin = { version = "0.29.0" }
 winit = "0.27.2"
 
 # optional native:
 dark-light = { version = "0.2.1", optional = true }
 directories-next = { version = "2", optional = true }
-egui-wgpu = { version = "0.19.0", path = "../egui-wgpu", optional = true, features = ["winit"] } # if wgpu is used, use it with winit
+egui-wgpu = { version = "0.19.0", path = "../egui-wgpu", optional = true, features = [
+  "winit",
+] }
 puffin = { version = "0.13", optional = true }
 wgpu = { version = "0.14", optional = true }
 
@@ -94,7 +96,6 @@ wgpu = { version = "0.14", optional = true }
 # web:
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 bytemuck = "1.7"
-getrandom = { version = "0.2", features = ["js"] } # used by ahash
 js-sys = "0.3"
 percent-encoding = "2.1"
 wasm-bindgen = "0.2"
@@ -144,5 +145,5 @@ web-sys = { version = "0.3.58", features = [
 
 # optional web:
 egui-wgpu = { version = "0.19.0", path = "../egui-wgpu", optional = true } # if wgpu is used, use it without (!) winit
-tts = { version = "0.20", optional = true } # Can't use 0.21-0.24 due to compilation problems on linux
+tts = { version = "0.20", optional = true }                                # Can't use 0.21-0.24 due to compilation problems on linux
 wgpu = { version = "0.14", optional = true, features = ["webgl"] }

--- a/crates/egui/Cargo.toml
+++ b/crates/egui/Cargo.toml
@@ -57,7 +57,10 @@ serde = ["dep:serde", "epaint/serde"]
 [dependencies]
 epaint = { version = "0.19.0", path = "../epaint", default-features = false }
 
-ahash = "0.8"
+ahash = { version = "0.8.1", default-features = false, features = [
+    "no-rng", # we don't need DOS-protection, so we let users opt-in to it instead
+    "std",
+] }
 nohash-hasher = "0.2"
 
 #! ### Optional dependencies
@@ -68,4 +71,6 @@ ron = { version = "0.8", optional = true }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
 
 # egui doesn't log much, but when it does, it uses [`tracing`](https://docs.rs/tracing).
-tracing = { version = "0.1", optional = true, default-features = false, features = ["std"] }
+tracing = { version = "0.1", optional = true, default-features = false, features = [
+    "std",
+] }

--- a/crates/egui_glium/Cargo.toml
+++ b/crates/egui_glium/Cargo.toml
@@ -44,7 +44,10 @@ egui = { version = "0.19.0", path = "../egui", default-features = false, feature
 ] }
 egui-winit = { version = "0.19.0", path = "../egui-winit", default-features = false }
 
-ahash = "0.8"
+ahash = { version = "0.8.1", default-features = false, features = [
+  "no-rng", # we don't need DOS-protection, so we let users opt-in to it instead
+  "std",
+] }
 bytemuck = "1.7"
 glium = "0.32"
 

--- a/crates/epaint/Cargo.toml
+++ b/crates/epaint/Cargo.toml
@@ -56,7 +56,10 @@ serde = ["dep:serde", "ahash/serde", "emath/serde"]
 emath = { version = "0.19.0", path = "../emath" }
 
 ab_glyph = "0.2.11"
-ahash = "0.8"
+ahash = { version = "0.8.1", default-features = false, features = [
+  "no-rng", # we don't need DOS-protection, so we let users opt-in to it instead
+  "std",
+] }
 nohash-hasher = "0.2"
 
 #! ### Optional dependencies
@@ -77,7 +80,7 @@ serde = { version = "1", optional = true, features = ["derive", "rc"] }
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backtrace = { version = "0.3", optional = true }
-parking_lot = "0.12" # Using parking_lot over std::sync::Mutex gives 50% speedups in some real-world scenarios.
+parking_lot = "0.12"                             # Using parking_lot over std::sync::Mutex gives 50% speedups in some real-world scenarios.
 
 # web:
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
Previously, `egui` users needed to add this to their `Cargo.toml`:

```toml
[target.'cfg(target_arch = "wasm32")'.dependencies]
getrandom = { version = "0.2", features = ["js"] }
```

(see https://github.com/emilk/egui/issues/2009).

Thanks to https://github.com/tkaitchuck/aHash/pull/131 we can use ahash with a fixed seed, and let users opt-in to a random seed if they want it.