### PR TITLE
Scroll bar visibility options

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -74,6 +74,14 @@ pub struct ScrollAreaOutput<R> {
     pub inner_rect: Rect,
 }
 
+/// Indicate whether the horizontal and vertical scroll bars must be always visible, hidden or visible when needed.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ScrollBarVisibility {
+    AlwaysVisible,
+    VisibleWhenNeeded,
+    AlwaysHidden,
+}
+
 /// Add vertical and/or horizontal scrolling to a contained [`Ui`].
 ///
 /// ```
@@ -93,7 +101,7 @@ pub struct ScrollArea {
     auto_shrink: [bool; 2],
     max_size: Vec2,
     min_scrolled_size: Vec2,
-    always_show_scroll: bool,
+    scroll_bar_visibility: ScrollBarVisibility,
     id_source: Option<Id>,
     offset_x: Option<f32>,
     offset_y: Option<f32>,
@@ -131,14 +139,14 @@ impl ScrollArea {
     }
 
     /// Create a scroll area where you decide which axis has scrolling enabled.
-    /// For instance, `ScrollAre::new([true, false])` enable horizontal scrolling.
+    /// For instance, `ScrollArea::new([true, false])` enables horizontal scrolling.
     pub fn new(has_bar: [bool; 2]) -> Self {
         Self {
             has_bar,
             auto_shrink: [true; 2],
             max_size: Vec2::INFINITY,
             min_scrolled_size: Vec2::splat(64.0),
-            always_show_scroll: false,
+            scroll_bar_visibility: ScrollBarVisibility::AlwaysHidden,
             id_source: None,
             offset_x: None,
             offset_y: None,
@@ -190,10 +198,11 @@ impl ScrollArea {
         self
     }
 
-    /// If `false` (default), the scroll bar will be hidden when not needed/
-    /// If `true`, the scroll bar will always be displayed even if not needed.
-    pub fn always_show_scroll(mut self, always_show_scroll: bool) -> Self {
-        self.always_show_scroll = always_show_scroll;
+    /// Set the visibility of both horizontal and vertical scroll bars.
+    ///
+    /// With `ScrollBarVisibility::VisibleWhenNeeded` (default), the scroll bar will be visible only when needed.
+    pub fn scroll_bar_visibility(mut self, scroll_bar_visibility: ScrollBarVisibility) -> Self {
+        self.scroll_bar_visibility = scroll_bar_visibility;
         self
     }
 
@@ -328,7 +337,7 @@ struct Prepared {
     /// How much horizontal and vertical space are used up by the
     /// width of the vertical bar, and the height of the horizontal bar?
     current_bar_use: Vec2,
-    always_show_scroll: bool,
+    scroll_bar_visibility: ScrollBarVisibility,
     /// Where on the screen the content is (excludes scroll bars).
     inner_rect: Rect,
     content_ui: Ui,
@@ -346,7 +355,7 @@ impl ScrollArea {
             auto_shrink,
             max_size,
             min_scrolled_size,
-            always_show_scroll,
+            scroll_bar_visibility,
             id_source,
             offset_x,
             offset_y,
@@ -373,7 +382,7 @@ impl ScrollArea {
 
         let current_hscroll_bar_height = if !has_bar[0] {
             0.0
-        } else if always_show_scroll {
+        } else if scroll_bar_visibility == ScrollBarVisibility::AlwaysVisible {
             max_scroll_bar_width
         } else {
             max_scroll_bar_width * ui.ctx().animate_bool(id.with("h"), state.show_scroll[0])
@@ -381,7 +390,7 @@ impl ScrollArea {
 
         let current_vscroll_bar_width = if !has_bar[1] {
             0.0
-        } else if always_show_scroll {
+        } else if scroll_bar_visibility == ScrollBarVisibility::AlwaysVisible {
             max_scroll_bar_width
         } else {
             max_scroll_bar_width * ui.ctx().animate_bool(id.with("v"), state.show_scroll[1])
@@ -501,7 +510,7 @@ impl ScrollArea {
             has_bar,
             auto_shrink,
             current_bar_use,
-            always_show_scroll,
+            scroll_bar_visibility,
             inner_rect,
             content_ui,
             viewport,
@@ -612,7 +621,7 @@ impl Prepared {
             has_bar,
             auto_shrink,
             mut current_bar_use,
-            always_show_scroll,
+            scroll_bar_visibility,
             content_ui,
             viewport: _,
             scrolling_enabled,
@@ -706,10 +715,13 @@ impl Prepared {
             }
         }
 
-        let show_scroll_this_frame = [
-            content_is_too_large[0] || always_show_scroll,
-            content_is_too_large[1] || always_show_scroll,
-        ];
+        let show_scroll_this_frame = match scroll_bar_visibility {
+            ScrollBarVisibility::AlwaysVisible => [true, true],
+            ScrollBarVisibility::VisibleWhenNeeded => {
+                [content_is_too_large[0], content_is_too_large[1]]
+            }
+            ScrollBarVisibility::AlwaysHidden => [false, false],
+        };
 
         let max_scroll_bar_width = max_scroll_bar_width_with_margin(ui);
 


### PR DESCRIPTION
Enables the user to set whether the horizontal and vertical scroll bars must be always visible, hidden or visible when needed, in the context of a ScrollArea.

`egui::ScrollArea::vertical().scroll_bar_visibility(ScrollBarVisibility::AlwaysVisible).show(ui, |ui| {});`

To consider adding a method for each option in order to shorter and simplify the code, e.g.:
`egui::ScrollArea::vertical().scroll_bar_always_visible().show(ui, |ui| {});`

Closes <https://github.com/emilk/egui/issues/2608>.