### PR TITLE
Add `trailing_fill()` toggle to `Slider`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 * ⚠️ BREAKING: `egui::Context` now use closures for locking ([#2625](https://github.com/emilk/egui/pull/2625)):
   * `ctx.input().key_pressed(Key::A)` -> `ctx.input(|i| i.key_pressed(Key::A))`
   * `ui.memory().toggle_popup(popup_id)` -> `ui.memory_mut(|mem| mem.toggle_popup(popup_id))`
-  * Add `Slider::trailing_color` for trailing color behind the circle like a `ProgressBar`
+* Add `Slider::trailing_fill` for trailing color behind the circle like a `ProgressBar` ([#2660](https://github.com/emilk/egui/pull/2660)).
 
 ### Added ⭐
 * Add `Response::drag_started_by` and `Response::drag_released_by` for convenience, similar to `dragged` and `dragged_by` ([#2507](https://github.com/emilk/egui/pull/2507)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 * ⚠️ BREAKING: `egui::Context` now use closures for locking ([#2625](https://github.com/emilk/egui/pull/2625)):
   * `ctx.input().key_pressed(Key::A)` -> `ctx.input(|i| i.key_pressed(Key::A))`
   * `ui.memory().toggle_popup(popup_id)` -> `ui.memory_mut(|mem| mem.toggle_popup(popup_id))`
+  * Add `Slider::trailing_color` for trailing color behind the circle like a `ProgressBar`
 
 ### Added ⭐
 * Add `Response::drag_started_by` and `Response::drag_released_by` for convenience, similar to `dragged` and `dragged_by` ([#2507](https://github.com/emilk/egui/pull/2507)).

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1332,7 +1332,7 @@ impl Visuals {
 
             striped,
 
-            slider_trailing_fill: _,
+            slider_trailing_fill,
         } = self;
 
         ui.collapsing("Background Colors", |ui| {
@@ -1394,6 +1394,8 @@ impl Visuals {
         );
 
         ui.checkbox(striped, "By default, add stripes to grids and tables?");
+
+        ui.checkbox(slider_trailing_fill, "Add trailing color to sliders");
 
         ui.vertical_centered(|ui| reset_button(ui, self));
     }

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -506,6 +506,11 @@ pub struct Visuals {
     /// Wether or not Grids and Tables should be striped by default
     /// (have alternating rows differently colored).
     pub striped: bool,
+
+    /// Show trailing color behind the circle of a [`Slider`]. Default is OFF.
+    ///
+    /// Enabling this will affect ALL sliders, and can be enabled/disabled per slider with [`Slider::trailing_fill`].
+    pub slider_trailing_fill: bool,
 }
 
 impl Visuals {
@@ -764,6 +769,8 @@ impl Visuals {
             indent_has_left_vline: true,
 
             striped: false,
+
+            slider_trailing_fill: false,
         }
     }
 
@@ -1324,6 +1331,8 @@ impl Visuals {
             indent_has_left_vline,
 
             striped,
+
+            slider_trailing_fill: _,
         } = self;
 
         ui.collapsing("Background Colors", |ui| {

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -642,10 +642,9 @@ impl<'a> Slider<'a> {
             let center = self.marker_center(position_1d, &rail_rect);
 
             // Decide if we should add trailing fill.
-            let trailing_fill = match self.trailing_fill {
-                Some(override_bool) => override_bool,
-                None => ui.visuals().slider_trailing_fill,
-            };
+            let trailing_fill = self
+                .trailing_fill
+                .unwrap_or_else(|| ui.visuals().slider_trailing_fill);
 
             // Paint trailing fill.
             if trailing_fill {

--- a/crates/egui_demo_lib/src/demo/sliders.rs
+++ b/crates/egui_demo_lib/src/demo/sliders.rs
@@ -16,6 +16,7 @@ pub struct Sliders {
     pub integer: bool,
     pub vertical: bool,
     pub value: f64,
+    pub trailing_fill: bool,
 }
 
 impl Default for Sliders {
@@ -31,6 +32,7 @@ impl Default for Sliders {
             integer: false,
             vertical: false,
             value: 10.0,
+            trailing_fill: false,
         }
     }
 }
@@ -64,6 +66,7 @@ impl super::View for Sliders {
             integer,
             vertical,
             value,
+            trailing_fill,
         } = self;
 
         ui.label("You can click a slider value to edit it with the keyboard.");
@@ -95,7 +98,8 @@ impl super::View for Sliders {
                     .smart_aim(*smart_aim)
                     .orientation(orientation)
                     .text("i32 demo slider")
-                    .step_by(istep),
+                    .step_by(istep)
+                    .trailing_fill(*trailing_fill),
             );
             *value = value_i32 as f64;
         } else {
@@ -106,7 +110,8 @@ impl super::View for Sliders {
                     .smart_aim(*smart_aim)
                     .orientation(orientation)
                     .text("f64 demo slider")
-                    .step_by(istep),
+                    .step_by(istep)
+                    .trailing_fill(*trailing_fill),
             );
 
             ui.label(
@@ -126,14 +131,21 @@ impl super::View for Sliders {
             Slider::new(min, type_min..=type_max)
                 .logarithmic(true)
                 .smart_aim(*smart_aim)
-                .text("left"),
+                .text("left")
+                .trailing_fill(*trailing_fill),
         );
         ui.add(
             Slider::new(max, type_min..=type_max)
                 .logarithmic(true)
                 .smart_aim(*smart_aim)
-                .text("right"),
+                .text("right")
+                .trailing_fill(*trailing_fill),
         );
+
+        ui.separator();
+
+        ui.checkbox(trailing_fill, "Toggle trailing color");
+        ui.label("When enabled, trailing color will be painted up until the circle.");
 
         ui.separator();
 


### PR DESCRIPTION
Adds a boolean toggle to `Slider` that enables trailing color behind the circle. The color used is the same as a `ProgressBar`, it is sourced from `ui.visuals().selection.bg_fill`.

Usage:
```rust
ui.add(Slider::new(&mut my_slider_value, 0.0..=100.0));                      // No-color (default)
ui.add(Slider::new(&mut my_slider_value, 0.0..=100.0).trailing_color(true)); // Trailing color
```

Before:
![before](https://user-images.githubusercontent.com/101352116/216216877-22021215-e867-4e45-a311-cb932370c899.gif)

After:
![after](https://user-images.githubusercontent.com/101352116/216216895-150eaeda-e3d0-4405-877c-727618ff4003.gif)

Vertical & Horizontal:
![orientation](https://user-images.githubusercontent.com/101352116/216216926-2b2cdc13-a5c2-4698-a89c-2cef769fe264.gif)