### PR TITLE
fix all clippy lints and remove them from allow list in cranky

### DIFF
--- a/Cranky.toml
+++ b/Cranky.toml
@@ -116,7 +116,6 @@ allow = [
   # TODO(emilk): enable more lints
   "clippy::type_complexity",
   "clippy::undocumented_unsafe_blocks",
-  "clippy::manual_range_contains",
   "trivial_casts",
   "unsafe_op_in_unsafe_fn",             # `unsafe_op_in_unsafe_fn` may become the default in future Rust versions: https://github.com/rust-lang/rust/issues/71668
   "unused_qualifications",

--- a/crates/ecolor/src/color32.rs
+++ b/crates/ecolor/src/color32.rs
@@ -173,7 +173,7 @@ impl Color32 {
 
     /// Multiply with 0.5 to make color half as opaque.
     pub fn linear_multiply(self, factor: f32) -> Color32 {
-        crate::ecolor_assert!(0.0 <= factor && factor <= 1.0);
+        crate::ecolor_assert!((0.0..=1.0).contains(&factor));
         // As an unfortunate side-effect of using premultiplied alpha
         // we need a somewhat expensive conversion to linear space and back.
         Rgba::from(self).multiply(factor).into()

--- a/crates/ecolor/src/rgba.rs
+++ b/crates/ecolor/src/rgba.rs
@@ -96,22 +96,22 @@ impl Rgba {
     }
 
     pub fn from_luminance_alpha(l: f32, a: f32) -> Self {
-        crate::ecolor_assert!(0.0 <= l && l <= 1.0);
-        crate::ecolor_assert!(0.0 <= a && a <= 1.0);
+        crate::ecolor_assert!((0.0..=1.0).contains(&l));
+        crate::ecolor_assert!((0.0..=1.0).contains(&a));
         Self([l * a, l * a, l * a, a])
     }
 
     /// Transparent black
     #[inline(always)]
     pub fn from_black_alpha(a: f32) -> Self {
-        crate::ecolor_assert!(0.0 <= a && a <= 1.0);
+        crate::ecolor_assert!((0.0..=1.0).contains(&a));
         Self([0.0, 0.0, 0.0, a])
     }
 
     /// Transparent white
     #[inline(always)]
     pub fn from_white_alpha(a: f32) -> Self {
-        crate::ecolor_assert!(0.0 <= a && a <= 1.0, "a: {}", a);
+        crate::ecolor_assert!((0.0..=1.0).contains(&a), "a: {}", a);
         Self([a, a, a, a])
     }
 

--- a/crates/egui_demo_app/src/apps/custom3d_glow.rs
+++ b/crates/egui_demo_app/src/apps/custom3d_glow.rs
@@ -146,12 +146,11 @@ impl RotatingTriangle {
                         ),
                     );
                     gl.compile_shader(shader);
-                    if !gl.get_shader_compile_status(shader) {
-                        panic!(
-                            "Failed to compile custom_3d_glow: {}",
-                            gl.get_shader_info_log(shader)
-                        );
-                    }
+                    assert!(
+                        gl.get_shader_compile_status(shader),
+                        "Failed to compile custom_3d_glow: {}",
+                        gl.get_shader_info_log(shader)
+                    );
                     gl.attach_shader(program, shader);
                     shader
                 })


### PR DESCRIPTION
As a new version has been published, its better to clean up clippy lints before any other major pull requests.