### PR TITLE
fix wrong variable name

### DIFF
--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -339,7 +339,7 @@ mod glow_integration {
 
             // try egl and fallback to windows wgl. Windows is the only platform that *requires* window handle to create display.
             #[cfg(target_os = "windows")]
-            let preference = glutin::display::DisplayApiPreference::EglThenWgl(Some(window_handle));
+            let preference = glutin::display::DisplayApiPreference::EglThenWgl(Some(raw_window_handle));
             // try egl and fallback to x11 glx
             #[cfg(target_os = "linux")]
             let preference = glutin::display::DisplayApiPreference::EglThenGlx(Box::new(

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -339,7 +339,8 @@ mod glow_integration {
 
             // try egl and fallback to windows wgl. Windows is the only platform that *requires* window handle to create display.
             #[cfg(target_os = "windows")]
-            let preference = glutin::display::DisplayApiPreference::EglThenWgl(Some(raw_window_handle));
+            let preference =
+                glutin::display::DisplayApiPreference::EglThenWgl(Some(raw_window_handle));
             // try egl and fallback to x11 glx
             #[cfg(target_os = "linux")]
             let preference = glutin::display::DisplayApiPreference::EglThenGlx(Box::new(


### PR DESCRIPTION
I used rust analyzer's rename functionality and it seems the feature gated code is not affected by that.

I am surprised that the CI hasn't caught this one.