### PR TITLE
Add feature to snap slider to user-specified values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 * Add `Plot::clamp_grid` to only show grid where there is data ([#2480](https://github.com/emilk/egui/pull/2480)).
 * Add `ScrollArea::drag_to_scroll` if you want to turn off that feature.
 * Add `Response::on_hover_and_drag_cursor`.
+* Add `Slider::smart_aim_values`, which lets the user define certain points to snap the slider to when clicking or dragging.
 
 ### Changed 🔧
 * Improved plot grid appearance ([#2412](https://github.com/emilk/egui/pull/2412)).

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -315,7 +315,7 @@ impl Response {
         self.is_pointer_button_down_on
     }
 
-    /// What the underlying data changed?
+    /// Was the underlying data changed?
     ///
     /// e.g. the slider was dragged, text was entered in a [`TextEdit`](crate::TextEdit) etc.
     /// Always `false` for something like a [`Button`](crate::Button).

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -222,9 +222,14 @@ impl<'a> Slider<'a> {
     /// This only has an effect when [`smart_aim`] is ON. `snap_radius` defines the range around
     /// the mouse where the slider will snap to the given values. To be useful, this should be
     /// somewhat large (and definitely larger than [`InputState::aim_radius`]). Default is 0.1.
-    pub fn smart_aim_values<Num: emath::Numeric>(mut self, smart_aim_values: Vec<Num>, snap_radius: f32) -> Self {
+    pub fn smart_aim_values<Num: emath::Numeric>(
+        mut self,
+        smart_aim_values: Vec<Num>,
+        snap_radius: f32,
+    ) -> Self {
         self.snap_radius = snap_radius.clamp(0.0, 1.0);
-        self.smart_aim_values = smart_aim_values.into_iter()
+        self.smart_aim_values = smart_aim_values
+            .into_iter()
             .map(|n| n.to_f64().clamp(*self.range.start(), *self.range.end()))
             .collect();
         self.smart_aim_values
@@ -576,7 +581,8 @@ impl<'a> Slider<'a> {
                     let norm_value = normalized_from_value(value, self.range.clone(), &self.spec);
                     let mut closest_distance = f64::INFINITY;
                     for snap in self.smart_aim_values.iter().copied() {
-                        let snap_norm_value = normalized_from_value(snap, self.range.clone(), &self.spec);
+                        let snap_norm_value =
+                            normalized_from_value(snap, self.range.clone(), &self.spec);
                         let distance = (norm_value - snap_norm_value).abs();
                         if distance < closest_distance {
                             closest_snap = snap;
@@ -675,13 +681,17 @@ impl<'a> Slider<'a> {
 
             if self.smart_aim {
                 for smart_aim_value in &self.smart_aim_values {
-                    let snap_position_1d = self.position_from_value(*smart_aim_value, position_range.clone());
+                    let snap_position_1d =
+                        self.position_from_value(*smart_aim_value, position_range.clone());
                     let center = self.marker_center(snap_position_1d, &rail_rect);
                     ui.painter().add(epaint::CircleShape {
                         center,
                         radius: 2.0,
                         fill: ui.visuals().widgets.noninteractive.bg_fill,
-                        stroke: Stroke { width: 0.0, color: Default::default() },
+                        stroke: Stroke {
+                            width: 0.0,
+                            color: Default::default(),
+                        },
                     });
                 }
             }

--- a/crates/egui_demo_lib/src/demo/sliders.rs
+++ b/crates/egui_demo_lib/src/demo/sliders.rs
@@ -11,6 +11,8 @@ pub struct Sliders {
     pub logarithmic: bool,
     pub clamp_to_range: bool,
     pub smart_aim: bool,
+    pub snap_aim: bool,
+    pub smart_aim_values: Vec<f64>,
     pub step: f64,
     pub use_steps: bool,
     pub integer: bool,
@@ -26,6 +28,8 @@ impl Default for Sliders {
             logarithmic: true,
             clamp_to_range: false,
             smart_aim: true,
+            snap_aim: false,
+            smart_aim_values: vec![],
             step: 10.0,
             use_steps: false,
             integer: false,
@@ -59,6 +63,8 @@ impl super::View for Sliders {
             logarithmic,
             clamp_to_range,
             smart_aim,
+            snap_aim,
+            smart_aim_values,
             step,
             use_steps,
             integer,
@@ -93,6 +99,7 @@ impl super::View for Sliders {
                     .logarithmic(*logarithmic)
                     .clamp_to_range(*clamp_to_range)
                     .smart_aim(*smart_aim)
+                    .smart_aim_values(smart_aim_values.clone(), 0.1)
                     .orientation(orientation)
                     .text("i32 demo slider")
                     .step_by(istep),
@@ -104,6 +111,7 @@ impl super::View for Sliders {
                     .logarithmic(*logarithmic)
                     .clamp_to_range(*clamp_to_range)
                     .smart_aim(*smart_aim)
+                    .smart_aim_values(smart_aim_values.clone(), 0.1)
                     .orientation(orientation)
                     .text("f64 demo slider")
                     .step_by(istep),
@@ -134,6 +142,15 @@ impl super::View for Sliders {
                 .smart_aim(*smart_aim)
                 .text("right"),
         );
+
+        if *snap_aim {
+            let range = *max - *min;
+
+            // Set the smart aim values to 1/3 and 2/3 of the range, for demo-ing
+            *smart_aim_values = vec![range / 3.0, range * 2.0 / 3.0];
+        } else {
+            *smart_aim_values = vec![];
+        }
 
         ui.separator();
 
@@ -172,6 +189,10 @@ impl super::View for Sliders {
 
         ui.checkbox(smart_aim, "Smart Aim");
         ui.label("Smart Aim will guide you towards round values when you drag the slider so you you are more likely to hit 250 than 247.23");
+        ui.add_space(8.0);
+
+        ui.checkbox(snap_aim, "Snap Aim");
+        ui.label("Snap Aim will snap the slider to user-defined values when close to them (Smart Aim must also be enabled).");
         ui.add_space(8.0);
 
         ui.vertical_centered(|ui| {

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -44,7 +44,11 @@ impl eframe::App for MyApp {
             });
             ui.add(egui::Slider::new(&mut self.age, 0..=120).text("age"));
 
-            ui.add(egui::Slider::new::<f64>(&mut self.float_value, 0.0..=1.0).text("snap").smart_aim_values(vec![0.0,0.3,0.7, f64::NAN], 0.1));
+            ui.add(
+                egui::Slider::new::<f64>(&mut self.float_value, 0.0..=1.0)
+                    .text("snap")
+                    .smart_aim_values(vec![0.0, 0.3, 0.7, f64::NAN], 0.1),
+            );
             if ui.button("Click each year").clicked() {
                 self.age += 1;
             }

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -20,6 +20,7 @@ fn main() -> Result<(), eframe::Error> {
 struct MyApp {
     name: String,
     age: u32,
+    float_value: f64,
 }
 
 impl Default for MyApp {
@@ -27,6 +28,7 @@ impl Default for MyApp {
         Self {
             name: "Arthur".to_owned(),
             age: 42,
+            float_value: 0.0,
         }
     }
 }
@@ -41,6 +43,8 @@ impl eframe::App for MyApp {
                     .labelled_by(name_label.id);
             });
             ui.add(egui::Slider::new(&mut self.age, 0..=120).text("age"));
+
+            ui.add(egui::Slider::new::<f64>(&mut self.float_value, 0.0..=1.0).text("snap").smart_aim_values(vec![0.0,0.3,0.7, f64::NAN], 0.1));
             if ui.button("Click each year").clicked() {
                 self.age += 1;
             }

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -20,7 +20,6 @@ fn main() -> Result<(), eframe::Error> {
 struct MyApp {
     name: String,
     age: u32,
-    float_value: f64,
 }
 
 impl Default for MyApp {
@@ -28,7 +27,6 @@ impl Default for MyApp {
         Self {
             name: "Arthur".to_owned(),
             age: 42,
-            float_value: 0.0,
         }
     }
 }
@@ -43,12 +41,6 @@ impl eframe::App for MyApp {
                     .labelled_by(name_label.id);
             });
             ui.add(egui::Slider::new(&mut self.age, 0..=120).text("age"));
-
-            ui.add(
-                egui::Slider::new::<f64>(&mut self.float_value, 0.0..=1.0)
-                    .text("snap")
-                    .smart_aim_values(vec![0.0, 0.3, 0.7, f64::NAN], 0.1),
-            );
             if ui.button("Click each year").clicked() {
                 self.age += 1;
             }


### PR DESCRIPTION
![Screenshot from 2022-12-28 12-54-54](https://user-images.githubusercontent.com/19912588/209853191-6706960f-6f93-4a61-bb18-96ac885fce2f.png)

Allows user to set "snap" points with `Slider::smart_aim_values`. When the slider marker is within a user-specified range of one of these points, it will jump to that point. If `smart_aim` is disabled, then these values don't do anything. If `smart_aim` is enabled, then regular smart aim is used as normal whenever the marker is outside the user-specified range of these snap points.

I added it to the demo app for seeing how it works. I'm open to feedback to make sure it fits in with the structural and stylistic requirements of the project.
