### PR TITLE
Add 'none' alias to Sense::hover

### DIFF
--- a/crates/egui/src/sense.rs
+++ b/crates/egui/src/sense.rs
@@ -16,6 +16,7 @@ pub struct Sense {
 
 impl Sense {
     /// Senses no clicks or drags. Only senses mouse hover.
+    #[doc(alias = "none")]
     pub fn hover() -> Self {
         Self {
             click: false,


### PR DESCRIPTION
This makes the method easier to find. The name "hover" does not make it immediately obvious that it actually sets all the fields to false.

![Alias showing in rustdoc output](https://user-images.githubusercontent.com/58113890/201552750-ceb55917-c985-4d45-8ba1-39531dcd4c17.png)
