### PR TITLE
add an optional custom shadow implemention setting

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -339,7 +339,7 @@ impl Area {
             //     Rect::from_center_size(area_rect.center(), visibility_factor * area_rect.size());
 
             let frame = frame.multiply_with_opacity(visibility_factor);
-            painter.add(frame.paint(area_rect));
+            painter.add(frame.paint(area_rect, ctx));
         }
     }
 }
@@ -378,7 +378,7 @@ impl Prepared {
             bounds.max.at_least(self.state.pos + Vec2::splat(32.0)),
         );
 
-        let shadow_radius = ctx.style().visuals.window_shadow.extrusion; // hacky
+        let shadow_radius = ctx.style().visuals.window_shadow.extrusion * 2.0; // hacky
         let clip_rect_margin = ctx.style().visuals.clip_rect_margin.max(shadow_radius);
 
         let clip_rect = Rect::from_min_max(self.state.pos, bounds.max)

--- a/crates/egui/src/containers/frame.rs
+++ b/crates/egui/src/containers/frame.rs
@@ -222,7 +222,7 @@ impl Frame {
         InnerResponse::new(ret, response)
     }
 
-    pub fn paint(&self, outer_rect: Rect) -> Shape {
+    pub fn paint(&self, outer_rect: Rect, ctx: &Context) -> Shape {
         let Self {
             inner_margin: _,
             outer_margin: _,
@@ -242,8 +242,12 @@ impl Frame {
         if shadow == Default::default() {
             frame_shape
         } else {
-            let shadow = shadow.tessellate(outer_rect, rounding);
-            let shadow = Shape::Mesh(shadow);
+            let shadow = if let Some(custom_shadow) = &*ctx.custom_shadow_provider() {
+                custom_shadow(shadow, outer_rect, rounding)
+            } else {
+                let shadow = shadow.tessellate(outer_rect, rounding);
+                Shape::Mesh(shadow)
+            };
             Shape::Vec(vec![shadow, frame_shape])
         }
     }
@@ -274,7 +278,7 @@ impl Prepared {
         } = self;
 
         if ui.is_rect_visible(paint_rect) {
-            let shape = frame.paint(paint_rect);
+            let shape = frame.paint(paint_rect, ui.ctx());
             ui.painter().set(where_to_put_background, shape);
         }
 

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -70,6 +70,8 @@ struct ContextImpl {
 
     #[cfg(feature = "accesskit")]
     is_accesskit_enabled: bool,
+
+    custom_shadow: Option<Arc<dyn Fn(Shadow, Rect, Rounding) -> Shape + Send + Sync>>,
 }
 
 impl ContextImpl {
@@ -1023,6 +1025,20 @@ impl Context {
         pos = self.round_pos_to_pixels(pos);
 
         Rect::from_min_size(pos, window.size())
+    }
+
+    pub fn custom_shadow_provider(
+        &self,
+    ) -> RwLockReadGuard<'_, Option<Arc<dyn Fn(Shadow, Rect, Rounding) -> Shape + Send + Sync>>>
+    {
+        RwLockReadGuard::map(self.read(), |f| &f.custom_shadow)
+    }
+
+    pub fn set_custom_shadow_provider(
+        &self,
+        custom_shadow: Option<Arc<dyn Fn(Shadow, Rect, Rounding) -> Shape + Send + Sync>>,
+    ) {
+        self.write().custom_shadow = custom_shadow;
     }
 }
 


### PR DESCRIPTION
while the default shadow is good at cross platform and runs pretty fast, sometimes a custom implemention could give a slightly better visual result, for example: 
default | a [blur shader](https://madebyevan.com/shaders/fast-rounded-rectangle-shadows/) on the glow backend
---- | ----
![](https://user-images.githubusercontent.com/13201009/211305978-bcb9da94-e678-4840-be61-19fb65e10681.png) | ![](https://user-images.githubusercontent.com/13201009/211305994-ca8c1ab6-dac1-4bf1-ae36-de03955e2355.png)

this kind of backend specific global override could easily make egui looks inconsistent between backends so im not sure its a good choice, but it does makes shadow rendering more flexible..