### PR TITLE
Fix close button not working

### DIFF
--- a/examples/custom_window_frame/src/main.rs
+++ b/examples/custom_window_frame/src/main.rs
@@ -84,15 +84,6 @@ fn custom_window_frame(
                 Stroke::new(1.0, text_color),
             );
 
-            // Add the close button:
-            let close_response = ui.put(
-                Rect::from_min_size(rect.left_top(), Vec2::splat(height)),
-                Button::new(RichText::new("❌").size(height - 4.0)).frame(false),
-            );
-            if close_response.clicked() {
-                frame.close();
-            }
-
             // Interact with the title bar (drag to move window):
             let title_bar_rect = {
                 let mut rect = rect;
@@ -103,6 +94,15 @@ fn custom_window_frame(
                 ui.interact(title_bar_rect, Id::new("title_bar"), Sense::click());
             if title_bar_response.is_pointer_button_down_on() {
                 frame.drag_window();
+            }
+            
+            // Add the close button:
+            let close_response = ui.put(
+                Rect::from_min_size(rect.left_top(), Vec2::splat(height)),
+                Button::new(RichText::new("❌").size(height - 4.0)).frame(false),
+            );
+            if close_response.clicked() {
+                frame.close();
             }
 
             // Add the contents:

--- a/examples/custom_window_frame/src/main.rs
+++ b/examples/custom_window_frame/src/main.rs
@@ -95,7 +95,7 @@ fn custom_window_frame(
             if title_bar_response.is_pointer_button_down_on() {
                 frame.drag_window();
             }
-            
+
             // Add the close button:
             let close_response = ui.put(
                 Rect::from_min_size(rect.left_top(), Vec2::splat(height)),


### PR DESCRIPTION
By adding the close button after the title bar drag listener the close button will sense clicks.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Closes <https://github.com/emilk/egui/issues/1834>.
