### PR TITLE
Combobox .wrap(true) width usage

### DIFF
--- a/crates/egui/src/containers/combo_box.rs
+++ b/crates/egui/src/containers/combo_box.rs
@@ -265,37 +265,35 @@ fn combo_box_dyn<'c, R>(
     let button_response = button_frame(ui, button_id, is_popup_open, Sense::click(), |ui| {
         // We don't want to change width when user selects something new
         let full_minimum_width = if wrap_enabled {
-            // currently selected value's text will be wrapped if needed, so occupy the available width
+            // Currently selected value's text will be wrapped if needed, so occupy the available width.
             ui.available_width()
         } else {
-            // occupy at least the minimum width assigned to Slider and ComboBox
+            // Occupy at least the minimum width assigned to Slider and ComboBox.
             ui.spacing().slider_width - 2.0 * margin.x
         };
         let icon_size = Vec2::splat(ui.spacing().icon_width);
         let wrap_width = if wrap_enabled {
-            // use the available width, currently selected value's text will be wrapped if exceeds this value
+            // Use the available width, currently selected value's text will be wrapped if exceeds this value.
             ui.available_width() - ui.spacing().item_spacing.x - icon_size.x
         } else {
-            // use all the width necessary to display the currently selected value's text
+            // Use all the width necessary to display the currently selected value's text.
             f32::INFINITY
         };
 
         let galley =
             selected_text.into_galley(ui, Some(wrap_enabled), wrap_width, TextStyle::Button);
-        
-        // the width necessary to contain the whole widget with the currently selected value's text
+
+        // The width necessary to contain the whole widget with the currently selected value's text.
         let width = if wrap_enabled {
             full_minimum_width
-        }
-        else {
-            // occupy at least the minimum width needed to contain the widget with the currently selected value's text
+        } else {
+            // Occupy at least the minimum width needed to contain the widget with the currently selected value's text.
             galley.size().x + ui.spacing().item_spacing.x + icon_size.x
         };
 
-        
-        // case : wrap_enabled : occupy all the available width
-        // case : !wrap_enabled : occupy at least the minimum width assigned to Slider and ComboBox,
-        // increase if the currently selected value needs additional horizontal space to fully display its text (up to wrap_width (f32::INFINITY))
+        // Case : wrap_enabled : occupy all the available width.
+        // Case : !wrap_enabled : occupy at least the minimum width assigned to Slider and ComboBox,
+        // increase if the currently selected value needs additional horizontal space to fully display its text (up to wrap_width (f32::INFINITY)).
         let width = width.at_least(full_minimum_width);
         let height = galley.size().y.max(icon_size.y);
 

--- a/crates/egui/src/containers/combo_box.rs
+++ b/crates/egui/src/containers/combo_box.rs
@@ -265,21 +265,37 @@ fn combo_box_dyn<'c, R>(
     let button_response = button_frame(ui, button_id, is_popup_open, Sense::click(), |ui| {
         // We don't want to change width when user selects something new
         let full_minimum_width = if wrap_enabled {
-            ui.available_width() - ui.spacing().item_spacing.x * 2.0
+            // currently selected value's text will be wrapped if needed, so occupy the available width
+            ui.available_width()
         } else {
+            // occupy at least the minimum width assigned to Slider and ComboBox
             ui.spacing().slider_width - 2.0 * margin.x
         };
         let icon_size = Vec2::splat(ui.spacing().icon_width);
         let wrap_width = if wrap_enabled {
+            // use the available width, currently selected value's text will be wrapped if exceeds this value
             ui.available_width() - ui.spacing().item_spacing.x - icon_size.x
         } else {
+            // use all the width necessary to display the currently selected value's text
             f32::INFINITY
         };
 
         let galley =
             selected_text.into_galley(ui, Some(wrap_enabled), wrap_width, TextStyle::Button);
+        
+        // the width necessary to contain the whole widget with the currently selected value's text
+        let width = if wrap_enabled {
+            full_minimum_width
+        }
+        else {
+            // occupy at least the minimum width needed to contain the widget with the currently selected value's text
+            galley.size().x + ui.spacing().item_spacing.x + icon_size.x
+        };
 
-        let width = galley.size().x + ui.spacing().item_spacing.x + icon_size.x;
+        
+        // case : wrap_enabled : occupy all the available width
+        // case : !wrap_enabled : occupy at least the minimum width assigned to Slider and ComboBox,
+        // increase if the currently selected value needs additional horizontal space to fully display its text (up to wrap_width (f32::INFINITY))
         let width = width.at_least(full_minimum_width);
         let height = galley.size().y.max(icon_size.y);
 


### PR DESCRIPTION
Currently when a combobox has .wrap(true) it does note use all the available width.

![image](https://user-images.githubusercontent.com/68190772/208248969-a1f05dae-4d1a-4064-83fa-c8b0e0de79d3.png)

This PR fixes it.

![image](https://user-images.githubusercontent.com/68190772/208248983-f3e916d2-7a61-4a6f-9365-8e33be2809e1.png)

This PR does not change the original .wrap(false) behaviours.

![image](https://user-images.githubusercontent.com/68190772/208248994-0f2336a3-5344-455d-b7e9-bc205eece2dd.png)
