### PR TITLE
eframe: App::on_exit is no longer available for wasm32

### DIFF
--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -9,6 +9,9 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 #### Desktop/Native:
 * `eframe::run_native` now returns a `Result` ([#2433](https://github.com/emilk/egui/pull/2433)).
 
+#### Web:
+* `App::on_exit` is no longer available for `wasm32` ([#2436](https://github.com/emilk/egui/pull/2436)).
+
 
 ## 0.20.1 - 2022-12-11
 * Fix docs.rs build ([#2420](https://github.com/emilk/egui/pull/2420)).

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -125,12 +125,14 @@ pub trait App {
     ///
     /// To get a [`glow`] context you need to compile with the `glow` feature flag,
     /// and run eframe with the glow backend.
+    #[cfg(not(target_arch = "wasm32"))]
     #[cfg(feature = "glow")]
     fn on_exit(&mut self, _gl: Option<&glow::Context>) {}
 
     /// Called once on shutdown, after [`Self::save`].
     ///
     /// If you need to abort an exit use [`Self::on_close_event`].
+    #[cfg(not(target_arch = "wasm32"))]
     #[cfg(not(feature = "glow"))]
     fn on_exit(&mut self) {}
 

--- a/crates/eframe/src/web/backend.rs
+++ b/crates/eframe/src/web/backend.rs
@@ -1,8 +1,7 @@
 use egui::{
     mutex::{Mutex, MutexGuard},
-    TexturesDelta,
+    pos2, Color32, TexturesDelta,
 };
-pub use egui::{pos2, Color32};
 
 use crate::{epi, App};
 


### PR DESCRIPTION
It was never called in wasm32, so no need to have it there
