### PR TITLE
fix bezier curve assertion fail

### DIFF
--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -1507,6 +1507,10 @@ impl Tessellator {
         stroke: Stroke,
         out: &mut Mesh,
     ) {
+        if points.len() < 2 {
+            return;
+        }
+
         self.scratchpad_path.clear();
         if closed {
             self.scratchpad_path.add_line_loop(points);


### PR DESCRIPTION
bezier curve can cause assertion fail and panic in some edge cases (typically when there are overlapping points).
<details>
<summary>example</summary>

![image](https://user-images.githubusercontent.com/13201009/209523858-e8a1ca8b-4116-4aee-9a15-8e455eec6e40.png)
</details>

this patch adds a check to ensure that there are enough points in the curve flatten result.