### PR TITLE
Fix: `button_padding` when using image+text buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 * Add `Plot::clamp_grid` to only show grid where there is data ([#2480](https://github.com/emilk/egui/pull/2480)).
 * Add `ScrollArea::drag_to_scroll` if you want to turn off that feature.
 * Add `Response::on_hover_and_drag_cursor`.
+* Add `image_margin` field and method on `Button` widget to configure its layout ([#2510](https://github.com/emilk/egui/pull/2510)).
 
 ### Changed 🔧
 * Improved plot grid appearance ([#2412](https://github.com/emilk/egui/pull/2412)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 * Add `Plot::clamp_grid` to only show grid where there is data ([#2480](https://github.com/emilk/egui/pull/2480)).
 * Add `ScrollArea::drag_to_scroll` if you want to turn off that feature.
 * Add `Response::on_hover_and_drag_cursor`.
-* Add `image_margin` field and method on `Button` widget to configure its layout ([#2510](https://github.com/emilk/egui/pull/2510)).
 
 ### Changed 🔧
 * Improved plot grid appearance ([#2412](https://github.com/emilk/egui/pull/2412)).
@@ -21,6 +20,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 ### Fixed 🐛
 * Expose `TextEdit`'s multiline flag to AccessKit ([#2448](https://github.com/emilk/egui/pull/2448)).
 * Don't render `\r` (Carriage Return) ([#2452](https://github.com/emilk/egui/pull/2452)).
+* The `button_padding` style option works closer as expected with image+text buttons now ([#2510](https://github.com/emilk/egui/pull/2510)).
 
 
 ## 0.20.1 - 2022-12-11 - Fix key-repeat

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -221,7 +221,10 @@ impl Widget for Button {
 
             if let Some(image) = image {
                 let image_rect = Rect::from_min_size(
-                    pos2(rect.min.x, rect.center().y - 0.5 - (image.size().y / 2.0)),
+                    pos2(
+                        rect.min.x + button_padding.x,
+                        rect.center().y - 0.5 - (image.size().y / 2.0),
+                    ),
                     image.size(),
                 );
                 image.paint_at(ui, image_rect);

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -176,15 +176,10 @@ impl Widget for Button {
         let mut desired_size = text.size();
         if let Some(image) = image {
             desired_size.x += image.size().x
-                + image_margin
-                    .map(|margin| margin.left + margin.right)
-                    .unwrap_or(0.0)
+                + image_margin.map_or(0.0, |margin| margin.left + margin.right)
                 + ui.spacing().icon_spacing;
             desired_size.y = desired_size.y.max(
-                image.size().y
-                    + image_margin
-                        .map(|margin| margin.top + margin.bottom)
-                        .unwrap_or(0.0),
+                image.size().y + image_margin.map_or(0.0, |margin| margin.top + margin.bottom),
             );
         }
         if let Some(shortcut_text) = &shortcut_text {
@@ -220,9 +215,7 @@ impl Widget for Button {
                     rect.min.x
                         + button_padding.x
                         + image.size().x
-                        + image_margin
-                            .map(|margin| margin.left + margin.right)
-                            .unwrap_or(0.0)
+                        + image_margin.map_or(0.0, |margin| margin.left + margin.right)
                         + icon_spacing,
                     rect.center().y - 0.5 * text.size().y,
                 )
@@ -248,7 +241,7 @@ impl Widget for Button {
             if let Some(image) = image {
                 let image_rect = Rect::from_min_size(
                     pos2(
-                        rect.min.x + image_margin.map(|margin| margin.left).unwrap_or(0.0),
+                        rect.min.x + image_margin.map_or(0.0, |margin| margin.left),
                         rect.center().y - 0.5 - (image.size().y / 2.0),
                     ),
                     image.size(),

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -165,7 +165,7 @@ impl Widget for Button {
         let mut desired_size = text.size();
         if let Some(image) = image {
             desired_size.x += image.size().x + ui.spacing().icon_spacing;
-            desired_size.y = desired_size.y.max(image.size().y)
+            desired_size.y = desired_size.y.max(image.size().y);
         }
         if let Some(shortcut_text) = &shortcut_text {
             desired_size.x += ui.spacing().item_spacing.x + shortcut_text.size().x;
@@ -221,10 +221,7 @@ impl Widget for Button {
 
             if let Some(image) = image {
                 let image_rect = Rect::from_min_size(
-                    pos2(
-                        rect.min.x + button_padding.x,
-                        rect.center().y - 0.5 - (image.size().y / 2.0),
-                    ),
+                    pos2(rect.min.x, rect.center().y - 0.5 - (image.size().y / 2.0)),
                     image.size(),
                 );
                 image.paint_at(ui, image_rect);

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -31,7 +31,6 @@ pub struct Button {
     frame: Option<bool>,
     min_size: Vec2,
     image: Option<widgets::Image>,
-    image_margin: Option<style::Margin>,
 }
 
 impl Button {
@@ -47,7 +46,6 @@ impl Button {
             frame: None,
             min_size: Vec2::ZERO,
             image: None,
-            image_margin: None,
         }
     }
 
@@ -128,14 +126,6 @@ impl Button {
         self.shortcut_text = shortcut_text.into();
         self
     }
-
-    /// Adds margin around image of image button
-    ///
-    /// Adding a image-margin to a button without an image is a noop
-    pub fn image_margin(mut self, margin: style::Margin) -> Self {
-        self.image_margin.replace(margin);
-        self
-    }
 }
 
 impl Widget for Button {
@@ -151,7 +141,6 @@ impl Widget for Button {
             frame,
             min_size,
             image,
-            image_margin,
         } = self;
 
         let frame = frame.unwrap_or_else(|| ui.visuals().button_frame);
@@ -175,12 +164,8 @@ impl Widget for Button {
 
         let mut desired_size = text.size();
         if let Some(image) = image {
-            desired_size.x += image.size().x
-                + image_margin.map_or(0.0, |margin| margin.left + margin.right)
-                + ui.spacing().icon_spacing;
-            desired_size.y = desired_size.y.max(
-                image.size().y + image_margin.map_or(0.0, |margin| margin.top + margin.bottom),
-            );
+            desired_size.x += image.size().x + ui.spacing().icon_spacing;
+            desired_size.y = desired_size.y.max(image.size().y)
         }
         if let Some(shortcut_text) = &shortcut_text {
             desired_size.x += ui.spacing().item_spacing.x + shortcut_text.size().x;
@@ -212,11 +197,7 @@ impl Widget for Button {
             let text_pos = if let Some(image) = image {
                 let icon_spacing = ui.spacing().icon_spacing;
                 pos2(
-                    rect.min.x
-                        + button_padding.x
-                        + image.size().x
-                        + image_margin.map_or(0.0, |margin| margin.left + margin.right)
-                        + icon_spacing,
+                    rect.min.x + button_padding.x + image.size().x + icon_spacing,
                     rect.center().y - 0.5 * text.size().y,
                 )
             } else {
@@ -241,7 +222,7 @@ impl Widget for Button {
             if let Some(image) = image {
                 let image_rect = Rect::from_min_size(
                     pos2(
-                        rect.min.x + image_margin.map_or(0.0, |margin| margin.left),
+                        rect.min.x + button_padding.x,
                         rect.center().y - 0.5 - (image.size().y / 2.0),
                     ),
                     image.size(),


### PR DESCRIPTION
Changes of the PR:

- fix `button_padding` functionality for buttons with images

Only the last comment of this PR is important. All other comments aren't relevant after my self review anymore.

----

### TODO:

- [x] Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
- [x] run `cargo fmt`
- [x] run `cargo clippy`
- [x] self-review
- [x] run `./sh/check.sh`

Closes <https://github.com/emilk/egui/issues/2509>.
