### PR TITLE
Add `rounding` fn to Button, to enable rounded buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 * Add `ScrollArea::drag_to_scroll` if you want to turn off that feature.
 * Add `Response::on_hover_and_drag_cursor`.
 * Add `Window::default_open` ([#2539](https://github.com/emilk/egui/pull/2539))
+* Add `Button::rounding` to enable round buttons ([#2539](https://github.com/emilk/egui/pull/2539))
 
 ### Changed 🔧
 * Improved plot grid appearance ([#2412](https://github.com/emilk/egui/pull/2412)).

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -30,6 +30,7 @@ pub struct Button {
     small: bool,
     frame: Option<bool>,
     min_size: Vec2,
+    rounding: Option<Rounding>,
     image: Option<widgets::Image>,
 }
 
@@ -45,6 +46,7 @@ impl Button {
             small: false,
             frame: None,
             min_size: Vec2::ZERO,
+            rounding: None,
             image: None,
         }
     }
@@ -117,6 +119,12 @@ impl Button {
         self
     }
 
+    /// Set the rounding of the button.
+    pub fn rounding(mut self, rounding: impl Into<Rounding>) -> Self {
+        self.rounding = Some(rounding.into());
+        self
+    }
+
     /// Show some text on the right side of the button, in weak color.
     ///
     /// Designed for menu buttons, for setting a keyboard shortcut text (e.g. `Ctrl+S`).
@@ -140,6 +148,7 @@ impl Widget for Button {
             small,
             frame,
             min_size,
+            rounding,
             image,
         } = self;
 
@@ -186,12 +195,9 @@ impl Widget for Button {
             if frame {
                 let fill = fill.unwrap_or(visuals.bg_fill);
                 let stroke = stroke.unwrap_or(visuals.bg_stroke);
-                ui.painter().rect(
-                    rect.expand(visuals.expansion),
-                    visuals.rounding,
-                    fill,
-                    stroke,
-                );
+                let rounding = rounding.unwrap_or(visuals.rounding);
+                ui.painter()
+                    .rect(rect.expand(visuals.expansion), rounding, fill, stroke);
             }
 
             let text_pos = if let Some(image) = image {


### PR DESCRIPTION
This PR adds rounding to `Button`. With this, a button can have different rounding then the global theme, it also allows us to simply make round buttons.
