### PR TITLE
Fix drag_value.edit_string unexpected reset

### DIFF
--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -499,6 +499,7 @@ impl<'a> Widget for DragValue<'a> {
             }
 
             if response.clicked() {
+                ui.memory().drag_value.edit_string = None;
                 ui.memory().request_focus(id);
             } else if response.dragged() {
                 ui.output().cursor_icon = CursorIcon::ResizeHorizontal;

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -379,6 +379,9 @@ impl<'a> Widget for DragValue<'a> {
         // screen readers.
         ui.memory().interested_in_focus(id);
         let is_kb_editing = ui.memory().has_focus(id);
+        if ui.memory().gained_focus(id) {
+            ui.memory().drag_value.edit_string = None
+        }
 
         let old_value = get(&mut get_set_value);
         let mut value = old_value;
@@ -476,7 +479,6 @@ impl<'a> Widget for DragValue<'a> {
             ui.memory().drag_value.edit_string = Some(value_text);
             response
         } else {
-            ui.memory().drag_value.edit_string = None;
             let button = Button::new(
                 RichText::new(format!("{}{}{}", prefix, value_text.clone(), suffix)).monospace(),
             )

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -380,7 +380,7 @@ impl<'a> Widget for DragValue<'a> {
         ui.memory().interested_in_focus(id);
         let is_kb_editing = ui.memory().has_focus(id);
         if ui.memory().gained_focus(id) {
-            ui.memory().drag_value.edit_string = None
+            ui.memory().drag_value.edit_string = None;
         }
 
         let old_value = get(&mut get_set_value);


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Make drag_value.edit_string None only during current focused widget update

Only two cases `edit_string` will be set to None (and reconstructed from `value`):

1. current widget gains focus.
2. current widget consumes up down key to change value.

Editing, Tabing and UpDown tested.

Close https://github.com/emilk/egui/issues/2418
Close https://github.com/emilk/egui/issues/2370
