### PR TITLE
eframe: Don't show window until after initialization

### DIFF
--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -146,7 +146,7 @@ pub fn handle_app_output(
         fullscreen,
         drag_window,
         window_pos,
-        visible: _,
+        visible: _, // handled in post_present
         always_on_top,
     } = app_output;
 

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -324,10 +324,8 @@ impl EpiIntegration {
             if app_output.close {
                 self.close = app.on_close_event();
             }
-            let visible = app_output.visible;
+            self.frame.output.visible = app_output.visible; // this is handled by post_present
             handle_app_output(window, self.egui_ctx.pixels_per_point(), app_output);
-            // TODO(logandark): find a nicer way to do this
-            self.frame.output.visible = visible;
         }
 
         let frame_time = (std::time::Instant::now() - frame_start).as_secs_f64() as f32;

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -146,7 +146,7 @@ pub fn handle_app_output(
         fullscreen,
         drag_window,
         window_pos,
-        visible,
+        visible: _,
         always_on_top,
     } = app_output;
 
@@ -181,10 +181,6 @@ pub fn handle_app_output(
 
     if drag_window {
         let _ = window.drag_window();
-    }
-
-    if let Some(visible) = visible {
-        window.set_visible(visible);
     }
 
     if let Some(always_on_top) = always_on_top {
@@ -240,7 +236,10 @@ impl EpiIntegration {
                 native_pixels_per_point: Some(native_pixels_per_point),
                 window_info: read_window_info(window, egui_ctx.pixels_per_point()),
             },
-            output: Default::default(),
+            output: epi::backend::AppOutput {
+                visible: Some(true),
+                ..Default::default()
+            },
             storage,
             #[cfg(feature = "glow")]
             gl,
@@ -325,7 +324,10 @@ impl EpiIntegration {
             if app_output.close {
                 self.close = app.on_close_event();
             }
+            let visible = app_output.visible;
             handle_app_output(window, self.egui_ctx.pixels_per_point(), app_output);
+            // TODO(logandark): find a nicer way to do this
+            self.frame.output.visible = visible;
         }
 
         let frame_time = (std::time::Instant::now() - frame_start).as_secs_f64() as f32;
@@ -339,6 +341,12 @@ impl EpiIntegration {
         let window_size_px = [inner_size.width, inner_size.height];
 
         app.post_rendering(window_size_px, &self.frame);
+    }
+
+    pub fn post_present(&mut self, window: &winit::window::Window) {
+        if let Some(visible) = self.frame.output.visible.take() {
+           window.set_visible(visible);
+        }
     }
 
     pub fn handle_platform_output(

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -345,7 +345,7 @@ impl EpiIntegration {
 
     pub fn post_present(&mut self, window: &winit::window::Window) {
         if let Some(visible) = self.frame.output.visible.take() {
-           window.set_visible(visible);
+            window.set_visible(visible);
         }
     }
 

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -416,10 +416,6 @@ mod glow_integration {
                 integration,
                 app,
             });
-
-            // TODO(logandark): This is a hack. we should put window visibility into Frame
-            self.paint();
-            self.running.as_ref().unwrap().gl_window.window().set_visible(true);
         }
     }
 
@@ -498,6 +494,8 @@ mod glow_integration {
                     gl_window.swap_buffers().unwrap();
                 }
 
+                integration.post_present(window);
+
                 let control_flow = if integration.should_close() {
                     EventResult::Exit
                 } else if repaint_after.is_zero() {
@@ -542,10 +540,8 @@ mod glow_integration {
                 winit::event::Event::Resumed => {
                     if self.running.is_none() {
                         self.init_run_state(event_loop);
-                        EventResult::Wait
-                    } else {
-                        EventResult::RepaintNow
                     }
+                    EventResult::RepaintAsap
                 }
                 winit::event::Event::Suspended => {
                     #[cfg(target_os = "android")]
@@ -792,10 +788,6 @@ mod wgpu_integration {
                 app,
             });
             self.window = Some(window);
-
-            // TODO(logandark): This is a hack. we should put window visibility into Frame
-            self.paint();
-            self.window.as_ref().unwrap().set_visible(true);
         }
     }
 
@@ -862,6 +854,7 @@ mod wgpu_integration {
                 );
 
                 integration.post_rendering(app.as_mut(), window);
+                integration.post_present(window);
 
                 let control_flow = if integration.should_close() {
                     EventResult::Exit
@@ -915,7 +908,6 @@ mod wgpu_integration {
                             );
                             self.set_window(window);
                         }
-                        EventResult::RepaintNow
                     } else {
                         let storage = epi_integration::create_storage(&self.app_name);
                         let window = Self::create_window(
@@ -925,8 +917,8 @@ mod wgpu_integration {
                             &self.native_options,
                         );
                         self.init_run_state(event_loop, storage, window);
-                        EventResult::Wait
                     }
+                    EventResult::RepaintAsap
                 }
                 winit::event::Event::Suspended => {
                     #[cfg(target_os = "android")]

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -331,7 +331,7 @@ mod glow_integration {
             let window_settings = epi_integration::load_window_settings(storage);
 
             let window_builder =
-                epi_integration::window_builder(native_options, &window_settings).with_title(title);
+                epi_integration::window_builder(native_options, &window_settings).with_title(title).with_visible(false);
 
             let gl_window = unsafe {
                 glutin::ContextBuilder::new()
@@ -392,6 +392,8 @@ mod glow_integration {
                     event_loop_proxy.lock().send_event(RequestRepaintEvent).ok();
                 });
             }
+
+            gl_window.window().set_visible(true);
 
             let app_creator = std::mem::take(&mut self.app_creator)
                 .expect("Single-use AppCreator has unexpectedly already been taken");
@@ -692,6 +694,7 @@ mod wgpu_integration {
             let window_settings = epi_integration::load_window_settings(storage);
             epi_integration::window_builder(native_options, &window_settings)
                 .with_title(title)
+                .with_visible(false)
                 .build(event_loop)
                 .unwrap()
         }
@@ -762,6 +765,8 @@ mod wgpu_integration {
                         .ok();
                 });
             }
+
+            window.set_visible(true);
 
             let app_creator = std::mem::take(&mut self.app_creator)
                 .expect("Single-use AppCreator has unexpectedly already been taken");

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -330,8 +330,9 @@ mod glow_integration {
             };
             let window_settings = epi_integration::load_window_settings(storage);
 
-            let window_builder =
-                epi_integration::window_builder(native_options, &window_settings).with_title(title).with_visible(false);
+            let window_builder = epi_integration::window_builder(native_options, &window_settings)
+                .with_title(title)
+                .with_visible(false);
 
             let gl_window = unsafe {
                 glutin::ContextBuilder::new()

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -394,8 +394,6 @@ mod glow_integration {
                 });
             }
 
-            gl_window.window().set_visible(true);
-
             let app_creator = std::mem::take(&mut self.app_creator)
                 .expect("Single-use AppCreator has unexpectedly already been taken");
             let mut app = app_creator(&epi::CreationContext {
@@ -418,6 +416,10 @@ mod glow_integration {
                 integration,
                 app,
             });
+
+            // TODO(logandark): This is a hack. we should put window visibility into Frame
+            self.paint();
+            self.running.as_ref().unwrap().gl_window.window().set_visible(true);
         }
     }
 
@@ -540,8 +542,10 @@ mod glow_integration {
                 winit::event::Event::Resumed => {
                     if self.running.is_none() {
                         self.init_run_state(event_loop);
+                        EventResult::Wait
+                    } else {
+                        EventResult::RepaintNow
                     }
-                    EventResult::RepaintAsap
                 }
                 winit::event::Event::Suspended => {
                     #[cfg(target_os = "android")]
@@ -767,8 +771,6 @@ mod wgpu_integration {
                 });
             }
 
-            window.set_visible(true);
-
             let app_creator = std::mem::take(&mut self.app_creator)
                 .expect("Single-use AppCreator has unexpectedly already been taken");
             let mut app = app_creator(&epi::CreationContext {
@@ -790,6 +792,10 @@ mod wgpu_integration {
                 app,
             });
             self.window = Some(window);
+
+            // TODO(logandark): This is a hack. we should put window visibility into Frame
+            self.paint();
+            self.window.as_ref().unwrap().set_visible(true);
         }
     }
 
@@ -909,6 +915,7 @@ mod wgpu_integration {
                             );
                             self.set_window(window);
                         }
+                        EventResult::RepaintNow
                     } else {
                         let storage = epi_integration::create_storage(&self.app_name);
                         let window = Self::create_window(
@@ -918,8 +925,8 @@ mod wgpu_integration {
                             &self.native_options,
                         );
                         self.init_run_state(event_loop, storage, window);
+                        EventResult::Wait
                     }
-                    EventResult::RepaintAsap
                 }
                 winit::event::Event::Suspended => {
                     #[cfg(target_os = "android")]

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -332,7 +332,7 @@ mod glow_integration {
 
             let window_builder = epi_integration::window_builder(native_options, &window_settings)
                 .with_title(title)
-                .with_visible(false);
+                .with_visible(false); // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
 
             let gl_window = unsafe {
                 glutin::ContextBuilder::new()

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -695,7 +695,7 @@ mod wgpu_integration {
             let window_settings = epi_integration::load_window_settings(storage);
             epi_integration::window_builder(native_options, &window_settings)
                 .with_title(title)
-                .with_visible(false)
+                .with_visible(false) // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
                 .build(event_loop)
                 .unwrap()
         }


### PR DESCRIPTION
Shortens #1802, but does not completely solve it. This looks to be a step in the right direction, though, and eframe should have been doing this anyway.

Marked as draft because:

- I have not run cranky since I don't have it installed
- This could be done better, for example by only showing the window after the first frame has already been painted
- Ultimately I just wanted to submit this as a first step, even if it's not yet perfect.