### PR TITLE
Fixed Plot `Line::fill` does not fill last segment correctly

### DIFF
--- a/crates/egui/src/widgets/plot/items/mod.rs
+++ b/crates/egui/src/widgets/plot/items/mod.rs
@@ -447,7 +447,7 @@ impl PlotItem for Line {
             let expected_intersections = 20;
             mesh.reserve_triangles((n_values - 1) * 2);
             mesh.reserve_vertices(n_values * 2 + expected_intersections);
-            values_tf[0..n_values].windows(2).for_each(|w| {
+            values_tf.windows(2).for_each(|w| {
                 let i = mesh.vertices.len() as u32;
                 mesh.colored_vertex(w[0], fill_color);
                 mesh.colored_vertex(pos2(w[0].x, y), fill_color);

--- a/crates/egui/src/widgets/plot/items/mod.rs
+++ b/crates/egui/src/widgets/plot/items/mod.rs
@@ -447,7 +447,7 @@ impl PlotItem for Line {
             let expected_intersections = 20;
             mesh.reserve_triangles((n_values - 1) * 2);
             mesh.reserve_vertices(n_values * 2 + expected_intersections);
-            values_tf[0..n_values - 1].windows(2).for_each(|w| {
+            values_tf[0..n_values].windows(2).for_each(|w| {
                 let i = mesh.vertices.len() as u32;
                 mesh.colored_vertex(w[0], fill_color);
                 mesh.colored_vertex(pos2(w[0].x, y), fill_color);


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->
This pr fix Plot `Line::fill` didn't fill correctly because missing second to last vertex.

From
![image](https://user-images.githubusercontent.com/30611421/201043669-05719226-ea07-4fc5-be21-66b0987de2f5.png)
To
![image](https://user-images.githubusercontent.com/30611421/201043823-426af818-5215-42a8-b0c8-bff1875a5256.png)

Closes https://github.com/emilk/egui/issues/1477.
