### PR TITLE
[wgpu] Add depth stencil initialization to `Painter`

### DIFF
--- a/crates/egui-wgpu/CHANGELOG.md
+++ b/crates/egui-wgpu/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the `egui-wgpu` integration will be noted in this file.
 * Only a single vertex & index buffer is now created and resized when necessary (previously, vertex/index buffers were allocated for every mesh) ([#2148](https://github.com/emilk/egui/pull/2148)).
 * `Renderer::update_texture` no longer creates a new `wgpu::Sampler` with every new texture ([#2198](https://github.com/emilk/egui/pull/2198))
 * `Painter`'s instance/device/adapter/surface creation is now configurable via `WgpuConfiguration` ([#2207](https://github.com/emilk/egui/pull/2207))
+* Fix panic on using a depth buffer ([#2316](https://github.com/emilk/egui/pull/2316))
 
 ## 0.19.0 - 2022-08-20
 * Enables deferred render + surface state initialization for Android ([#1634](https://github.com/emilk/egui/pull/1634)).

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -176,7 +176,7 @@ impl Painter {
                     width,
                     height,
                 });
-                self.configure_surface(width, height);
+                self.resize_and_generate_depth_texture_view(width, height);
             }
             None => {
                 self.surface_state = None;
@@ -195,28 +195,36 @@ impl Painter {
             .map(|rs| rs.device.limits().max_texture_dimension_2d as usize)
     }
 
+    pub fn resize_and_generate_depth_texture_view(
+        &mut self,
+        width_in_pixels: u32,
+        height_in_pixels: u32,
+    ) {
+        self.configure_surface(width_in_pixels, height_in_pixels);
+        let device = &self.render_state.as_ref().unwrap().device;
+        self.depth_texture_view = self.depth_format.map(|depth_format| {
+            device
+                .create_texture(&wgpu::TextureDescriptor {
+                    label: Some("egui_depth_texture"),
+                    size: wgpu::Extent3d {
+                        width: width_in_pixels,
+                        height: height_in_pixels,
+                        depth_or_array_layers: 1,
+                    },
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    dimension: wgpu::TextureDimension::D2,
+                    format: depth_format,
+                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                        | wgpu::TextureUsages::TEXTURE_BINDING,
+                })
+                .create_view(&wgpu::TextureViewDescriptor::default())
+        });
+    }
+
     pub fn on_window_resized(&mut self, width_in_pixels: u32, height_in_pixels: u32) {
         if self.surface_state.is_some() {
-            self.configure_surface(width_in_pixels, height_in_pixels);
-            let device = &self.render_state.as_ref().unwrap().device;
-            self.depth_texture_view = self.depth_format.map(|depth_format| {
-                device
-                    .create_texture(&wgpu::TextureDescriptor {
-                        label: Some("egui_depth_texture"),
-                        size: wgpu::Extent3d {
-                            width: width_in_pixels,
-                            height: height_in_pixels,
-                            depth_or_array_layers: 1,
-                        },
-                        mip_level_count: 1,
-                        sample_count: 1,
-                        dimension: wgpu::TextureDimension::D2,
-                        format: depth_format,
-                        usage: wgpu::TextureUsages::RENDER_ATTACHMENT
-                            | wgpu::TextureUsages::TEXTURE_BINDING,
-                    })
-                    .create_view(&wgpu::TextureViewDescriptor::default())
-            });
+            self.resize_and_generate_depth_texture_view(width_in_pixels, height_in_pixels);
         } else {
             error!("Ignoring window resize notification with no surface created via Painter::set_window()");
         }
@@ -230,14 +238,6 @@ impl Painter {
         textures_delta: &egui::TexturesDelta,
     ) {
         crate::profile_function!();
-
-        if self.depth_format.is_some() && self.depth_texture_view.is_none() {
-            self.surface_state
-                .as_ref()
-                .map(|rs| (rs.width, rs.height))
-                .iter()
-                .for_each(|&(width, height)| self.on_window_resized(width, height));
-        }
 
         let render_state = match self.render_state.as_mut() {
             Some(rs) => rs,

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -231,6 +231,14 @@ impl Painter {
     ) {
         crate::profile_function!();
 
+        if self.depth_format.is_some() && self.depth_texture_view.is_none() {
+            self.surface_state
+                .as_ref()
+                .map(|rs| (rs.width, rs.height))
+                .iter()
+                .for_each(|&(width, height)| self.on_window_resized(width, height));
+        }
+
         let render_state = match self.render_state.as_mut() {
             Some(rs) => rs,
             None => return,


### PR DESCRIPTION
I was getting panics in the `egui_demo_app` when using a depth buffer. To add the depth buffer I had modified:

```rust
// egui_demo_app/src/main.rs
let options = eframe::NativeOptions {
    drag_and_drop_support: true,

    initial_window_size: Some([1280.0, 1024.0].into()),

    #[cfg(feature = "wgpu")]
    renderer: eframe::Renderer::Wgpu,
    depth_buffer: 1, // <-- enable depth buffer

    ..Default::default()
};
```
and
```rust
// egui_demo_app/src/apps/custom3d_wgpu.rs
// in create_render_pipeline
depth_stencil: Some(wgpu::DepthStencilState {
    format: wgpu::TextureFormat::Depth32Float,
    depth_write_enabled: true,
    depth_compare: wgpu::CompareFunction::Less,
    stencil: wgpu::StencilState::default(),
    bias: wgpu::DepthBiasState::default(),
}),
```

I realized that because the first frame can render before the window is set, it is possible for `depth_buffer` to exist, while `depth_texture_view` to be `None`. This check stopped the crash for me, but if there is an issue with this solution I would be happy to refactor.