### PR TITLE
fix: Compute mesh u16 split size corretly

### DIFF
--- a/crates/epaint/src/mesh.rs
+++ b/crates/epaint/src/mesh.rs
@@ -191,7 +191,7 @@ impl Mesh {
     pub fn split_to_u16(self) -> Vec<Mesh16> {
         crate::epaint_assert!(self.is_valid());
 
-        const MAX_SIZE: u32 = 1 << 16;
+        const MAX_SIZE: u32 = std::u16::MAX as u32;
 
         if self.vertices.len() < MAX_SIZE as usize {
             // Common-case optimization:


### PR DESCRIPTION
The u16 max value is `1<<16 - 1` not `1<<16` (https://doc.rust-lang.org/std/u16/constant.MAX.html)