### PR TITLE
Point to caller's location when using log_or_panic

### DIFF
--- a/crates/egui_extras/src/strip.rs
+++ b/crates/egui_extras/src/strip.rs
@@ -144,6 +144,7 @@ pub struct Strip<'a, 'b> {
 }
 
 impl<'a, 'b> Strip<'a, 'b> {
+    #[cfg_attr(debug_assertions, track_caller)]
     fn next_cell_size(&mut self) -> (CellSize, CellSize) {
         let size = if let Some(size) = self.sizes.get(self.size_index) {
             self.size_index += 1;
@@ -163,6 +164,7 @@ impl<'a, 'b> Strip<'a, 'b> {
     }
 
     /// Add cell contents.
+    #[cfg_attr(debug_assertions, track_caller)]
     pub fn cell(&mut self, add_contents: impl FnOnce(&mut Ui)) {
         let (width, height) = self.next_cell_size();
         let striped = false;
@@ -171,6 +173,7 @@ impl<'a, 'b> Strip<'a, 'b> {
     }
 
     /// Add an empty cell.
+    #[cfg_attr(debug_assertions, track_caller)]
     pub fn empty(&mut self) {
         let (width, height) = self.next_cell_size();
         self.layout.empty(width, height);

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -1026,6 +1026,7 @@ impl<'a, 'b> TableRow<'a, 'b> {
     /// Add the contents of a column.
     ///
     /// Return the used space (`min_rect`) plus the [`Response`] of the whole cell.
+    #[cfg_attr(debug_assertions, track_caller)]
     pub fn col(&mut self, add_cell_contents: impl FnOnce(&mut Ui)) -> (Rect, Response) {
         let col_index = self.col_index;
 


### PR DESCRIPTION
Incorrect use of methods like table's `col()` can panic, but the panic points to egui's guts instead of the call site that user would recognize. This adds `#[track_caller]` to make the panic location point to user's code.