### PR TITLE
eframe: Repaint immediately on RepaintAsap, fixes #903

### DIFF
--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -26,12 +26,12 @@ enum EventResult {
     /// be used in special situations if the window must be repainted while
     /// handling a specific event. This occurs on Windows when handling resizes.
     ///
-    /// `RepaintAsap` introduces a one-frame delay, and should therefore only be
+    /// `RepaintNow` introduces a one-frame delay, and should therefore only be
     /// used for extremely urgent repaints.
-    RepaintAsap,
+    RepaintNow,
     /// Queues a repaint for once the event loop handles its next redraw. Exists
     /// so that multiple input events can be handled in one frame. Does not
-    /// cause any delay like `RepaintAsap`.
+    /// cause any delay like `RepaintNow`.
     RepaintNext,
     RepaintAt(Instant),
     Exit,
@@ -129,7 +129,7 @@ fn run_and_return(event_loop: &mut EventLoop<RequestRepaintEvent>, mut winit_app
 
         match event_result {
             EventResult::Wait => {}
-            EventResult::RepaintAsap => {
+            EventResult::RepaintNow => {
                 tracing::trace!("Repaint caused by winit::Event: {:?}", event);
                 next_repaint_time = Instant::now() + Duration::from_secs(1_000_000_000);
                 winit_app.paint();
@@ -210,7 +210,7 @@ fn run_and_exit(
 
         match event_result {
             EventResult::Wait => {}
-            EventResult::RepaintAsap => {
+            EventResult::RepaintNow => {
                 next_repaint_time = Instant::now() + Duration::from_secs(1_000_000_000);
                 winit_app.paint();
             }
@@ -557,7 +557,7 @@ mod glow_integration {
                     if self.running.is_none() {
                         self.init_run_state(event_loop);
                     }
-                    EventResult::RepaintAsap
+                    EventResult::RepaintNow
                 }
                 winit::event::Event::Suspended => {
                     #[cfg(target_os = "android")]
@@ -630,7 +630,7 @@ mod glow_integration {
                             EventResult::Exit
                         } else if event_response.repaint {
                             if repaint_asap {
-                                EventResult::RepaintAsap
+                                EventResult::RepaintNow
                             } else {
                                 EventResult::RepaintNext
                             }
@@ -954,7 +954,7 @@ mod wgpu_integration {
                         );
                         self.init_run_state(event_loop, storage, window);
                     }
-                    EventResult::RepaintAsap
+                    EventResult::RepaintNow
                 }
                 winit::event::Event::Suspended => {
                     #[cfg(target_os = "android")]
@@ -1019,7 +1019,7 @@ mod wgpu_integration {
                             EventResult::Exit
                         } else if event_response.repaint {
                             if repaint_asap {
-                                EventResult::RepaintAsap
+                                EventResult::RepaintNow
                             } else {
                                 EventResult::RepaintNext
                             }

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -26,8 +26,8 @@ enum EventResult {
     /// be used in special situations if the window must be repainted while
     /// handling a specific event. This occurs on Windows when handling resizes.
     ///
-    /// `RepaintNow` introduces a one-frame delay, and should therefore only be
-    /// used for extremely urgent repaints.
+    /// `RepaintNow` creates a new frame synchronously, and should therefore
+    /// only be used for extremely urgent repaints.
     RepaintNow,
     /// Queues a repaint for once the event loop handles its next redraw. Exists
     /// so that multiple input events can be handled in one frame. Does not

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -121,7 +121,8 @@ fn run_and_return(event_loop: &mut EventLoop<RequestRepaintEvent>, mut winit_app
             EventResult::Wait => {}
             EventResult::RepaintAsap => {
                 tracing::trace!("Repaint caused by winit::Event: {:?}", event);
-                next_repaint_time = Instant::now();
+                next_repaint_time = Instant::now() + Duration::from_secs(1_000_000_000);
+                winit_app.paint();
             }
             EventResult::RepaintAt(repaint_time) => {
                 next_repaint_time = next_repaint_time.min(repaint_time);
@@ -196,7 +197,8 @@ fn run_and_exit(
         match event_result {
             EventResult::Wait => {}
             EventResult::RepaintAsap => {
-                next_repaint_time = Instant::now();
+                next_repaint_time = Instant::now() + Duration::from_secs(1_000_000_000);
+                winit_app.paint();
             }
             EventResult::RepaintAt(repaint_time) => {
                 next_repaint_time = next_repaint_time.min(repaint_time);


### PR DESCRIPTION
This completely eliminates the white flickering seen on Windows when rapidly resizing a window on the glow backend. The reason that happens is because DWM only waits for the resize event to be delivered before displaying the window at its new size. You must repaint synchronously inside that iteration of the event loop or else you get flickering.

Draft because there may be another reason why it was done this way; there was no comment explaining it so I am unsure.