### PR TITLE
add set_plot_bounds method, giving users the ability to set the plot bounds themselves.

### DIFF
--- a/crates/egui/src/widgets/plot/mod.rs
+++ b/crates/egui/src/widgets/plot/mod.rs
@@ -1040,6 +1040,11 @@ impl PlotUi {
         *self.last_screen_transform.bounds()
     }
 
+    /// Set the plot bounds. Can be useful for implementing alternative plot navigation methods.
+    pub fn set_plot_bounds(&mut self, plot_bounds: PlotBounds) {
+        self.last_screen_transform.set_bounds(plot_bounds);
+    }
+
     /// Move the plot bounds. Can be useful for implementing alternative plot navigation methods.
     pub fn translate_bounds(&mut self, delta_pos: Vec2) {
         self.last_screen_transform.translate_bounds(delta_pos);

--- a/crates/egui/src/widgets/plot/transform.rs
+++ b/crates/egui/src/widgets/plot/transform.rs
@@ -18,6 +18,10 @@ impl PlotBounds {
         max: [-f64::INFINITY; 2],
     };
 
+    pub fn new(min: [f64; 2], max: [f64; 2]) -> Self {
+        Self { min, max }
+    }
+
     pub fn min(&self) -> [f64; 2] {
         self.min
     }

--- a/crates/egui/src/widgets/plot/transform.rs
+++ b/crates/egui/src/widgets/plot/transform.rs
@@ -18,7 +18,7 @@ impl PlotBounds {
         max: [-f64::INFINITY; 2],
     };
 
-    pub fn new(min: [f64; 2], max: [f64; 2]) -> Self {
+    pub fn from_min_max(min: [f64; 2], max: [f64; 2]) -> Self {
         Self { min, max }
     }
 


### PR DESCRIPTION
This PR adds the method `set_plot_bounds()` to give users more control over the bounds of the plot. Some requested this in discussion #1328 . To use this, the user needs to be able to create `PlotBounds` structs so I added a `PlotBounds::new()` method as well.  
To give an example for usecases: implementing a digital oscilloscope or a serial plotter where you have fixed ranges controlled from other parts in or outside of the app.  
This is sort of continuing #2145, which added the ability to translate the plot bounds by a delta.

I am not sure about adding this to the changelog? Let me know if I should add it, or if it is trivial and not worth mentioning.

Also: thank you for creating egui!
