### PR TITLE
Only show tooltips when mouse pointer is still

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 
 ### Changed 🔧
 * Panels always have a separator line, but no stroke on other sides. Their spacing has also changed slightly ([#2261](https://github.com/emilk/egui/pull/2261)).
+* Tooltips are only shown when mouse pointer is still ([#2263](https://github.com/emilk/egui/pull/2263)).
 
 ### Fixed 🐛
 * ⚠️ BREAKING: Fix text being too small ([#2069](https://github.com/emilk/egui/pull/2069)).

--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -2,8 +2,6 @@
 //! It has no frame or own size. It is potentially movable.
 //! It is the foundation for windows and popups.
 
-use std::{fmt::Debug, hash::Hash};
-
 use crate::*;
 
 /// State that is persisted between frames.
@@ -56,9 +54,9 @@ pub struct Area {
 }
 
 impl Area {
-    pub fn new(id_source: impl Hash) -> Self {
+    pub fn new(id: impl Into<Id>) -> Self {
         Self {
-            id: Id::new(id_source),
+            id: id.into(),
             movable: true,
             interactable: true,
             enabled: true,

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -6,13 +6,13 @@ use crate::*;
 
 /// Same state for all tooltips.
 #[derive(Clone, Debug, Default)]
-pub(crate) struct MonoState {
+pub(crate) struct PopupState {
     last_id: Option<Id>,
     last_size: Vec<Vec2>,
 }
 
-impl MonoState {
-    fn load(ctx: &Context) -> Option<Self> {
+impl PopupState {
+    pub fn load(ctx: &Context) -> Option<Self> {
         ctx.data().get_temp(Id::null())
     }
 
@@ -44,6 +44,10 @@ impl MonoState {
         self.last_size.clear();
         self.last_size.extend((0..index).map(|_| Vec2::ZERO));
         self.last_size.push(size);
+    }
+
+    pub fn is_open(ctx: &Context, id: &Id) -> bool {
+        Self::load(ctx).map_or(false, |state| state.last_id == Some(*id))
     }
 }
 
@@ -181,7 +185,7 @@ fn show_tooltip_at_avoid_dyn<'c, R>(
         return None; // No good place for a tooltip :(
     };
 
-    let mut state = MonoState::load(ctx).unwrap_or_default();
+    let mut state = PopupState::load(ctx).unwrap_or_default();
     let expected_size = state.tooltip_size(id, count);
     let expected_size = expected_size.unwrap_or_else(|| vec2(64.0, 32.0));
 

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -155,6 +155,8 @@ fn show_tooltip_at_avoid_dyn<'c, R>(
     mut avoid_rect: Rect,
     add_contents: Box<dyn FnOnce(&mut Ui) -> R + 'c>,
 ) -> Option<R> {
+    let spacing = 4.0;
+
     // if there are multiple tooltips open they should use the same common_id for the `tooltip_size` caching to work.
     let mut frame_state =
         ctx.frame_state()
@@ -168,9 +170,9 @@ fn show_tooltip_at_avoid_dyn<'c, R>(
     let mut position = if frame_state.rect.is_positive() {
         avoid_rect = avoid_rect.union(frame_state.rect);
         if above {
-            frame_state.rect.left_top()
+            frame_state.rect.left_top() - spacing * Vec2::Y
         } else {
-            frame_state.rect.left_bottom()
+            frame_state.rect.left_bottom() + spacing * Vec2::Y
         }
     } else if let Some(position) = suggested_position {
         position
@@ -199,10 +201,10 @@ fn show_tooltip_at_avoid_dyn<'c, R>(
         if new_rect.shrink(1.0).intersects(avoid_rect) {
             if above {
                 // place below instead:
-                position = avoid_rect.left_bottom();
+                position = avoid_rect.left_bottom() + spacing * Vec2::Y;
             } else {
                 // place above instead:
-                position = Pos2::new(position.x, avoid_rect.min.y - expected_size.y);
+                position = Pos2::new(position.x, avoid_rect.min.y - expected_size.y - spacing);
             }
         }
     }

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -39,7 +39,7 @@ impl<'open> Window<'open> {
     /// If you need a changing title, you must call `window.id(…)` with a fixed id.
     pub fn new(title: impl Into<WidgetText>) -> Self {
         let title = title.into().fallback_text_style(TextStyle::Heading);
-        let area = Area::new(title.text());
+        let area = Area::new(Id::new(title.text()));
         Self {
             title,
             open: None,

--- a/crates/egui/src/frame_state.rs
+++ b/crates/egui/src/frame_state.rs
@@ -3,8 +3,8 @@ use std::ops::RangeInclusive;
 use crate::*;
 
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct TooltipRect {
-    pub id: Id,
+pub(crate) struct TooltipFrameState {
+    pub common_id: Id,
     pub rect: Rect,
     pub count: usize,
 }
@@ -32,7 +32,7 @@ pub(crate) struct FrameState {
     /// If a tooltip has been shown this frame, where was it?
     /// This is used to prevent multiple tooltips to cover each other.
     /// Initialized to `None` at the start of each frame.
-    pub(crate) tooltip_rect: Option<TooltipRect>,
+    pub(crate) tooltip_state: Option<TooltipFrameState>,
 
     /// Set to [`InputState::scroll_delta`] on the start of each frame.
     ///
@@ -50,7 +50,7 @@ impl Default for FrameState {
             available_rect: Rect::NAN,
             unused_rect: Rect::NAN,
             used_by_panels: Rect::NAN,
-            tooltip_rect: None,
+            tooltip_state: None,
             scroll_delta: Vec2::ZERO,
             scroll_target: [None, None],
         }
@@ -64,7 +64,7 @@ impl FrameState {
             available_rect,
             unused_rect,
             used_by_panels,
-            tooltip_rect,
+            tooltip_state,
             scroll_delta,
             scroll_target,
         } = self;
@@ -73,7 +73,7 @@ impl FrameState {
         *available_rect = input.screen_rect();
         *unused_rect = input.screen_rect();
         *used_by_panels = Rect::NOTHING;
-        *tooltip_rect = None;
+        *tooltip_state = None;
         *scroll_delta = input.scroll_delta;
         *scroll_target = [None, None];
     }

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -117,7 +117,7 @@ pub(crate) fn submenu_button<R>(
 /// wrapper for the contents of every menu.
 pub(crate) fn menu_ui<'c, R>(
     ctx: &Context,
-    menu_id: impl std::hash::Hash,
+    menu_id: impl Into<Id>,
     menu_state_arc: &Arc<RwLock<MenuState>>,
     add_contents: impl FnOnce(&mut Ui) -> R + 'c,
 ) -> InnerResponse<R> {

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -399,10 +399,10 @@ impl Response {
             // We only show the tooltip when the mouse pointer is still,
             // but once shown we keep showing it until the mouse leaves the parent.
 
-            use crate::containers::popup::PopupState;
-
             let is_pointer_still = self.ctx.input().pointer.is_still();
-            if !is_pointer_still && !PopupState::is_open(&self.ctx, &self.id.with("__tooltip")) {
+            if !is_pointer_still
+                && !crate::popup::was_tooltip_open_last_frame(&self.ctx, self.id.with("__tooltip"))
+            {
                 // wait for mouse to stop
                 self.ctx.request_repaint();
                 return false;

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -386,6 +386,11 @@ impl Response {
         self
     }
 
+    /// Was the tooltip open last frame?
+    pub fn is_tooltip_open(&self) -> bool {
+        crate::popup::was_tooltip_open_last_frame(&self.ctx, self.id.with("__tooltip"))
+    }
+
     fn should_show_hover_ui(&self) -> bool {
         if self.ctx.memory().everything_is_visible() {
             return true;
@@ -400,9 +405,7 @@ impl Response {
             // but once shown we keep showing it until the mouse leaves the parent.
 
             let is_pointer_still = self.ctx.input().pointer.is_still();
-            if !is_pointer_still
-                && !crate::popup::was_tooltip_open_last_frame(&self.ctx, self.id.with("__tooltip"))
-            {
+            if !is_pointer_still && !self.is_tooltip_open() {
                 // wait for mouse to stop
                 self.ctx.request_repaint();
                 return false;

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -395,12 +395,18 @@ impl Response {
             return false;
         }
 
-        if self.ctx.style().interaction.show_tooltips_only_when_still
-            && !self.ctx.input().pointer.is_still()
-        {
-            // wait for mouse to stop
-            self.ctx.request_repaint();
-            return false;
+        if self.ctx.style().interaction.show_tooltips_only_when_still {
+            // We only show the tooltip when the mouse pointer is still,
+            // but once shown we keep showing it until the mouse leaves the parent.
+
+            use crate::containers::popup::PopupState;
+
+            let is_pointer_still = self.ctx.input().pointer.is_still();
+            if !is_pointer_still && !PopupState::is_open(&self.ctx, &self.id.with("__tooltip")) {
+                // wait for mouse to stop
+                self.ctx.request_repaint();
+                return false;
+            }
         }
 
         // We don't want tooltips of things while we are dragging them,

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -668,7 +668,7 @@ impl Default for Interaction {
         Self {
             resize_grab_radius_side: 5.0,
             resize_grab_radius_corner: 10.0,
-            show_tooltips_only_when_still: false,
+            show_tooltips_only_when_still: true,
         }
     }
 }


### PR DESCRIPTION
Revert to the old behavior by setting `style.interaction.show_tooltips_only_when_still = false`.
