### PR TITLE
add functions to check which button triggered a drag start & end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 
 ## Unreleased
 ### Added ⭐
+* Add `Response::drag_started_by` and `Response::drag_released_by` for convenience, similar to `dragged` and `dragged_by`.
+* Add `PointerState::*_pressed` to check if the given button was pressed in this frame.
 * `Event::Key` now has a `repeat` field that is set to `true` if the event was the result of a key-repeat ([#2435](https://github.com/emilk/egui/pull/2435)).
 * Add `Slider::drag_value_speed`, which lets you ask for finer precision when dragging the slider value rather than the actual slider.
 * Add `Memory::any_popup_open`, which returns true if any popup is currently open ([#2464](https://github.com/emilk/egui/pull/2464)).
@@ -18,6 +20,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 * Improved the algorithm for picking the number of decimals to show when hovering values in the `Plot`.
 
 ### Fixed 🐛
+* Trigger `PointerEvent::Released` for drags ([#2094](https://github.com/emilk/egui/pull/2094)).
 * Expose `TextEdit`'s multiline flag to AccessKit ([#2448](https://github.com/emilk/egui/pull/2448)).
 * Don't render `\r` (Carriage Return) ([#2452](https://github.com/emilk/egui/pull/2452)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 
 ## Unreleased
 ### Added ⭐
-* Add `Response::drag_started_by` and `Response::drag_released_by` for convenience, similar to `dragged` and `dragged_by`.
-* Add `PointerState::*_pressed` to check if the given button was pressed in this frame.
+* Add `Response::drag_started_by` and `Response::drag_released_by` for convenience, similar to `dragged` and `dragged_by` ([#2507](https://github.com/emilk/egui/pull/2507)).
+* Add `PointerState::*_pressed` to check if the given button was pressed in this frame ([#2507](https://github.com/emilk/egui/pull/2507)).
 * `Event::Key` now has a `repeat` field that is set to `true` if the event was the result of a key-repeat ([#2435](https://github.com/emilk/egui/pull/2435)).
 * Add `Slider::drag_value_speed`, which lets you ask for finer precision when dragging the slider value rather than the actual slider.
 * Add `Memory::any_popup_open`, which returns true if any popup is currently open ([#2464](https://github.com/emilk/egui/pull/2464)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 * Improved the algorithm for picking the number of decimals to show when hovering values in the `Plot`.
 
 ### Fixed 🐛
-* Trigger `PointerEvent::Released` for drags ([#2094](https://github.com/emilk/egui/pull/2094)).
+* Trigger `PointerEvent::Released` for drags ([#2507](https://github.com/emilk/egui/pull/2507)).
 * Expose `TextEdit`'s multiline flag to AccessKit ([#2448](https://github.com/emilk/egui/pull/2448)).
 * Don't render `\r` (Carriage Return) ([#2452](https://github.com/emilk/egui/pull/2452)).
 

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -564,17 +564,17 @@ impl Context {
                             }
                         }
                     }
-                    PointerEvent::Released(click) => {
+                    PointerEvent::Released { click, button } => {
                         response.drag_released = response.dragged;
                         response.dragged = false;
 
                         if hovered && response.is_pointer_button_down_on {
                             if let Some(click) = click {
                                 let clicked = hovered && response.is_pointer_button_down_on;
-                                response.clicked[click.button as usize] = clicked;
-                                response.double_clicked[click.button as usize] =
+                                response.clicked[*button as usize] = clicked;
+                                response.double_clicked[*button as usize] =
                                     clicked && click.is_double();
-                                response.triple_clicked[click.button as usize] =
+                                response.triple_clicked[*button as usize] =
                                     clicked && click.is_triple();
                             }
                         }

--- a/crates/egui/src/input_state.rs
+++ b/crates/egui/src/input_state.rs
@@ -777,11 +777,28 @@ impl PointerState {
         self.pointer_events.iter().any(|event| event.is_release())
     }
 
+    /// Was the button given pressed this frame?
+    pub fn button_pressed(&self, button: PointerButton) -> bool {
+        self.pointer_events
+            .iter()
+            .any(|event| matches!(event, &PointerEvent::Pressed{button: b, ..} if button == b))
+    }
+
     /// Was the button given released this frame?
     pub fn button_released(&self, button: PointerButton) -> bool {
         self.pointer_events
             .iter()
             .any(|event| matches!(event, &PointerEvent::Released{button: b, ..} if button == b))
+    }
+
+    /// Was the primary button pressed this frame?
+    pub fn primary_pressed(&self) -> bool {
+        self.button_pressed(PointerButton::Primary)
+    }
+
+    /// Was the secondary button pressed this frame?
+    pub fn secondary_pressed(&self) -> bool {
+        self.button_pressed(PointerButton::Secondary)
     }
 
     /// Was the primary button released this frame?
@@ -846,18 +863,6 @@ impl PointerState {
     pub fn secondary_clicked(&self) -> bool {
         self.button_clicked(PointerButton::Secondary)
     }
-
-    // /// Was this button pressed (`!down -> down`) this frame?
-    // /// This can sometimes return `true` even if `any_down() == false`
-    // /// because a press can be shorted than one frame.
-    // pub fn button_pressed(&self, button: PointerButton) -> bool {
-    //     self.pointer_events.iter().any(|event| event.is_press())
-    // }
-
-    // /// Was this button released (`down -> !down`) this frame?
-    // pub fn button_released(&self, button: PointerButton) -> bool {
-    //     self.pointer_events.iter().any(|event| event.is_release())
-    // }
 
     /// Is this button currently down?
     #[inline(always)]

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -278,9 +278,19 @@ impl Response {
         self.dragged && self.ctx.input().pointer.any_pressed()
     }
 
+    /// Did a drag on this widgets by the button begin this frame?
+    pub fn drag_started_by(&self, button: PointerButton) -> bool {
+        self.drag_started() && self.ctx.input().pointer.button_pressed(button)
+    }
+
     /// The widget was being dragged, but now it has been released.
     pub fn drag_released(&self) -> bool {
         self.drag_released
+    }
+
+    /// The widget was being dragged by the button, but now it has been released.
+    pub fn drag_released_by(&self, button: PointerButton) -> bool {
+        self.drag_released() && self.ctx.input().pointer.button_released(button)
     }
 
     /// If dragged, how many points were we dragged and in what direction?


### PR DESCRIPTION
currently its hard to figure out which button triggered a drag start & end event:
* for `drag_started`, checking `response.drag_started() && ui.input().pointer.button_down( ... )` usually works. however this could be false positive when multiple buttons are dragging at the same time.
* for `drag_released`, there seems to be no way at all.

to improve this, `button_pressed` is added to precisely check buttons of drag starts. and make `button_released` independent of clicks (closes https://github.com/emilk/egui/issues/2094) to check buttons of drag releases.
some utility functions are added to `Response` for convenience.