### PR TITLE
Expose area interactable and movable to Window api.

### DIFF
--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -85,7 +85,7 @@ impl<'open> Window<'open> {
         self
     }
 
-    /// If `false` the window will be in movable.
+    /// If `false` the window will be immovable.
     pub fn movable(mut self, movable: bool) -> Self {
         self.area = self.area.movable(movable);
         self

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -85,6 +85,12 @@ impl<'open> Window<'open> {
         self
     }
 
+    /// If `false` the window will be in movable.
+    pub fn movable(mut self, movable: bool) -> Self {
+        self.area = self.area.movable(movable);
+        self
+    }
+
     /// Usage: `Window::new(…).mutate(|w| w.resize = w.resize.auto_expand_width(true))`
     // TODO(emilk): I'm not sure this is a good interface for this.
     pub fn mutate(mut self, mutate: impl Fn(&mut Self)) -> Self {

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -79,6 +79,12 @@ impl<'open> Window<'open> {
         self
     }
 
+    /// If `false` the window will be non-interactive.
+    pub fn interactable(mut self, interactable: bool) -> Self {
+        self.area = self.area.interactable(interactable);
+        self
+    }
+
     /// Usage: `Window::new(…).mutate(|w| w.resize = w.resize.auto_expand_width(true))`
     // TODO(emilk): I'm not sure this is a good interface for this.
     pub fn mutate(mut self, mutate: impl Fn(&mut Self)) -> Self {


### PR DESCRIPTION
As an alternative to `enabled` I would like to make the window non-interactable. The use case for this is to debug floating windows that are open during gameplay but should not get any input. Also, I like to have control over the movability of a window.