### PR TITLE
DO NOT MERGE: Add debug logging to help fix weird WSLg bug

### DIFF
--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -133,6 +133,13 @@ fn largest_monitor_point_size<E>(event_loop: &EventLoopWindowTarget<E>) -> egui:
     for monitor in event_loop.available_monitors() {
         let size = monitor.size().to_logical::<f32>(monitor.scale_factor());
         let size = egui::vec2(size.width, size.height);
+        tracing::info!(
+            "Monitor size: {}x{} pixels, {}x{} points",
+            monitor.size().width,
+            monitor.size().height,
+            size.x,
+            size.y
+        );
         max_size = max_size.max(size);
     }
 

--- a/crates/egui-winit/src/window_settings.rs
+++ b/crates/egui-winit/src/window_settings.rs
@@ -62,6 +62,12 @@ impl WindowSettings {
         }
 
         if let Some(inner_size_points) = self.inner_size_points {
+            tracing::info!(
+                "Restoring window size to {}x{} points, with fullscreen={}",
+                inner_size_points.x,
+                inner_size_points.y,
+                self.fullscreen
+            );
             window
                 .with_inner_size(winit::dpi::LogicalSize {
                     width: inner_size_points.x as f64,
@@ -80,6 +86,8 @@ impl WindowSettings {
         use egui::NumExt as _;
 
         if let Some(size) = &mut self.inner_size_points {
+            tracing::info!("Clamping size to {}x{} points", max_size.x, max_size.y);
+
             // Prevent ridiculously small windows
             let min_size = egui::Vec2::splat(64.0);
             *size = size.at_least(min_size);

--- a/crates/egui_demo_app/src/main.rs
+++ b/crates/egui_demo_app/src/main.rs
@@ -1,6 +1,7 @@
 //! Demo app for egui
-
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
+
+use eframe::{egui_wgpu, wgpu};
 
 // When compiling natively:
 fn main() -> Result<(), eframe::EframeError> {
@@ -19,12 +20,26 @@ fn main() -> Result<(), eframe::EframeError> {
     tracing_subscriber::fmt::init();
 
     let options = eframe::NativeOptions {
-        drag_and_drop_support: true,
+        initial_window_size: Some([1600.0, 1200.0].into()),
+        min_window_size: Some([600.0, 240.0].into()),
 
-        initial_window_size: Some([1280.0, 1024.0].into()),
+        follow_system_theme: false,
+        default_theme: eframe::Theme::Dark,
 
-        #[cfg(feature = "wgpu")]
         renderer: eframe::Renderer::Wgpu,
+        wgpu_options: egui_wgpu::WgpuConfiguration {
+            device_descriptor: wgpu::DeviceDescriptor {
+                features: wgpu::Features::empty(),
+                limits: wgpu::Limits {
+                    max_texture_dimension_2d: 8192,
+                    ..wgpu::Limits::downlevel_webgl2_defaults()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        depth_buffer: 0,
+        multisampling: 0, // the 3D views do their own MSAA
 
         ..Default::default()
     };


### PR DESCRIPTION
@Omotoye reported in a private repository that when restoring fullscreen on WSLg, they get a crash. This adds a bunch of logging to help diagnose what is going wrong.

Please help test this:

```sh
git clone git@github.com:emilk/egui.git
cd egui
git checkout emilk/debug-fullscreen-failure
```

Then run this:

```sh
RUST_LOG=debug cargo r -p egui_demo_app --no-default-features --features wgpu,persistence
```

toggle fullscreen (F11), exit, and then run the same command again.

Does it work, or fail in the same way?

Please share the log from the two runs!