### PR TITLE
hsva color_slider_2d orientation change

### DIFF
--- a/crates/egui/src/widgets/color_picker.rs
+++ b/crates/egui/src/widgets/color_picker.rs
@@ -155,6 +155,12 @@ fn color_slider_1d(ui: &mut Ui, value: &mut f32, color_at: impl Fn(f32) -> Color
     response
 }
 
+/// # Arguments
+/// * `x_value` - X axis, either saturation or value (0.0-1.0).
+/// * `y_value` - Y axis, either saturation or value (0.0-1.0).
+/// * `color_at` - A function that dictates how the mix of saturation and value will be displayed in the 2d slider.
+/// E.g.: color_at(hsvag.s as x_value, hsvag.v as y_value) displays the colors as follows: top-left: white \[s: 0.0, v: 1.0], top-right: fully saturated color \[s: 1.0, v: 1.0], bottom-right: black \[s: 0.0, v: 1.0]
+///
 fn color_slider_2d(
     ui: &mut Ui,
     x_value: &mut f32,
@@ -308,7 +314,7 @@ fn color_picker_hsvag_2d(ui: &mut Ui, hsva: &mut HsvaGamma, alpha: Alpha) {
         color_slider_1d(ui, v, |v| HsvaGamma { v, ..opaque }.into()).on_hover_text("Value");
     }
 
-    color_slider_2d(ui, v, s, |v, s| HsvaGamma { s, v, ..opaque }.into());
+    color_slider_2d(ui, s, v, |s, v| HsvaGamma { s, v, ..opaque }.into());
 }
 
 //// Shows a color picker where the user can change the given [`Hsva`] color.

--- a/crates/egui/src/widgets/color_picker.rs
+++ b/crates/egui/src/widgets/color_picker.rs
@@ -159,7 +159,7 @@ fn color_slider_1d(ui: &mut Ui, value: &mut f32, color_at: impl Fn(f32) -> Color
 /// * `x_value` - X axis, either saturation or value (0.0-1.0).
 /// * `y_value` - Y axis, either saturation or value (0.0-1.0).
 /// * `color_at` - A function that dictates how the mix of saturation and value will be displayed in the 2d slider.
-/// E.g.: color_at(hsvag.s as x_value, hsvag.v as y_value) displays the colors as follows: top-left: white \[s: 0.0, v: 1.0], top-right: fully saturated color \[s: 1.0, v: 1.0], bottom-right: black \[s: 0.0, v: 1.0]
+/// E.g.: `|x_value, y_value| HsvaGamma { h: 1.0, s: x_value, v: y_value, a: 1.0 }.into()` displays the colors as follows: top-left: white \[s: 0.0, v: 1.0], top-right: fully saturated color \[s: 1.0, v: 1.0], bottom-right: black \[s: 0.0, v: 1.0].
 ///
 fn color_slider_2d(
     ui: &mut Ui,


### PR DESCRIPTION
Swaps the hsva's saturation and value positions when used as arguments when calling the color_slider_2d, in order to make it display the color mix in a way more common in the image alteration softwares space.
`color_slider_2d(ui, v, s, |v, s| HsvaGamma { s, v, ..opaque }.into())`
to
`color_slider_2d(ui, s, v, |s, v| HsvaGamma { s, v, ..opaque }.into())`

![image](https://user-images.githubusercontent.com/68190772/218323975-ca295644-1de9-4bba-aace-3f79e732e052.png)

Closes <https://github.com/emilk/egui/issues/2681>.