### PR TITLE
egui-winit: fix unsafe API of Clipboard::new

### DIFF
--- a/crates/egui-winit/CHANGELOG.md
+++ b/crates/egui-winit/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to the `egui-winit` integration will be noted in this file.
 
 
 ## Unreleased
-
+* Fix unsafe API: remove `State::new_with_wayland_display`; change `Clipboard::new` to take `&EventLoopWindowTarget<T>`.
 
 ## 0.21.1 - 2023-02-12
 * Fixed crash when window position is in an invalid state, which could happen e.g. due to changes in monitor size or DPI ([#2722](https://github.com/emilk/egui/issues/2722)).

--- a/crates/egui-winit/src/clipboard.rs
+++ b/crates/egui-winit/src/clipboard.rs
@@ -147,9 +147,12 @@ fn init_smithay_clipboard<T>(
             tracing::debug!("Initializing smithay clipboard…");
             #[allow(unsafe_code)]
             return Some(unsafe { smithay_clipboard::Clipboard::new(display) });
+        } else {
+            tracing::debug!("Cannot initialize smithay clipboard without a display handle");
+            return;
         }
     }
 
-    tracing::debug!("Cannot initialize smithay clipboard without a display handle");
+    tracing::debug!("You need to enable the 'wayland' feature of 'egui-winit' to get a working clipboard");
     None
 }

--- a/crates/egui-winit/src/clipboard.rs
+++ b/crates/egui-winit/src/clipboard.rs
@@ -146,15 +146,18 @@ fn init_smithay_clipboard<T>(
         if let Some(display) = _event_loop.wayland_display() {
             tracing::debug!("Initializing smithay clipboard…");
             #[allow(unsafe_code)]
-            return Some(unsafe { smithay_clipboard::Clipboard::new(display) });
+            Some(unsafe { smithay_clipboard::Clipboard::new(display) })
         } else {
             tracing::debug!("Cannot initialize smithay clipboard without a display handle");
-            return;
+            None
         }
     }
 
-    tracing::debug!(
-        "You need to enable the 'wayland' feature of 'egui-winit' to get a working clipboard"
-    );
-    None
+    #[cfg(not(feature = "wayland"))]
+    {
+        tracing::debug!(
+            "You need to enable the 'wayland' feature of 'egui-winit' to get a working clipboard"
+        );
+        None
+    }
 }

--- a/crates/egui-winit/src/clipboard.rs
+++ b/crates/egui-winit/src/clipboard.rs
@@ -29,7 +29,7 @@ impl Clipboard {
     ///
     /// # Safety
     ///
-    /// The returned `Clipboard` must not outive the input `_event_loop`.
+    /// The returned `Clipboard` must not outlive the input `_event_loop`.
     pub fn new<T>(_event_loop: &EventLoopWindowTarget<T>) -> Self {
         Self {
             #[cfg(all(feature = "arboard", not(target_os = "android")))]

--- a/crates/egui-winit/src/clipboard.rs
+++ b/crates/egui-winit/src/clipboard.rs
@@ -153,6 +153,8 @@ fn init_smithay_clipboard<T>(
         }
     }
 
-    tracing::debug!("You need to enable the 'wayland' feature of 'egui-winit' to get a working clipboard");
+    tracing::debug!(
+        "You need to enable the 'wayland' feature of 'egui-winit' to get a working clipboard"
+    );
     None
 }

--- a/crates/egui-winit/src/clipboard.rs
+++ b/crates/egui-winit/src/clipboard.rs
@@ -30,7 +30,6 @@ impl Clipboard {
     /// # Safety
     ///
     /// The returned `Clipboard` must not outive the input `_event_loop`.
-    #[allow(unused_variables)]
     pub fn new<T>(_event_loop: &EventLoopWindowTarget<T>) -> Self {
         Self {
             #[cfg(all(feature = "arboard", not(target_os = "android")))]

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -9,8 +9,6 @@
 
 #![allow(clippy::manual_range_contains)]
 
-use std::os::raw::c_void;
-
 #[cfg(feature = "accesskit")]
 pub use accesskit_winit;
 pub use egui;
@@ -85,11 +83,12 @@ pub struct State {
 }
 
 impl State {
+    /// Construct a new instance
+    ///
+    /// # Safety
+    ///
+    /// The returned `State` must not outive the input `_event_loop`.
     pub fn new<T>(event_loop: &EventLoopWindowTarget<T>) -> Self {
-        Self::new_with_wayland_display(wayland_display(event_loop))
-    }
-
-    pub fn new_with_wayland_display(wayland_display: Option<*mut c_void>) -> Self {
         let egui_input = egui::RawInput {
             has_focus: false, // winit will tell us when we have focus
             ..Default::default()
@@ -103,7 +102,7 @@ impl State {
             current_cursor_icon: None,
             current_pixels_per_point: 1.0,
 
-            clipboard: clipboard::Clipboard::new(wayland_display),
+            clipboard: clipboard::Clipboard::new(event_loop),
 
             simulate_touch_screen: false,
             pointer_touch_id: None,
@@ -868,28 +867,6 @@ fn translate_cursor(cursor_icon: egui::CursorIcon) -> Option<winit::window::Curs
         egui::CursorIcon::Wait => Some(winit::window::CursorIcon::Wait),
         egui::CursorIcon::ZoomIn => Some(winit::window::CursorIcon::ZoomIn),
         egui::CursorIcon::ZoomOut => Some(winit::window::CursorIcon::ZoomOut),
-    }
-}
-
-/// Returns a Wayland display handle if the target is running Wayland
-fn wayland_display<T>(_event_loop: &EventLoopWindowTarget<T>) -> Option<*mut c_void> {
-    #[cfg(feature = "wayland")]
-    #[cfg(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd"
-    ))]
-    {
-        use winit::platform::wayland::EventLoopWindowTargetExtWayland as _;
-        return _event_loop.wayland_display();
-    }
-
-    #[allow(unreachable_code)]
-    {
-        let _ = _event_loop;
-        None
     }
 }
 

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -87,7 +87,7 @@ impl State {
     ///
     /// # Safety
     ///
-    /// The returned `State` must not outive the input `_event_loop`.
+    /// The returned `State` must not outlive the input `_event_loop`.
     pub fn new<T>(event_loop: &EventLoopWindowTarget<T>) -> Self {
         let egui_input = egui::RawInput {
             has_focus: false, // winit will tell us when we have focus


### PR DESCRIPTION
So, `window_clipboard` is not (very actively) maintained and I had a look around...

- Winit doesn't [*yet*](https://github.com/rust-windowing/winit/pull/2156) have a Clipboard API
- `copypasta` is maintained, supports the "primary" clipboard, but makes no attempt to provide a Wayland-X11 abstraction
- `arboard` is maintained, supports HTML and uncompressed RGBA images, but makes no attempt to provide a Wayland-X11 abstraction
- `egui-winit` does have this abstraction, but with an unsafe API

[smithay_clipboard::Clipboard::new](https://docs.rs/smithay-clipboard/latest/smithay_clipboard/struct.Clipboard.html#method.new) notes:

> `display` must be a valid `*mut wl_display` pointer, and it must remain valid for as long as Clipboard object is alive.

This change addresses the first point (prevents calling `Clipboard::new` with an arbitrary pointer).

Addressing the second point with Rust's lifetimes would *probably* be very frustrating. I haven't tried. Addressing it by marking `Clipboard::new` and `State::new` as `unsafe` would be another approach, but would result in all code within `State::new` being compiled in `unsafe` mode, would violate your `#[forbid(unsafe)]` policy and is probably needlessly onerous (given that observing broken behaviour is unlikely), so I opted merely to add documentation here.

---

I ran `sh/check` but `egui-glow` fails `cargo check --all-features` (on X11). Nothing to do with me.