### PR TITLE
eframe: Automatically change theme when system dark/light mode changes

### DIFF
--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -149,6 +149,7 @@ web-sys = { version = "0.3.58", features = [
   "KeyboardEvent",
   "Location",
   "MediaQueryList",
+  "MediaQueryListEvent",
   "MouseEvent",
   "Navigator",
   "Performance",

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -557,7 +557,7 @@ impl Theme {
 }
 
 impl Theme {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "dark-light"))]
     pub(crate) fn from_winit_theme(theme: winit::window::Theme) -> Self {
         match theme {
             winit::window::Theme::Dark => Theme::Dark,

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -556,25 +556,6 @@ impl Theme {
     }
 }
 
-impl Theme {
-    #[cfg(all(not(target_arch = "wasm32"), feature = "dark-light"))]
-    pub(crate) fn from_winit_theme(theme: winit::window::Theme) -> Self {
-        match theme {
-            winit::window::Theme::Dark => Theme::Dark,
-            winit::window::Theme::Light => Theme::Light,
-        }
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    pub(crate) fn dark_mode(dark_mode: bool) -> Self {
-        if dark_mode {
-            Theme::Dark
-        } else {
-            Theme::Light
-        }
-    }
-}
-
 // ----------------------------------------------------------------------------
 
 /// WebGL Context options

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -330,6 +330,8 @@ pub struct NativeOptions {
     /// By default, this is `true` on Mac and Windows, but `false` on Linux
     /// due to <https://github.com/frewsxcv/rust-dark-light/issues/17>.
     ///
+    /// On Mac and Windows the theme will automatically change when the dark vs light mode preference is changed.
+    ///
     /// See also [`Self::default_theme`].
     pub follow_system_theme: bool,
 

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -323,14 +323,14 @@ pub struct NativeOptions {
     #[cfg(any(feature = "glow", feature = "wgpu"))]
     pub renderer: Renderer,
 
-    /// Only used if the `dark-light` feature is enabled:
-    ///
     /// Try to detect and follow the system preferred setting for dark vs light mode.
     ///
     /// By default, this is `true` on Mac and Windows, but `false` on Linux
     /// due to <https://github.com/frewsxcv/rust-dark-light/issues/17>.
     ///
     /// On Mac and Windows the theme will automatically change when the dark vs light mode preference is changed.
+    ///
+    /// This only works on Linux if the `dark-light` feature is enabled.
     ///
     /// See also [`Self::default_theme`].
     pub follow_system_theme: bool,

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -554,6 +554,16 @@ impl Theme {
     }
 }
 
+impl Theme {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn from_winit_theme(theme: winit::window::Theme) -> Self {
+        match theme {
+            winit::window::Theme::Dark => Theme::Dark,
+            winit::window::Theme::Light => Theme::Light,
+        }
+    }
+}
+
 // ----------------------------------------------------------------------------
 
 /// WebGL Context options

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -562,6 +562,15 @@ impl Theme {
             winit::window::Theme::Light => Theme::Light,
         }
     }
+
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) fn dark_mode(dark_mode: bool) -> Self {
+        if dark_mode {
+            Theme::Dark
+        } else {
+            Theme::Light
+        }
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -308,6 +308,7 @@ pub struct EpiIntegration {
     close: bool,
     can_drag_window: bool,
     window_state: WindowState,
+    follow_system_theme: bool,
 }
 
 impl EpiIntegration {
@@ -316,6 +317,7 @@ impl EpiIntegration {
         max_texture_side: usize,
         window: &winit::window::Window,
         system_theme: Option<Theme>,
+        follow_system_theme: bool,
         storage: Option<Box<dyn epi::Storage>>,
         #[cfg(feature = "glow")] gl: Option<std::sync::Arc<glow::Context>>,
         #[cfg(feature = "wgpu")] wgpu_render_state: Option<egui_wgpu::RenderState>,
@@ -363,6 +365,7 @@ impl EpiIntegration {
             close: false,
             can_drag_window: false,
             window_state,
+            follow_system_theme,
         }
     }
 
@@ -425,6 +428,12 @@ impl EpiIntegration {
             } => self.can_drag_window = true,
             WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
                 self.frame.info.native_pixels_per_point = Some(*scale_factor as _);
+            }
+            #[cfg(feature = "dark-light")]
+            WindowEvent::ThemeChanged(winit_theme) if self.follow_system_theme => {
+                let theme = Theme::from_winit_theme(*winit_theme);
+                self.frame.info.system_theme = Some(theme);
+                self.egui_ctx.set_visuals(theme.egui_visuals());
             }
             _ => {}
         }

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -312,6 +312,7 @@ pub struct EpiIntegration {
 }
 
 impl EpiIntegration {
+    #[allow(clippy::too_many_arguments)]
     pub fn new<E>(
         event_loop: &EventLoopWindowTarget<E>,
         max_texture_side: usize,

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -124,7 +124,7 @@ pub fn window_builder<E>(
         // Restore pos/size from previous session
         window_settings.clamp_to_sane_values(largest_monitor_point_size(event_loop));
         #[cfg(windows)]
-        window_settings.clamp_window_to_sane_position(&event_loop);
+        window_settings.clamp_window_to_sane_position(event_loop);
         window_builder = window_settings.initialize_window(window_builder);
         window_settings.inner_size_points()
     } else {

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -308,7 +308,6 @@ pub struct EpiIntegration {
     close: bool,
     can_drag_window: bool,
     window_state: WindowState,
-    #[cfg(feature = "dark-light")]
     follow_system_theme: bool,
 }
 
@@ -319,7 +318,7 @@ impl EpiIntegration {
         max_texture_side: usize,
         window: &winit::window::Window,
         system_theme: Option<Theme>,
-        #[cfg(feature = "dark-light")] follow_system_theme: bool,
+        follow_system_theme: bool,
         storage: Option<Box<dyn epi::Storage>>,
         #[cfg(feature = "glow")] gl: Option<std::sync::Arc<glow::Context>>,
         #[cfg(feature = "wgpu")] wgpu_render_state: Option<egui_wgpu::RenderState>,
@@ -367,7 +366,6 @@ impl EpiIntegration {
             close: false,
             can_drag_window: false,
             window_state,
-            #[cfg(feature = "dark-light")]
             follow_system_theme,
         }
     }
@@ -432,7 +430,6 @@ impl EpiIntegration {
             WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
                 self.frame.info.native_pixels_per_point = Some(*scale_factor as _);
             }
-            #[cfg(feature = "dark-light")]
             WindowEvent::ThemeChanged(winit_theme) if self.follow_system_theme => {
                 let theme = theme_from_winit_theme(*winit_theme);
                 self.frame.info.system_theme = Some(theme);
@@ -578,7 +575,6 @@ pub fn load_egui_memory(_storage: Option<&dyn epi::Storage>) -> Option<egui::Mem
     None
 }
 
-#[cfg(feature = "dark-light")]
 pub(crate) fn theme_from_winit_theme(theme: winit::window::Theme) -> Theme {
     match theme {
         winit::window::Theme::Dark => Theme::Dark,

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -434,7 +434,7 @@ impl EpiIntegration {
             }
             #[cfg(feature = "dark-light")]
             WindowEvent::ThemeChanged(winit_theme) if self.follow_system_theme => {
-                let theme = Theme::from_winit_theme(*winit_theme);
+                let theme = theme_from_winit_theme(*winit_theme);
                 self.frame.info.system_theme = Some(theme);
                 self.egui_ctx.set_visuals(theme.egui_visuals());
             }
@@ -576,4 +576,12 @@ pub fn load_egui_memory(_storage: Option<&dyn epi::Storage>) -> Option<egui::Mem
     }
     #[cfg(not(feature = "persistence"))]
     None
+}
+
+#[cfg(feature = "dark-light")]
+pub(crate) fn theme_from_winit_theme(theme: winit::window::Theme) -> Theme {
+    match theme {
+        winit::window::Theme::Dark => Theme::Dark,
+        winit::window::Theme::Light => Theme::Light,
+    }
 }

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -308,6 +308,7 @@ pub struct EpiIntegration {
     close: bool,
     can_drag_window: bool,
     window_state: WindowState,
+    #[cfg(feature = "dark-light")]
     follow_system_theme: bool,
 }
 
@@ -318,7 +319,7 @@ impl EpiIntegration {
         max_texture_side: usize,
         window: &winit::window::Window,
         system_theme: Option<Theme>,
-        follow_system_theme: bool,
+        #[cfg(feature = "dark-light")] follow_system_theme: bool,
         storage: Option<Box<dyn epi::Storage>>,
         #[cfg(feature = "glow")] gl: Option<std::sync::Arc<glow::Context>>,
         #[cfg(feature = "wgpu")] wgpu_render_state: Option<egui_wgpu::RenderState>,
@@ -366,6 +367,7 @@ impl EpiIntegration {
             close: false,
             can_drag_window: false,
             window_state,
+            #[cfg(feature = "dark-light")]
             follow_system_theme,
         }
     }

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -1435,8 +1435,8 @@ fn system_theme(window: &winit::window::Window, options: &NativeOptions) -> Opti
     }
 }
 
-// winit only correctly reads the system theme macos and windows,
-// so on linux we fall back to using dark-light (if enabled).
+// Winit only reads the system theme on macOS and Windows.
+// On Linux we have to fall back on dark-light (if enabled).
 // See: https://github.com/rust-windowing/winit/issues/1549
 #[cfg(not(any(target_os = "windows", target_os = "macos")))]
 fn system_theme(window: &winit::window::Window, options: &NativeOptions) -> Option<crate::Theme> {

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -681,7 +681,6 @@ mod glow_integration {
                 painter.max_texture_side(),
                 gl_window.window(),
                 system_theme,
-                #[cfg(feature = "dark-light")]
                 self.native_options.follow_system_theme,
                 storage,
                 Some(gl.clone()),
@@ -1125,7 +1124,6 @@ mod wgpu_integration {
                 painter.max_texture_side().unwrap_or(2048),
                 &window,
                 system_theme,
-                #[cfg(feature = "dark-light")]
                 self.native_options.follow_system_theme,
                 storage,
                 #[cfg(feature = "glow")]

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -681,6 +681,7 @@ mod glow_integration {
                 painter.max_texture_side(),
                 gl_window.window(),
                 system_theme,
+                #[cfg(feature = "dark-light")]
                 self.native_options.follow_system_theme,
                 storage,
                 Some(gl.clone()),
@@ -1124,6 +1125,7 @@ mod wgpu_integration {
                 painter.max_texture_side().unwrap_or(2048),
                 &window,
                 system_theme,
+                #[cfg(feature = "dark-light")]
                 self.native_options.follow_system_theme,
                 storage,
                 #[cfg(feature = "glow")]

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -681,6 +681,7 @@ mod glow_integration {
                 painter.max_texture_side(),
                 gl_window.window(),
                 system_theme,
+                self.native_options.follow_system_theme,
                 storage,
                 Some(gl.clone()),
                 #[cfg(feature = "wgpu")]
@@ -1123,6 +1124,7 @@ mod wgpu_integration {
                 painter.max_texture_side().unwrap_or(2048),
                 &window,
                 system_theme,
+                self.native_options.follow_system_theme,
                 storage,
                 #[cfg(feature = "glow")]
                 None,

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -1439,6 +1439,6 @@ fn system_theme(window: &winit::window::Window, options: &NativeOptions) -> Opti
 // On Linux we have to fall back on dark-light (if enabled).
 // See: https://github.com/rust-windowing/winit/issues/1549
 #[cfg(not(any(target_os = "windows", target_os = "macos")))]
-fn system_theme(window: &winit::window::Window, options: &NativeOptions) -> Option<crate::Theme> {
+fn system_theme(_window: &winit::window::Window, options: &NativeOptions) -> Option<crate::Theme> {
     options.system_theme()
 }

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -53,8 +53,6 @@ pub fn install_document_events(runner_container: &mut AppRunnerContainer) -> Res
     let window = web_sys::window().unwrap();
     let document = window.document().unwrap();
 
-    add_color_scheme_change_event_listener(&window, runner_container)?;
-
     runner_container.add_event_listener(
         &document,
         "keydown",
@@ -209,11 +207,12 @@ pub fn install_document_events(runner_container: &mut AppRunnerContainer) -> Res
     Ok(())
 }
 
-fn add_color_scheme_change_event_listener(
-    window: &web_sys::Window,
+pub fn install_color_scheme_change_event(
     runner_container: &mut AppRunnerContainer,
 ) -> Result<(), JsValue> {
-    if let Some(media_query_list) = prefers_color_scheme_dark(window)? {
+    let window = web_sys::window().unwrap();
+
+    if let Some(media_query_list) = prefers_color_scheme_dark(&window)? {
         runner_container.add_event_listener::<web_sys::MediaQueryListEvent>(
             &media_query_list,
             "change",

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -213,7 +213,7 @@ fn add_color_scheme_change_event_listener(
     window: &web_sys::Window,
     runner_container: &mut AppRunnerContainer,
 ) -> Result<(), JsValue> {
-    if let Some(media_query_list) = prefers_color_scheme_dark(&window)? {
+    if let Some(media_query_list) = prefers_color_scheme_dark(window)? {
         runner_container.add_event_listener::<web_sys::MediaQueryListEvent>(
             &media_query_list,
             "change",

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -221,6 +221,7 @@ fn add_color_scheme_change_event_listener(
                 let theme = theme_from_dark_mode(event.matches());
                 runner_lock.frame.info.system_theme = Some(theme);
                 runner_lock.egui_ctx().set_visuals(theme.egui_visuals());
+                runner_lock.needs_repaint.repaint_asap();
             },
         )?;
     }

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -218,11 +218,7 @@ fn add_color_scheme_change_event_listener(
             &media_query_list,
             "change",
             |event, mut runner_lock| {
-                let theme = if event.matches() {
-                    Theme::Dark
-                } else {
-                    Theme::Light
-                };
+                let theme = Theme::dark_mode(event.matches());
                 runner_lock.frame.info.system_theme = Some(theme);
                 runner_lock.egui_ctx().set_visuals(theme.egui_visuals());
             },

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -218,7 +218,7 @@ fn add_color_scheme_change_event_listener(
             &media_query_list,
             "change",
             |event, mut runner_lock| {
-                let theme = Theme::dark_mode(event.matches());
+                let theme = theme_from_dark_mode(event.matches());
                 runner_lock.frame.info.system_theme = Some(theme);
                 runner_lock.egui_ctx().set_visuals(theme.egui_visuals());
             },

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -79,7 +79,7 @@ pub fn system_theme() -> Option<Theme> {
         .and_then(|window| prefers_color_scheme_dark(&window).transpose())?
         .ok()?
         .matches();
-    Some(if dark_mode { Theme::Dark } else { Theme::Light })
+    Some(Theme::dark_mode(dark_mode))
 }
 
 fn prefers_color_scheme_dark(window: &web_sys::Window) -> Result<Option<MediaQueryList>, JsValue> {

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -75,9 +75,8 @@ pub fn native_pixels_per_point() -> f32 {
 }
 
 pub fn system_theme() -> Option<Theme> {
-    let dark_mode = web_sys::window()
-        .and_then(|window| prefers_color_scheme_dark(&window).transpose())?
-        .ok()?
+    let dark_mode = prefers_color_scheme_dark(&web_sys::window()?)
+        .ok()??
         .matches();
     Some(Theme::dark_mode(dark_mode))
 }

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -78,11 +78,19 @@ pub fn system_theme() -> Option<Theme> {
     let dark_mode = prefers_color_scheme_dark(&web_sys::window()?)
         .ok()??
         .matches();
-    Some(Theme::dark_mode(dark_mode))
+    Some(theme_from_dark_mode(dark_mode))
 }
 
 fn prefers_color_scheme_dark(window: &web_sys::Window) -> Result<Option<MediaQueryList>, JsValue> {
     window.match_media("(prefers-color-scheme: dark)")
+}
+
+fn theme_from_dark_mode(dark_mode: bool) -> Theme {
+    if dark_mode {
+        Theme::Dark
+    } else {
+        Theme::Light
+    }
 }
 
 pub fn canvas_element(canvas_id: &str) -> Option<web_sys::HtmlCanvasElement> {

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -36,7 +36,7 @@ use std::sync::{
 
 use egui::Vec2;
 use wasm_bindgen::prelude::*;
-use web_sys::EventTarget;
+use web_sys::{EventTarget, MediaQueryList};
 
 use input::*;
 
@@ -75,11 +75,15 @@ pub fn native_pixels_per_point() -> f32 {
 }
 
 pub fn system_theme() -> Option<Theme> {
-    let dark_mode = web_sys::window()?
-        .match_media("(prefers-color-scheme: dark)")
-        .ok()??
+    let dark_mode = web_sys::window()
+        .and_then(|window| prefers_color_scheme_dark(&window).transpose())?
+        .ok()?
         .matches();
     Some(if dark_mode { Theme::Dark } else { Theme::Light })
+}
+
+fn prefers_color_scheme_dark(window: &web_sys::Window) -> Result<Option<MediaQueryList>, JsValue> {
+    window.match_media("(prefers-color-scheme: dark)")
 }
 
 pub fn canvas_element(canvas_id: &str) -> Option<web_sys::HtmlCanvasElement> {


### PR DESCRIPTION
I noticed that `eframe` does not change the theme when the system dark/light mode is changed while the app is running.

For `winit` reacting to the change is fairly easy: There's a [`ThemeChanged`] event. It's not supported everywhere, but I guess it's better than nothing :).

For web, there's a [`change`](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/change_event) event on `MediaQueryList`.

https://user-images.githubusercontent.com/4602612/219874514-6bdedbad-14b8-4069-bd7d-fdf03a8c2a67.mp4

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

[`ThemeChanged`]: https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.ThemeChanged
[`change`]: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/change_event