### PR TITLE
Size `Slider` based off `Spacing` instead of `TextStyle::Body`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 
 ## Unreleased
 
+### Added ⭐
+* Add `Spacing::slider_thickness` to globally set thickness (not width/length!) of `Slider`.
+* Add `Slider::thickness` to set thickness per `Slider`.
+* Add `Slider::circle_size` to set the circle size of a `Slider`.
 
 ## 0.21.0 - 2023-02-08 - Deadlock fix and style customizability
 * ⚠️ BREAKING: `egui::Context` now use closures for locking ([#2625](https://github.com/emilk/egui/pull/2625)):

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -268,8 +268,12 @@ pub struct Spacing {
     /// Anything clickable should be (at least) this size.
     pub interact_size: Vec2, // TODO(emilk): rename min_interact_size ?
 
-    /// Default width of a [`Slider`].
+    /// Default width (length) of a [`Slider`].
+    /// This controls the height when the [`Slider`] is vertical.
     pub slider_width: f32,
+
+    /// Default thickness of a [`Slider`].
+    pub slider_thickness: f32,
 
     /// Default (minimum) width of a [`ComboBox`](crate::ComboBox).
     pub combo_width: f32,
@@ -715,6 +719,7 @@ impl Default for Spacing {
             indent: 18.0, // match checkbox/radio-button with `button_padding.x + icon_width + icon_spacing`
             interact_size: vec2(40.0, 18.0),
             slider_width: 100.0,
+            slider_thickness: 12.5, // This is the default size of `TextStyle::Body`
             combo_width: 100.0,
             text_edit_width: 280.0,
             icon_width: 14.0,
@@ -1044,6 +1049,7 @@ impl Spacing {
             indent,
             interact_size,
             slider_width,
+            slider_thickness,
             combo_width,
             text_edit_width,
             icon_width,
@@ -1073,6 +1079,10 @@ impl Spacing {
         ui.horizontal(|ui| {
             ui.add(DragValue::new(slider_width).clamp_range(0.0..=1000.0));
             ui.label("Slider width");
+        });
+        ui.horizontal(|ui| {
+            ui.add(DragValue::new(slider_thickness).clamp_range(0.0..=1000.0));
+            ui.label("Slider thickness");
         });
         ui.horizontal(|ui| {
             ui.add(DragValue::new(combo_width).clamp_range(0.0..=1000.0));


### PR DESCRIPTION
Most widgets are statically sized based off a value in `Spacing`, but `Slider` is not, instead its size is determined by [the height of `TextStyle::Body`](https://github.com/emilk/egui/blob/master/crates/egui/src/widgets/slider.rs#L784-L786). This leads to awkward scaling.

This PR adds `slider_thickness` to `Spacing` that all sliders will use instead.

The default size is `12.5`, which is the same default size as right now (since `TextStyle::Body` is also `12.5`).

It also adds overrides per slider:
```rust
Slider::new(&mut s, 0.0..1.0).thickness(my_f32);
```
This may be a breaking change as some users may be relying on `Slider` scailing with their `TextStyle::Body` text size.

Before:
![before](https://user-images.githubusercontent.com/101352116/218236011-580db347-8034-4a4c-9690-4fb1d2b735cb.jpg)

After:
![after](https://user-images.githubusercontent.com/101352116/218236522-c45f2d32-3df4-43c0-b02e-0c5f744a7c32.jpg)

Also: Sliders that are even slightly bigger than the default have a rectangle that peeks out of the circle so the default circle-to-rect ratio was changed slightly (circle is a bit bigger):

Before:
![before2](https://user-images.githubusercontent.com/101352116/218236005-1e176238-f714-4bcd-96e0-8adccf6f5673.jpg)
After:
![after2](https://user-images.githubusercontent.com/101352116/218235999-e480b635-f716-4c18-97f8-a1c61a69ca10.jpg)

Very large sliders will still have peeking rectangles so an override was added to this as well:
```rust
Slider::new(&mut s, 0.0..1.0).circle_size(my_f32);
```