### PR TITLE
Implement toggle for `egui::Window` to only accept move events from the title bar.

### DIFF
--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -648,6 +648,7 @@ fn window_interaction(
     if window_interaction.is_none() {
         if let Some(hover_window_interaction) = resize_hover(ctx, possible, area_layer_id, rect_resize) {
             hover_window_interaction.set_cursor(ctx);
+            window_interaction = Some(hover_window_interaction);
         }
         if let Some(hover_window_interaction) = hover(ctx, possible, area_layer_id, rect_move) {
             if ctx.input(|i| i.pointer.any_pressed() && i.pointer.primary_down()) {

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -648,9 +648,15 @@ fn window_interaction(
     if window_interaction.is_none() {
         if let Some(hover_window_interaction) = resize_hover(ctx, possible, area_layer_id, rect_resize) {
             hover_window_interaction.set_cursor(ctx);
-            window_interaction = Some(hover_window_interaction);
-        }
-        if let Some(hover_window_interaction) = hover(ctx, possible, area_layer_id, rect_move) {
+            if ctx.input(|i| i.pointer.any_pressed() && i.pointer.primary_down()) {
+                ctx.memory_mut(|mem| {
+                    mem.interaction.drag_id = Some(id);
+                    mem.interaction.drag_is_window = true;
+                    window_interaction = Some(hover_window_interaction);
+                    mem.window_interaction = window_interaction;
+                });
+            }
+        } else if let Some(hover_window_interaction) = hover(ctx, possible, area_layer_id, rect_move) {
             if ctx.input(|i| i.pointer.any_pressed() && i.pointer.primary_down()) {
                 ctx.memory_mut(|mem| {
                     mem.interaction.drag_id = Some(id);

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -703,10 +703,10 @@ fn hover(
         Some(WindowInteraction {
             area_layer_id,
             start_rect: rect,
-            left,
-            right,
-            top,
-            bottom,
+            left: false,
+            right: false,
+            top: false,
+            bottom: false
         })
     } else {
         None

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -349,7 +349,7 @@ impl<'open> Window<'open> {
         let move_interaction_rect = match move_title_bar_only && with_title_bar {
             true => {
                 let mut copy = last_frame_outer_rect;
-                copy.set_bottom(title_bar_height);
+                copy.set_bottom(copy.top() + title_bar_height);
                 copy
             }
             false => { last_frame_outer_rect }


### PR DESCRIPTION
Closes #2774. For a more detailed description of the problem, refer to that issue.

[demo gif](https://gifyu.com/image/S7ukY).

List of changes
- Added `egui::Window::movable_from_contents()` to toggle the new behaviour on.
- In `window::window_interaction()`, split resize and move behaviour, since they might now use two different rects.

My apologies that there are so many commits, it's the unfortunate result of some dependencies I have to manage while developing. Just squashing on merge should get rid of the problem.