### PR TITLE
Improve the look of thin lines, making them look weaker 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 ## 0.20.1 - 2022-12-11 - Fix key-repeat
 ### Changed 🔧
 * `InputState`: all press functions again include key repeates (like in egui 0.19) ([#2429](https://github.com/emilk/egui/pull/2429)).
+* Improve the look of thin white lines ([#2437](https://github.com/emilk/egui/pull/2437)).
 
 ### Fixed 🐛
 * Fix key-repeats for `TextEdit`, `Slider`s, etc ([#2429](https://github.com/emilk/egui/pull/2429)).

--- a/Cranky.toml
+++ b/Cranky.toml
@@ -113,10 +113,11 @@ warn = [
 ]
 
 allow = [
-  # TODO(emilk): enable more lints
+  "clippy::manual_range_contains", # This one is just annoying
+
+  # Some of these we should try to put in "warn":
   "clippy::type_complexity",
   "clippy::undocumented_unsafe_blocks",
-  "clippy::manual_range_contains",
   "trivial_casts",
   "unsafe_op_in_unsafe_fn",             # `unsafe_op_in_unsafe_fn` may become the default in future Rust versions: https://github.com/rust-lang/rust/issues/71668
   "unused_qualifications",

--- a/Cranky.toml
+++ b/Cranky.toml
@@ -115,4 +115,9 @@ warn = [
 allow = [
   # TODO(emilk): enable more lints
   "clippy::type_complexity",
+  "clippy::undocumented_unsafe_blocks",
+  "clippy::manual_range_contains",
+  "trivial_casts",
+  "unsafe_op_in_unsafe_fn",             # `unsafe_op_in_unsafe_fn` may become the default in future Rust versions: https://github.com/rust-lang/rust/issues/71668
+  "unused_qualifications",
 ]

--- a/crates/ecolor/CHANGELOG.md
+++ b/crates/ecolor/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to the `ecolor` crate will be noted in this file.
 
 
 ## Unreleased
+* Add `Color32::gamma_multiply` ([#2437](https://github.com/emilk/egui/pull/2437)).
 
 
 ## 0.20.0 - 2022-12-08

--- a/crates/ecolor/Cargo.toml
+++ b/crates/ecolor/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/emilk/egui"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/emilk/egui"
-categories = ["mathematics", "encoding", "images"]
+categories = ["mathematics", "encoding"]
 keywords = ["gui", "color", "conversion", "gamedev", "images"]
 include = ["../LICENSE-APACHE", "../LICENSE-MIT", "**/*.rs", "Cargo.toml"]
 

--- a/crates/ecolor/src/color32.rs
+++ b/crates/ecolor/src/color32.rs
@@ -171,7 +171,27 @@ impl Color32 {
         Rgba::from(*self).to_srgba_unmultiplied()
     }
 
-    /// Multiply with 0.5 to make color half as opaque.
+    /// Multiply with 0.5 to make color half as opaque, perceptually.
+    ///
+    /// Fast multiplication in gamma-space.
+    ///
+    /// This is perceptually even, and faster that [`Self::linear_multiply`].
+    #[inline]
+    pub fn gamma_multiply(self, factor: f32) -> Color32 {
+        crate::ecolor_assert!(0.0 <= factor && factor <= 1.0);
+        let Self([r, g, b, a]) = self;
+        Self([
+            (r as f32 * factor + 0.5) as u8,
+            (g as f32 * factor + 0.5) as u8,
+            (b as f32 * factor + 0.5) as u8,
+            (a as f32 * factor + 0.5) as u8,
+        ])
+    }
+
+    /// Multiply with 0.5 to make color half as opaque in linear space.
+    ///
+    /// This is using linear space, which is not perceptually even.
+    /// You may want to use [`Self::gamma_multiply`] instead.
     pub fn linear_multiply(self, factor: f32) -> Color32 {
         crate::ecolor_assert!(0.0 <= factor && factor <= 1.0);
         // As an unfortunate side-effect of using premultiplied alpha

--- a/crates/ecolor/src/color32.rs
+++ b/crates/ecolor/src/color32.rs
@@ -173,7 +173,7 @@ impl Color32 {
 
     /// Multiply with 0.5 to make color half as opaque.
     pub fn linear_multiply(self, factor: f32) -> Color32 {
-        crate::ecolor_assert!((0.0..=1.0).contains(&factor));
+        crate::ecolor_assert!(0.0 <= factor && factor <= 1.0);
         // As an unfortunate side-effect of using premultiplied alpha
         // we need a somewhat expensive conversion to linear space and back.
         Rgba::from(self).multiply(factor).into()

--- a/crates/ecolor/src/lib.rs
+++ b/crates/ecolor/src/lib.rs
@@ -100,7 +100,7 @@ fn fast_round(r: f32) -> u8 {
 pub fn test_srgba_conversion() {
     for b in 0..=255 {
         let l = linear_f32_from_gamma_u8(b);
-        assert!((0.0..=1.0).contains(&l));
+        assert!(0.0 <= l && l <= 1.0);
         assert_eq!(gamma_u8_from_linear_f32(l), b);
     }
 }

--- a/crates/ecolor/src/rgba.rs
+++ b/crates/ecolor/src/rgba.rs
@@ -96,22 +96,22 @@ impl Rgba {
     }
 
     pub fn from_luminance_alpha(l: f32, a: f32) -> Self {
-        crate::ecolor_assert!((0.0..=1.0).contains(&l));
-        crate::ecolor_assert!((0.0..=1.0).contains(&a));
+        crate::ecolor_assert!(0.0 <= l && l <= 1.0);
+        crate::ecolor_assert!(0.0 <= a && a <= 1.0);
         Self([l * a, l * a, l * a, a])
     }
 
     /// Transparent black
     #[inline(always)]
     pub fn from_black_alpha(a: f32) -> Self {
-        crate::ecolor_assert!((0.0..=1.0).contains(&a));
+        crate::ecolor_assert!(0.0 <= a && a <= 1.0);
         Self([0.0, 0.0, 0.0, a])
     }
 
     /// Transparent white
     #[inline(always)]
     pub fn from_white_alpha(a: f32) -> Self {
-        crate::ecolor_assert!((0.0..=1.0).contains(&a), "a: {}", a);
+        crate::ecolor_assert!(0.0 <= a && a <= 1.0, "a: {}", a);
         Self([a, a, a, a])
     }
 

--- a/crates/eframe/src/web/backend.rs
+++ b/crates/eframe/src/web/backend.rs
@@ -2,7 +2,6 @@ use egui::{
     mutex::{Mutex, MutexGuard},
     TexturesDelta,
 };
-pub use egui::{pos2, Color32};
 
 use crate::{epi, App};
 

--- a/crates/egui_demo_app/src/apps/custom3d_glow.rs
+++ b/crates/egui_demo_app/src/apps/custom3d_glow.rs
@@ -146,12 +146,12 @@ impl RotatingTriangle {
                         ),
                     );
                     gl.compile_shader(shader);
-                    if !gl.get_shader_compile_status(shader) {
-                        panic!(
-                            "Failed to compile custom_3d_glow: {}",
-                            gl.get_shader_info_log(shader)
-                        );
-                    }
+                    assert!(
+                        gl.get_shader_compile_status(shader),
+                        "Failed to compile custom_3d_glow {shader_type}: {}",
+                        gl.get_shader_info_log(shader)
+                    );
+
                     gl.attach_shader(program, shader);
                     shader
                 })

--- a/crates/egui_demo_app/src/apps/custom3d_glow.rs
+++ b/crates/egui_demo_app/src/apps/custom3d_glow.rs
@@ -146,11 +146,12 @@ impl RotatingTriangle {
                         ),
                     );
                     gl.compile_shader(shader);
-                    assert!(
-                        gl.get_shader_compile_status(shader),
-                        "Failed to compile custom_3d_glow: {}",
-                        gl.get_shader_info_log(shader)
-                    );
+                    if !gl.get_shader_compile_status(shader) {
+                        panic!(
+                            "Failed to compile custom_3d_glow: {}",
+                            gl.get_shader_info_log(shader)
+                        );
+                    }
                     gl.attach_shader(program, shader);
                     shader
                 })

--- a/crates/egui_demo_lib/src/color_test.rs
+++ b/crates/egui_demo_lib/src/color_test.rs
@@ -460,21 +460,21 @@ fn paint_fine_lines_and_text(painter: &egui::Painter, mut rect: Rect, color: Col
                 Align2::LEFT_TOP,
                 format!("{:.0}% white", 100.0 * opacity),
                 FontId::proportional(14.0),
-                Color32::WHITE.linear_multiply(opacity),
+                Color32::WHITE.gamma_multiply(opacity),
             );
             painter.text(
                 rect.center_top() + vec2(80.0, y),
                 Align2::LEFT_TOP,
                 format!("{:.0}% gray", 100.0 * opacity),
                 FontId::proportional(14.0),
-                Color32::GRAY.linear_multiply(opacity),
+                Color32::GRAY.gamma_multiply(opacity),
             );
             painter.text(
                 rect.center_top() + vec2(160.0, y),
                 Align2::LEFT_TOP,
                 format!("{:.0}% black", 100.0 * opacity),
                 FontId::proportional(14.0),
-                Color32::BLACK.linear_multiply(opacity),
+                Color32::BLACK.gamma_multiply(opacity),
             );
             y += 20.0;
         }
@@ -495,8 +495,8 @@ fn paint_fine_lines_and_text(painter: &egui::Painter, mut rect: Rect, color: Col
 
     rect.max.x = rect.center().x;
 
-    rect = rect.shrink(12.0);
-    for width in [0.5, 1.0, 2.0] {
+    rect = rect.shrink(16.0);
+    for width in [0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0] {
         painter.text(
             rect.left_top(),
             Align2::CENTER_CENTER,
@@ -517,8 +517,8 @@ fn paint_fine_lines_and_text(painter: &egui::Painter, mut rect: Rect, color: Col
             Stroke::new(width, color),
         ));
 
-        rect.min.y += 32.0;
-        rect.max.x -= 32.0;
+        rect.min.y += 24.0;
+        rect.max.x -= 24.0;
     }
 
     rect.min.y += 16.0;

--- a/crates/epaint/CHANGELOG.md
+++ b/crates/epaint/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to the epaint crate will be documented in this file.
 
 
 ## Unreleased
+* Improve the look of thin white lines ([#2437](https://github.com/emilk/egui/pull/2437)).
 
 
 ## 0.20.0 - 2022-12-08

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -957,10 +957,9 @@ fn stroke_path(
 }
 
 fn mul_color(color: Color32, factor: f32) -> Color32 {
-    crate::epaint_assert!(0.0 <= factor && factor <= 1.0);
-    // As an unfortunate side-effect of using premultiplied alpha
-    // we need a somewhat expensive conversion to linear space and back.
-    color.linear_multiply(factor)
+    // The fast gamma-space multiply also happens to be perceptually better.
+    // Win-win!
+    color.gamma_multiply(factor)
 }
 
 // ----------------------------------------------------------------------------

--- a/examples/custom_3d_glow/src/main.rs
+++ b/examples/custom_3d_glow/src/main.rs
@@ -145,9 +145,11 @@ impl RotatingTriangle {
                         .expect("Cannot create shader");
                     gl.shader_source(shader, &format!("{}\n{}", shader_version, shader_source));
                     gl.compile_shader(shader);
-                    if !gl.get_shader_compile_status(shader) {
-                        panic!("{}", gl.get_shader_info_log(shader));
-                    }
+                    assert!(
+                        gl.get_shader_compile_status(shader),
+                        "Failed to compile {shader_type}: {}",
+                        gl.get_shader_info_log(shader)
+                    );
                     gl.attach_shader(program, shader);
                     shader
                 })


### PR DESCRIPTION
The big difference is for bright lines on dark background.

Before:
![Screen Shot 2022-12-12 at 15 55 18](https://user-images.githubusercontent.com/1148717/207077457-4a64efa5-f7b3-41ab-9761-7737be36e26f.png)

After:
![Screen Shot 2022-12-12 at 15 54 47](https://user-images.githubusercontent.com/1148717/207077478-85c924c2-ebd9-4e9b-b0e7-1edf32934a43.png)

The new code is also faster.