### PR TITLE
eframe error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,6 +1325,7 @@ dependencies = [
  "raw-window-handle 0.5.0",
  "ron",
  "serde",
+ "thiserror",
  "tracing",
  "tts",
  "wasm-bindgen",

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -6,6 +6,9 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 
 ## Unreleased
 
+#### Desktop/Native:
+* `eframe::run_native` now returns a `Result` ([#2433](https://github.com/emilk/egui/pull/2433)).
+
 
 ## 0.20.1 - 2022-12-11
 * Fix docs.rs build ([#2420](https://github.com/emilk/egui/pull/2420)).

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -72,6 +72,7 @@ egui = { version = "0.20.0", path = "../egui", default-features = false, feature
   "bytemuck",
   "tracing",
 ] }
+thiserror = "1.0.37"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 #! ### Optional dependencies

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -708,6 +708,7 @@ impl Frame {
     #[doc(alias = "exit")]
     #[doc(alias = "quit")]
     pub fn close(&mut self) {
+        tracing::debug!("eframe::Frame::close called");
         self.output.close = true;
     }
 

--- a/crates/eframe/src/lib.rs
+++ b/crates/eframe/src/lib.rs
@@ -127,7 +127,7 @@ pub async fn start_web(
     canvas_id: &str,
     web_options: WebOptions,
     app_creator: AppCreator,
-) -> Result<AppRunnerRef, wasm_bindgen::JsValue> {
+) -> std::result::Result<AppRunnerRef, wasm_bindgen::JsValue> {
     let handle = web::start(canvas_id, web_options, app_creator).await?;
 
     Ok(handle)
@@ -216,11 +216,11 @@ pub enum EframeError {
     #[error("winit error: {0}")]
     Winit(#[from] winit::error::OsError),
 
-    #[cfg(feature = "glow")]
+    #[cfg(all(feature = "glow", not(target_arch = "wasm32")))]
     #[error("glutin error: {0}")]
     Glutin(#[from] glutin::error::Error),
 
-    #[cfg(feature = "glow")]
+    #[cfg(all(feature = "glow", not(target_arch = "wasm32")))]
     #[error("Found no glutin configs matching the template: {0:?}")]
     NoGlutinConfigs(glutin::config::ConfigTemplate),
 

--- a/crates/eframe/src/lib.rs
+++ b/crates/eframe/src/lib.rs
@@ -212,6 +212,10 @@ pub fn run_native(
 /// The different problems that can occur when trying to run `eframe`.
 #[derive(thiserror::Error, Debug)]
 pub enum EframeError {
+    #[cfg(not(target_arch = "wasm32"))]
+    #[error("winit error: {0}")]
+    Winit(#[from] winit::error::OsError),
+
     #[cfg(feature = "glow")]
     #[error("glutin error: {0}")]
     Glutin(#[from] glutin::error::Error),

--- a/crates/eframe/src/lib.rs
+++ b/crates/eframe/src/lib.rs
@@ -212,6 +212,14 @@ pub fn run_native(
 /// The different problems that can occur when trying to run `eframe`.
 #[derive(thiserror::Error, Debug)]
 pub enum EframeError {
+    #[cfg(feature = "glow")]
+    #[error("glutin error: {0}")]
+    Glutin(#[from] glutin::error::Error),
+
+    #[cfg(feature = "glow")]
+    #[error("Found no glutin configs matching the template: {0:?}")]
+    NoGlutinConfigs(glutin::config::ConfigTemplate),
+
     #[cfg(feature = "wgpu")]
     #[error("WGPU error: {0}")]
     Wgpu(#[from] wgpu::RequestDeviceError),

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -308,8 +308,15 @@ impl EpiIntegration {
         use winit::event::{ElementState, MouseButton, WindowEvent};
 
         match event {
-            WindowEvent::CloseRequested => self.close = app.on_close_event(),
-            WindowEvent::Destroyed => self.close = true,
+            WindowEvent::CloseRequested => {
+                tracing::debug!("Received WindowEvent::CloseRequested");
+                self.close = app.on_close_event();
+                tracing::debug!("App::on_close_event returned {}", self.close);
+            }
+            WindowEvent::Destroyed => {
+                tracing::debug!("Received WindowEvent::Destroyed");
+                self.close = true;
+            }
             WindowEvent::MouseInput {
                 button: MouseButton::Left,
                 state: ElementState::Pressed,
@@ -351,6 +358,7 @@ impl EpiIntegration {
             self.can_drag_window = false;
             if app_output.close {
                 self.close = app.on_close_event();
+                tracing::debug!("App::on_close_event returned {}", self.close);
             }
             self.frame.output.visible = app_output.visible; // this is handled by post_present
             handle_app_output(window, self.egui_ctx.pixels_per_point(), app_output);

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -49,6 +49,7 @@ pub fn read_window_info(window: &winit::window::Window, pixels_per_point: f32) -
 }
 
 pub fn window_builder(
+    title: &str,
     native_options: &epi::NativeOptions,
     window_settings: &Option<WindowSettings>,
 ) -> winit::window::WindowBuilder {
@@ -73,13 +74,17 @@ pub fn window_builder(
     let window_icon = icon_data.clone().and_then(load_icon);
 
     let mut window_builder = winit::window::WindowBuilder::new()
+        .with_title(title)
         .with_always_on_top(*always_on_top)
         .with_decorations(*decorated)
         .with_fullscreen(fullscreen.then(|| winit::window::Fullscreen::Borderless(None)))
         .with_maximized(*maximized)
         .with_resizable(*resizable)
         .with_transparent(*transparent)
-        .with_window_icon(window_icon);
+        .with_window_icon(window_icon)
+        // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
+        // We must also keep the window hidden until AccessKit is initialized.
+        .with_visible(false);
 
     #[cfg(target_os = "macos")]
     if *fullsize_content {

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -440,7 +440,9 @@ const STORAGE_WINDOW_KEY: &str = "window";
 pub fn load_window_settings(_storage: Option<&dyn epi::Storage>) -> Option<WindowSettings> {
     #[cfg(feature = "persistence")]
     {
-        epi::get_value(_storage?, STORAGE_WINDOW_KEY)
+        let mut settings: WindowSettings = epi::get_value(_storage?, STORAGE_WINDOW_KEY)?;
+        settings.clamp_to_sane_values();
+        Some(settings)
     }
     #[cfg(not(feature = "persistence"))]
     None

--- a/crates/eframe/src/native/file_storage.rs
+++ b/crates/eframe/src/native/file_storage.rs
@@ -26,6 +26,7 @@ impl FileStorage {
     /// Store the state in this .ron file.
     pub fn from_ron_filepath(ron_filepath: impl Into<PathBuf>) -> Self {
         let ron_filepath: PathBuf = ron_filepath.into();
+        tracing::debug!("Loading app state from {:?}…", ron_filepath);
         Self {
             kv: read_ron(&ron_filepath).unwrap_or_default(),
             ron_filepath,

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -106,7 +106,7 @@ fn run_and_return(
 ) -> Result<()> {
     use winit::platform::run_return::EventLoopExtRunReturn as _;
 
-    tracing::debug!("event_loop.run_return");
+    tracing::debug!("Entering the winit event loop (run_return)…");
 
     let mut next_repaint_time = Instant::now();
 
@@ -115,7 +115,7 @@ fn run_and_return(
     event_loop.run_return(|event, event_loop, control_flow| {
         let event_result = match &event {
             winit::event::Event::LoopDestroyed => {
-                tracing::debug!("winit::event::Event::LoopDestroyed");
+                tracing::debug!("Received Event::LoopDestroyed");
                 EventResult::Exit
             }
 
@@ -149,6 +149,7 @@ fn run_and_return(
                 Ok(event_result) => event_result,
                 Err(err) => {
                     returned_result = Err(err);
+                    tracing::debug!("Exiting because of an error");
                     EventResult::Exit
                 }
             },
@@ -206,13 +207,16 @@ fn run_and_return(
 }
 
 fn run_and_exit(event_loop: EventLoop<UserEvent>, mut winit_app: impl WinitApp + 'static) -> ! {
-    tracing::debug!("event_loop.run");
+    tracing::debug!("Entering the winit event loop (run)…");
 
     let mut next_repaint_time = Instant::now();
 
     event_loop.run(move |event, event_loop, control_flow| {
         let event_result = match event {
-            winit::event::Event::LoopDestroyed => EventResult::Exit,
+            winit::event::Event::LoopDestroyed => {
+                tracing::debug!("Received Event::LoopDestroyed");
+                EventResult::Exit
+            }
 
             // Platform-dependent event handlers to workaround a winit bug
             // See: https://github.com/rust-windowing/winit/issues/987
@@ -252,7 +256,7 @@ fn run_and_exit(event_loop: EventLoop<UserEvent>, mut winit_app: impl WinitApp +
                 next_repaint_time = next_repaint_time.min(repaint_time);
             }
             EventResult::Exit => {
-                tracing::debug!("Quitting…");
+                tracing::debug!("Quitting - saving app state…");
                 winit_app.save_and_destroy();
                 #[allow(clippy::exit)]
                 std::process::exit(0);
@@ -802,7 +806,8 @@ mod glow_integration {
                             winit::event::WindowEvent::CloseRequested
                                 if running.integration.should_close() =>
                             {
-                                return Ok(EventResult::Exit)
+                                tracing::debug!("Received WindowEvent::CloseRequested");
+                                return Ok(EventResult::Exit);
                             }
                             _ => {}
                         }
@@ -1228,7 +1233,8 @@ mod wgpu_integration {
                             winit::event::WindowEvent::CloseRequested
                                 if running.integration.should_close() =>
                             {
-                                return Ok(EventResult::Exit)
+                                tracing::debug!("Received WindowEvent::CloseRequested");
+                                return Ok(EventResult::Exit);
                             }
                             _ => {}
                         };

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -496,20 +496,16 @@ mod glow_integration {
         fn create_glutin_windowed_context(
             event_loop: &EventLoopWindowTarget<UserEvent>,
             storage: Option<&dyn epi::Storage>,
-            title: &String,
+            title: &str,
             native_options: &NativeOptions,
         ) -> Result<(GlutinWindowContext, glow::Context)> {
             crate::profile_function!();
 
             let window_settings = epi_integration::load_window_settings(storage);
 
-            let window_builder = epi_integration::window_builder(native_options, &window_settings)
-                .with_title(title)
-                .with_transparent(native_options.transparent)
-                // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
-                // We must also keep the window hidden until AccessKit is initialized.
-                .with_visible(false);
-            let winit_window = window_builder.build(event_loop)?;
+            let winit_window =
+                epi_integration::window_builder(title, native_options, &window_settings)
+                    .build(event_loop)?;
             // a lot of the code below has been lifted from glutin example in their repo.
             let glutin_window_context =
                 unsafe { GlutinWindowContext::new(winit_window, native_options)? };
@@ -936,16 +932,12 @@ mod wgpu_integration {
         fn create_window(
             event_loop: &EventLoopWindowTarget<UserEvent>,
             storage: Option<&dyn epi::Storage>,
-            title: &String,
+            title: &str,
             native_options: &NativeOptions,
         ) -> Result<winit::window::Window> {
             let window_settings = epi_integration::load_window_settings(storage);
             Ok(
-                epi_integration::window_builder(native_options, &window_settings)
-                    .with_title(title)
-                    // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
-                    // We must also keep the window hidden until AccessKit is initialized.
-                    .with_visible(false)
+                epi_integration::window_builder(title, native_options, &window_settings)
                     .build(event_loop)?,
             )
         }

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -509,9 +509,7 @@ mod glow_integration {
                 // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
                 // We must also keep the window hidden until AccessKit is initialized.
                 .with_visible(false);
-            let winit_window = window_builder
-                .build(event_loop)
-                .expect("failed to create winit window");
+            let winit_window = window_builder.build(event_loop)?;
             // a lot of the code below has been lifted from glutin example in their repo.
             let glutin_window_context =
                 unsafe { GlutinWindowContext::new(winit_window, native_options)? };
@@ -940,15 +938,16 @@ mod wgpu_integration {
             storage: Option<&dyn epi::Storage>,
             title: &String,
             native_options: &NativeOptions,
-        ) -> winit::window::Window {
+        ) -> Result<winit::window::Window> {
             let window_settings = epi_integration::load_window_settings(storage);
-            epi_integration::window_builder(native_options, &window_settings)
-                .with_title(title)
-                // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
-                // We must also keep the window hidden until AccessKit is initialized.
-                .with_visible(false)
-                .build(event_loop)
-                .unwrap()
+            Ok(
+                epi_integration::window_builder(native_options, &window_settings)
+                    .with_title(title)
+                    // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
+                    // We must also keep the window hidden until AccessKit is initialized.
+                    .with_visible(false)
+                    .build(event_loop)?,
+            )
         }
 
         #[allow(unsafe_code)]
@@ -1167,7 +1166,7 @@ mod wgpu_integration {
                                 running.integration.frame.storage(),
                                 &self.app_name,
                                 &self.native_options,
-                            );
+                            )?;
                             self.set_window(window)?;
                         }
                     } else {
@@ -1177,7 +1176,7 @@ mod wgpu_integration {
                             storage.as_deref(),
                             &self.app_name,
                             &self.native_options,
-                        );
+                        )?;
                         self.init_run_state(event_loop, storage, window)?;
                     }
                     EventResult::RepaintNow

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -1175,7 +1175,7 @@ mod wgpu_integration {
                 }
                 winit::event::Event::Suspended => {
                     #[cfg(target_os = "android")]
-                    self.drop_window();
+                    self.drop_window()?;
                     EventResult::Wait
                 }
 

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -305,6 +305,8 @@ fn center_window_pos(
 mod glow_integration {
     use std::sync::Arc;
 
+    use egui::NumExt as _;
+
     use super::*;
 
     // Note: that the current Glutin API design tightly couples the GL context with
@@ -416,8 +418,8 @@ mod glow_integration {
                 glutin::context::ContextAttributesBuilder::new().build(Some(raw_window_handle));
             // for surface creation.
             let (width, height): (u32, u32) = winit_window.inner_size().into();
-            let width = std::num::NonZeroU32::new(width).expect("Size must not be zero");
-            let height = std::num::NonZeroU32::new(height).expect("Size must not be zero");
+            let width = std::num::NonZeroU32::new(width.at_least(1)).unwrap();
+            let height = std::num::NonZeroU32::new(height.at_least(1)).unwrap();
             let surface_attributes =
                 glutin::surface::SurfaceAttributesBuilder::<glutin::surface::WindowSurface>::new()
                     .build(raw_window_handle, width, height);
@@ -441,10 +443,8 @@ mod glow_integration {
 
         fn resize(&self, physical_size: winit::dpi::PhysicalSize<u32>) {
             use glutin::surface::GlSurface;
-            let width =
-                std::num::NonZeroU32::new(physical_size.width).expect("Size must not be zero");
-            let height =
-                std::num::NonZeroU32::new(physical_size.height).expect("Size must not be zero");
+            let width = std::num::NonZeroU32::new(physical_size.width.at_least(1)).unwrap();
+            let height = std::num::NonZeroU32::new(physical_size.height.at_least(1)).unwrap();
             self.gl_surface.resize(&self.gl_context, width, height);
         }
 

--- a/crates/egui-wgpu/CHANGELOG.md
+++ b/crates/egui-wgpu/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to the `egui-wgpu` integration will be noted in this file.
 
 
 ## Unreleased
-* Fix panic if we can't find a device ([#2428](https://github.com/emilk/egui/pull/2428))
+* Return `Err` instead of panic if we can't find a device ([#2428](https://github.com/emilk/egui/pull/2428)).
 
 
 ## 0.20.0 - 2022-12-08 - web support

--- a/crates/egui-winit/src/window_settings.rs
+++ b/crates/egui-winit/src/window_settings.rs
@@ -46,12 +46,13 @@ impl WindowSettings {
         &self,
         mut window: winit::window::WindowBuilder,
     ) -> winit::window::WindowBuilder {
-        if !cfg!(target_os = "windows") {
-            // If the app last ran on two monitors and only one is now connected, then
-            // the given position is invalid.
-            // If this happens on Mac, the window is clamped into valid area.
-            // If this happens on Windows, the window is hidden and very difficult to find.
-            // So we don't restore window positions on Windows.
+        // If the app last ran on two monitors and only one is now connected, then
+        // the given position is invalid.
+        // If this happens on Mac, the window is clamped into valid area.
+        // If this happens on Windows, the window is hidden and very difficult to find.
+        // So we don't restore window positions on Windows.
+        let try_restore_position = !cfg!(target_os = "windows");
+        if try_restore_position {
             if let Some(pos) = self.position {
                 window = window.with_position(winit::dpi::PhysicalPosition {
                     x: pos.x as f64,

--- a/crates/egui-winit/src/window_settings.rs
+++ b/crates/egui-winit/src/window_settings.rs
@@ -74,4 +74,12 @@ impl WindowSettings {
             window
         }
     }
+
+    pub fn clamp_to_sane_values(&mut self) {
+        if let Some(size) = &mut self.inner_size_points {
+            // Prevent ridiculously small windows
+            let min_size = egui::Vec2::splat(64.0);
+            *size = size.max(min_size);
+        }
+    }
 }

--- a/crates/egui_demo_app/src/main.rs
+++ b/crates/egui_demo_app/src/main.rs
@@ -4,6 +4,17 @@
 
 // When compiling natively:
 fn main() -> Result<(), eframe::EframeError> {
+    {
+        // Silence wgpu log spam (https://github.com/gfx-rs/wgpu/issues/3206)
+        let mut rust_log = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_owned());
+        for loud_crate in ["naga", "wgpu_core", "wgpu_hal"] {
+            if !rust_log.contains(&format!("{loud_crate}=")) {
+                rust_log += &format!(",{loud_crate}=warn");
+            }
+        }
+        std::env::set_var("RUST_LOG", rust_log);
+    }
+
     // Log to stdout (if you run with `RUST_LOG=debug`).
     tracing_subscriber::fmt::init();
 

--- a/crates/egui_demo_app/src/main.rs
+++ b/crates/egui_demo_app/src/main.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
 // When compiling natively:
-fn main() {
+fn main() -> Result<(), eframe::EframeError> {
     // Log to stdout (if you run with `RUST_LOG=debug`).
     tracing_subscriber::fmt::init();
 
@@ -21,5 +21,5 @@ fn main() {
         "egui demo app",
         options,
         Box::new(|cc| Box::new(egui_demo_app::WrapApp::new(cc))),
-    );
+    )
 }

--- a/crates/egui_glow/examples/pure_glow.rs
+++ b/crates/egui_glow/examples/pure_glow.rs
@@ -223,9 +223,9 @@ fn create_display(
             height: 600.0,
         })
         .with_title("egui_glow example")
-        .with_visible(false)
+        .with_visible(false) // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
         .build(event_loop)
-        .unwrap(); // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
+        .unwrap();
 
     // a lot of the code below has been lifted from glutin example in their repo.
     let glutin_window_context = unsafe { GlutinWindowContext::new(winit_window) };

--- a/examples/confirm_exit/src/main.rs
+++ b/examples/confirm_exit/src/main.rs
@@ -2,7 +2,7 @@
 
 use eframe::egui;
 
-fn main() {
+fn main() -> Result<(), eframe::EframeError> {
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(320.0, 240.0)),
         ..Default::default()
@@ -11,7 +11,7 @@ fn main() {
         "Confirm exit",
         options,
         Box::new(|_cc| Box::new(MyApp::default())),
-    );
+    )
 }
 
 #[derive(Default)]

--- a/examples/custom_3d_glow/src/main.rs
+++ b/examples/custom_3d_glow/src/main.rs
@@ -6,7 +6,7 @@ use eframe::egui;
 use egui::mutex::Mutex;
 use std::sync::Arc;
 
-fn main() {
+fn main() -> Result<(), eframe::EframeError> {
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(350.0, 380.0)),
         multisampling: 8,
@@ -17,7 +17,7 @@ fn main() {
         "Custom 3D painting in eframe using glow",
         options,
         Box::new(|cc| Box::new(MyApp::new(cc))),
-    );
+    )
 }
 
 struct MyApp {

--- a/examples/custom_3d_three-d/src/main.rs
+++ b/examples/custom_3d_three-d/src/main.rs
@@ -4,7 +4,7 @@
 use eframe::egui;
 
 #[cfg(not(target_arch = "wasm32"))]
-fn main() {
+fn main() -> Result<(), eframe::EframeError> {
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(550.0, 610.0)),
         multisampling: 8,
@@ -16,7 +16,7 @@ fn main() {
         "Custom 3D painting in eframe!",
         options,
         Box::new(|cc| Box::new(MyApp::new(cc))),
-    );
+    )
 }
 
 pub struct MyApp {

--- a/examples/custom_font/src/main.rs
+++ b/examples/custom_font/src/main.rs
@@ -2,7 +2,7 @@
 
 use eframe::egui;
 
-fn main() {
+fn main() -> Result<(), eframe::EframeError> {
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(320.0, 240.0)),
         ..Default::default()
@@ -11,7 +11,7 @@ fn main() {
         "egui example: custom font",
         options,
         Box::new(|cc| Box::new(MyApp::new(cc))),
-    );
+    )
 }
 
 fn setup_custom_fonts(ctx: &egui::Context) {

--- a/examples/custom_font_style/src/main.rs
+++ b/examples/custom_font_style/src/main.rs
@@ -58,14 +58,14 @@ impl eframe::App for MyApp {
     }
 }
 
-fn main() {
+fn main() -> Result<(), eframe::EframeError> {
     let options = eframe::NativeOptions::default();
 
     eframe::run_native(
         "egui example: global font style",
         options,
         Box::new(|cc| Box::new(MyApp::new(cc))),
-    );
+    )
 }
 
 pub const LOREM_IPSUM: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";

--- a/examples/custom_window_frame/src/main.rs
+++ b/examples/custom_window_frame/src/main.rs
@@ -4,7 +4,7 @@
 
 use eframe::egui;
 
-fn main() {
+fn main() -> Result<(), eframe::EframeError> {
     let options = eframe::NativeOptions {
         // Hide the OS-specific "chrome" around the window:
         decorated: false,
@@ -18,7 +18,7 @@ fn main() {
         "Custom window frame", // unused title
         options,
         Box::new(|_cc| Box::new(MyApp::default())),
-    );
+    )
 }
 
 #[derive(Default)]

--- a/examples/download_image/src/main.rs
+++ b/examples/download_image/src/main.rs
@@ -4,13 +4,13 @@ use eframe::egui;
 use egui_extras::RetainedImage;
 use poll_promise::Promise;
 
-fn main() {
+fn main() -> Result<(), eframe::EframeError> {
     let options = eframe::NativeOptions::default();
     eframe::run_native(
         "Download and show an image with eframe/egui",
         options,
         Box::new(|_cc| Box::new(MyApp::default())),
-    );
+    )
 }
 
 #[derive(Default)]

--- a/examples/file_dialog/src/main.rs
+++ b/examples/file_dialog/src/main.rs
@@ -2,7 +2,7 @@
 
 use eframe::egui;
 
-fn main() {
+fn main() -> Result<(), eframe::EframeError> {
     let options = eframe::NativeOptions {
         drag_and_drop_support: true,
         initial_window_size: Some(egui::vec2(320.0, 240.0)),
@@ -12,7 +12,7 @@ fn main() {
         "Native file dialogs and drag-and-drop files",
         options,
         Box::new(|_cc| Box::new(MyApp::default())),
-    );
+    )
 }
 
 #[derive(Default)]

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -2,7 +2,7 @@
 
 use eframe::egui;
 
-fn main() {
+fn main() -> Result<(), eframe::EframeError> {
     // Log to stdout (if you run with `RUST_LOG=debug`).
     tracing_subscriber::fmt::init();
 
@@ -14,7 +14,7 @@ fn main() {
         "My egui App",
         options,
         Box::new(|_cc| Box::new(MyApp::default())),
-    );
+    )
 }
 
 struct MyApp {

--- a/examples/keyboard_events/src/main.rs
+++ b/examples/keyboard_events/src/main.rs
@@ -2,7 +2,7 @@
 
 use eframe::egui;
 use egui::*;
-fn main() {
+fn main() -> Result<(), eframe::EframeError> {
     // Log to stdout (if you run with `RUST_LOG=debug`).
     tracing_subscriber::fmt::init();
 
@@ -11,7 +11,7 @@ fn main() {
         "Keyboard events",
         options,
         Box::new(|_cc| Box::new(Content::default())),
-    );
+    )
 }
 
 #[derive(Default)]

--- a/examples/puffin_profiler/src/main.rs
+++ b/examples/puffin_profiler/src/main.rs
@@ -2,7 +2,7 @@
 
 use eframe::egui;
 
-fn main() {
+fn main() -> Result<(), eframe::EframeError> {
     start_puffin_server(); // NOTE: you may only want to call this if the users specifies some flag or clicks a button!
 
     let options = eframe::NativeOptions::default();
@@ -10,7 +10,7 @@ fn main() {
         "My egui App",
         options,
         Box::new(|_cc| Box::new(MyApp::default())),
-    );
+    )
 }
 
 #[derive(Default)]

--- a/examples/retained_image/src/main.rs
+++ b/examples/retained_image/src/main.rs
@@ -3,7 +3,7 @@
 use eframe::egui;
 use egui_extras::RetainedImage;
 
-fn main() {
+fn main() -> Result<(), eframe::EframeError> {
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(300.0, 900.0)),
         ..Default::default()
@@ -13,7 +13,7 @@ fn main() {
         "Show an image with eframe/egui",
         options,
         Box::new(|_cc| Box::new(MyApp::default())),
-    );
+    )
 }
 
 struct MyApp {

--- a/examples/screenshot/src/main.rs
+++ b/examples/screenshot/src/main.rs
@@ -6,13 +6,13 @@ use eframe::{
 };
 use itertools::Itertools as _;
 
-fn main() {
+fn main() -> Result<(), eframe::EframeError> {
     let options = eframe::NativeOptions::default();
     eframe::run_native(
         "Take screenshots and display with eframe/egui",
         options,
         Box::new(|_cc| Box::new(MyApp::default())),
-    );
+    )
 }
 
 #[derive(Default)]

--- a/examples/serial_windows/src/main.rs
+++ b/examples/serial_windows/src/main.rs
@@ -2,7 +2,7 @@
 
 use eframe::egui;
 
-fn main() {
+fn main() -> Result<(), eframe::EframeError> {
     if cfg!(target_os = "macos") {
         eprintln!("WARNING: this example does not work on Mac! See https://github.com/emilk/egui/issues/1918");
     }
@@ -18,7 +18,7 @@ fn main() {
         "First Window",
         options.clone(),
         Box::new(|_cc| Box::new(MyApp::default())),
-    );
+    )?;
 
     std::thread::sleep(std::time::Duration::from_secs(2));
 
@@ -27,7 +27,7 @@ fn main() {
         "Second Window",
         options.clone(),
         Box::new(|_cc| Box::new(MyApp::default())),
-    );
+    )?;
 
     std::thread::sleep(std::time::Duration::from_secs(2));
 
@@ -36,7 +36,7 @@ fn main() {
         "Third Window",
         options,
         Box::new(|_cc| Box::new(MyApp::default())),
-    );
+    )
 }
 
 #[derive(Default)]

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -6,7 +6,7 @@
 
 use eframe::egui;
 
-fn main() {
+fn main() -> Result<(), eframe::EframeError> {
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(1000.0, 700.0)),
         ..Default::default()
@@ -15,7 +15,7 @@ fn main() {
         "svg example",
         options,
         Box::new(|_cc| Box::new(MyApp::default())),
-    );
+    )
 }
 
 struct MyApp {


### PR DESCRIPTION
This adds a bunch of improved error handling during `eframe` startup.

`eframe::run_native` now returns a `Result`.

`eframe` is also better at logging why it is shutting down, if you run with `RUST_LOG=debug`.