### PR TITLE
DragValue: when keyboard editing, only update the value on focus lost

### DIFF
--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -475,6 +475,8 @@ impl<'a> Widget for DragValue<'a> {
                     .desired_width(ui.spacing().interact_size.x)
                     .font(text_style),
             );
+            // Only update the value when the user presses enter, or clicks elsewhere. NOT every frame.
+            // See https://github.com/emilk/egui/issues/2687            
             if response.lost_focus() {
                 let parsed_value = match custom_parser {
                     Some(parser) => parser(&value_text),

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -476,7 +476,7 @@ impl<'a> Widget for DragValue<'a> {
                     .font(text_style),
             );
             // Only update the value when the user presses enter, or clicks elsewhere. NOT every frame.
-            // See https://github.com/emilk/egui/issues/2687            
+            // See https://github.com/emilk/egui/issues/2687
             if response.lost_focus() {
                 let parsed_value = match custom_parser {
                     Some(parser) => parser(&value_text),

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -395,21 +395,36 @@ impl<'a> Widget for DragValue<'a> {
         let max_decimals = max_decimals.unwrap_or(auto_decimals + 2);
         let auto_decimals = auto_decimals.clamp(min_decimals, max_decimals);
 
+        let change = ui.input_mut(|input| {
+            let mut change = 0.0;
+
+            if is_kb_editing {
+                // This deliberately doesn't listen for left and right arrow keys,
+                // because when editing, these are used to move the caret.
+                // This behavior is consistent with other editable spinner/stepper
+                // implementations, such as Chromium's (for HTML5 number input).
+                // It is also normal for such controls to go directly into edit mode
+                // when they receive keyboard focus, and some screen readers
+                // assume this behavior, so having a separate mode for incrementing
+                // and decrementing, that supports all arrow keys, would be
+                // problematic.
+                change += input.count_and_consume_key(Modifiers::NONE, Key::ArrowUp) as f64
+                    - input.count_and_consume_key(Modifiers::NONE, Key::ArrowDown) as f64;
+            }
+
+            #[cfg(feature = "accesskit")]
+            {
+                use accesskit::Action;
+                change += input.num_accesskit_action_requests(id, Action::Increment) as f64
+                    - input.num_accesskit_action_requests(id, Action::Decrement) as f64;
+            }
+
+            change
+        });
+
         #[cfg(feature = "accesskit")]
         {
             use accesskit::{Action, ActionData};
-
-            let change = ui.input_mut(|input| {
-                let mut change = 0.0;
-
-                if !is_kb_editing {
-                    change += input.num_accesskit_action_requests(id, Action::Increment) as f64
-                        - input.num_accesskit_action_requests(id, Action::Decrement) as f64;
-                }
-
-                change
-            });
-
             ui.input(|input| {
                 for request in input.accesskit_action_requests(id, Action::SetValue) {
                     if let Some(ActionData::NumericValue(new_value)) = request.data {
@@ -417,11 +432,11 @@ impl<'a> Widget for DragValue<'a> {
                     }
                 }
             });
+        }
 
-            if change != 0.0 {
-                value += speed * change;
-                value = emath::round_to_decimals(value, auto_decimals);
-            }
+        if change != 0.0 {
+            value += speed * change;
+            value = emath::round_to_decimals(value, auto_decimals);
         }
 
         value = clamp_to_range(value, clamp_range.clone());


### PR DESCRIPTION
Closes <https://github.com/emilk/egui/issues/2687>

Since the underlying `TextEdit` is `singleline`, pressing enter also results in lost focus.

I demonstrate two instances of this below. I press enter after the first edit, then click away after the second.

![demo](https://user-images.githubusercontent.com/3968357/217361557-b74f2fba-d271-4d1d-b07e-ce543a6b8c34.gif)

I also shuffled some of the accesskit stuff. The up and down arrow keys probably shouldn't change the value during keyboard editing either. That little change allowed me to consolidate the accesskit code a bit better. I'm not sure how to test it.

As far as testing goes, `./sh/check.sh` failed in my environment (WSL 2) for some winit / platform reason. Clippy has no complaints about my changes.