### PR TITLE
epaint: cover default fonts in the license field

### DIFF
--- a/crates/epaint/Cargo.toml
+++ b/crates/epaint/Cargo.toml
@@ -6,7 +6,7 @@ description = "Minimal 2D graphics library for GUI work"
 edition = "2021"
 rust-version = "1.65"
 homepage = "https://github.com/emilk/egui/tree/master/crates/epaint"
-license = "MIT OR Apache-2.0"
+license = "(MIT OR Apache-2.0) AND OFL-1.1 AND LicenseRef-UFL-1.0" # OFL and UFL used by default_fonts. See https://github.com/emilk/egui/issues/2321
 readme = "README.md"
 repository = "https://github.com/emilk/egui/tree/master/crates/epaint"
 categories = ["graphics", "gui"]
@@ -18,6 +18,8 @@ include = [
   "Cargo.toml",
   "fonts/*.ttf",
   "fonts/*.txt",
+  "fonts/OFL.txt",
+  "fonts/UFL.txt",
 ]
 
 [package.metadata.docs.rs]

--- a/deny.toml
+++ b/deny.toml
@@ -36,7 +36,7 @@ skip = [
     { name = "ttf-parser" }, # different versions pulled in by ab_glyph and usvg
 ]
 skip-tree = [
-    { name = "criterion" }, # dev-dependnecy
+    { name = "criterion" }, # dev-dependency
     { name = "glium" },     # legacy crate, lots of old dependencies
     { name = "rfd" },       # example dependency
     { name = "three-d" },   # example dependency
@@ -49,18 +49,19 @@ allow-osi-fsf-free = "neither"
 confidence-threshold = 0.92 # We want really high confidence when inferring licenses from text
 copyleft = "deny"
 allow = [
-    # "Apache-2.0 WITH LLVM-exception", # https://spdx.org/licenses/LLVM-exception.html
-    "Apache-2.0",       # https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)
-    "BSD-2-Clause",     # https://tldrlegal.com/license/bsd-2-clause-license-(freebsd)
-    "BSD-3-Clause",     # https://tldrlegal.com/license/bsd-3-clause-license-(revised)
-    "BSL-1.0",          # https://tldrlegal.com/license/boost-software-license-1.0-explained
-    "CC0-1.0",          # https://creativecommons.org/publicdomain/zero/1.0/
-    "ISC",              # https://tldrlegal.com/license/-isc-license
-    "MIT",              # https://tldrlegal.com/license/mit-license
-    "MPL-2.0",          # https://www.mozilla.org/en-US/MPL/2.0/FAQ/ - see Q11
-    "OpenSSL",          # https://www.openssl.org/source/license.html
-    "Unicode-DFS-2016", # https://spdx.org/licenses/Unicode-DFS-2016.html
-    "Zlib",             # https://tldrlegal.com/license/zlib-libpng-license-(zlib)
+    "Apache-2.0",         # https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)
+    "BSD-2-Clause",       # https://tldrlegal.com/license/bsd-2-clause-license-(freebsd)
+    "BSD-3-Clause",       # https://tldrlegal.com/license/bsd-3-clause-license-(revised)
+    "BSL-1.0",            # https://tldrlegal.com/license/boost-software-license-1.0-explained
+    "CC0-1.0",            # https://creativecommons.org/publicdomain/zero/1.0/
+    "ISC",                # https://tldrlegal.com/license/-isc-license
+    "LicenseRef-UFL-1.0", # https://tldrlegal.com/license/ubuntu-font-license,-1.0 - no official SPDX, see https://github.com/emilk/egui/issues/2321
+    "MIT",                # https://tldrlegal.com/license/mit-license
+    "MPL-2.0",            # https://www.mozilla.org/en-US/MPL/2.0/FAQ/ - see Q11
+    "OFL-1.1",            # https://spdx.org/licenses/OFL-1.1.html
+    "OpenSSL",            # https://www.openssl.org/source/license.html
+    "Unicode-DFS-2016",   # https://spdx.org/licenses/Unicode-DFS-2016.html
+    "Zlib",               # https://tldrlegal.com/license/zlib-libpng-license-(zlib)
 ]
 
 [[licenses.clarify]]


### PR DESCRIPTION
Handles https://github.com/emilk/egui/issues/2321 with the simplest solution.

As pointed out by @repi in the issue, the downside of this simple solution is that it adds OFL and UFL as licenses for all epaint users, even those not enabling the `default_fonts` feature flag. But at least this is a start.