### PR TITLE
`Plot::Item::allow_hover` give possibility to masked the interaction on hovered item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 
 ## Unreleased
 ### Added ⭐
+* Add `Plot::Item::allow_hover` give possibility to masked the interaction on  hovered item. 
 * `Event::Key` now has a `repeat` field that is set to `true` if the event was the result of a key-repeat ([#2435](https://github.com/emilk/egui/pull/2435)).
 * Add `Slider::drag_value_speed`, which lets you ask for finer precision when dragging the slider value rather than the actual slider.
 * Add `Memory::any_popup_open`, which returns true if any popup is currently open ([#2464](https://github.com/emilk/egui/pull/2464)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 
 ## Unreleased
 ### Added ⭐
-* Add `Plot::Item::allow_hover` give possibility to masked the interaction on  hovered item. 
+* Add `Plot::Item::allow_hover` give possibility to masked the interaction on hovered item. 
 * `Event::Key` now has a `repeat` field that is set to `true` if the event was the result of a key-repeat ([#2435](https://github.com/emilk/egui/pull/2435)).
 * Add `Slider::drag_value_speed`, which lets you ask for finer precision when dragging the slider value rather than the actual slider.
 * Add `Memory::any_popup_open`, which returns true if any popup is currently open ([#2464](https://github.com/emilk/egui/pull/2464)).

--- a/crates/egui/src/widgets/plot/items/mod.rs
+++ b/crates/egui/src/widgets/plot/items/mod.rs
@@ -45,6 +45,8 @@ pub(super) trait PlotItem {
 
     fn highlighted(&self) -> bool;
 
+    fn allow_hover(&self) -> bool;
+
     fn geometry(&self) -> PlotGeometry<'_>;
 
     fn bounds(&self) -> PlotBounds;
@@ -119,6 +121,7 @@ pub struct HLine {
     pub(super) stroke: Stroke,
     pub(super) name: String,
     pub(super) highlight: bool,
+    pub(super) allow_hover: bool,
     pub(super) style: LineStyle,
 }
 
@@ -129,6 +132,7 @@ impl HLine {
             stroke: Stroke::new(1.0, Color32::TRANSPARENT),
             name: String::default(),
             highlight: false,
+            allow_hover: true,
             style: LineStyle::Solid,
         }
     }
@@ -136,6 +140,12 @@ impl HLine {
     /// Highlight this line in the plot by scaling up the line.
     pub fn highlight(mut self, highlight: bool) -> Self {
         self.highlight = highlight;
+        self
+    }
+
+    // Allowed hovering this line in the plot.
+    pub fn allow_hover(mut self, hovering: bool) -> Self {
+        self.allow_hover = hovering;
         self
     }
 
@@ -216,6 +226,10 @@ impl PlotItem for HLine {
         self.highlight
     }
 
+    fn allow_hover(&self) -> bool {
+        self.allow_hover
+    }
+
     fn geometry(&self) -> PlotGeometry<'_> {
         PlotGeometry::None
     }
@@ -235,6 +249,7 @@ pub struct VLine {
     pub(super) stroke: Stroke,
     pub(super) name: String,
     pub(super) highlight: bool,
+    pub(super) allow_hover: bool,
     pub(super) style: LineStyle,
 }
 
@@ -245,6 +260,7 @@ impl VLine {
             stroke: Stroke::new(1.0, Color32::TRANSPARENT),
             name: String::default(),
             highlight: false,
+            allow_hover: true,
             style: LineStyle::Solid,
         }
     }
@@ -252,6 +268,12 @@ impl VLine {
     /// Highlight this line in the plot by scaling up the line.
     pub fn highlight(mut self, highlight: bool) -> Self {
         self.highlight = highlight;
+        self
+    }
+
+    // Allowed hovering this line in the plot.
+    pub fn allow_hover(mut self, hovering: bool) -> Self {
+        self.allow_hover = hovering;
         self
     }
 
@@ -332,6 +354,10 @@ impl PlotItem for VLine {
         self.highlight
     }
 
+    fn allow_hover(&self) -> bool {
+        self.allow_hover
+    }
+
     fn geometry(&self) -> PlotGeometry<'_> {
         PlotGeometry::None
     }
@@ -350,6 +376,7 @@ pub struct Line {
     pub(super) stroke: Stroke,
     pub(super) name: String,
     pub(super) highlight: bool,
+    pub(super) allow_hover: bool,
     pub(super) fill: Option<f32>,
     pub(super) style: LineStyle,
 }
@@ -361,6 +388,7 @@ impl Line {
             stroke: Stroke::new(1.0, Color32::TRANSPARENT),
             name: Default::default(),
             highlight: false,
+            allow_hover: true,
             fill: None,
             style: LineStyle::Solid,
         }
@@ -369,6 +397,12 @@ impl Line {
     /// Highlight this line in the plot by scaling up the line.
     pub fn highlight(mut self, highlight: bool) -> Self {
         self.highlight = highlight;
+        self
+    }
+
+    // Allowed hovering this line in the plot.
+    pub fn allow_hover(mut self, hovering: bool) -> Self {
+        self.allow_hover = hovering;
         self
     }
 
@@ -502,6 +536,10 @@ impl PlotItem for Line {
         self.highlight
     }
 
+    fn allow_hover(&self) -> bool {
+        self.allow_hover
+    }
+
     fn geometry(&self) -> PlotGeometry<'_> {
         PlotGeometry::Points(self.series.points())
     }
@@ -517,6 +555,7 @@ pub struct Polygon {
     pub(super) stroke: Stroke,
     pub(super) name: String,
     pub(super) highlight: bool,
+    pub(super) allow_hover: bool,
     pub(super) fill_alpha: f32,
     pub(super) style: LineStyle,
 }
@@ -528,6 +567,7 @@ impl Polygon {
             stroke: Stroke::new(1.0, Color32::TRANSPARENT),
             name: Default::default(),
             highlight: false,
+            allow_hover: true,
             fill_alpha: DEFAULT_FILL_ALPHA,
             style: LineStyle::Solid,
         }
@@ -537,6 +577,12 @@ impl Polygon {
     /// transparency.
     pub fn highlight(mut self, highlight: bool) -> Self {
         self.highlight = highlight;
+        self
+    }
+
+    // Allowed hovering this line in the plot.
+    pub fn allow_hover(mut self, hovering: bool) -> Self {
+        self.allow_hover = hovering;
         self
     }
 
@@ -632,6 +678,10 @@ impl PlotItem for Polygon {
         self.highlight
     }
 
+    fn allow_hover(&self) -> bool {
+        self.allow_hover
+    }
+
     fn geometry(&self) -> PlotGeometry<'_> {
         PlotGeometry::Points(self.series.points())
     }
@@ -648,6 +698,7 @@ pub struct Text {
     pub(super) position: PlotPoint,
     pub(super) name: String,
     pub(super) highlight: bool,
+    pub(super) allow_hover: bool,
     pub(super) color: Color32,
     pub(super) anchor: Align2,
 }
@@ -659,6 +710,7 @@ impl Text {
             position,
             name: Default::default(),
             highlight: false,
+            allow_hover: true,
             color: Color32::TRANSPARENT,
             anchor: Align2::CENTER_CENTER,
         }
@@ -667,6 +719,12 @@ impl Text {
     /// Highlight this text in the plot by drawing a rectangle around it.
     pub fn highlight(mut self, highlight: bool) -> Self {
         self.highlight = highlight;
+        self
+    }
+
+    // Allowed hovering this line in the plot.
+    pub fn allow_hover(mut self, hovering: bool) -> Self {
+        self.allow_hover = hovering;
         self
     }
 
@@ -746,6 +804,10 @@ impl PlotItem for Text {
         self.highlight
     }
 
+    fn allow_hover(&self) -> bool {
+        self.allow_hover
+    }
+
     fn geometry(&self) -> PlotGeometry<'_> {
         PlotGeometry::None
     }
@@ -769,6 +831,7 @@ pub struct Points {
     pub(super) radius: f32,
     pub(super) name: String,
     pub(super) highlight: bool,
+    pub(super) allow_hover: bool,
     pub(super) stems: Option<f32>,
 }
 
@@ -782,6 +845,7 @@ impl Points {
             radius: 1.0,
             name: Default::default(),
             highlight: false,
+            allow_hover: true,
             stems: None,
         }
     }
@@ -795,6 +859,12 @@ impl Points {
     /// Highlight these points in the plot by scaling up their markers.
     pub fn highlight(mut self, highlight: bool) -> Self {
         self.highlight = highlight;
+        self
+    }
+
+    // Allowed hovering this line in the plot.
+    pub fn allow_hover(mut self, hovering: bool) -> Self {
+        self.allow_hover = hovering;
         self
     }
 
@@ -984,6 +1054,10 @@ impl PlotItem for Points {
         self.highlight
     }
 
+    fn allow_hover(&self) -> bool {
+        self.allow_hover
+    }
+
     fn geometry(&self) -> PlotGeometry<'_> {
         PlotGeometry::Points(self.series.points())
     }
@@ -1000,6 +1074,7 @@ pub struct Arrows {
     pub(super) color: Color32,
     pub(super) name: String,
     pub(super) highlight: bool,
+    pub(super) allow_hover: bool,
 }
 
 impl Arrows {
@@ -1010,12 +1085,19 @@ impl Arrows {
             color: Color32::TRANSPARENT,
             name: Default::default(),
             highlight: false,
+            allow_hover: true,
         }
     }
 
     /// Highlight these arrows in the plot.
     pub fn highlight(mut self, highlight: bool) -> Self {
         self.highlight = highlight;
+        self
+    }
+
+    // Allowed hovering this line in the plot.
+    pub fn allow_hover(mut self, hovering: bool) -> Self {
+        self.allow_hover = hovering;
         self
     }
 
@@ -1099,6 +1181,10 @@ impl PlotItem for Arrows {
         self.highlight
     }
 
+    fn allow_hover(&self) -> bool {
+        self.allow_hover
+    }
+
     fn geometry(&self) -> PlotGeometry<'_> {
         PlotGeometry::Points(self.origins.points())
     }
@@ -1118,6 +1204,7 @@ pub struct PlotImage {
     pub(super) bg_fill: Color32,
     pub(super) tint: Color32,
     pub(super) highlight: bool,
+    pub(super) allow_hover: bool,
     pub(super) name: String,
 }
 
@@ -1132,6 +1219,7 @@ impl PlotImage {
             position: center_position,
             name: Default::default(),
             highlight: false,
+            allow_hover: true,
             texture_id: texture_id.into(),
             uv: Rect::from_min_max(pos2(0.0, 0.0), pos2(1.0, 1.0)),
             size: size.into(),
@@ -1143,6 +1231,12 @@ impl PlotImage {
     /// Highlight this image in the plot.
     pub fn highlight(mut self, highlight: bool) -> Self {
         self.highlight = highlight;
+        self
+    }
+
+    // Allowed hovering this line in the plot.
+    pub fn allow_hover(mut self, hovering: bool) -> Self {
+        self.allow_hover = hovering;
         self
     }
 
@@ -1234,6 +1328,10 @@ impl PlotItem for PlotImage {
         self.highlight
     }
 
+    fn allow_hover(&self) -> bool {
+        self.allow_hover
+    }
+
     fn geometry(&self) -> PlotGeometry<'_> {
         PlotGeometry::None
     }
@@ -1264,6 +1362,7 @@ pub struct BarChart {
     /// A custom element formatter
     pub(super) element_formatter: Option<Box<dyn Fn(&Bar, &BarChart) -> String>>,
     highlight: bool,
+    allow_hover: bool,
 }
 
 impl BarChart {
@@ -1275,6 +1374,7 @@ impl BarChart {
             name: String::new(),
             element_formatter: None,
             highlight: false,
+            allow_hover: true,
         }
     }
 
@@ -1333,6 +1433,12 @@ impl BarChart {
     /// Highlight all plot elements.
     pub fn highlight(mut self, highlight: bool) -> Self {
         self.highlight = highlight;
+        self
+    }
+
+    // Allowed hovering this line in the plot.
+    pub fn allow_hover(mut self, hovering: bool) -> Self {
+        self.allow_hover = hovering;
         self
     }
 
@@ -1395,6 +1501,10 @@ impl PlotItem for BarChart {
         self.highlight
     }
 
+    fn allow_hover(&self) -> bool {
+        self.allow_hover
+    }
+
     fn geometry(&self) -> PlotGeometry<'_> {
         PlotGeometry::Rects
     }
@@ -1434,6 +1544,7 @@ pub struct BoxPlot {
     /// A custom element formatter
     pub(super) element_formatter: Option<Box<dyn Fn(&BoxElem, &BoxPlot) -> String>>,
     highlight: bool,
+    allow_hover: bool,
 }
 
 impl BoxPlot {
@@ -1445,6 +1556,7 @@ impl BoxPlot {
             name: String::new(),
             element_formatter: None,
             highlight: false,
+            allow_hover: true,
         }
     }
 
@@ -1500,6 +1612,12 @@ impl BoxPlot {
         self
     }
 
+    // Allowed hovering this line in the plot.
+    pub fn allow_hover(mut self, hovering: bool) -> Self {
+        self.allow_hover = hovering;
+        self
+    }
+
     /// Add a custom way to format an element.
     /// Can be used to display a set number of decimals or custom labels.
     pub fn element_formatter(
@@ -1536,6 +1654,10 @@ impl PlotItem for BoxPlot {
 
     fn highlighted(&self) -> bool {
         self.highlight
+    }
+
+    fn allow_hover(&self) -> bool {
+        self.allow_hover
     }
 
     fn geometry(&self) -> PlotGeometry<'_> {

--- a/crates/egui/src/widgets/plot/mod.rs
+++ b/crates/egui/src/widgets/plot/mod.rs
@@ -1574,7 +1574,9 @@ impl PreparedPlot {
 
         let interact_radius_sq: f32 = (16.0f32).powi(2);
 
-        let candidates = items.iter().filter_map(|item| {
+        let candidates = items.iter()
+        .filter(|entry| entry.allow_hover() == true)
+        .filter_map(|item| {
             let item = &**item;
             let closest = item.find_closest(pointer, transform);
 

--- a/crates/egui/src/widgets/plot/mod.rs
+++ b/crates/egui/src/widgets/plot/mod.rs
@@ -1580,8 +1580,8 @@ impl PreparedPlot {
                 let item = &**item;
                 let closest = item.find_closest(pointer, transform);
 
-                Some(item).zip(closest)
-            });
+            Some(item).zip(closest)
+        });
 
         let closest = candidates
             .min_by_key(|(_, elem)| elem.dist_sq.ord())

--- a/crates/egui/src/widgets/plot/mod.rs
+++ b/crates/egui/src/widgets/plot/mod.rs
@@ -1575,13 +1575,13 @@ impl PreparedPlot {
         let interact_radius_sq: f32 = (16.0f32).powi(2);
 
         let candidates = items.iter()
-        .filter(|entry| entry.allow_hover() == true)
-        .filter_map(|item| {
-            let item = &**item;
-            let closest = item.find_closest(pointer, transform);
+            .filter(|entry| entry.allow_hover() == true)
+            .filter_map(|item| {
+                let item = &**item;
+                let closest = item.find_closest(pointer, transform);
 
-            Some(item).zip(closest)
-        });
+                Some(item).zip(closest)
+            });
 
         let closest = candidates
             .min_by_key(|(_, elem)| elem.dist_sq.ord())


### PR DESCRIPTION
This is particularly interesting if you want to authorize a single hover tooltip on an item in the event of an interaction.