### PR TITLE
select all text when drag value gets focus

### DIFF
--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -507,6 +507,12 @@ impl<'a> Widget for DragValue<'a> {
                     mem.drag_value.edit_string = None;
                     mem.request_focus(id);
                 });
+                let mut state = TextEdit::load_state(ui.ctx(), id).unwrap_or_default();
+                state.set_ccursor_range(Some(text::CCursorRange::two(
+                    epaint::text::cursor::CCursor::default(),
+                    epaint::text::cursor::CCursor::new(value_text.chars().count()),
+                )));
+                state.store(ui.ctx(), response.id);
             } else if response.dragged() {
                 ui.ctx().set_cursor_icon(CursorIcon::ResizeHorizontal);
 


### PR DESCRIPTION
currently drag value textboxes reuse the cursor state from the previous focus, which doesnt really make sense imo.

this patch ensures all texts are selected when a drag value is clicked, so user can type directly to overwrite the value.
seems that other common ui toolkits also behave like this.