### PR TITLE
feat(non-fading-painter): implement custom fade painter

### DIFF
--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use epaint::mutex::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
+use crate::painter::TempPainter;
 use crate::{
     containers::*, ecolor::*, epaint::text::Fonts, layout::*, menu::MenuState, placer::Placer,
     widgets::*, *,
@@ -206,6 +207,11 @@ impl Ui {
     #[inline]
     pub fn painter(&self) -> &Painter {
         &self.painter
+    }
+
+    /// Get a painter with the specified fade color within this ['Ui']
+    pub fn painter_with_fade(&mut self, fade_color: Option<Color32>) -> TempPainter {
+        TempPainter::new(&mut self.painter, fade_color)
     }
 
     /// If `false`, the [`Ui`] does not allow any interaction and


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

This is just a try to solve <https://github.com/emilk/egui/issues/2576>. Other than just fixing the issue, it also enables setting a custom fade color which might be useful aswell.

The overhead is quiet minimal. The `fade_to_color` is set before and after the use of the new widget, which shouldn't be too big of an overhead.

The only downside of this approach is that the new function `ui.painter_with_fade(...)` requires a mutable reference to `ui` which clashes with other references (mostly of form `let style  = ui.style()` or `let visuals = ui.visuals()`). However, these references can be reordered and properly scoped to fix the issue. 

This is just a PoC implementation and I'm interested in your opinion. It's currently just implemented for `Button` and can be used there with the new `fade` method. If you think the changes are reasonable, I'll implement similar methods for the other structs and clean up the PR.

Closes <https://github.com/emilk/egui/issues/2576>.