### PR TITLE
Clamp eframe window size to at most the size of the largest monitor

### DIFF
--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -255,10 +255,10 @@ pub struct NativeOptions {
     /// The initial inner size of the native window in points (logical pixels).
     pub initial_window_size: Option<egui::Vec2>,
 
-    /// The minimum inner window size
+    /// The minimum inner window size in points (logical pixels).
     pub min_window_size: Option<egui::Vec2>,
 
-    /// The maximum inner window size
+    /// The maximum inner window size in points (logical pixels).
     pub max_window_size: Option<egui::Vec2>,
 
     /// Should the app window be resizable?

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -504,7 +504,7 @@ mod glow_integration {
             let window_settings = epi_integration::load_window_settings(storage);
 
             let winit_window =
-                epi_integration::window_builder(title, native_options, &window_settings)
+                epi_integration::window_builder(event_loop, title, native_options, window_settings)
                     .build(event_loop)?;
             // a lot of the code below has been lifted from glutin example in their repo.
             let glutin_window_context =
@@ -937,7 +937,7 @@ mod wgpu_integration {
         ) -> Result<winit::window::Window> {
             let window_settings = epi_integration::load_window_settings(storage);
             Ok(
-                epi_integration::window_builder(title, native_options, &window_settings)
+                epi_integration::window_builder(event_loop, title, native_options, window_settings)
                     .build(event_loop)?,
             )
         }

--- a/crates/egui-winit/src/window_settings.rs
+++ b/crates/egui-winit/src/window_settings.rs
@@ -76,11 +76,14 @@ impl WindowSettings {
         }
     }
 
-    pub fn clamp_to_sane_values(&mut self) {
+    pub fn clamp_to_sane_values(&mut self, max_size: egui::Vec2) {
+        use egui::NumExt as _;
+
         if let Some(size) = &mut self.inner_size_points {
             // Prevent ridiculously small windows
             let min_size = egui::Vec2::splat(64.0);
-            *size = size.max(min_size);
+            *size = size.at_least(min_size);
+            *size = size.at_most(max_size);
         }
     }
 }


### PR DESCRIPTION
This can hopefully fix some reported bugs where a fullscreen application would try to restore with a window size larger than the monitor size, causing crashes on some Linux environments.
