### PR TITLE
Add link to `tauri-egui` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ These are the official egui integrations:
 * [`screen-13-egui`](https://github.com/attackgoat/screen-13/tree/master/contrib/screen-13-egui) for [Screen 13](https://github.com/attackgoat/screen-13).
 * [`egui_skia`](https://github.com/lucasmerlin/egui_skia) for [skia](https://github.com/rust-skia/rust-skia/tree/master/skia-safe).
 * [`smithay-egui`](https://github.com/Smithay/smithay-egui) for [smithay](https://github.com/Smithay/smithay/).
+* [`tauri-egui`](https://github.com/tauri-apps/tauri-egui) for [tauri](https://github.com/tauri-apps/tauri).
 
 Missing an integration for the thing you're working on? Create one, it's easy!
 


### PR DESCRIPTION
add a 3rd party integration: tauri-egui for tauri

