### PR TITLE
Re-enable egui-winit for egui-glow on web

### DIFF
--- a/crates/egui_glow/Cargo.toml
+++ b/crates/egui_glow/Cargo.toml
@@ -47,6 +47,7 @@ winit = ["egui-winit"]
 egui = { version = "0.20.0", path = "../egui", default-features = false, features = [
   "bytemuck",
 ] }
+egui-winit = { version = "0.20.0", path = "../egui-winit", optional = true, default-features = false }
 
 bytemuck = "1.7"
 glow = "0.11"
@@ -59,7 +60,6 @@ document-features = { version = "0.2", optional = true }
 
 # Native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-egui-winit = { version = "0.20.0", path = "../egui-winit", optional = true, default-features = false }
 puffin = { version = "0.14", optional = true }
 
 # Web:

--- a/crates/egui_glow/src/lib.rs
+++ b/crates/egui_glow/src/lib.rs
@@ -20,9 +20,9 @@ mod vao;
 
 pub use shader_version::ShaderVersion;
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "winit"))]
+#[cfg(feature = "winit")]
 pub mod winit;
-#[cfg(all(not(target_arch = "wasm32"), feature = "winit"))]
+#[cfg(feature = "winit")]
 pub use winit::*;
 
 /// Check for OpenGL error and report it using `tracing::error`.


### PR DESCRIPTION
I tried this myself, and I do not think there is any reason to block the winit feature from egui-glow on wasm platforms.