### PR TITLE
`egui_extras::Table` improvements

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -66,6 +66,10 @@ pub struct ScrollAreaOutput<R> {
     /// The current state of the scroll area.
     pub state: State,
 
+    /// The size of the content. If this is larger than [`Self::inner_rect`],
+    /// then there was need for scrolling.
+    pub content_size: Vec2,
+
     /// Where on the screen the content is (excludes scroll bars).
     pub inner_rect: Rect,
 }
@@ -198,6 +202,8 @@ impl ScrollArea {
 
     /// Set the horizontal and vertical scroll offset position.
     ///
+    /// Positive offset means scrolling down/right.
+    ///
     /// See also: [`Self::vertical_scroll_offset`], [`Self::horizontal_scroll_offset`],
     /// [`Ui::scroll_to_cursor`](crate::ui::Ui::scroll_to_cursor) and
     /// [`Response::scroll_to_me`](crate::Response::scroll_to_me)
@@ -209,6 +215,8 @@ impl ScrollArea {
 
     /// Set the vertical scroll offset position.
     ///
+    /// Positive offset means scrolling down.
+    ///
     /// See also: [`Self::scroll_offset`], [`Ui::scroll_to_cursor`](crate::ui::Ui::scroll_to_cursor) and
     /// [`Response::scroll_to_me`](crate::Response::scroll_to_me)
     pub fn vertical_scroll_offset(mut self, offset: f32) -> Self {
@@ -217,6 +225,8 @@ impl ScrollArea {
     }
 
     /// Set the horizontal scroll offset position.
+    ///
+    /// Positive offset means scrolling right.
     ///
     /// See also: [`Self::scroll_offset`], [`Ui::scroll_to_cursor`](crate::ui::Ui::scroll_to_cursor) and
     /// [`Response::scroll_to_me`](crate::Response::scroll_to_me)
@@ -541,18 +551,20 @@ impl ScrollArea {
         let id = prepared.id;
         let inner_rect = prepared.inner_rect;
         let inner = add_contents(&mut prepared.content_ui, prepared.viewport);
-        let state = prepared.end(ui);
+        let (content_size, state) = prepared.end(ui);
         ScrollAreaOutput {
             inner,
             id,
             state,
+            content_size,
             inner_rect,
         }
     }
 }
 
 impl Prepared {
-    fn end(self, ui: &mut Ui) -> State {
+    /// Returns content size and state
+    fn end(self, ui: &mut Ui) -> (Vec2, State) {
         let Prepared {
             id,
             mut state,
@@ -847,7 +859,7 @@ impl Prepared {
 
         state.store(ui.ctx(), id);
 
-        state
+        (content_size, state)
     }
 }
 

--- a/crates/egui_demo_app/Cargo.toml
+++ b/crates/egui_demo_app/Cargo.toml
@@ -20,8 +20,8 @@ default = ["glow", "persistence"]
 
 http = ["ehttp", "image", "poll-promise", "egui_extras/image"]
 persistence = ["eframe/persistence", "egui/persistence", "serde"]
-screen_reader = ["eframe/screen_reader"]                                        # experimental
-serde = ["dep:serde", "egui_demo_lib/serde", "egui_extras/serde", "egui/serde"]
+screen_reader = ["eframe/screen_reader"]                          # experimental
+serde = ["dep:serde", "egui_demo_lib/serde", "egui/serde"]
 syntax_highlighting = ["egui_demo_lib/syntax_highlighting"]
 
 glow = ["eframe/glow"]

--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -136,7 +136,7 @@ impl TableDemo {
             .column(Column::remainder());
 
         if let Some(row_nr) = self.scroll_to_row.take() {
-            table = table.scroll_to_row(row_nr);
+            table = table.scroll_to_row(row_nr, None);
         }
 
         table

--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -10,6 +10,7 @@ enum DemoType {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct TableDemo {
     demo: DemoType,
+    striped: bool,
     resizable: bool,
     num_rows: usize,
     row_to_scroll_to: i32,
@@ -20,6 +21,7 @@ impl Default for TableDemo {
     fn default() -> Self {
         Self {
             demo: DemoType::Manual,
+            striped: true,
             resizable: true,
             num_rows: 10_000,
             row_to_scroll_to: 0,
@@ -54,7 +56,10 @@ fn scroll_offset_for_row(ui: &egui::Ui, row: i32) -> f32 {
 impl super::View for TableDemo {
     fn ui(&mut self, ui: &mut egui::Ui) {
         ui.vertical(|ui| {
-            ui.checkbox(&mut self.resizable, "Resizable columns");
+            ui.horizontal(|ui| {
+                ui.checkbox(&mut self.striped, "Striped");
+                ui.checkbox(&mut self.resizable, "Resizable columns");
+            });
 
             ui.label("Table type:");
             ui.radio_value(&mut self.demo, DemoType::Manual, "Few, manual rows");
@@ -118,7 +123,7 @@ impl TableDemo {
         let text_height = egui::TextStyle::Body.resolve(ui.style()).size;
 
         let mut table = TableBuilder::new(ui)
-            .striped(true)
+            .striped(self.striped)
             .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
             .column(Size::initial(60.0).at_least(40.0))
             .column(Size::initial(60.0).at_least(40.0))

--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -128,7 +128,8 @@ impl TableDemo {
             .column(Size::initial(60.0).at_least(40.0))
             .column(Size::initial(60.0).at_least(40.0))
             .column(Size::remainder().at_least(60.0))
-            .resizable(self.resizable);
+            .resizable(self.resizable)
+            .auto_size_columns(true);
 
         if let Some(y_scroll) = self.vertical_scroll_offset.take() {
             table = table.vertical_scroll_offset(y_scroll);

--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -245,7 +245,7 @@ fn expanding_content(ui: &mut egui::Ui) {
 }
 
 fn long_text(row_index: usize) -> String {
-    format!("Row {row_index} has some long text that you may want to clip, or it will overflow")
+    format!("Row {row_index} has some long text that you may want to clip, or it will take up too much horizontal space!")
 }
 
 fn thick_row(row_index: usize) -> bool {

--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -125,10 +125,11 @@ impl TableDemo {
         let mut table = TableBuilder::new(ui)
             .striped(self.striped)
             .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
-            .column(Size::initial(60.0).at_least(40.0))
-            .column(Size::initial(60.0).at_least(40.0))
-            .column(Size::remainder().at_least(60.0))
+            .column(Size::initial(60.0))
+            .column(Size::initial(60.0))
+            .column(Size::remainder())
             .resizable(self.resizable)
+            .clip(false)
             .auto_size_columns(true);
 
         if let Some(y_scroll) = self.vertical_scroll_offset.take() {

--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -118,18 +118,17 @@ impl super::View for TableDemo {
 
 impl TableDemo {
     fn table_ui(&mut self, ui: &mut egui::Ui) {
-        use egui_extras::{Size, TableBuilder};
+        use egui_extras::{Column, TableBuilder};
 
         let text_height = egui::TextStyle::Body.resolve(ui.style()).size;
 
         let mut table = TableBuilder::new(ui)
             .striped(self.striped)
             .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
-            .column(Size::initial(60.0))
-            .column(Size::initial(60.0))
-            .column(Size::remainder())
+            .column(Column::auto())
+            .column(Column::auto())
+            .column(Column::remainder())
             .resizable(self.resizable)
-            .clip(false)
             .auto_size_columns(true);
 
         if let Some(y_scroll) = self.vertical_scroll_offset.take() {

--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -83,13 +83,12 @@ impl super::View for TableDemo {
             }
 
             if self.demo == DemoType::ManyHomogenous {
-                ui.add(
+                let slider_response = ui.add(
                     egui::Slider::new(&mut self.row_to_scroll_to, 0..=self.num_rows as i32)
                         .logarithmic(true)
                         .text("Row to scroll to"),
                 );
-
-                if ui.button("Scroll to row").clicked() {
+                if slider_response.changed() {
                     self.vertical_scroll_offset
                         .replace(scroll_offset_for_row(ui, self.row_to_scroll_to));
                 }
@@ -125,11 +124,14 @@ impl TableDemo {
         let mut table = TableBuilder::new(ui)
             .striped(self.striped)
             .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
-            .column(Column::auto().resizable(false))
             .column(Column::auto())
-            .column(Column::remainder())
-            .resizable(self.resizable)
-            .auto_size_columns(true);
+            .column(
+                Column::initial(100.0)
+                    .at_least(40.0)
+                    .resizable(true)
+                    .clip(true),
+            )
+            .column(Column::remainder());
 
         if let Some(y_scroll) = self.vertical_scroll_offset.take() {
             table = table.vertical_scroll_offset(y_scroll);
@@ -138,13 +140,13 @@ impl TableDemo {
         table
             .header(20.0, |mut header| {
                 header.col(|ui| {
-                    ui.heading("Row");
+                    ui.strong("Row");
                 });
                 header.col(|ui| {
-                    ui.heading("Clock");
+                    ui.strong("Long text");
                 });
                 header.col(|ui| {
-                    ui.heading("Content");
+                    ui.strong("Content");
                 });
             })
             .body(|mut body| match self.demo {
@@ -157,7 +159,7 @@ impl TableDemo {
                                 ui.label(row_index.to_string());
                             });
                             row.col(|ui| {
-                                ui.label(clock_emoji(row_index));
+                                ui.label(long_text(row_index));
                             });
                             row.col(|ui| {
                                 ui.style_mut().wrap = Some(false);
@@ -176,7 +178,7 @@ impl TableDemo {
                             ui.label(row_index.to_string());
                         });
                         row.col(|ui| {
-                            ui.label(clock_emoji(row_index));
+                            ui.label(long_text(row_index));
                         });
                         row.col(|ui| {
                             ui.add(
@@ -203,7 +205,7 @@ impl TableDemo {
                             });
                             row.col(|ui| {
                                 ui.centered_and_justified(|ui| {
-                                    ui.label(clock_emoji(row_index));
+                                    ui.label(long_text(row_index));
                                 });
                             });
                             row.col(|ui| {
@@ -223,10 +225,8 @@ impl TableDemo {
     }
 }
 
-fn clock_emoji(row_index: usize) -> String {
-    char::from_u32(0x1f550 + row_index as u32 % 24)
-        .unwrap()
-        .to_string()
+fn long_text(row_index: usize) -> String {
+    format!("Row {row_index} has some long text that you may want to clip, or it will overflow")
 }
 
 fn thick_row(row_index: usize) -> bool {

--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -125,6 +125,7 @@ impl TableDemo {
             .striped(self.striped)
             .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
             .column(Column::auto())
+            .column(Column::initial(100.0).range(40.0..=300.0).resizable(true))
             .column(
                 Column::initial(100.0)
                     .at_least(40.0)
@@ -143,7 +144,10 @@ impl TableDemo {
                     ui.strong("Row");
                 });
                 header.col(|ui| {
-                    ui.strong("Long text");
+                    ui.strong("Expanding content");
+                });
+                header.col(|ui| {
+                    ui.strong("Clipped text");
                 });
                 header.col(|ui| {
                     ui.strong("Content");
@@ -157,6 +161,9 @@ impl TableDemo {
                         body.row(row_height, |mut row| {
                             row.col(|ui| {
                                 ui.label(row_index.to_string());
+                            });
+                            row.col(|ui| {
+                                expanding_content(ui);
                             });
                             row.col(|ui| {
                                 ui.label(long_text(row_index));
@@ -176,6 +183,9 @@ impl TableDemo {
                     body.rows(text_height, self.num_rows, |row_index, mut row| {
                         row.col(|ui| {
                             ui.label(row_index.to_string());
+                        });
+                        row.col(|ui| {
+                            expanding_content(ui);
                         });
                         row.col(|ui| {
                             ui.label(long_text(row_index));
@@ -199,30 +209,38 @@ impl TableDemo {
                         (0..self.num_rows).into_iter().map(row_thickness),
                         |row_index, mut row| {
                             row.col(|ui| {
-                                ui.centered_and_justified(|ui| {
-                                    ui.label(row_index.to_string());
-                                });
+                                ui.label(row_index.to_string());
                             });
                             row.col(|ui| {
-                                ui.centered_and_justified(|ui| {
-                                    ui.label(long_text(row_index));
-                                });
+                                expanding_content(ui);
                             });
                             row.col(|ui| {
-                                ui.centered_and_justified(|ui| {
-                                    ui.style_mut().wrap = Some(false);
-                                    if thick_row(row_index) {
-                                        ui.heading("Extra thick row");
-                                    } else {
-                                        ui.label("Normal row");
-                                    }
-                                });
+                                ui.label(long_text(row_index));
+                            });
+                            row.col(|ui| {
+                                ui.style_mut().wrap = Some(false);
+                                if thick_row(row_index) {
+                                    ui.heading("Extra thick row");
+                                } else {
+                                    ui.label("Normal row");
+                                }
                             });
                         },
                     );
                 }
             });
     }
+}
+
+fn expanding_content(ui: &mut egui::Ui) {
+    let width = ui.available_width().clamp(20.0, 200.0);
+    let height = ui.available_height();
+    let (rect, _response) = ui.allocate_exact_size(egui::vec2(width, height), egui::Sense::hover());
+    ui.painter().hline(
+        rect.x_range(),
+        rect.center().y,
+        (1.0, ui.visuals().text_color()),
+    );
 }
 
 fn long_text(row_index: usize) -> String {

--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -125,7 +125,7 @@ impl TableDemo {
         let mut table = TableBuilder::new(ui)
             .striped(self.striped)
             .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
-            .column(Column::auto())
+            .column(Column::auto().resizable(false))
             .column(Column::auto())
             .column(Column::remainder())
             .resizable(self.resizable)

--- a/crates/egui_extras/Cargo.toml
+++ b/crates/egui_extras/Cargo.toml
@@ -29,9 +29,6 @@ default = []
 ## Enable [`DatePickerButton`] widget.
 datepicker = ["chrono"]
 
-## Allow serialization using [`serde`](https://docs.rs/serde).
-serde = ["dep:serde"]
-
 ## Support loading svg images.
 svg = ["resvg", "tiny-skia", "usvg"]
 
@@ -41,6 +38,8 @@ tracing = ["dep:tracing", "egui/tracing"]
 
 [dependencies]
 egui = { version = "0.19.0", path = "../egui", default-features = false }
+
+serde = { version = "1", features = ["derive"] }
 
 #! ### Optional dependencies
 
@@ -62,9 +61,6 @@ image = { version = "0.24", optional = true, default-features = false }
 resvg = { version = "0.23", optional = true }
 tiny-skia = { version = "0.6", optional = true } # must be updated in lock-step with resvg
 usvg = { version = "0.23", optional = true }
-
-# feature "serde":
-serde = { version = "1", features = ["derive"], optional = true }
 
 # feature "tracing"
 tracing = { version = "0.1", optional = true, default-features = false, features = [

--- a/crates/egui_extras/src/datepicker/button.rs
+++ b/crates/egui_extras/src/datepicker/button.rs
@@ -2,8 +2,7 @@ use super::popup::DatePickerPopup;
 use chrono::{Date, Utc};
 use egui::{Area, Button, Frame, InnerResponse, Key, Order, RichText, Ui, Widget};
 
-#[derive(Default, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Default, Clone, serde::Deserialize, serde::Serialize)]
 pub(crate) struct DatePickerButtonState {
     pub picker_visible: bool,
 }

--- a/crates/egui_extras/src/datepicker/popup.rs
+++ b/crates/egui_extras/src/datepicker/popup.rs
@@ -1,7 +1,10 @@
-use super::{button::DatePickerButtonState, month_data};
-use crate::{Size, StripBuilder, TableBuilder};
 use chrono::{Date, Datelike, NaiveDate, Utc, Weekday};
+
 use egui::{Align, Button, Color32, ComboBox, Direction, Id, Layout, RichText, Ui, Vec2};
+
+use super::{button::DatePickerButtonState, month_data};
+
+use crate::{Column, Size, StripBuilder, TableBuilder};
 
 #[derive(Default, Clone, serde::Deserialize, serde::Serialize)]
 struct DatePickerPopupState {
@@ -243,8 +246,7 @@ impl<'a> DatePickerPopup<'a> {
                         ui.spacing_mut().item_spacing = Vec2::new(1.0, 2.0);
                         TableBuilder::new(ui)
                             .scroll(false)
-                            .clip(false)
-                            .columns(Size::remainder(), if self.calendar_week { 8 } else { 7 })
+                            .columns(Column::remainder(), if self.calendar_week { 8 } else { 7 })
                             .header(height, |mut header| {
                                 if self.calendar_week {
                                     header.col(|ui| {

--- a/crates/egui_extras/src/datepicker/popup.rs
+++ b/crates/egui_extras/src/datepicker/popup.rs
@@ -3,8 +3,7 @@ use crate::{Size, StripBuilder, TableBuilder};
 use chrono::{Date, Datelike, NaiveDate, Utc, Weekday};
 use egui::{Align, Button, Color32, ComboBox, Direction, Id, Layout, RichText, Ui, Vec2};
 
-#[derive(Default, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Default, Clone, serde::Deserialize, serde::Serialize)]
 struct DatePickerPopupState {
     year: i32,
     month: u32,

--- a/crates/egui_extras/src/datepicker/popup.rs
+++ b/crates/egui_extras/src/datepicker/popup.rs
@@ -245,7 +245,7 @@ impl<'a> DatePickerPopup<'a> {
                     strip.cell(|ui| {
                         ui.spacing_mut().item_spacing = Vec2::new(1.0, 2.0);
                         TableBuilder::new(ui)
-                            .scroll(false)
+                            .vscroll(false)
                             .columns(Column::remainder(), if self.calendar_week { 8 } else { 7 })
                             .header(height, |mut header| {
                                 if self.calendar_week {

--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -31,7 +31,7 @@ pub struct StripLayout<'l> {
     pub(crate) ui: &'l mut Ui,
     direction: CellDirection,
     pub(crate) rect: Rect,
-    cursor: Pos2,
+    pub(crate) cursor: Pos2,
     max: Pos2,
     cell_layout: egui::Layout,
 }

--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -32,6 +32,8 @@ pub struct StripLayout<'l> {
     direction: CellDirection,
     pub(crate) rect: Rect,
     pub(crate) cursor: Pos2,
+    /// Keeps track of the max used position,
+    /// so we know how much space we used.
     max: Pos2,
     cell_layout: egui::Layout,
 }
@@ -110,12 +112,18 @@ impl<'l> StripLayout<'l> {
         let used_rect = self.cell(clip, max_rect, add_cell_contents);
 
         self.set_pos(max_rect);
-        let response = self
-            .ui
-            .allocate_rect(max_rect.union(used_rect), Sense::hover());
+
+        let allocation_rect = if clip {
+            max_rect
+        } else {
+            max_rect.union(used_rect)
+        };
+
+        let response = self.ui.allocate_rect(allocation_rect, Sense::hover());
 
         (used_rect, response)
     }
+
     /// only needed for layouts with multiple lines, like [`Table`](crate::Table).
     pub fn end_line(&mut self) {
         match self.direction {

--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -33,17 +33,11 @@ pub struct StripLayout<'l> {
     pub(crate) rect: Rect,
     cursor: Pos2,
     max: Pos2,
-    pub(crate) clip: bool,
     cell_layout: egui::Layout,
 }
 
 impl<'l> StripLayout<'l> {
-    pub(crate) fn new(
-        ui: &'l mut Ui,
-        direction: CellDirection,
-        clip: bool,
-        cell_layout: egui::Layout,
-    ) -> Self {
+    pub(crate) fn new(ui: &'l mut Ui, direction: CellDirection, cell_layout: egui::Layout) -> Self {
         let rect = ui.available_rect_before_wrap();
         let pos = rect.left_top();
 
@@ -53,7 +47,6 @@ impl<'l> StripLayout<'l> {
             rect,
             cursor: pos,
             max: pos,
-            clip,
             cell_layout,
         }
     }
@@ -97,6 +90,7 @@ impl<'l> StripLayout<'l> {
     /// Return the used space (`min_rect`) plus the [`Response`] of the whole cell.
     pub(crate) fn add(
         &mut self,
+        clip: bool,
         striped: bool,
         width: CellSize,
         height: CellSize,
@@ -113,7 +107,7 @@ impl<'l> StripLayout<'l> {
                 .rect_filled(stripe_rect, 0.0, self.ui.visuals().faint_bg_color);
         }
 
-        let used_rect = self.cell(max_rect, add_cell_contents);
+        let used_rect = self.cell(clip, max_rect, add_cell_contents);
 
         self.set_pos(max_rect);
         let response = self
@@ -144,10 +138,10 @@ impl<'l> StripLayout<'l> {
         self.ui.allocate_rect(rect, Sense::hover());
     }
 
-    fn cell(&mut self, rect: Rect, add_cell_contents: impl FnOnce(&mut Ui)) -> Rect {
+    fn cell(&mut self, clip: bool, rect: Rect, add_cell_contents: impl FnOnce(&mut Ui)) -> Rect {
         let mut child_ui = self.ui.child_ui(rect, self.cell_layout);
 
-        if self.clip {
+        if clip {
             let margin = egui::Vec2::splat(self.ui.visuals().clip_rect_margin);
             let margin = margin.min(0.5 * self.ui.spacing().item_spacing);
             let clip_rect = rect.expand2(margin);

--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -94,34 +94,26 @@ impl<'l> StripLayout<'l> {
 
     pub(crate) fn add(
         &mut self,
+        striped: bool,
         width: CellSize,
         height: CellSize,
         add_contents: impl FnOnce(&mut Ui),
     ) -> Response {
         let rect = self.cell_rect(&width, &height);
+
+        if striped {
+            // Make sure we don't have a gap in the stripe background:
+            let stripe_rect = rect.expand2(0.5 * self.ui.spacing().item_spacing);
+
+            self.ui
+                .painter()
+                .rect_filled(stripe_rect, 0.0, self.ui.visuals().faint_bg_color);
+        }
+
         let used_rect = self.cell(rect, add_contents);
         self.set_pos(rect);
         self.ui.allocate_rect(rect.union(used_rect), Sense::hover())
     }
-
-    pub(crate) fn add_striped(
-        &mut self,
-        width: CellSize,
-        height: CellSize,
-        add_contents: impl FnOnce(&mut Ui),
-    ) -> Response {
-        let rect = self.cell_rect(&width, &height);
-
-        // Make sure we don't have a gap in the stripe background:
-        let rect = rect.expand2(0.5 * self.ui.spacing().item_spacing);
-
-        self.ui
-            .painter()
-            .rect_filled(rect, 0.0, self.ui.visuals().faint_bg_color);
-
-        self.add(width, height, add_contents)
-    }
-
     /// only needed for layouts with multiple lines, like [`Table`](crate::Table).
     pub fn end_line(&mut self) {
         match self.direction {

--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -100,7 +100,7 @@ impl<'l> StripLayout<'l> {
         striped: bool,
         width: CellSize,
         height: CellSize,
-        add_contents: impl FnOnce(&mut Ui),
+        add_cell_contents: impl FnOnce(&mut Ui),
     ) -> (Rect, Response) {
         let max_rect = self.cell_rect(&width, &height);
 
@@ -113,7 +113,7 @@ impl<'l> StripLayout<'l> {
                 .rect_filled(stripe_rect, 0.0, self.ui.visuals().faint_bg_color);
         }
 
-        let used_rect = self.cell(max_rect, add_contents);
+        let used_rect = self.cell(max_rect, add_cell_contents);
 
         self.set_pos(max_rect);
         let response = self
@@ -144,7 +144,7 @@ impl<'l> StripLayout<'l> {
         self.ui.allocate_rect(rect, Sense::hover());
     }
 
-    fn cell(&mut self, rect: Rect, add_contents: impl FnOnce(&mut Ui)) -> Rect {
+    fn cell(&mut self, rect: Rect, add_cell_contents: impl FnOnce(&mut Ui)) -> Rect {
         let mut child_ui = self.ui.child_ui(rect, self.cell_layout);
 
         if self.clip {
@@ -154,7 +154,7 @@ impl<'l> StripLayout<'l> {
             child_ui.set_clip_rect(clip_rect.intersect(child_ui.clip_rect()));
         }
 
-        add_contents(&mut child_ui);
+        add_cell_contents(&mut child_ui);
         child_ui.min_rect()
     }
 

--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -87,7 +87,7 @@ impl<'l> StripLayout<'l> {
         self.set_pos(self.cell_rect(&width, &height));
     }
 
-    /// This is the innermost part of [`Table`] and [`Strip`].
+    /// This is the innermost part of [`crate::Table`] and [`crate::Strip`].
     ///
     /// Return the used space (`min_rect`) plus the [`Response`] of the whole cell.
     pub(crate) fn add(

--- a/crates/egui_extras/src/strip.rs
+++ b/crates/egui_extras/src/strip.rs
@@ -98,15 +98,11 @@ impl<'a> StripBuilder<'a> {
             self.ui.available_rect_before_wrap().width(),
             self.ui.spacing().item_spacing.x,
         );
-        let mut layout = StripLayout::new(
-            self.ui,
-            CellDirection::Horizontal,
-            self.clip,
-            self.cell_layout,
-        );
+        let mut layout = StripLayout::new(self.ui, CellDirection::Horizontal, self.cell_layout);
         strip(Strip {
             layout: &mut layout,
             direction: CellDirection::Horizontal,
+            clip: self.clip,
             sizes: widths,
             size_index: 0,
         });
@@ -125,15 +121,11 @@ impl<'a> StripBuilder<'a> {
             self.ui.available_rect_before_wrap().height(),
             self.ui.spacing().item_spacing.y,
         );
-        let mut layout = StripLayout::new(
-            self.ui,
-            CellDirection::Vertical,
-            self.clip,
-            self.cell_layout,
-        );
+        let mut layout = StripLayout::new(self.ui, CellDirection::Vertical, self.cell_layout);
         strip(Strip {
             layout: &mut layout,
             direction: CellDirection::Vertical,
+            clip: self.clip,
             sizes: heights,
             size_index: 0,
         });
@@ -146,6 +138,7 @@ impl<'a> StripBuilder<'a> {
 pub struct Strip<'a, 'b> {
     layout: &'b mut StripLayout<'a>,
     direction: CellDirection,
+    clip: bool,
     sizes: Vec<f32>,
     size_index: usize,
 }
@@ -173,7 +166,8 @@ impl<'a, 'b> Strip<'a, 'b> {
     pub fn cell(&mut self, add_contents: impl FnOnce(&mut Ui)) {
         let (width, height) = self.next_cell_size();
         let striped = false;
-        self.layout.add(striped, width, height, add_contents);
+        self.layout
+            .add(self.clip, striped, width, height, add_contents);
     }
 
     /// Add an empty cell.
@@ -184,7 +178,7 @@ impl<'a, 'b> Strip<'a, 'b> {
 
     /// Add a strip as cell.
     pub fn strip(&mut self, strip_builder: impl FnOnce(StripBuilder<'_>)) {
-        let clip = self.layout.clip;
+        let clip = self.clip;
         self.cell(|ui| {
             strip_builder(StripBuilder::new(ui).clip(clip));
         });

--- a/crates/egui_extras/src/strip.rs
+++ b/crates/egui_extras/src/strip.rs
@@ -172,7 +172,8 @@ impl<'a, 'b> Strip<'a, 'b> {
     /// Add cell contents.
     pub fn cell(&mut self, add_contents: impl FnOnce(&mut Ui)) {
         let (width, height) = self.next_cell_size();
-        self.layout.add(width, height, add_contents);
+        let striped = false;
+        self.layout.add(striped, width, height, add_contents);
     }
 
     /// Add an empty cell.

--- a/crates/egui_extras/src/strip.rs
+++ b/crates/egui_extras/src/strip.rs
@@ -56,11 +56,11 @@ impl<'a> StripBuilder<'a> {
             ui,
             sizing: Default::default(),
             cell_layout,
-            clip: true,
+            clip: false,
         }
     }
 
-    /// Should we clip the contents of each cell? Default: `true`.
+    /// Should we clip the contents of each cell? Default: `false`.
     pub fn clip(mut self, clip: bool) -> Self {
         self.clip = clip;
         self

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -651,11 +651,7 @@ impl<'a, 'b> TableRow<'a, 'b> {
         let width = CellSize::Absolute(width);
         let height = CellSize::Absolute(self.height);
 
-        if self.striped {
-            self.layout.add_striped(width, height, add_contents)
-        } else {
-            self.layout.add(width, height, add_contents)
-        }
+        self.layout.add(self.striped, width, height, add_contents)
     }
 }
 

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -637,6 +637,7 @@ impl<'a> Table<'a> {
 }
 
 /// The body of a table.
+///
 /// Is created by calling `body` on a [`Table`] (after adding a header row) or [`TableBuilder`] (without a header row).
 pub struct TableBody<'a> {
     layout: StripLayout<'a>,
@@ -654,6 +655,7 @@ pub struct TableBody<'a> {
     start_y: f32,
     end_y: f32,
 
+    /// Look for this row to scroll to.
     scroll_to_row: Option<usize>,
 
     /// If we find the correct row to scroll to,
@@ -662,6 +664,13 @@ pub struct TableBody<'a> {
 }
 
 impl<'a> TableBody<'a> {
+    /// Where in screen-space is the table body?
+    pub fn max_rect(&self) -> Rect {
+        self.layout
+            .rect
+            .translate(egui::vec2(0.0, self.scroll_offset_y()))
+    }
+
     fn scroll_offset_y(&self) -> f32 {
         self.start_y - self.layout.rect.top()
     }

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -7,8 +7,7 @@ use egui::{Align, NumExt as _, Rect, Response, Ui, Vec2};
 
 use crate::{
     layout::{CellDirection, CellSize},
-    sizing::Sizing,
-    Size, StripLayout,
+    StripLayout,
 };
 
 // -----------------------------------------------------------------=----------
@@ -83,7 +82,7 @@ impl Column {
     /// Can this column be resized by dragging the column separator?
     ///
     /// If you don't call this, the fallback value of
-    /// [`Table::resizable`] is used (which by default is `false`).
+    /// [`TableBuilder::resizable`] is used (which by default is `false`).
     pub fn resizable(mut self, resizable: bool) -> Self {
         self.resizable = Some(resizable);
         self
@@ -132,8 +131,10 @@ impl Column {
     }
 }
 
-fn to_sizing(columns: &[Column]) -> Sizing {
-    let mut sizing = Sizing::default();
+fn to_sizing(columns: &[Column]) -> crate::sizing::Sizing {
+    use crate::Size;
+
+    let mut sizing = crate::sizing::Sizing::default();
     for column in columns {
         let size = match column.initial_width {
             InitialColumnSize::Absolute(width) => Size::exact(width),
@@ -159,7 +160,7 @@ fn to_sizing(columns: &[Column]) -> Sizing {
 /// ### Example
 /// ```
 /// # egui::__run_test_ui(|ui| {
-/// use egui_extras::{TableBuilder, Size};
+/// use egui_extras::{TableBuilder, Column};
 /// TableBuilder::new(ui)
 ///     .column(Column::auto())
 ///     .column(Column::remainder())
@@ -609,7 +610,7 @@ impl<'a> Table<'a> {
 
             x += *column_width + spacing_x;
 
-            // If the last column is Size::Remainder, then let it fill the remainder!
+            // If the last column is 'remainder', then let it fill the remainder!
             let is_last_column = i + 1 == columns.len();
             if is_last_column && column.initial_width == InitialColumnSize::Remainder {
                 let eps = 0.1; // just to avoid some rounding errors.
@@ -769,9 +770,9 @@ impl<'a> TableBody<'a> {
     /// ### Example
     /// ```
     /// # egui::__run_test_ui(|ui| {
-    /// use egui_extras::{TableBuilder, Size};
+    /// use egui_extras::{TableBuilder, Column};
     /// TableBuilder::new(ui)
-    ///     .column(Size::remainder().at_least(100.0))
+    ///     .column(Column::remainder().at_least(100.0))
     ///     .body(|mut body| {
     ///         let row_height = 18.0;
     ///         let num_rows = 10_000;
@@ -847,9 +848,9 @@ impl<'a> TableBody<'a> {
     /// ### Example
     /// ```
     /// # egui::__run_test_ui(|ui| {
-    /// use egui_extras::{TableBuilder, Size};
+    /// use egui_extras::{TableBuilder, Column};
     /// TableBuilder::new(ui)
-    ///     .column(Size::remainder().at_least(100.0))
+    ///     .column(Column::remainder().at_least(100.0))
     ///     .body(|mut body| {
     ///         let row_heights: Vec<f32> = vec![60.0, 18.0, 31.0, 240.0];
     ///         body.heterogeneous_rows(row_heights.into_iter(), |row_index, mut row| {

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -9,7 +9,7 @@ use crate::{
     Size, StripLayout,
 };
 
-use egui::{Rect, Response, Ui, Vec2};
+use egui::{NumExt as _, Rect, Response, Ui, Vec2};
 
 /// Builder for a [`Table`] with (optional) fixed header and scrolling body.
 ///
@@ -427,7 +427,12 @@ impl<'a> Table<'a> {
                         if let Some(pointer) = ui.ctx().pointer_latest_pos() {
                             let new_width = *column_width + pointer.x - x;
                             let (min, max) = sizing.sizes[i].range();
-                            let new_width = new_width.clamp(min, max);
+                            let mut new_width = new_width.clamp(min, max);
+                            if !clip {
+                                // If we don't clip, we don't want to shrink below the
+                                // size that was actually used.
+                                new_width = new_width.at_least(max_used_widths[i]);
+                            }
                             let x = x - *column_width + new_width;
                             p0.x = x;
                             p1.x = x;

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -276,8 +276,7 @@ impl<'a> TableBuilder<'a> {
 
 // ----------------------------------------------------------------------------
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 struct TableReizeState {
     column_widths: Vec<f32>,
 }

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -355,17 +355,10 @@ impl<'a> Table<'a> {
                 let mut p1 = egui::pos2(x, bottom);
                 let line_rect = egui::Rect::from_min_max(p0, p1)
                     .expand(ui.style().interaction.resize_grab_radius_side);
-                let mouse_over_resize_line = ui.rect_contains_pointer(line_rect);
+                let resize_response =
+                    ui.interact(line_rect, resize_id, egui::Sense::click_and_drag());
 
-                let any_pressed_and_down = {
-                    let pointer = &ui.input().pointer;
-                    pointer.any_pressed() && pointer.any_down()
-                };
-                if any_pressed_and_down && mouse_over_resize_line {
-                    ui.memory().set_dragged_id(resize_id);
-                }
-                let is_resizing = ui.memory().is_being_dragged(resize_id);
-                if is_resizing {
+                if resize_response.dragged() {
                     if let Some(pointer) = ui.ctx().pointer_latest_pos() {
                         let new_width = *width + pointer.x - x;
                         let (min, max) = sizing.sizes[i].range();
@@ -382,13 +375,13 @@ impl<'a> Table<'a> {
                     let pointer = &ui.input().pointer;
                     pointer.any_down() || pointer.any_pressed()
                 };
-                let resize_hover = mouse_over_resize_line && !dragging_something_else;
+                let resize_hover = resize_response.hovered() && !dragging_something_else;
 
-                if resize_hover || is_resizing {
+                if resize_hover || resize_response.dragged() {
                     ui.output().cursor_icon = egui::CursorIcon::ResizeColumn;
                 }
 
-                let stroke = if is_resizing {
+                let stroke = if resize_response.dragged() {
                     ui.style().visuals.widgets.active.bg_stroke
                 } else if resize_hover {
                     ui.style().visuals.widgets.hovered.bg_stroke

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -548,8 +548,14 @@ impl<'a> Table<'a> {
                         let mut new_width = *column_width + pointer.x - x;
                         if !column.clip {
                             // Unless we clip we don't want to shrink below the
-                            // size that was actually used:
-                            new_width = new_width.at_least(max_used_widths[i]);
+                            // size that was actually used.
+                            // However, we still want to allow content that shrinks when you try
+                            // to make the column less wide, so we allow some small shrinkage each frame:
+                            // big enough to allow shrinking over time, small enough not to look ugly when
+                            // shrinking fails. This is a bit of a HACK around immediate mode.
+                            let max_shrinkage_per_frame = 8.0;
+                            new_width =
+                                new_width.at_least(max_used_widths[i] - max_shrinkage_per_frame);
                         }
                         new_width = new_width.clamp(min_width, max_width);
 

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -183,7 +183,7 @@ fn to_sizing(columns: &[Column]) -> Sizing {
 pub struct TableBuilder<'a> {
     ui: &'a mut Ui,
     columns: Vec<Column>,
-    scroll: bool,
+    vscroll: bool,
     striped: bool,
     resizable: bool,
     stick_to_bottom: bool,
@@ -197,7 +197,7 @@ impl<'a> TableBuilder<'a> {
         Self {
             ui,
             columns: Default::default(),
-            scroll: true,
+            vscroll: true,
             striped: false,
             resizable: false,
             stick_to_bottom: false,
@@ -206,10 +206,15 @@ impl<'a> TableBuilder<'a> {
         }
     }
 
-    /// Enable scrollview in body (default: true)
-    pub fn scroll(mut self, scroll: bool) -> Self {
-        self.scroll = scroll;
+    /// Enable vertical scrolling in body (default: true)
+    pub fn vscroll(mut self, vscroll: bool) -> Self {
+        self.vscroll = vscroll;
         self
+    }
+
+    #[deprecated = "Renamed to vscroll"]
+    pub fn scroll(self, vscroll: bool) -> Self {
+        self.vscroll(vscroll)
     }
 
     /// Enable striped row background for improved readability (default: false)
@@ -241,7 +246,7 @@ impl<'a> TableBuilder<'a> {
         self
     }
 
-    /// Set the vertical scroll offset position.
+    /// Set the vertical scroll offset position, in points.
     pub fn vertical_scroll_offset(mut self, offset: f32) -> Self {
         self.scroll_offset_y = Some(offset);
         self
@@ -269,7 +274,7 @@ impl<'a> TableBuilder<'a> {
 
     fn available_width(&self) -> f32 {
         self.ui.available_rect_before_wrap().width()
-            - if self.scroll {
+            - if self.vscroll {
                 self.ui.spacing().item_spacing.x + self.ui.spacing().scroll_bar_width
             } else {
                 0.0
@@ -283,7 +288,7 @@ impl<'a> TableBuilder<'a> {
         let Self {
             ui,
             columns,
-            scroll,
+            vscroll,
             striped,
             resizable,
             stick_to_bottom,
@@ -326,7 +331,7 @@ impl<'a> TableBuilder<'a> {
             widths: state.column_widths,
             max_used_widths,
             first_frame_auto_size_columns,
-            scroll,
+            vscroll,
             resizable,
             striped,
             stick_to_bottom,
@@ -345,7 +350,7 @@ impl<'a> TableBuilder<'a> {
         let Self {
             ui,
             columns,
-            scroll,
+            vscroll,
             striped,
             resizable,
             stick_to_bottom,
@@ -373,7 +378,7 @@ impl<'a> TableBuilder<'a> {
             widths: state.column_widths,
             max_used_widths,
             first_frame_auto_size_columns,
-            scroll,
+            vscroll,
             resizable,
             striped,
             stick_to_bottom,
@@ -433,7 +438,7 @@ pub struct Table<'a> {
     /// Accumulated maximum used widths for each column.
     max_used_widths: Vec<f32>,
     first_frame_auto_size_columns: bool,
-    scroll: bool,
+    vscroll: bool,
     resizable: bool,
     striped: bool,
     stick_to_bottom: bool,
@@ -457,7 +462,7 @@ impl<'a> Table<'a> {
             widths,
             mut max_used_widths,
             first_frame_auto_size_columns,
-            scroll,
+            vscroll,
             striped,
             stick_to_bottom,
             scroll_offset_y,
@@ -466,7 +471,7 @@ impl<'a> Table<'a> {
 
         let avail_rect = ui.available_rect_before_wrap();
 
-        let mut scroll_area = egui::ScrollArea::new([false, scroll])
+        let mut scroll_area = egui::ScrollArea::new([false, vscroll])
             .auto_shrink([true; 2])
             .stick_to_bottom(stick_to_bottom);
 


### PR DESCRIPTION
In fact, it is now so good it should perhaps be moved into `egui` proper.

![auto-size-table-columns](https://user-images.githubusercontent.com/1148717/204859984-d34e916c-ae46-4c6d-9f53-727caf1a4a05.gif)

## Improvements
The improvements are legion:

* Auto-sized columns from the start
* Double-click columns to auto-size them
* Set which columns are resizable
* Turn clipping on/off on a per-column basis
* Add `scroll_to_row`
* Add functions to control the height of a scrollable table
* Fix bugs when putting `Table` inside of a horizontal `ScrollArea`
* Many other bug fixes

## Changes
* All `Table` now store state. You may see warnings about reused table ids. Use `ui.push_id` to fix this.
* `TableBuilder::column` takes a `Column` instead of a `Size`
* `Column` controls default size, size range, resizing, and clipping of columns
* `Column::auto` should be the go-to choice.
* Added `Table::scroll_to_row`
* Added `Table::min_scrolled_height` and `Table::max_scroll_height`
* Added `TableBody::max_size`
* `Table::scroll` renamed `Table::vscroll`
* `egui_extras::Strip` now has `clip: false` by default.