### PR TITLE
Fix rounding errors with font scaling

### DIFF
--- a/crates/epaint/CHANGELOG.md
+++ b/crates/epaint/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to the epaint crate will be documented in this file.
 * Don't render `\r` (Carriage Return) ([#2452](https://github.com/emilk/egui/pull/2452)).
 * Fix bug in `Mesh::split_to_u16` ([#2459](https://github.com/emilk/egui/pull/2459)).
 * Improve rendering of very thin rectangles.
+* Fix rounding errors with font scaling ([#2490](https://github.com/emilk/egui/pull/2490)):
+  * Added opt-in feature `proportional_font_scaling` to maintain text bounding box sizes when display DPI is changed.
 
 
 ## 0.20.0 - 2022-12-08

--- a/crates/epaint/Cargo.toml
+++ b/crates/epaint/Cargo.toml
@@ -49,6 +49,9 @@ deadlock_detection = ["dep:backtrace"]
 ## If you plan on specifying your own fonts you may disable this feature.
 default_fonts = []
 
+## Enabling this feature will allow fixed-width fonts to scale correctly for any display DPI.
+proportional_font_scaling = []
+
 ## Enable additional checks if debug assertions are enabled (debug builds).
 extra_debug_asserts = [
   "emath/extra_debug_asserts",


### PR DESCRIPTION
I am working on something like a terminal emulator. It needs to have a fixed width font that renders identically on all platforms. One of the problems I am facing right now is that with the `pixels_per_point` value at 2.0 on macOS and 1.0 on Windows, scaling the fonts ends up rendering slightly differently in these environments.

Here are some screenshots with a grid of characters rendered on Windows and macOS. I initially developed this on macOS, so it is showing what I "expected" to see on Windows:

macOS:

![prosaic-macos](https://user-images.githubusercontent.com/456942/208758152-0e169436-9638-4e3d-928f-bafb97338ed2.png)

Windows:

![prosaic-windows](https://user-images.githubusercontent.com/456942/208758169-4b36ac5a-bf30-4b30-b341-923237a4a756.png)

They both have exactly 800x600 `LogicalSize` inner window size, e.g. it's 800x600 physical pixels on Windows, and 1600x1200 physical pixels on macOS. But clearly the font size is ever so slightly different enough that the cursor isn't clipped in the corner of the window on Windows, as it is on macOS.

This PR attempts to address the bug.

<details><summary>Reveal outdated patch description</summary>

First, we notice that `Font::round_to_pixel()` is called with a point size that is already scaled by `pixels_per_point`, and it internally resizes by dividing after rounding. This leads to rounding errors. For example, suppose the point size is 16.27 and `pixels_per_point` is 2.0:

```rust
(16.27 * 2.0).round() == 33.0

33.0 / 2.0 == 16.5
```

Compare this when `pixels_per_point` is 1.0:

```rust
(16.27 * 1.0).round() == 16.0

16.0 / 1.0 == 16.0
```

If instead we `floor` the value, then we get the same result, regardless of the value of `pixels_per_point`:

```rust
(16.27 * 2.0).floor() == 32.0

32.0 / 2.0 == 16.0
```

Secondly, the same issue occurs with the horizontal advance, so we change that `round` to `floor` also.
</details>

----

Description of the new patch:

We defer the scaling of the font to as late as possible (e.g. when drawing glyphs). The fonts themselves now only store sizes in points (unscaled). Rounding of positions is still done, but it uses the font _points_ coordinate space instead of _physical pixels_. This accounts for the kerning differences on high DPI displays as shown in screenshots below.

The result is that the rasterization looks identical on Windows where `pixels_per_point == 1.0`, but the rasterization on macOS (`pixels_per_point == 2.0`) now more closely resembles what is seen on Windows:

![prosaic-macos-fixed](https://user-images.githubusercontent.com/456942/208760677-b948d796-43c4-4aa5-8216-c3be99af7212.png)

----

I'll leave this as a draft PR to open discussion. I could be wrong, but I believe this is the correct way to address the problem. I'll leave a list of items that I know need to be done before this can be accepted.

TODO:

- [x] Add changelog entry
- [x] ~~Update comments and function names to reference flooring instead of rounding~~