### PR TITLE
Fix typo in cargo run command.

### DIFF
--- a/examples/keyboard_events/README.md
+++ b/examples/keyboard_events/README.md
@@ -1,5 +1,5 @@
 ```sh
-cargo run -p hello_world
+cargo run -p keyboard_events
 ```
 
 ![](screenshot.png)


### PR DESCRIPTION
I think someone by mistake wrote `cargo run -p hello_world` instead of `cargo run -p keyboard_events`.