### PR TITLE
Fix docs.rs build issues for eframe, egui-winit, egui_glium, egui_glow

### DIFF
--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -5,6 +5,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 
 
 ## Unreleased
+* Fix docs.rs build ([#2420](https://github.com/emilk/egui/pull/2420)).
 
 
 ## 0.20.0 - 2022-12-08 - AccessKit integration and `wgpu` web support

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -14,7 +14,9 @@ keywords = ["egui", "gui", "gamedev"]
 include = ["../LICENSE-APACHE", "../LICENSE-MIT", "**/*.rs", "Cargo.toml"]
 
 [package.metadata.docs.rs]
-all-features = true
+# Avoid speech-dispatcher dependencies - see https://docs.rs/crate/eframe/0.20.0/builds/695200
+no-default-features = true
+features = ["document-features", "glow", "wgpu", "persistence", "wgpu"]
 
 [lib]
 

--- a/crates/egui-winit/CHANGELOG.md
+++ b/crates/egui-winit/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to the `egui-winit` integration will be noted in this file.
 
 
 ## Unreleased
+* Fix docs.rs build ([#2420](https://github.com/emilk/egui/pull/2420)).
 
 
 ## 0.20.0 - 2022-12-08

--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -14,7 +14,8 @@ keywords = ["winit", "egui", "gui", "gamedev"]
 include = ["../LICENSE-APACHE", "../LICENSE-MIT", "**/*.rs", "Cargo.toml"]
 
 [package.metadata.docs.rs]
-all-features = true
+# Avoid speech-dispatcher dependencies - see https://docs.rs/crate/egui-winit/0.20.0/builds/695196
+features = ["document-features"]
 
 
 [features]

--- a/crates/egui_glium/CHANGELOG.md
+++ b/crates/egui_glium/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to the `egui_glium` integration will be noted in this file.
 
 
 ## Unreleased
+* Fix docs.rs build ([#2420](https://github.com/emilk/egui/pull/2420)).
 
 
 ## 0.20.0 - 2022-12-08

--- a/crates/egui_glium/Cargo.toml
+++ b/crates/egui_glium/Cargo.toml
@@ -20,7 +20,8 @@ include = [
 ]
 
 [package.metadata.docs.rs]
-all-features = true
+# Avoid speech-dispatcher dependencies - see https://docs.rs/crate/egui_glium/0.20.0/builds/695197
+features = ["document-features"]
 
 
 [features]

--- a/crates/egui_glow/CHANGELOG.md
+++ b/crates/egui_glow/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to the `egui_glow` integration will be noted in this file.
 
 
 ## Unreleased
+* Fix docs.rs build ([#2420](https://github.com/emilk/egui/pull/2420)).
 
 
 ## 0.20.0 - 2022-12-08

--- a/crates/egui_glow/Cargo.toml
+++ b/crates/egui_glow/Cargo.toml
@@ -20,7 +20,8 @@ include = [
 ]
 
 [package.metadata.docs.rs]
-all-features = true
+# Avoid speech-dispatcher dependencies - see https://docs.rs/crate/egui_glow/0.20.0/builds/695194
+features = ["document-features"]
 
 
 [features]


### PR DESCRIPTION
I hope we can get rid of the `tts` crate very soon, now that AcessKit has landed. It is only used for web atm. Should probably be removed from all native libraries.