### PR TITLE
`DragValue` and `Slider` text is now proportional instead of monospace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 * Improved plot grid appearance ([#2412](https://github.com/emilk/egui/pull/2412)).
 * Improved the algorithm for picking the number of decimals to show when hovering values in the `Plot`.
 * Default `ComboBox` is now controlled with `Spacing::combo_width` ([#2621](https://github.com/emilk/egui/pull/2621)).
+* `DragValue` and `Slider` now use the proportional font ([#2638](https://github.com/emilk/egui/pull/2638)).
 
 ### Fixed 🐛
 * Trigger `PointerEvent::Released` for drags ([#2507](https://github.com/emilk/egui/pull/2507)).

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -174,6 +174,9 @@ pub struct Style {
     /// ```
     pub text_styles: BTreeMap<TextStyle, FontId>,
 
+    /// The style to use for [`DragValue`] text.
+    pub drag_value_text_style: TextStyle,
+
     /// If set, labels buttons wtc will use this to determine whether or not
     /// to wrap the text at the right edge of the [`Ui`] they are in.
     /// By default this is `None`.
@@ -678,6 +681,7 @@ impl Default for Style {
             override_font_id: None,
             override_text_style: None,
             text_styles: default_text_styles(),
+            drag_value_text_style: TextStyle::Button,
             wrap: None,
             spacing: Spacing::default(),
             interaction: Interaction::default(),
@@ -922,6 +926,7 @@ impl Style {
             override_font_id,
             override_text_style,
             text_styles,
+            drag_value_text_style,
             wrap: _,
             spacing,
             interaction,
@@ -959,6 +964,19 @@ impl Style {
                         let text =
                             crate::RichText::new(style.to_string()).text_style(style.clone());
                         ui.selectable_value(override_text_style, Some(style), text);
+                    }
+                });
+            ui.end_row();
+
+            ui.label("Text style of DragValue:");
+            crate::ComboBox::from_id_source("drag_value_text_style")
+                .selected_text(drag_value_text_style.to_string())
+                .show_ui(ui, |ui| {
+                    let all_text_styles = ui.style().text_styles();
+                    for style in all_text_styles {
+                        let text =
+                            crate::RichText::new(style.to_string()).text_style(style.clone());
+                        ui.selectable_value(drag_value_text_style, style, text);
                     }
                 });
             ui.end_row();

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -456,6 +456,8 @@ impl<'a> Widget for DragValue<'a> {
             }
         };
 
+        let text_style = ui.style().drag_value_text_style.clone();
+
         // some clones below are redundant if AccessKit is disabled
         #[allow(clippy::redundant_clone)]
         let mut response = if is_kb_editing {
@@ -467,7 +469,7 @@ impl<'a> Widget for DragValue<'a> {
                 TextEdit::singleline(&mut value_text)
                     .id(id)
                     .desired_width(button_width)
-                    .font(TextStyle::Monospace),
+                    .font(text_style),
             );
             let parsed_value = match custom_parser {
                 Some(parser) => parser(&value_text),
@@ -481,7 +483,8 @@ impl<'a> Widget for DragValue<'a> {
             response
         } else {
             let button = Button::new(
-                RichText::new(format!("{}{}{}", prefix, value_text.clone(), suffix)).monospace(),
+                RichText::new(format!("{}{}{}", prefix, value_text.clone(), suffix))
+                    .text_style(text_style),
             )
             .wrap(false)
             .sense(Sense::click_and_drag())


### PR DESCRIPTION
Control with `Style::drag_value_text_style`