### PR TITLE
Emilk/extend separators

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -426,15 +426,26 @@ impl ScrollArea {
 
         let content_max_rect = Rect::from_min_size(inner_rect.min - state.offset, content_max_size);
         let mut content_ui = ui.child_ui(content_max_rect, *ui.layout());
-        let mut content_clip_rect = inner_rect.expand(ui.visuals().clip_rect_margin);
-        content_clip_rect = content_clip_rect.intersect(ui.clip_rect());
-        // Nice handling of forced resizing beyond the possible:
-        for d in 0..2 {
-            if !has_bar[d] {
-                content_clip_rect.max[d] = ui.clip_rect().max[d] - current_bar_use[d];
+
+        {
+            // Clip the content, but only when we really need to:
+            let clip_rect_margin = ui.visuals().clip_rect_margin;
+            let mut content_clip_rect = ui.clip_rect();
+            for d in 0..2 {
+                if has_bar[d] {
+                    if state.content_is_too_large[d] {
+                        content_clip_rect.min[d] = inner_rect.min[d] - clip_rect_margin;
+                        content_clip_rect.max[d] = inner_rect.max[d] + clip_rect_margin;
+                    }
+
+                    if state.show_scroll[d] {
+                        // Make sure content doesn't cover scroll bars:
+                        content_clip_rect.max[1 - d] = inner_rect.max[1 - d] + clip_rect_margin;
+                    }
+                }
             }
+            content_ui.set_clip_rect(content_clip_rect);
         }
-        content_ui.set_clip_rect(content_clip_rect);
 
         let viewport = Rect::from_min_size(Pos2::ZERO + state.offset, inner_size);
 

--- a/crates/egui/src/widgets/separator.rs
+++ b/crates/egui/src/widgets/separator.rs
@@ -14,6 +14,7 @@ use crate::*;
 #[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
 pub struct Separator {
     spacing: f32,
+    grow: f32,
     is_horizontal_line: Option<bool>,
 }
 
@@ -21,6 +22,7 @@ impl Default for Separator {
     fn default() -> Self {
         Self {
             spacing: 6.0,
+            grow: 0.0,
             is_horizontal_line: None,
         }
     }
@@ -28,12 +30,19 @@ impl Default for Separator {
 
 impl Separator {
     /// How much space we take up. The line is painted in the middle of this.
+    ///
+    /// In a vertical layout, with a horizontal Separator,
+    /// this is the height of the separator widget.
+    ///
+    /// In a horizontal layout, with a vertical Separator,
+    /// this is the width of the separator widget.
     pub fn spacing(mut self, spacing: f32) -> Self {
         self.spacing = spacing;
         self
     }
 
     /// Explicitly ask for a horizontal line.
+    ///
     /// By default you will get a horizontal line in vertical layouts,
     /// and a vertical line in horizontal layouts.
     pub fn horizontal(mut self) -> Self {
@@ -42,10 +51,31 @@ impl Separator {
     }
 
     /// Explicitly ask for a vertical line.
+    ///
     /// By default you will get a horizontal line in vertical layouts,
     /// and a vertical line in horizontal layouts.
     pub fn vertical(mut self) -> Self {
         self.is_horizontal_line = Some(false);
+        self
+    }
+
+    /// Extend each end of the separator line by this much.
+    ///
+    /// The default is to take up the available width/height of the parent.
+    ///
+    /// This will make the line extend outside the parent ui.
+    pub fn grow(mut self, extra: f32) -> Self {
+        self.grow += extra;
+        self
+    }
+
+    /// Contract each end of the separator line by this much.
+    ///
+    /// The default is to take up the available width/height of the parent.
+    ///
+    /// This effectively adds margins to the line.
+    pub fn shrink(mut self, shrink: f32) -> Self {
+        self.grow -= shrink;
         self
     }
 }
@@ -54,6 +84,7 @@ impl Widget for Separator {
     fn ui(self, ui: &mut Ui) -> Response {
         let Separator {
             spacing,
+            grow,
             is_horizontal_line,
         } = self;
 
@@ -75,14 +106,14 @@ impl Widget for Separator {
             let painter = ui.painter();
             if is_horizontal_line {
                 painter.hline(
-                    rect.x_range(),
+                    (rect.left() - grow)..=(rect.right() + grow),
                     painter.round_to_pixel(rect.center().y),
                     stroke,
                 );
             } else {
                 painter.vline(
                     painter.round_to_pixel(rect.center().x),
-                    rect.y_range(),
+                    (rect.top() - grow)..=(rect.bottom() + grow),
                     stroke,
                 );
             }

--- a/crates/egui_demo_lib/src/demo/window_with_panels.rs
+++ b/crates/egui_demo_lib/src/demo/window_with_panels.rs
@@ -85,6 +85,8 @@ fn lorem_ipsum(ui: &mut egui::Ui) {
         egui::Layout::top_down(egui::Align::LEFT).with_cross_justify(true),
         |ui| {
             ui.label(egui::RichText::new(crate::LOREM_IPSUM_LONG).small().weak());
+            ui.add(egui::Separator::default().grow(8.0));
+            ui.label(egui::RichText::new(crate::LOREM_IPSUM_LONG).small().weak());
         },
     );
 }


### PR DESCRIPTION
[Add Separator::grow and Separator::shrink](https://github.com/emilk/egui/commit/55589a130855818b9f2754910f40baa11cc21ef3) to allow users to control the width of horizontal separators.

To let the separators (and other widgets) to paint "outside the lines", the `ScrollArea` has been tweaked to only clip its content if absolutely necessary.