### PR TITLE
Give each tooltip area its own unique `Id`

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -236,8 +236,10 @@ impl Area {
             let interact_id = layer_id.id.with("move");
             let sense = if movable {
                 Sense::click_and_drag()
-            } else {
+            } else if interactable {
                 Sense::click() // allow clicks to bring to front
+            } else {
+                Sense::hover()
             };
 
             let move_response = ctx.interact(

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -209,7 +209,8 @@ fn show_tooltip_at_avoid_dyn<'c, R>(
 
     let position = position.at_least(ctx.input().screen_rect().min);
 
-    let InnerResponse { inner, response } = show_tooltip_area_dyn(ctx, id, position, add_contents);
+    let InnerResponse { inner, response } =
+        show_tooltip_area_dyn(ctx, id.with(count), position, add_contents);
 
     state.set_tooltip_size(id, count, response.rect.size());
     state.store(ctx);


### PR DESCRIPTION
This is important when you have several tooltips open at the same time