### PR TITLE
Do not emit changed responses on unchanged values in selectable_value/radio_value

### DIFF
--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1447,7 +1447,7 @@ impl Ui {
         text: impl Into<WidgetText>,
     ) -> Response {
         let mut response = self.radio(*current_value == alternative, text);
-        if response.clicked() {
+        if response.clicked() && *current_value != alternative {
             *current_value = alternative;
             response.mark_changed();
         }
@@ -1475,7 +1475,7 @@ impl Ui {
         text: impl Into<WidgetText>,
     ) -> Response {
         let mut response = self.selectable_label(*current_value == selected_value, text);
-        if response.clicked() {
+        if response.clicked() && *current_value != selected_value {
             *current_value = selected_value;
             response.mark_changed();
         }


### PR DESCRIPTION
The `selectable_value` and `radio_value` methods did not take into account that you can click on the very same widget multiple times in a row. They emitted `changed` responses on every click, even when the underlying value did not change.