### PR TITLE
Implement accessibility APIs via AccessKit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 * Added `Area::constrain` and `Window::constrain` which constrains area to the screen bounds. ([#2270](https://github.com/emilk/egui/pull/2270)).
 * Added `Area::pivot` and `Window::pivot` which controls what part of the window to position. ([#2303](https://github.com/emilk/egui/pull/2303)).
 * Added support for [thin space](https://en.wikipedia.org/wiki/Thin_space).
+* Added optional integration with [AccessKit](https://accesskit.dev/) for implementing platform accessibility APIs. ([#2294](https://github.com/emilk/egui/pull/2294)).
 
 ### Changed 🔧
 * Panels always have a separator line, but no stroke on other sides. Their spacing has also changed slightly ([#2261](https://github.com/emilk/egui/pull/2261)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9f45191913a5a83cee9e9ec161fe20216d345d0eaa321ec599f69188fa5b0d"
+checksum = "7c22c90fa269beac30826b50ff07c4e0fb1dbc7a6dd80555e1d61f9c599db752"
 dependencies = [
  "accesskit",
  "parking_lot",
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_macos"
-version = "0.1.1"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe873b1f135b6538ef3c044424703dc6f381e9232ef84a3f080f4c3731d791b"
+checksum = "64dbd336bb7fc43fa3bfc8b59e5cbab880421983dd043d540ce3d6db3f099e4c"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a936fb4082e46649748c3c3089bfe5e41f59e1246503ab8e18e1ad81683559"
+checksum = "40846a52cc28969f8e9f10fdcc946c2119121e38e9388c42cbdf1a4b6c0a7aef"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_winit"
-version = "0.6.0"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f036fe9dbb998ddca93fcefb8343988bb799eeb534144b5164f2cdb1056068eb"
+checksum = "c5d8630e275f2958ddab357e7dfc11abe41d28b1eba114e0d80cf3df672426fd"
 dependencies = [
  "accesskit",
  "accesskit_macos",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_macos"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64dbd336bb7fc43fa3bfc8b59e5cbab880421983dd043d540ce3d6db3f099e4c"
+checksum = "efa5b671f649a554d8c27b238ba69e5eac8be4809713ebc6cfeca78ebb0ee639"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -54,14 +54,14 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40846a52cc28969f8e9f10fdcc946c2119121e38e9388c42cbdf1a4b6c0a7aef"
+checksum = "fa69568d9c5df0b964f1ca1bc49e865732f256832cf21775b08a736975501682"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
  "arrayvec 0.7.2",
- "lazy-init",
+ "once_cell",
  "parking_lot",
  "paste",
  "windows 0.42.0",
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_winit"
-version = "0.6.6"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d8630e275f2958ddab357e7dfc11abe41d28b1eba114e0d80cf3df672426fd"
+checksum = "ee81f4dce90c61ccbf8579ad2f0c7650022e8a5bb8bd10cd62438cad6330a2ff"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2235,12 +2235,6 @@ dependencies = [
  "arrayvec 0.7.2",
  "serde",
 ]
-
-[[package]]
-name = "lazy-init"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f40963626ac12dcaf92afc15e4c3db624858c92fd9f8ba2125eaada3ac2706f"
 
 [[package]]
 name = "lazy_static"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13739d7177fbd22bb0ed28badfff9f372f8bef46c863db4e1c6248f6b223b6e"
 
 [[package]]
+name = "accesskit"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f58dda4ca012077ac19d2062ccc30187fa5588f377961be11674c3ca5f8df1"
+dependencies = [
+ "enumset",
+ "kurbo",
+ "serde",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9f45191913a5a83cee9e9ec161fe20216d345d0eaa321ec599f69188fa5b0d"
+dependencies = [
+ "accesskit",
+ "parking_lot",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe873b1f135b6538ef3c044424703dc6f381e9232ef84a3f080f4c3731d791b"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "objc2",
+ "once_cell",
+ "parking_lot",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a936fb4082e46649748c3c3089bfe5e41f59e1246503ab8e18e1ad81683559"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "arrayvec 0.7.2",
+ "lazy-init",
+ "parking_lot",
+ "paste",
+ "windows 0.42.0",
+]
+
+[[package]]
+name = "accesskit_winit"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f036fe9dbb998ddca93fcefb8343988bb799eeb534144b5164f2cdb1056068eb"
+dependencies = [
+ "accesskit",
+ "accesskit_macos",
+ "accesskit_windows",
+ "parking_lot",
+ "winit",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +430,25 @@ name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "block-sys"
+version = "0.1.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa55741ee90902547802152aaf3f8e5248aab7e21468089560d4c8840561146"
+dependencies = [
+ "objc-sys",
+]
+
+[[package]]
+name = "block2"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd9e63c1744f755c2f60332b88de39d341e5e86239014ad839bd71c106dec42"
+dependencies = [
+ "block-sys",
+ "objc2-encode",
+]
 
 [[package]]
 name = "bumpalo"
@@ -923,8 +1004,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+dependencies = [
+ "darling_core 0.14.2",
+ "darling_macro 0.14.2",
 ]
 
 [[package]]
@@ -942,12 +1033,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+dependencies = [
+ "darling_core 0.14.2",
  "quote",
  "syn",
 ]
@@ -1165,6 +1280,7 @@ dependencies = [
 name = "egui"
 version = "0.19.0"
 dependencies = [
+ "accesskit",
  "ahash 0.8.1",
  "document-features",
  "epaint",
@@ -1193,6 +1309,7 @@ dependencies = [
 name = "egui-winit"
 version = "0.19.0"
 dependencies = [
+ "accesskit_winit",
  "arboard",
  "document-features",
  "egui",
@@ -1355,6 +1472,28 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f58dc3c5e468259f19f2d46304a6b28f1c3d034442e14b322d2b850e36f6d5ae"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enumset"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19be8061a06ab6f3a6cf21106c873578bf01bd42ad15e0311a9c76161cb1c753"
+dependencies = [
+ "enumset_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e7b551eba279bf0fa88b83a46330168c1560a52a94f5126f892f0b364ab3e0"
+dependencies = [
+ "darling 0.14.2",
  "proc-macro2",
  "quote",
  "syn",
@@ -2094,7 +2233,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a53776d271cfb873b17c618af0298445c88afc52837f3e948fa3fafd131f449"
 dependencies = [
  "arrayvec 0.7.2",
+ "serde",
 ]
+
+[[package]]
+name = "lazy-init"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f40963626ac12dcaf92afc15e4c3db624858c92fd9f8ba2125eaada3ac2706f"
 
 [[package]]
 name = "lazy_static"
@@ -2340,7 +2486,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0df7ac00c4672f9d5aece54ee3347520b7e20f158656c7db2e6de01902eb7a6c"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -2502,6 +2648,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.2.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b9834c1e95694a05a828b59f55fa2afec6288359cda67146126b3f90a55d7"
+
+[[package]]
+name = "objc2"
+version = "0.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe31e5425d3d0b89a15982c024392815da40689aceb34bad364d58732bcfd649"
+dependencies = [
+ "block2",
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "2.0.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abfcac41015b00a120608fdaa6938c44cb983fee294351cc4bac7638b4e50512"
+dependencies = [
+ "objc-sys",
+]
+
+[[package]]
 name = "objc_exception"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2624,6 +2796,12 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "peeking_take_while"
@@ -4365,6 +4543,7 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0286ba339aa753e70765d521bb0242cc48e1194562bfa2a2ad7ac8a6de28f5d5"
 dependencies = [
+ "windows-implement",
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc 0.42.0",
  "windows_i686_gnu 0.42.0",
@@ -4372,6 +4551,17 @@ dependencies = [
  "windows_x86_64_gnu 0.42.0",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9539b6bd3eadbd9de66c9666b22d802b833da7e996bc06896142e09854a61767"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4491,9 +4681,9 @@ checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winit"
-version = "0.27.2"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a8f3e9d742401efcfe833b8f84960397482ff049cb7bf59a112e14a4be97f7"
+checksum = "bb796d6fbd86b2fd896c9471e6f04d39d750076ebe5680a3958f00f5ab97657c"
 dependencies = [
  "bitflags",
  "cocoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ checksum = "a13739d7177fbd22bb0ed28badfff9f372f8bef46c863db4e1c6248f6b223b6e"
 
 [[package]]
 name = "accesskit"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f58dda4ca012077ac19d2062ccc30187fa5588f377961be11674c3ca5f8df1"
+checksum = "3083ac5a97521e35388ca80cf365b6be5210962cc59f11ee238cd92ac2fa9524"
 dependencies = [
  "enumset",
  "kurbo",
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c22c90fa269beac30826b50ff07c4e0fb1dbc7a6dd80555e1d61f9c599db752"
+checksum = "df122220244ca3ab93f6a42da59a5f8b379c8846dbcaedf922d95636d22c4e10"
 dependencies = [
  "accesskit",
  "parking_lot",
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_macos"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa5b671f649a554d8c27b238ba69e5eac8be4809713ebc6cfeca78ebb0ee639"
+checksum = "55c97d7b5cbb2409e05b016406a1bd057237d120205cb63220ca86c2ea3790a1"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa69568d9c5df0b964f1ca1bc49e865732f256832cf21775b08a736975501682"
+checksum = "4b0cfda25182b83b24e350434a3f63676252a00a295f32760a14d3f55feb8493"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_winit"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee81f4dce90c61ccbf8579ad2f0c7650022e8a5bb8bd10cd62438cad6330a2ff"
+checksum = "cdf20fecd6573e03bebcb4de267f82431e5ea39a293b62aa51a45bdfd69ef39b"
 dependencies = [
  "accesskit",
  "accesskit_macos",

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+doc-valid-idents = ["AccessKit", ".."]

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -18,6 +18,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 * Web: Add `WebInfo::user_agent` ([#2202](https://github.com/emilk/egui/pull/2202)).
 * Wgpu device/adapter/surface creation has now various configuration options exposed via `NativeOptions/WebOptions::wgpu_options` ([#2207](https://github.com/emilk/egui/pull/2207)).
 * Fix: Make sure that `native_pixels_per_point` is updated ([#2256](https://github.com/emilk/egui/pull/2256)).
+* Added optional, but enabled by default, integration with [AccessKit](https://accesskit.dev/) for implementing platform accessibility APIs. ([#2294](https://github.com/emilk/egui/pull/2294)).
 
 
 ## 0.19.0 - 2022-08-20

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -20,7 +20,10 @@ all-features = true
 
 
 [features]
-default = ["default_fonts", "glow"]
+default = ["accesskit", "default_fonts", "glow"]
+
+## Enable platform accessibility API implementations through [AccessKit](https://accesskit.dev/).
+accesskit = ["egui/accesskit", "egui-winit/accesskit"]
 
 ## Detect dark mode system preference using [`dark-light`](https://docs.rs/dark-light).
 ##

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -272,8 +272,17 @@ impl EpiIntegration {
         window: &winit::window::Window,
         event_loop_proxy: winit::event_loop::EventLoopProxy<E>,
     ) {
+        let egui_ctx = self.egui_ctx.clone();
         self.egui_winit
-            .init_accesskit(window, event_loop_proxy, self.egui_ctx.clone());
+            .init_accesskit(window, event_loop_proxy, move || {
+                // This function is called when an accessibility client
+                // (e.g. screen reader) makes its first request. If we got here,
+                // we know that an accessibility tree is actually wanted.
+                egui_ctx.enable_accesskit();
+                // Enqueue a repaint so we'll receive a full tree update soon.
+                egui_ctx.request_repaint();
+                egui::accesskit_placeholder_tree_update()
+            });
     }
 
     pub fn warm_up(&mut self, app: &mut dyn epi::App, window: &winit::window::Window) {

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -3,6 +3,10 @@ use winit::event_loop::EventLoopWindowTarget;
 #[cfg(target_os = "macos")]
 use winit::platform::macos::WindowBuilderExtMacOS as _;
 
+#[cfg(feature = "accesskit")]
+use egui::accesskit;
+#[cfg(feature = "accesskit")]
+use egui_winit::accesskit_winit;
 use egui_winit::{native_pixels_per_point, EventResponse, WindowSettings};
 
 use crate::{epi, Theme, WindowInfo};
@@ -262,6 +266,15 @@ impl EpiIntegration {
         }
     }
 
+    #[cfg(feature = "accesskit")]
+    pub fn init_accesskit<E: From<accesskit_winit::ActionRequestEvent> + Send>(
+        &mut self,
+        window: &winit::window::Window,
+        event_loop_proxy: winit::event_loop::EventLoopProxy<E>,
+    ) {
+        self.egui_winit.init_accesskit(window, event_loop_proxy);
+    }
+
     pub fn warm_up(&mut self, app: &mut dyn epi::App, window: &winit::window::Window) {
         crate::profile_function!();
         let saved_memory: egui::Memory = self.egui_ctx.memory().clone();
@@ -299,6 +312,11 @@ impl EpiIntegration {
         }
 
         self.egui_winit.on_event(&self.egui_ctx, event)
+    }
+
+    #[cfg(feature = "accesskit")]
+    pub fn on_accesskit_action_request(&mut self, request: accesskit::ActionRequest) {
+        self.egui_winit.on_accesskit_action_request(request);
     }
 
     pub fn update(

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -272,7 +272,8 @@ impl EpiIntegration {
         window: &winit::window::Window,
         event_loop_proxy: winit::event_loop::EventLoopProxy<E>,
     ) {
-        self.egui_winit.init_accesskit(window, event_loop_proxy);
+        self.egui_winit
+            .init_accesskit(window, event_loop_proxy, self.egui_ctx.clone());
     }
 
     pub fn warm_up(&mut self, app: &mut dyn epi::App, window: &winit::window::Window) {

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -4,6 +4,8 @@
 use std::time::Duration;
 use std::time::Instant;
 
+#[cfg(feature = "accesskit")]
+use egui_winit::accesskit_winit;
 use egui_winit::winit;
 use winit::event_loop::{
     ControlFlow, EventLoop, EventLoopBuilder, EventLoopProxy, EventLoopWindowTarget,
@@ -15,6 +17,15 @@ use crate::epi;
 #[derive(Debug)]
 pub enum UserEvent {
     RequestRepaint,
+    #[cfg(feature = "accesskit")]
+    AccessKitActionRequest(accesskit_winit::ActionRequestEvent),
+}
+
+#[cfg(feature = "accesskit")]
+impl From<accesskit_winit::ActionRequestEvent> for UserEvent {
+    fn from(inner: accesskit_winit::ActionRequestEvent) -> Self {
+        Self::AccessKitActionRequest(inner)
+    }
 }
 
 // ----------------------------------------------------------------------------
@@ -350,7 +361,9 @@ mod glow_integration {
 
             let window_builder = epi_integration::window_builder(native_options, &window_settings)
                 .with_title(title)
-                .with_visible(false); // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
+                // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
+                // We must also keep the window hidden until AccessKit is initialized.
+                .with_visible(false);
 
             let gl_window = unsafe {
                 glutin::ContextBuilder::new()
@@ -397,6 +410,10 @@ mod glow_integration {
                 #[cfg(feature = "wgpu")]
                 None,
             );
+            #[cfg(feature = "accesskit")]
+            {
+                integration.init_accesskit(gl_window.window(), self.repaint_proxy.lock().clone());
+            }
             let theme = system_theme.unwrap_or(self.native_options.default_theme);
             integration.egui_ctx.set_visuals(theme.egui_visuals());
 
@@ -646,6 +663,21 @@ mod glow_integration {
                         EventResult::Wait
                     }
                 }
+                #[cfg(feature = "accesskit")]
+                winit::event::Event::UserEvent(UserEvent::AccessKitActionRequest(
+                    accesskit_winit::ActionRequestEvent { request, .. },
+                )) => {
+                    if let Some(running) = &mut self.running {
+                        running
+                            .integration
+                            .on_accesskit_action_request(request.clone());
+                        // As a form of user input, accessibility actions should
+                        // lead to a repaint.
+                        EventResult::RepaintNext
+                    } else {
+                        EventResult::Wait
+                    }
+                }
                 _ => EventResult::Wait,
             }
         }
@@ -738,7 +770,9 @@ mod wgpu_integration {
             let window_settings = epi_integration::load_window_settings(storage);
             epi_integration::window_builder(native_options, &window_settings)
                 .with_title(title)
-                .with_visible(false) // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
+                // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
+                // We must also keep the window hidden until AccessKit is initialized.
+                .with_visible(false)
                 .build(event_loop)
                 .unwrap()
         }
@@ -794,6 +828,10 @@ mod wgpu_integration {
                 None,
                 wgpu_render_state.clone(),
             );
+            #[cfg(feature = "accesskit")]
+            {
+                integration.init_accesskit(&window, self.repaint_proxy.lock().unwrap().clone());
+            }
             let theme = system_theme.unwrap_or(self.native_options.default_theme);
             integration.egui_ctx.set_visuals(theme.egui_visuals());
 
@@ -1033,6 +1071,21 @@ mod wgpu_integration {
                         } else {
                             EventResult::Wait
                         }
+                    } else {
+                        EventResult::Wait
+                    }
+                }
+                #[cfg(feature = "accesskit")]
+                winit::event::Event::UserEvent(UserEvent::AccessKitActionRequest(
+                    accesskit_winit::ActionRequestEvent { request, .. },
+                )) => {
+                    if let Some(running) = &mut self.running {
+                        running
+                            .integration
+                            .on_accesskit_action_request(request.clone());
+                        // As a form of user input, accessibility actions should
+                        // lead to a repaint.
+                        EventResult::RepaintNext
                     } else {
                         EventResult::Wait
                     }

--- a/crates/eframe/src/web/backend.rs
+++ b/crates/eframe/src/web/backend.rs
@@ -400,6 +400,8 @@ impl AppRunner {
             events: _, // already handled
             mutable_text_under_cursor,
             text_cursor_pos,
+            #[cfg(feature = "accesskit")]
+                accesskit_update: _, // not currently implemented
         } = platform_output;
 
         set_cursor_icon(cursor_icon);

--- a/crates/egui-winit/CHANGELOG.md
+++ b/crates/egui-winit/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the `egui-winit` integration will be noted in this file.
 ## Unreleased
 * The default features of the `winit` crate are not enabled if the default features of `egui-winit` are disabled too ([#1971](https://github.com/emilk/egui/pull/1971))
 * Added new feature `wayland` which enables Wayland support ([#1971](https://github.com/emilk/egui/pull/1971))
+* Added optional integration with [AccessKit](https://accesskit.dev/) for implementing platform accessibility APIs. ([#2294](https://github.com/emilk/egui/pull/2294)).
 
 ## 0.19.0 - 2022-08-20
 * MSRV (Minimum Supported Rust Version) is now `1.61.0` ([#1846](https://github.com/emilk/egui/pull/1846)).

--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -61,7 +61,7 @@ winit = { version = "0.27.2", default-features = false }
 document-features = { version = "0.2", optional = true }
 
 # feature accesskit
-accesskit_winit = { version = "0.7.0", optional = true }
+accesskit_winit = { version = "0.7.1", optional = true }
 
 puffin = { version = "0.14", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -61,7 +61,7 @@ winit = { version = "0.27.2", default-features = false }
 document-features = { version = "0.2", optional = true }
 
 # feature accesskit
-accesskit_winit = { version = "0.6.0", optional = true }
+accesskit_winit = { version = "0.6.6", optional = true }
 
 puffin = { version = "0.14", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -61,7 +61,7 @@ winit = { version = "0.27.2", default-features = false }
 document-features = { version = "0.2", optional = true }
 
 # feature accesskit
-accesskit_winit = { version = "0.6.6", optional = true }
+accesskit_winit = { version = "0.7.0", optional = true }
 
 puffin = { version = "0.14", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -20,6 +20,9 @@ all-features = true
 [features]
 default = ["clipboard", "links", "wayland", "winit/default"]
 
+## Enable platform accessibility API implementations through [AccessKit](https://accesskit.dev/).
+accesskit = ["accesskit_winit", "egui/accesskit"]
+
 ## [`bytemuck`](https://docs.rs/bytemuck) enables you to cast [`egui::epaint::Vertex`], [`egui::Vec2`] etc to `&[u8]`.
 bytemuck = ["egui/bytemuck"]
 
@@ -56,6 +59,9 @@ winit = { version = "0.27.2", default-features = false }
 
 ## Enable this when generating docs.
 document-features = { version = "0.2", optional = true }
+
+# feature accesskit
+accesskit_winit = { version = "0.6.0", optional = true }
 
 puffin = { version = "0.14", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -132,21 +132,11 @@ impl State {
         &mut self,
         window: &winit::window::Window,
         event_loop_proxy: winit::event_loop::EventLoopProxy<T>,
-        egui_ctx: egui::Context,
+        initial_tree_update_factory: impl 'static + FnOnce() -> accesskit::TreeUpdate + Send,
     ) {
         self.accesskit = Some(accesskit_winit::Adapter::new(
             window,
-            move || {
-                // This function is called when an accessibility client
-                // (e.g. screen reader) makes its first request. If we got here,
-                // we know that an accessibility tree is actually wanted.
-                // Tell egui that AccessKit is active, and return a placeholder
-                // tree for now. `egui::Context::accesskit_activated`
-                // will request a repaint, and that will provide the first
-                // real accessibility tree.
-                egui_ctx.accesskit_activated();
-                egui::accesskit_placeholder_tree_update()
-            },
+            initial_tree_update_factory,
             event_loop_proxy,
         ));
     }

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -136,7 +136,7 @@ impl State {
     ) {
         self.accesskit = Some(accesskit_winit::Adapter::new(
             window,
-            Box::new(move || {
+            move || {
                 // This function is called when an accessibility client
                 // (e.g. screen reader) makes its first request. If we got here,
                 // we know that an accessibility tree is actually wanted.
@@ -146,7 +146,7 @@ impl State {
                 // real accessibility tree.
                 egui_ctx.accesskit_activated();
                 egui::accesskit_placeholder_tree_update()
-            }),
+            },
             event_loop_proxy,
         ));
     }

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -11,7 +11,11 @@
 
 use std::os::raw::c_void;
 
+#[cfg(feature = "accesskit")]
+pub use accesskit_winit;
 pub use egui;
+#[cfg(feature = "accesskit")]
+use egui::accesskit;
 pub use winit;
 
 pub mod clipboard;
@@ -86,6 +90,9 @@ pub struct State {
 
     /// track ime state
     input_method_editor_started: bool,
+
+    #[cfg(feature = "accesskit")]
+    accesskit: Option<accesskit_winit::Adapter>,
 }
 
 impl State {
@@ -114,7 +121,23 @@ impl State {
             pointer_touch_id: None,
 
             input_method_editor_started: false,
+
+            #[cfg(feature = "accesskit")]
+            accesskit: None,
         }
+    }
+
+    #[cfg(feature = "accesskit")]
+    pub fn init_accesskit<T: From<accesskit_winit::ActionRequestEvent> + Send>(
+        &mut self,
+        window: &winit::window::Window,
+        event_loop_proxy: winit::event_loop::EventLoopProxy<T>,
+    ) {
+        self.accesskit = Some(accesskit_winit::Adapter::new(
+            window,
+            Box::new(egui::accesskit_placeholder_tree_update),
+            event_loop_proxy,
+        ));
     }
 
     /// Call this once a graphics context has been created to update the maximum texture dimensions
@@ -374,6 +397,16 @@ impl State {
         }
     }
 
+    /// Call this when there is a new [`accesskit::ActionRequest`].
+    ///
+    /// The result can be found in [`Self::egui_input`] and be extracted with [`Self::take_egui_input`].
+    #[cfg(feature = "accesskit")]
+    pub fn on_accesskit_action_request(&mut self, request: accesskit::ActionRequest) {
+        self.egui_input
+            .events
+            .push(egui::Event::AccessKitActionRequest(request));
+    }
+
     fn on_mouse_button_input(
         &mut self,
         state: winit::event::ElementState,
@@ -592,6 +625,8 @@ impl State {
             events: _,                    // handled above
             mutable_text_under_cursor: _, // only used in eframe web
             text_cursor_pos,
+            #[cfg(feature = "accesskit")]
+            accesskit_update,
         } = platform_output;
         self.current_pixels_per_point = egui_ctx.pixels_per_point(); // someone can have changed it to scale the UI
 
@@ -607,6 +642,13 @@ impl State {
 
         if let Some(egui::Pos2 { x, y }) = text_cursor_pos {
             window.set_ime_position(winit::dpi::LogicalPosition { x, y });
+        }
+
+        #[cfg(feature = "accesskit")]
+        {
+            if let Some(accesskit) = self.accesskit.as_ref() {
+                accesskit.update(accesskit_update);
+            }
         }
     }
 

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -132,10 +132,21 @@ impl State {
         &mut self,
         window: &winit::window::Window,
         event_loop_proxy: winit::event_loop::EventLoopProxy<T>,
+        egui_ctx: egui::Context,
     ) {
         self.accesskit = Some(accesskit_winit::Adapter::new(
             window,
-            Box::new(egui::accesskit_placeholder_tree_update),
+            Box::new(move || {
+                // This function is called when an accessibility client
+                // (e.g. screen reader) makes its first request. If we got here,
+                // we know that an accessibility tree is actually wanted.
+                // Tell egui that AccessKit is active, and return a placeholder
+                // tree for now. `egui::Context::accesskit_activated`
+                // will request a repaint, and that will provide the first
+                // real accessibility tree.
+                egui_ctx.accesskit_activated();
+                egui::accesskit_placeholder_tree_update()
+            }),
             event_loop_proxy,
         ));
     }
@@ -645,10 +656,8 @@ impl State {
         }
 
         #[cfg(feature = "accesskit")]
-        {
-            if let Some(accesskit) = self.accesskit.as_ref() {
-                accesskit.update(accesskit_update);
-            }
+        if let Some(accesskit) = self.accesskit.as_ref() {
+            accesskit.update_if_active(|| accesskit_update);
         }
     }
 

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -657,7 +657,9 @@ impl State {
 
         #[cfg(feature = "accesskit")]
         if let Some(accesskit) = self.accesskit.as_ref() {
-            accesskit.update_if_active(|| accesskit_update);
+            if let Some(update) = accesskit_update {
+                accesskit.update_if_active(|| update);
+            }
         }
     }
 

--- a/crates/egui/Cargo.toml
+++ b/crates/egui/Cargo.toml
@@ -57,7 +57,6 @@ serde = ["dep:serde", "epaint/serde", "accesskit?/serde"]
 [dependencies]
 epaint = { version = "0.19.0", path = "../epaint", default-features = false }
 
-accesskit = { version = "0.8.1", optional = true }
 ahash = { version = "0.8.1", default-features = false, features = [
     "no-rng", # we don't need DOS-protection, so we let users opt-in to it instead
     "std",
@@ -65,6 +64,10 @@ ahash = { version = "0.8.1", default-features = false, features = [
 nohash-hasher = "0.2"
 
 #! ### Optional dependencies
+## Exposes detailed accessibility implementation required by platform
+## accessibility APIs. Also requires support in the egui integration.
+accesskit = { version = "0.8.1", optional = true }
+
 ## Enable this when generating docs.
 document-features = { version = "0.2", optional = true }
 

--- a/crates/egui/Cargo.toml
+++ b/crates/egui/Cargo.toml
@@ -52,11 +52,12 @@ mint = ["epaint/mint"]
 persistence = ["serde", "epaint/serde", "ron"]
 
 ## Allow serialization using [`serde`](https://docs.rs/serde).
-serde = ["dep:serde", "epaint/serde"]
+serde = ["dep:serde", "epaint/serde", "accesskit?/serde"]
 
 [dependencies]
 epaint = { version = "0.19.0", path = "../epaint", default-features = false }
 
+accesskit = { version = "0.8.0", optional = true }
 ahash = { version = "0.8.1", default-features = false, features = [
     "no-rng", # we don't need DOS-protection, so we let users opt-in to it instead
     "std",

--- a/crates/egui/Cargo.toml
+++ b/crates/egui/Cargo.toml
@@ -57,7 +57,7 @@ serde = ["dep:serde", "epaint/serde", "accesskit?/serde"]
 [dependencies]
 epaint = { version = "0.19.0", path = "../epaint", default-features = false }
 
-accesskit = { version = "0.8.0", optional = true }
+accesskit = { version = "0.8.1", optional = true }
 ahash = { version = "0.8.1", default-features = false, features = [
     "no-rng", # we don't need DOS-protection, so we let users opt-in to it instead
     "std",

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -480,7 +480,7 @@ impl Context {
         self.check_for_id_clash(id, rect, "widget");
 
         #[cfg(feature = "accesskit")]
-        if self.is_accesskit_active() && sense.focusable {
+        if sense.focusable {
             // Make sure anything that can receive focus has an AccessKit node.
             // TODO(mwcampbell): For nodes that are filled from widget info,
             // some information is written to the node twice.
@@ -1589,12 +1589,6 @@ impl Context {
             .accesskit_update
             .is_some()
             .then(move || RwLockWriteGuard::map(ctx, |c| c.accesskit_node(id, parent_id)))
-    }
-
-    /// Returns whether AccessKit is active for the current frame.
-    #[cfg(feature = "accesskit")]
-    pub fn is_accesskit_active(&self) -> bool {
-        self.output().accesskit_update.is_some()
     }
 
     /// Enable generation of AccessKit tree updates in all future frames.

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -154,6 +154,11 @@ impl ContextImpl {
     #[cfg(feature = "accesskit")]
     fn accesskit_node(&mut self, id: Id, parent_id: Option<Id>) -> &mut accesskit::Node {
         let nodes = self.frame_state.accesskit_nodes.as_mut().unwrap();
+        // We have to override clippy's map_entry lint here, because the
+        // insertion path also modifies another entry, to establish
+        // the parent/child relationship. Using `HashMap::entry` here
+        // would require two mutable borrows at once.
+        #[allow(clippy::map_entry)]
         if !nodes.contains_key(&id) {
             nodes.insert(id, Default::default());
             let parent_id = parent_id.unwrap_or_else(crate::accesskit_root_id);

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1589,6 +1589,11 @@ impl Context {
 
 /// ## Accessibility
 impl Context {
+    /// Create an AccessKit node with the specified ID if one doesn't already
+    /// exist, then call the provided function with a mutable reference
+    /// to the node. Node that the `parent_id` parameter is ignored if the node
+    /// already exists. If AccessKit isn't active for this frame, this method
+    /// does nothing.
     #[cfg(feature = "accesskit")]
     pub fn mutate_accesskit_node(
         &self,
@@ -1599,11 +1604,18 @@ impl Context {
         self.write().mutate_accesskit_node(id, parent_id, f);
     }
 
+    /// Returns whether AccessKit is active for the current frame.
     #[cfg(feature = "accesskit")]
     pub fn is_accesskit_active(&self) -> bool {
         self.read().is_accesskit_active_this_frame()
     }
 
+    /// Indicates that AccessKit has been activated and egui should generate
+    /// AccessKit tree updates for all subsequent frames. Also requests a repaint
+    /// so a full AccessKit tree will be available as soon as the repaint
+    /// is done. As soon as the egui integration knows that accessibility support
+    /// is desired, it must call this method and provide a placeholder tree
+    /// to AccessKit through the [`crate::accesskit_placeholder_tree_update`] method.
     #[cfg(feature = "accesskit")]
     pub fn accesskit_activated(&self) {
         let mut ctx = self.write();

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -159,13 +159,8 @@ impl ContextImpl {
     fn accesskit_node(&mut self, id: Id) -> &mut accesskit::Node {
         let state = self.frame_state.accesskit_state.as_mut().unwrap();
         let nodes = &mut state.nodes;
-        // We have to override clippy's map_entry lint here, because the
-        // insertion path also modifies another entry, to establish
-        // the parent/child relationship. Using `HashMap::entry` here
-        // would require two mutable borrows at once.
-        #[allow(clippy::map_entry)]
-        if !nodes.contains_key(&id) {
-            nodes.insert(id, Default::default());
+        if let std::collections::hash_map::Entry::Vacant(entry) = nodes.entry(id) {
+            entry.insert(Default::default());
             let parent_id = state.parent_stack.last().unwrap();
             let parent = nodes.get_mut(parent_id).unwrap();
             parent.children.push(id.accesskit_id());

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1577,7 +1577,7 @@ impl Context {
 impl Context {
     /// If AccessKit support is active for the current frame, get or create
     /// a node with the specified ID and return a mutable reference to it.
-    /// `parent_id is ignored if the node already exists.
+    /// `parent_id` is ignored if the node already exists.
     #[cfg(feature = "accesskit")]
     pub fn accesskit_node(
         &self,

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1596,7 +1596,7 @@ impl Context {
         parent_id: Option<Id>,
         f: impl FnOnce(&mut accesskit::Node),
     ) {
-        self.write().mutate_accesskit_node(id, parent_id, f)
+        self.write().mutate_accesskit_node(id, parent_id, f);
     }
 
     #[cfg(feature = "accesskit")]

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -268,6 +268,10 @@ pub enum Event {
         /// The value is in the range from 0.0 (no pressure) to 1.0 (maximum pressure).
         force: f32,
     },
+
+    /// An assistive technology (e.g. screen reader) requested an action.
+    #[cfg(feature = "accesskit")]
+    AccessKitActionRequest(accesskit::ActionRequest),
 }
 
 /// Mouse button (or similar for touch input)

--- a/crates/egui/src/data/output.rs
+++ b/crates/egui/src/data/output.rs
@@ -87,7 +87,7 @@ pub struct PlatformOutput {
     pub text_cursor_pos: Option<crate::Pos2>,
 
     #[cfg(feature = "accesskit")]
-    pub accesskit_update: accesskit::TreeUpdate,
+    pub accesskit_update: Option<accesskit::TreeUpdate>,
 }
 
 impl PlatformOutput {

--- a/crates/egui/src/frame_state.rs
+++ b/crates/egui/src/frame_state.rs
@@ -9,6 +9,13 @@ pub(crate) struct TooltipFrameState {
     pub count: usize,
 }
 
+#[cfg(feature = "accesskit")]
+#[derive(Clone)]
+pub(crate) struct AccessKitFrameState {
+    pub(crate) nodes: IdMap<Box<accesskit::Node>>,
+    pub(crate) parent_stack: Vec<Id>,
+}
+
 /// State that is collected during a frame and then cleared.
 /// Short-term (single frame) memory.
 #[derive(Clone)]
@@ -43,7 +50,7 @@ pub(crate) struct FrameState {
     pub(crate) scroll_target: [Option<(RangeInclusive<f32>, Option<Align>)>; 2],
 
     #[cfg(feature = "accesskit")]
-    pub(crate) accesskit_nodes: Option<IdMap<Box<accesskit::Node>>>,
+    pub(crate) accesskit_state: Option<AccessKitFrameState>,
 }
 
 impl Default for FrameState {
@@ -57,7 +64,7 @@ impl Default for FrameState {
             scroll_delta: Vec2::ZERO,
             scroll_target: [None, None],
             #[cfg(feature = "accesskit")]
-            accesskit_nodes: None,
+            accesskit_state: None,
         }
     }
 }
@@ -73,7 +80,7 @@ impl FrameState {
             scroll_delta,
             scroll_target,
             #[cfg(feature = "accesskit")]
-            accesskit_nodes,
+            accesskit_state,
         } = self;
 
         used_ids.clear();
@@ -85,7 +92,7 @@ impl FrameState {
         *scroll_target = [None, None];
         #[cfg(feature = "accesskit")]
         {
-            *accesskit_nodes = None;
+            *accesskit_state = None;
         }
     }
 

--- a/crates/egui/src/frame_state.rs
+++ b/crates/egui/src/frame_state.rs
@@ -43,7 +43,7 @@ pub(crate) struct FrameState {
     pub(crate) scroll_target: [Option<(RangeInclusive<f32>, Option<Align>)>; 2],
 
     #[cfg(feature = "accesskit")]
-    pub(crate) accesskit_nodes: IdMap<usize>,
+    pub(crate) accesskit_nodes: Option<IdMap<Box<accesskit::Node>>>,
 }
 
 impl Default for FrameState {
@@ -57,7 +57,7 @@ impl Default for FrameState {
             scroll_delta: Vec2::ZERO,
             scroll_target: [None, None],
             #[cfg(feature = "accesskit")]
-            accesskit_nodes: Default::default(),
+            accesskit_nodes: None,
         }
     }
 }
@@ -85,7 +85,7 @@ impl FrameState {
         *scroll_target = [None, None];
         #[cfg(feature = "accesskit")]
         {
-            accesskit_nodes.clear();
+            *accesskit_nodes = None;
         }
     }
 

--- a/crates/egui/src/frame_state.rs
+++ b/crates/egui/src/frame_state.rs
@@ -41,6 +41,9 @@ pub(crate) struct FrameState {
 
     /// horizontal, vertical
     pub(crate) scroll_target: [Option<(RangeInclusive<f32>, Option<Align>)>; 2],
+
+    #[cfg(feature = "accesskit")]
+    pub(crate) accesskit_nodes: IdMap<usize>,
 }
 
 impl Default for FrameState {
@@ -53,6 +56,8 @@ impl Default for FrameState {
             tooltip_state: None,
             scroll_delta: Vec2::ZERO,
             scroll_target: [None, None],
+            #[cfg(feature = "accesskit")]
+            accesskit_nodes: Default::default(),
         }
     }
 }
@@ -67,6 +72,8 @@ impl FrameState {
             tooltip_state,
             scroll_delta,
             scroll_target,
+            #[cfg(feature = "accesskit")]
+            accesskit_nodes,
         } = self;
 
         used_ids.clear();
@@ -76,6 +83,10 @@ impl FrameState {
         *tooltip_state = None;
         *scroll_delta = input.scroll_delta;
         *scroll_target = [None, None];
+        #[cfg(feature = "accesskit")]
+        {
+            accesskit_nodes.clear();
+        }
     }
 
     /// How much space is still available after panels has been added.

--- a/crates/egui/src/id.rs
+++ b/crates/egui/src/id.rs
@@ -69,6 +69,11 @@ impl Id {
     pub(crate) fn value(&self) -> u64 {
         self.0
     }
+
+    #[cfg(feature = "accesskit")]
+    pub(crate) fn accesskit_id(&self) -> accesskit::NodeId {
+        std::num::NonZeroU64::new(self.0).unwrap().into()
+    }
 }
 
 impl std::fmt::Debug for Id {

--- a/crates/egui/src/input_state.rs
+++ b/crates/egui/src/input_state.rs
@@ -395,47 +395,30 @@ impl InputState {
     }
 
     #[cfg(feature = "accesskit")]
-    pub fn accesskit_action_request(
+    pub fn accesskit_action_requests(
         &self,
         id: crate::Id,
         action: accesskit::Action,
-    ) -> Option<&accesskit::ActionRequest> {
+    ) -> impl Iterator<Item = &accesskit::ActionRequest> {
         let accesskit_id = id.accesskit_id();
-        for event in &self.events {
+        self.events.iter().filter_map(move |event| {
             if let Event::AccessKitActionRequest(request) = event {
                 if request.target == accesskit_id && request.action == action {
                     return Some(request);
                 }
             }
-        }
-        None
+            None
+        })
     }
 
     #[cfg(feature = "accesskit")]
     pub fn has_accesskit_action_request(&self, id: crate::Id, action: accesskit::Action) -> bool {
-        self.accesskit_action_request(id, action).is_some()
+        self.accesskit_action_requests(id, action).next().is_some()
     }
 
     #[cfg(feature = "accesskit")]
-    pub fn num_accesskit_action_requests(
-        &self,
-        id: crate::Id,
-        desired_action: accesskit::Action,
-    ) -> usize {
-        let accesskit_id = id.accesskit_id();
-        self.events
-            .iter()
-            .filter(|event| {
-                matches!(
-                    event,
-                    Event::AccessKitActionRequest(accesskit::ActionRequest {
-                        target,
-                        action,
-                        ..
-                    }) if *target == accesskit_id && *action == desired_action
-                )
-            })
-            .count()
+    pub fn num_accesskit_action_requests(&self, id: crate::Id, action: accesskit::Action) -> usize {
+        self.accesskit_action_requests(id, action).count()
     }
 }
 

--- a/crates/egui/src/input_state.rs
+++ b/crates/egui/src/input_state.rs
@@ -393,6 +393,50 @@ impl InputState {
             }
         }
     }
+
+    #[cfg(feature = "accesskit")]
+    pub fn accesskit_action_request(
+        &self,
+        id: crate::Id,
+        action: accesskit::Action,
+    ) -> Option<&accesskit::ActionRequest> {
+        let accesskit_id = id.accesskit_id();
+        for event in &self.events {
+            if let Event::AccessKitActionRequest(request) = event {
+                if request.target == accesskit_id && request.action == action {
+                    return Some(request);
+                }
+            }
+        }
+        None
+    }
+
+    #[cfg(feature = "accesskit")]
+    pub fn has_accesskit_action_request(&self, id: crate::Id, action: accesskit::Action) -> bool {
+        self.accesskit_action_request(id, action).is_some()
+    }
+
+    #[cfg(feature = "accesskit")]
+    pub fn num_accesskit_action_requests(
+        &self,
+        id: crate::Id,
+        desired_action: accesskit::Action,
+    ) -> usize {
+        let accesskit_id = id.accesskit_id();
+        self.events
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    Event::AccessKitActionRequest(accesskit::ActionRequest {
+                        target,
+                        action,
+                        ..
+                    }) if *target == accesskit_id && *action == desired_action
+                )
+            })
+            .count()
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -324,6 +324,9 @@ pub mod util;
 pub mod widget_text;
 pub mod widgets;
 
+#[cfg(feature = "accesskit")]
+pub use accesskit;
+
 pub use epaint;
 pub use epaint::emath;
 
@@ -548,4 +551,28 @@ pub fn __run_test_ui(mut add_contents: impl FnMut(&mut Ui)) {
             add_contents(ui);
         });
     });
+}
+
+#[cfg(feature = "accesskit")]
+pub fn accesskit_root_id() -> Id {
+    Id::new("accesskit_root")
+}
+
+#[cfg(feature = "accesskit")]
+pub fn accesskit_placeholder_tree_update() -> accesskit::TreeUpdate {
+    use accesskit::{Node, Role, Tree, TreeUpdate};
+    use std::sync::Arc;
+
+    let root_id = accesskit_root_id().accesskit_id();
+    TreeUpdate {
+        nodes: vec![(
+            root_id,
+            Arc::new(Node {
+                role: Role::Window,
+                ..Default::default()
+            }),
+        )],
+        tree: Some(Tree::new(root_id)),
+        focus: None,
+    }
 }

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -558,8 +558,9 @@ pub fn accesskit_root_id() -> Id {
     Id::new("accesskit_root")
 }
 
-/// Return a tree update that the egui integration should provide to AccessKit
-/// before a real tree update is available. See also [`crate::Context::accesskit_activated`].
+/// Return a tree update that the egui integration should provide to the
+/// AccessKit adapter before a real tree update is available. See also
+/// [`crate::Context::accesskit_activated`].
 #[cfg(feature = "accesskit")]
 pub fn accesskit_placeholder_tree_update() -> accesskit::TreeUpdate {
     use accesskit::{Node, Role, Tree, TreeUpdate};

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -558,6 +558,8 @@ pub fn accesskit_root_id() -> Id {
     Id::new("accesskit_root")
 }
 
+/// Return a tree update that the egui integration should provide to AccessKit
+/// before a real tree update is available. See also [`crate::Context::accesskit_activated`].
 #[cfg(feature = "accesskit")]
 pub fn accesskit_placeholder_tree_update() -> accesskit::TreeUpdate {
     use accesskit::{Node, Role, Tree, TreeUpdate};

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -559,8 +559,8 @@ pub fn accesskit_root_id() -> Id {
 }
 
 /// Return a tree update that the egui integration should provide to the
-/// AccessKit adapter before a real tree update is available. See also
-/// [`crate::Context::accesskit_activated`].
+/// AccessKit adapter if it cannot immediately run the egui application
+/// to get a full tree update after running [`Context::enable_accesskit`].
 #[cfg(feature = "accesskit")]
 pub fn accesskit_placeholder_tree_update() -> accesskit::TreeUpdate {
     use accesskit::{Node, Role, Tree, TreeUpdate};

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -552,7 +552,7 @@ impl Response {
         if self.sense.focusable {
             node.focusable = true;
         }
-        if self.sense.click {
+        if self.sense.click && node.default_action_verb.is_none() {
             node.default_action_verb = Some(accesskit::DefaultActionVerb::Click);
         }
     }

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -604,6 +604,18 @@ impl Response {
     }
 
     /// Associate a label with a control for accessibility.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # egui::__run_test_ui(|ui| {
+    /// # let mut text = "Arthur".to_string();
+    /// ui.horizontal(|ui| {
+    ///     let label = ui.label("Your name: ");
+    ///     ui.text_edit_singleline(&mut text).labelled_by(label.id);
+    /// });
+    /// # });
+    /// ```
     pub fn labelled_by(self, id: Id) -> Self {
         #[cfg(feature = "accesskit")]
         if let Some(mut node) = self.ctx.accesskit_node(self.id) {

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -529,17 +529,17 @@ impl Response {
             self.output_event(event);
         } else {
             #[cfg(feature = "accesskit")]
-            self.ctx.mutate_accesskit_node(self.id, None, |node| {
-                self.fill_accesskit_node_from_widget_info(node, make_info());
-            });
+            if let Some(mut node) = self.ctx.accesskit_node(self.id, None) {
+                self.fill_accesskit_node_from_widget_info(&mut node, make_info());
+            }
         }
     }
 
     pub fn output_event(&self, event: crate::output::OutputEvent) {
         #[cfg(feature = "accesskit")]
-        self.ctx.mutate_accesskit_node(self.id, None, |node| {
-            self.fill_accesskit_node_from_widget_info(node, event.widget_info().clone());
-        });
+        if let Some(mut node) = self.ctx.accesskit_node(self.id, None) {
+            self.fill_accesskit_node_from_widget_info(&mut node, event.widget_info().clone());
+        }
         self.ctx.output().events.push(event);
     }
 
@@ -606,9 +606,9 @@ impl Response {
     /// Associate a label with a control for accessibility.
     pub fn labelled_by(self, id: Id) -> Self {
         #[cfg(feature = "accesskit")]
-        self.ctx.mutate_accesskit_node(self.id, None, |node| {
+        if let Some(mut node) = self.ctx.accesskit_node(self.id, None) {
             node.labelled_by.push(id.accesskit_id());
-        });
+        }
         #[cfg(not(feature = "accesskit"))]
         {
             let _ = id;

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -529,7 +529,7 @@ impl Response {
             self.output_event(event);
         } else {
             #[cfg(feature = "accesskit")]
-            if let Some(mut node) = self.ctx.accesskit_node(self.id, None) {
+            if let Some(mut node) = self.ctx.accesskit_node(self.id) {
                 self.fill_accesskit_node_from_widget_info(&mut node, make_info());
             }
         }
@@ -537,7 +537,7 @@ impl Response {
 
     pub fn output_event(&self, event: crate::output::OutputEvent) {
         #[cfg(feature = "accesskit")]
-        if let Some(mut node) = self.ctx.accesskit_node(self.id, None) {
+        if let Some(mut node) = self.ctx.accesskit_node(self.id) {
             self.fill_accesskit_node_from_widget_info(&mut node, event.widget_info().clone());
         }
         self.ctx.output().events.push(event);
@@ -606,7 +606,7 @@ impl Response {
     /// Associate a label with a control for accessibility.
     pub fn labelled_by(self, id: Id) -> Self {
         #[cfg(feature = "accesskit")]
-        if let Some(mut node) = self.ctx.accesskit_node(self.id, None) {
+        if let Some(mut node) = self.ctx.accesskit_node(self.id) {
             node.labelled_by.push(id.accesskit_id());
         }
         #[cfg(not(feature = "accesskit"))]

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -526,8 +526,91 @@ impl Response {
             None
         };
         if let Some(event) = event {
-            self.ctx.output().events.push(event);
+            self.output_event(event);
+        } else {
+            #[cfg(feature = "accesskit")]
+            {
+                self.fill_accesskit_node_from_widget_info(make_info());
+            }
         }
+    }
+
+    pub fn output_event(&self, event: crate::output::OutputEvent) {
+        #[cfg(feature = "accesskit")]
+        self.fill_accesskit_node_from_widget_info(event.widget_info().clone());
+        self.ctx.output().events.push(event);
+    }
+
+    #[cfg(feature = "accesskit")]
+    pub(crate) fn fill_accesskit_node_common(&self, node: &mut accesskit::Node) {
+        node.bounds = Some(accesskit::kurbo::Rect {
+            x0: self.rect.min.x.into(),
+            y0: self.rect.min.y.into(),
+            x1: self.rect.max.x.into(),
+            y1: self.rect.max.y.into(),
+        });
+        if self.sense.focusable {
+            node.focusable = true;
+        }
+        if self.sense.click {
+            node.default_action_verb = Some(accesskit::DefaultActionVerb::Click);
+        }
+    }
+
+    #[cfg(feature = "accesskit")]
+    fn fill_accesskit_node_from_widget_info(&self, info: crate::WidgetInfo) {
+        use crate::WidgetType;
+        use accesskit::{CheckedState, Role};
+
+        let mut node = self.ctx.accesskit_node(self.id, None);
+        self.fill_accesskit_node_common(&mut node);
+        node.role = match info.typ {
+            WidgetType::Label => Role::StaticText,
+            WidgetType::Link => Role::Link,
+            WidgetType::TextEdit => Role::TextField,
+            WidgetType::Button | WidgetType::ImageButton | WidgetType::CollapsingHeader => {
+                Role::Button
+            }
+            WidgetType::Checkbox => Role::CheckBox,
+            WidgetType::RadioButton => Role::RadioButton,
+            WidgetType::SelectableLabel => Role::ToggleButton,
+            WidgetType::ComboBox => Role::PopupButton,
+            WidgetType::Slider => Role::Slider,
+            WidgetType::DragValue => Role::SpinButton,
+            WidgetType::ColorButton => Role::ColorWell,
+            WidgetType::Other => Role::Unknown,
+        };
+        if let Some(label) = info.label {
+            node.name = Some(label.into());
+        }
+        if let Some(value) = info.current_text_value {
+            node.value = Some(value.into());
+        }
+        if let Some(value) = info.value {
+            node.numeric_value = Some(value);
+        }
+        if let Some(selected) = info.selected {
+            node.checked_state = Some(if selected {
+                CheckedState::True
+            } else {
+                CheckedState::False
+            });
+        }
+    }
+
+    /// Associate a label with a control for accessibility.
+    pub fn labelled_by(self, id: Id) -> Self {
+        #[cfg(feature = "accesskit")]
+        {
+            let mut node = self.ctx.accesskit_node(self.id, None);
+            node.labelled_by.push(id.accesskit_id());
+        }
+        #[cfg(not(feature = "accesskit"))]
+        {
+            let _ = id;
+        }
+
+        self
     }
 
     /// Response to secondary clicks (right-clicks) by showing the given menu.

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -417,6 +417,16 @@ impl<'a> Widget for DragValue<'a> {
             change
         };
 
+        #[cfg(feature = "accesskit")]
+        {
+            use accesskit::{Action, ActionData};
+            for request in ui.input().accesskit_action_requests(id, Action::SetValue) {
+                if let Some(ActionData::NumericValue(new_value)) = request.data {
+                    value = new_value;
+                }
+            }
+        }
+
         if change != 0.0 {
             value += speed * change;
             value = emath::round_to_decimals(value, auto_decimals);
@@ -543,6 +553,8 @@ impl<'a> Widget for DragValue<'a> {
             if clamp_range.end().is_finite() {
                 node.max_numeric_value = Some(*clamp_range.end());
             }
+            node.numeric_value_step = Some(speed);
+            node.actions |= Action::SetValue;
             if value < *clamp_range.end() {
                 node.actions |= Action::Increment;
             }

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -541,7 +541,7 @@ impl<'a> Widget for DragValue<'a> {
         response.widget_info(|| WidgetInfo::drag_value(value));
 
         #[cfg(feature = "accesskit")]
-        if let Some(mut node) = ui.ctx().accesskit_node(response.id, None) {
+        if let Some(mut node) = ui.ctx().accesskit_node(response.id) {
             use accesskit::Action;
             // If either end of the range is unbounded, it's better
             // to leave the corresponding AccessKit field set to None,

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -449,7 +449,8 @@ impl<'a> Widget for DragValue<'a> {
             }
         };
 
-        #[allow(clippy::redundant_clone)] // some clones below are redundant if AccessKit is disabled
+        // some clones below are redundant if AccessKit is disabled
+        #[allow(clippy::redundant_clone)]
         let mut response = if is_kb_editing {
             let button_width = ui.spacing().interact_size.x;
             let mut value_text = ui

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -541,9 +541,8 @@ impl<'a> Widget for DragValue<'a> {
         response.widget_info(|| WidgetInfo::drag_value(value));
 
         #[cfg(feature = "accesskit")]
-        {
+        ui.ctx().mutate_accesskit_node(response.id, None, |node| {
             use accesskit::Action;
-            let mut node = ui.ctx().accesskit_node(response.id, None);
             // If either end of the range is unbounded, it's better
             // to leave the corresponding AccessKit field set to None,
             // to allow for platform-specific default behavior.
@@ -586,7 +585,7 @@ impl<'a> Widget for DragValue<'a> {
                 let value_text = format!("{}{}{}", prefix, value_text, suffix);
                 node.value = Some(value_text.into());
             }
-        }
+        });
 
         response
     }

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -447,7 +447,7 @@ impl<'a> Widget for DragValue<'a> {
                 .drag_value
                 .edit_string
                 .take()
-                .unwrap_or(value_text.clone());
+                .unwrap_or_else(|| value_text.clone());
             let response = ui.add(
                 TextEdit::singleline(&mut value_text)
                     .id(id)

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -449,7 +449,7 @@ impl<'a> Widget for DragValue<'a> {
             }
         };
 
-        #[allow(clippy::redundant_clone)] // some clones below are dundant if AccessKit is disabled
+        #[allow(clippy::redundant_clone)] // some clones below are redundant if AccessKit is disabled
         let mut response = if is_kb_editing {
             let button_width = ui.spacing().interact_size.x;
             let mut value_text = ui

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -541,7 +541,7 @@ impl<'a> Widget for DragValue<'a> {
         response.widget_info(|| WidgetInfo::drag_value(value));
 
         #[cfg(feature = "accesskit")]
-        ui.ctx().mutate_accesskit_node(response.id, None, |node| {
+        if let Some(mut node) = ui.ctx().accesskit_node(response.id, None) {
             use accesskit::Action;
             // If either end of the range is unbounded, it's better
             // to leave the corresponding AccessKit field set to None,
@@ -585,7 +585,7 @@ impl<'a> Widget for DragValue<'a> {
                 let value_text = format!("{}{}{}", prefix, value_text, suffix);
                 node.value = Some(value_text.into());
             }
-        });
+        }
 
         response
     }

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -16,7 +16,7 @@ use crate::{widget_text::WidgetTextGalley, *};
 pub struct Label {
     text: WidgetText,
     wrap: Option<bool>,
-    sense: Sense,
+    sense: Option<Sense>,
 }
 
 impl Label {
@@ -24,7 +24,7 @@ impl Label {
         Self {
             text: text.into(),
             wrap: None,
-            sense: Sense::focusable_noninteractive(),
+            sense: None,
         }
     }
 
@@ -60,7 +60,7 @@ impl Label {
     /// # });
     /// ```
     pub fn sense(mut self, sense: Sense) -> Self {
-        self.sense = sense;
+        self.sense = Some(sense);
         self
     }
 }
@@ -68,9 +68,17 @@ impl Label {
 impl Label {
     /// Do layout and position the galley in the ui, without painting it or adding widget info.
     pub fn layout_in_ui(self, ui: &mut Ui) -> (Pos2, WidgetTextGalley, Response) {
+        let sense = self.sense.unwrap_or_else(|| {
+            // We only want to focus labels if the screen reader is on.
+            if ui.memory().options.screen_reader {
+                Sense::focusable_noninteractive()
+            } else {
+                Sense::hover()
+            }
+        });
         if let WidgetText::Galley(galley) = self.text {
             // If the user said "use this specific galley", then just use it:
-            let (rect, response) = ui.allocate_exact_size(galley.size(), self.sense);
+            let (rect, response) = ui.allocate_exact_size(galley.size(), sense);
             let pos = match galley.job.halign {
                 Align::LEFT => rect.left_top(),
                 Align::Center => rect.center_top(),
@@ -121,10 +129,10 @@ impl Label {
             let rect = text_galley.galley.rows[0]
                 .rect
                 .translate(vec2(pos.x, pos.y));
-            let mut response = ui.allocate_rect(rect, self.sense);
+            let mut response = ui.allocate_rect(rect, sense);
             for row in text_galley.galley.rows.iter().skip(1) {
                 let rect = row.rect.translate(vec2(pos.x, pos.y));
-                response |= ui.allocate_rect(rect, self.sense);
+                response |= ui.allocate_rect(rect, sense);
             }
             (pos, text_galley, response)
         } else {
@@ -144,7 +152,7 @@ impl Label {
             };
 
             let text_galley = text_job.into_galley(&ui.fonts());
-            let (rect, response) = ui.allocate_exact_size(text_galley.size(), self.sense);
+            let (rect, response) = ui.allocate_exact_size(text_galley.size(), sense);
             let pos = match text_galley.galley.job.halign {
                 Align::LEFT => rect.left_top(),
                 Align::Center => rect.center_top(),

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -756,7 +756,9 @@ impl<'a> Slider<'a> {
             }
         }
 
-        if self.show_value {
+        let slider_response = response.clone();
+
+        let value_response = if self.show_value {
             let position_range = self.position_range(&response.rect);
             let value_response = self.value_ui(ui, position_range);
             if value_response.gained_focus()
@@ -768,12 +770,23 @@ impl<'a> Slider<'a> {
                 response = value_response.union(response);
             } else {
                 // Use the slider id as the id for the whole widget
-                response = response.union(value_response);
+                response = response.union(value_response.clone());
             }
-        }
+            Some(value_response)
+        } else {
+            None
+        };
 
         if !self.text.is_empty() {
-            ui.add(Label::new(self.text.clone()).wrap(false));
+            let label_response = ui.add(Label::new(self.text.clone()).wrap(false));
+            // The slider already has an accessibility label via widget info,
+            // but sometimes it's useful for a screen reader to know
+            // that a piece of text is a label for another widget,
+            // e.g. so the text itself can be excluded from navigation.
+            slider_response.labelled_by(label_response.id);
+            if let Some(value_response) = value_response {
+                value_response.labelled_by(label_response.id);
+            }
         }
 
         response

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -740,7 +740,7 @@ impl<'a> Slider<'a> {
         response.widget_info(|| WidgetInfo::slider(value, self.text.text()));
 
         #[cfg(feature = "accesskit")]
-        ui.ctx().mutate_accesskit_node(response.id, None, |node| {
+        if let Some(mut node) = ui.ctx().accesskit_node(response.id, None) {
             use accesskit::Action;
             node.min_numeric_value = Some(*self.range.start());
             node.max_numeric_value = Some(*self.range.end());
@@ -753,7 +753,7 @@ impl<'a> Slider<'a> {
             if value > *clamp_range.start() {
                 node.actions |= Action::Decrement;
             }
-        });
+        }
 
         let slider_response = response.clone();
 

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -740,7 +740,7 @@ impl<'a> Slider<'a> {
         response.widget_info(|| WidgetInfo::slider(value, self.text.text()));
 
         #[cfg(feature = "accesskit")]
-        if let Some(mut node) = ui.ctx().accesskit_node(response.id, None) {
+        if let Some(mut node) = ui.ctx().accesskit_node(response.id) {
             use accesskit::Action;
             node.min_numeric_value = Some(*self.range.start());
             node.max_numeric_value = Some(*self.range.end());

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -450,7 +450,7 @@ impl<'a> Slider<'a> {
     /// If you use one of the integer constructors (e.g. `Slider::i32`) this is called for you,
     /// but if you want to have a slider for picking integer values in an `Slider::f64`, use this.
     pub fn integer(self) -> Self {
-        self.fixed_decimals(0).smallest_positive(1.0)
+        self.fixed_decimals(0).smallest_positive(1.0).step_by(1.0)
     }
 
     fn get_value(&mut self) -> f64 {

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -740,9 +740,8 @@ impl<'a> Slider<'a> {
         response.widget_info(|| WidgetInfo::slider(value, self.text.text()));
 
         #[cfg(feature = "accesskit")]
-        {
+        ui.ctx().mutate_accesskit_node(response.id, None, |node| {
             use accesskit::Action;
-            let mut node = ui.ctx().accesskit_node(response.id, None);
             node.min_numeric_value = Some(*self.range.start());
             node.max_numeric_value = Some(*self.range.end());
             node.numeric_value_step = self.step;
@@ -754,7 +753,7 @@ impl<'a> Slider<'a> {
             if value > *clamp_range.start() {
                 node.actions |= Action::Decrement;
             }
-        }
+        });
 
         let slider_response = response.clone();
 

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -578,6 +578,19 @@ impl<'a> Slider<'a> {
             self.set_value(new_value);
         }
 
+        #[cfg(feature = "accesskit")]
+        {
+            use accesskit::{Action, ActionData};
+            for request in ui
+                .input()
+                .accesskit_action_requests(response.id, Action::SetValue)
+            {
+                if let Some(ActionData::NumericValue(new_value)) = request.data {
+                    self.set_value(new_value);
+                }
+            }
+        }
+
         // Paint it:
         if ui.is_rect_visible(response.rect) {
             let value = self.get_value();
@@ -732,6 +745,8 @@ impl<'a> Slider<'a> {
             let mut node = ui.ctx().accesskit_node(response.id, None);
             node.min_numeric_value = Some(*self.range.start());
             node.max_numeric_value = Some(*self.range.end());
+            node.numeric_value_step = self.step;
+            node.actions |= Action::SetValue;
             let clamp_range = self.clamp_range();
             if value < *clamp_range.end() {
                 node.actions |= Action::Increment;

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -696,7 +696,8 @@ impl<'t> TextEdit<'t> {
                         y1: rect.max.y.into(),
                     });
                     node.text_direction = Some(TextDirection::LeftToRight);
-                    // TODO: more info for the whole row
+                    // TODO(mwcampbell): Set more node fields for the row
+                    // once AccessKit adapters expose text formatting info.
 
                     let glyph_count = row.glyphs.len();
                     let mut value = String::new();

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -659,84 +659,84 @@ impl<'t> TextEdit<'t> {
         }
 
         #[cfg(feature = "accesskit")]
-        if ui.ctx().is_accesskit_active() {
+        if let Some(mut node) = ui.ctx().accesskit_node(response.id, None) {
             use accesskit::{Role, TextDirection, TextPosition, TextSelection};
 
             let parent_id = response.id;
-            for (i, row) in galley.rows.iter().enumerate() {
-                let id = parent_id.with(i);
-                if let Some(mut node) = ui.ctx().accesskit_node(id, Some(parent_id)) {
-                    node.role = Role::InlineTextBox;
-                    let rect = row.rect.translate(text_draw_pos.to_vec2());
-                    node.bounds = Some(accesskit::kurbo::Rect {
-                        x0: rect.min.x.into(),
-                        y0: rect.min.y.into(),
-                        x1: rect.max.x.into(),
-                        y1: rect.max.y.into(),
-                    });
-                    node.text_direction = Some(TextDirection::LeftToRight);
-                    // TODO: more info for the whole row
 
-                    let glyph_count = row.glyphs.len();
-                    let mut value = String::new();
-                    value.reserve(glyph_count);
-                    let mut character_lengths = Vec::<u8>::new();
-                    character_lengths.reserve(glyph_count);
-                    let mut character_positions = Vec::<f32>::new();
-                    character_positions.reserve(glyph_count);
-                    let mut character_widths = Vec::<f32>::new();
-                    character_widths.reserve(glyph_count);
-                    let mut word_lengths = Vec::<u8>::new();
-                    let mut was_at_word_end = false;
-                    let mut last_word_start = 0usize;
-
-                    for glyph in &row.glyphs {
-                        let is_word_char = is_word_char(glyph.chr);
-                        if is_word_char && was_at_word_end {
-                            word_lengths.push((character_lengths.len() - last_word_start) as _);
-                            last_word_start = character_lengths.len();
-                        }
-                        was_at_word_end = !is_word_char;
-                        let old_len = value.len();
-                        value.push(glyph.chr);
-                        character_lengths.push((value.len() - old_len) as _);
-                        character_positions.push(glyph.pos.x - row.rect.min.x);
-                        character_widths.push(glyph.size.x);
-                    }
-
-                    if row.ends_with_newline {
-                        value.push('\n');
-                        character_lengths.push(1);
-                        character_positions.push(row.rect.max.x - row.rect.min.x);
-                        character_widths.push(0.0);
-                    }
-                    word_lengths.push((character_lengths.len() - last_word_start) as _);
-
-                    node.value = Some(value.into());
-                    node.character_lengths = character_lengths.into();
-                    node.character_positions = Some(character_positions.into());
-                    node.character_widths = Some(character_widths.into());
-                    node.word_lengths = word_lengths.into();
-                }
+            if let Some(cursor_range) = &cursor_range {
+                let anchor = &cursor_range.secondary.rcursor;
+                let focus = &cursor_range.primary.rcursor;
+                node.text_selection = Some(TextSelection {
+                    anchor: TextPosition {
+                        node: parent_id.with(anchor.row).accesskit_id(),
+                        character_index: anchor.column,
+                    },
+                    focus: TextPosition {
+                        node: parent_id.with(focus.row).accesskit_id(),
+                        character_index: focus.column,
+                    },
+                });
             }
 
-            if let Some(mut node) = ui.ctx().accesskit_node(parent_id, None) {
-                if let Some(cursor_range) = &cursor_range {
-                    let anchor = &cursor_range.secondary.rcursor;
-                    let focus = &cursor_range.primary.rcursor;
-                    node.text_selection = Some(TextSelection {
-                        anchor: TextPosition {
-                            node: parent_id.with(anchor.row).accesskit_id(),
-                            character_index: anchor.column,
-                        },
-                        focus: TextPosition {
-                            node: parent_id.with(focus.row).accesskit_id(),
-                            character_index: focus.column,
-                        },
-                    });
+            node.default_action_verb = Some(accesskit::DefaultActionVerb::Focus);
+
+            drop(node);
+
+            for (i, row) in galley.rows.iter().enumerate() {
+                let id = parent_id.with(i);
+                let mut node = ui.ctx().accesskit_node(id, Some(parent_id)).unwrap();
+                node.role = Role::InlineTextBox;
+                let rect = row.rect.translate(text_draw_pos.to_vec2());
+                node.bounds = Some(accesskit::kurbo::Rect {
+                    x0: rect.min.x.into(),
+                    y0: rect.min.y.into(),
+                    x1: rect.max.x.into(),
+                    y1: rect.max.y.into(),
+                });
+                node.text_direction = Some(TextDirection::LeftToRight);
+                // TODO: more info for the whole row
+
+                let glyph_count = row.glyphs.len();
+                let mut value = String::new();
+                value.reserve(glyph_count);
+                let mut character_lengths = Vec::<u8>::new();
+                character_lengths.reserve(glyph_count);
+                let mut character_positions = Vec::<f32>::new();
+                character_positions.reserve(glyph_count);
+                let mut character_widths = Vec::<f32>::new();
+                character_widths.reserve(glyph_count);
+                let mut word_lengths = Vec::<u8>::new();
+                let mut was_at_word_end = false;
+                let mut last_word_start = 0usize;
+
+                for glyph in &row.glyphs {
+                    let is_word_char = is_word_char(glyph.chr);
+                    if is_word_char && was_at_word_end {
+                        word_lengths.push((character_lengths.len() - last_word_start) as _);
+                        last_word_start = character_lengths.len();
+                    }
+                    was_at_word_end = !is_word_char;
+                    let old_len = value.len();
+                    value.push(glyph.chr);
+                    character_lengths.push((value.len() - old_len) as _);
+                    character_positions.push(glyph.pos.x - row.rect.min.x);
+                    character_widths.push(glyph.size.x);
                 }
 
-                node.default_action_verb = Some(accesskit::DefaultActionVerb::Focus);
+                if row.ends_with_newline {
+                    value.push('\n');
+                    character_lengths.push(1);
+                    character_positions.push(row.rect.max.x - row.rect.min.x);
+                    character_widths.push(0.0);
+                }
+                word_lengths.push((character_lengths.len() - last_word_start) as _);
+
+                node.value = Some(value.into());
+                node.character_lengths = character_lengths.into();
+                node.character_positions = Some(character_positions.into());
+                node.character_widths = Some(character_widths.into());
+                node.word_lengths = word_lengths.into();
             }
         }
 

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -665,7 +665,7 @@ impl<'t> TextEdit<'t> {
             let parent_id = response.id;
             for (i, row) in galley.rows.iter().enumerate() {
                 let id = parent_id.with(i);
-                ui.ctx().mutate_accesskit_node(id, Some(parent_id), |node| {
+                if let Some(mut node) = ui.ctx().accesskit_node(id, Some(parent_id)) {
                     node.role = Role::InlineTextBox;
                     let rect = row.rect.translate(text_draw_pos.to_vec2());
                     node.bounds = Some(accesskit::kurbo::Rect {
@@ -717,10 +717,10 @@ impl<'t> TextEdit<'t> {
                     node.character_positions = Some(character_positions.into());
                     node.character_widths = Some(character_widths.into());
                     node.word_lengths = word_lengths.into();
-                });
+                }
             }
 
-            ui.ctx().mutate_accesskit_node(parent_id, None, |node| {
+            if let Some(mut node) = ui.ctx().accesskit_node(parent_id, None) {
                 if let Some(cursor_range) = &cursor_range {
                     let anchor = &cursor_range.secondary.rcursor;
                     let focus = &cursor_range.primary.rcursor;
@@ -737,7 +737,7 @@ impl<'t> TextEdit<'t> {
                 }
 
                 node.default_action_verb = Some(accesskit::DefaultActionVerb::Focus);
-            });
+            }
         }
 
         TextEditOutput {

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -719,8 +719,9 @@ impl<'t> TextEdit<'t> {
                 node.word_lengths = word_lengths.into();
             }
 
+            let mut node = ui.ctx().accesskit_node(parent_id, None);
+
             if let Some(cursor_range) = &cursor_range {
-                let mut node = ui.ctx().accesskit_node(parent_id, None);
                 let anchor = &cursor_range.secondary.rcursor;
                 let focus = &cursor_range.primary.rcursor;
                 node.text_selection = Some(TextSelection {
@@ -734,6 +735,8 @@ impl<'t> TextEdit<'t> {
                     },
                 });
             }
+
+            node.default_action_verb = Some(accesskit::DefaultActionVerb::Focus);
         }
 
         TextEditOutput {

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -659,84 +659,85 @@ impl<'t> TextEdit<'t> {
         }
 
         #[cfg(feature = "accesskit")]
-        {
+        if ui.ctx().is_accesskit_active() {
             use accesskit::{Role, TextDirection, TextPosition, TextSelection};
 
             let parent_id = response.id;
             for (i, row) in galley.rows.iter().enumerate() {
                 let id = parent_id.with(i);
-                let mut node = ui.ctx().accesskit_node(id, Some(parent_id));
-                node.role = Role::InlineTextBox;
-                let rect = row.rect.translate(text_draw_pos.to_vec2());
-                node.bounds = Some(accesskit::kurbo::Rect {
-                    x0: rect.min.x.into(),
-                    y0: rect.min.y.into(),
-                    x1: rect.max.x.into(),
-                    y1: rect.max.y.into(),
-                });
-                node.text_direction = Some(TextDirection::LeftToRight);
-                // TODO: more info for the whole row
+                ui.ctx().mutate_accesskit_node(id, Some(parent_id), |node| {
+                    node.role = Role::InlineTextBox;
+                    let rect = row.rect.translate(text_draw_pos.to_vec2());
+                    node.bounds = Some(accesskit::kurbo::Rect {
+                        x0: rect.min.x.into(),
+                        y0: rect.min.y.into(),
+                        x1: rect.max.x.into(),
+                        y1: rect.max.y.into(),
+                    });
+                    node.text_direction = Some(TextDirection::LeftToRight);
+                    // TODO: more info for the whole row
 
-                let glyph_count = row.glyphs.len();
-                let mut value = String::new();
-                value.reserve(glyph_count);
-                let mut character_lengths = Vec::<u8>::new();
-                character_lengths.reserve(glyph_count);
-                let mut character_positions = Vec::<f32>::new();
-                character_positions.reserve(glyph_count);
-                let mut character_widths = Vec::<f32>::new();
-                character_widths.reserve(glyph_count);
-                let mut word_lengths = Vec::<u8>::new();
-                let mut was_at_word_end = false;
-                let mut last_word_start = 0usize;
+                    let glyph_count = row.glyphs.len();
+                    let mut value = String::new();
+                    value.reserve(glyph_count);
+                    let mut character_lengths = Vec::<u8>::new();
+                    character_lengths.reserve(glyph_count);
+                    let mut character_positions = Vec::<f32>::new();
+                    character_positions.reserve(glyph_count);
+                    let mut character_widths = Vec::<f32>::new();
+                    character_widths.reserve(glyph_count);
+                    let mut word_lengths = Vec::<u8>::new();
+                    let mut was_at_word_end = false;
+                    let mut last_word_start = 0usize;
 
-                for glyph in &row.glyphs {
-                    let is_word_char = is_word_char(glyph.chr);
-                    if is_word_char && was_at_word_end {
-                        word_lengths.push((character_lengths.len() - last_word_start) as _);
-                        last_word_start = character_lengths.len();
+                    for glyph in &row.glyphs {
+                        let is_word_char = is_word_char(glyph.chr);
+                        if is_word_char && was_at_word_end {
+                            word_lengths.push((character_lengths.len() - last_word_start) as _);
+                            last_word_start = character_lengths.len();
+                        }
+                        was_at_word_end = !is_word_char;
+                        let old_len = value.len();
+                        value.push(glyph.chr);
+                        character_lengths.push((value.len() - old_len) as _);
+                        character_positions.push(glyph.pos.x - row.rect.min.x);
+                        character_widths.push(glyph.size.x);
                     }
-                    was_at_word_end = !is_word_char;
-                    let old_len = value.len();
-                    value.push(glyph.chr);
-                    character_lengths.push((value.len() - old_len) as _);
-                    character_positions.push(glyph.pos.x - row.rect.min.x);
-                    character_widths.push(glyph.size.x);
-                }
 
-                if row.ends_with_newline {
-                    value.push('\n');
-                    character_lengths.push(1);
-                    character_positions.push(row.rect.max.x - row.rect.min.x);
-                    character_widths.push(0.0);
-                }
-                word_lengths.push((character_lengths.len() - last_word_start) as _);
+                    if row.ends_with_newline {
+                        value.push('\n');
+                        character_lengths.push(1);
+                        character_positions.push(row.rect.max.x - row.rect.min.x);
+                        character_widths.push(0.0);
+                    }
+                    word_lengths.push((character_lengths.len() - last_word_start) as _);
 
-                node.value = Some(value.into());
-                node.character_lengths = character_lengths.into();
-                node.character_positions = Some(character_positions.into());
-                node.character_widths = Some(character_widths.into());
-                node.word_lengths = word_lengths.into();
-            }
-
-            let mut node = ui.ctx().accesskit_node(parent_id, None);
-
-            if let Some(cursor_range) = &cursor_range {
-                let anchor = &cursor_range.secondary.rcursor;
-                let focus = &cursor_range.primary.rcursor;
-                node.text_selection = Some(TextSelection {
-                    anchor: TextPosition {
-                        node: parent_id.with(anchor.row).accesskit_id(),
-                        character_index: anchor.column,
-                    },
-                    focus: TextPosition {
-                        node: parent_id.with(focus.row).accesskit_id(),
-                        character_index: focus.column,
-                    },
+                    node.value = Some(value.into());
+                    node.character_lengths = character_lengths.into();
+                    node.character_positions = Some(character_positions.into());
+                    node.character_widths = Some(character_widths.into());
+                    node.word_lengths = word_lengths.into();
                 });
             }
 
-            node.default_action_verb = Some(accesskit::DefaultActionVerb::Focus);
+            ui.ctx().mutate_accesskit_node(parent_id, None, |node| {
+                if let Some(cursor_range) = &cursor_range {
+                    let anchor = &cursor_range.secondary.rcursor;
+                    let focus = &cursor_range.primary.rcursor;
+                    node.text_selection = Some(TextSelection {
+                        anchor: TextPosition {
+                            node: parent_id.with(anchor.row).accesskit_id(),
+                            character_index: anchor.column,
+                        },
+                        focus: TextPosition {
+                            node: parent_id.with(focus.row).accesskit_id(),
+                            character_index: focus.column,
+                        },
+                    });
+                }
+
+                node.default_action_verb = Some(accesskit::DefaultActionVerb::Focus);
+            });
         }
 
         TextEditOutput {

--- a/crates/egui/src/widgets/text_edit/cursor_range.rs
+++ b/crates/egui/src/widgets/text_edit/cursor_range.rs
@@ -1,7 +1,7 @@
 use epaint::text::cursor::*;
 
 /// A selected text range (could be a range of length zero).
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct CursorRange {
     /// When selecting with a mouse, this is where the mouse was released.

--- a/crates/epaint/src/text/cursor.rs
+++ b/crates/epaint/src/text/cursor.rs
@@ -113,7 +113,7 @@ impl PartialEq for PCursor {
 /// They all point to the same place, but in their own different ways.
 /// pcursor/rcursor can also point to after the end of the paragraph/row.
 /// Does not implement `PartialEq` because you must think which cursor should be equivalent.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Cursor {
     pub ccursor: CCursor,

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -37,11 +37,7 @@ impl eframe::App for MyApp {
                 ui.text_edit_singleline(&mut self.name)
                     .labelled_by(name_label.id);
             });
-            ui.add(
-                egui::Slider::new(&mut self.age, 0..=120)
-                    .step_by(1.0)
-                    .text("age"),
-            );
+            ui.add(egui::Slider::new(&mut self.age, 0..=120).text("age"));
             if ui.button("Click each year").clicked() {
                 self.age += 1;
             }

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -33,10 +33,15 @@ impl eframe::App for MyApp {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("My egui Application");
             ui.horizontal(|ui| {
-                ui.label("Your name: ");
-                ui.text_edit_singleline(&mut self.name);
+                let name_label = ui.label("Your name: ");
+                ui.text_edit_singleline(&mut self.name)
+                    .labelled_by(name_label.id);
             });
-            ui.add(egui::Slider::new(&mut self.age, 0..=120).text("age"));
+            ui.add(
+                egui::Slider::new(&mut self.age, 0..=120)
+                    .step_by(1.0)
+                    .text("age"),
+            );
             if ui.button("Click each year").clicked() {
                 self.age += 1;
             }


### PR DESCRIPTION
This PR makes egui accessible with assistive technologies such as screen readers. In contrast with egui's existing built-in screen reader, this PR uses AccessKit to implement platform accessibility APIs that are used by existing screen readers and other assistive technologies.

AccessKit is only implemented for Windows so far. I will focus on a Mac implementation over the next week or two.

We should discuss what level of completeness this branch needs to reach before being merged upstream. I haven't yet implemented support for all egui widgets. In general, this branch supports the widgets that were already accessible via `WidgetInfo`.

Closes <https://github.com/emilk/egui/issues/167>.