### PR TITLE
Move egui::util::History to emath::History

### DIFF
--- a/crates/egui/src/util/mod.rs
+++ b/crates/egui/src/util/mod.rs
@@ -2,11 +2,10 @@
 
 pub mod cache;
 pub(crate) mod fixed_cache;
-mod history;
 pub mod id_type_map;
 pub mod undoer;
 
-pub use history::History;
 pub use id_type_map::IdTypeMap;
 
+pub use epaint::emath::History;
 pub use epaint::util::{hash, hash_with};

--- a/crates/emath/src/history.rs
+++ b/crates/emath/src/history.rs
@@ -41,7 +41,7 @@ where
 {
     /// Example:
     /// ```
-    /// # use egui::util::History;
+    /// # use emath::History;
     /// # fn now() -> f64 { 0.0 }
     /// // Drop events that are older than one second,
     /// // as long we keep at least two events. Never keep more than a hundred events.

--- a/crates/emath/src/history.rs
+++ b/crates/emath/src/history.rs
@@ -125,7 +125,7 @@ where
     /// Values must be added with a monotonically increasing time, or at least not decreasing.
     pub fn add(&mut self, now: f64, value: T) {
         if let Some((last_time, _)) = self.values.back() {
-            crate::egui_assert!(now >= *last_time, "Time shouldn't move backwards");
+            crate::emath_assert!(now >= *last_time, "Time shouldn't move backwards");
         }
         self.total_count += 1;
         self.values.push_back((now, value));

--- a/crates/emath/src/lib.rs
+++ b/crates/emath/src/lib.rs
@@ -27,6 +27,7 @@ use std::ops::{Add, Div, Mul, RangeInclusive, Sub};
 // ----------------------------------------------------------------------------
 
 pub mod align;
+mod history;
 mod numeric;
 mod pos2;
 mod rect;
@@ -37,6 +38,7 @@ mod vec2;
 
 pub use {
     align::{Align, Align2},
+    history::History,
     numeric::*,
     pos2::*,
     rect::*,


### PR DESCRIPTION
It is a nice thing to use outside of egui,
and it is more math-related than GUI-related.