### PR TITLE
[WIP] Fix submenu flickering

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -142,7 +142,7 @@ impl Area {
 
     /// Positions the window and prevents it from being moved
     pub fn fixed_pos(mut self, fixed_pos: impl Into<Pos2>) -> Self {
-        self.new_pos = Some(fixed_pos.into());
+        self.default_pos = Some(fixed_pos.into());
         self.movable = false;
         self
     }

--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -142,7 +142,7 @@ impl Area {
 
     /// Positions the window and prevents it from being moved
     pub fn fixed_pos(mut self, fixed_pos: impl Into<Pos2>) -> Self {
-        self.default_pos = Some(fixed_pos.into());
+        self.new_pos = Some(fixed_pos.into());
         self.movable = false;
         self
     }

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -600,8 +600,9 @@ impl MenuState {
         // Two options:
         //   1. Change layer_id_at to not grow the rect for menu layers
         //   2. Change `area_contains` to use `resize_grab_radius_side`
-        // Number 1 is probably better because menus are not rezisable.
-        self.rect.expand(5.0).contains(pos)
+        // Number 1 is probably better because menus are not resizable.
+        let resize_grab_radius_side = 5.0;
+        self.rect.expand(resize_grab_radius_side).contains(pos)
             || self
                 .sub_menu
                 .as_ref()

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -144,7 +144,8 @@ pub(crate) fn menu_ui<'c, R>(
     let area = Area::new(menu_id)
         .order(Order::Foreground)
         .constrain(true)
-        .fixed_pos(pos)
+        .default_pos(pos)
+        .movable(false)
         .interactable(true)
         .drag_bounds(ctx.screen_rect());
     let inner_response = area.show(ctx, |ui| {
@@ -594,7 +595,13 @@ impl MenuState {
 
     /// Check if position is in the menu hierarchy's area.
     pub fn area_contains(&self, pos: Pos2) -> bool {
-        self.rect.contains(pos)
+        // HACK: hard-coded 5.0 but it should use the same logic as `Context::layer_id_at` to be correct as that's the
+        // source of truth on whether something is "on top" or not.
+        // Two options:
+        //   1. Change layer_id_at to not grow the rect for menu layers
+        //   2. Change `area_contains` to use `resize_grab_radius_side`
+        // Number 1 is probably better because menus are not rezisable.
+        self.rect.expand(5.0).contains(pos)
             || self
                 .sub_menu
                 .as_ref()


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

## Problem
Submenus flicker and are generally unusable, as shown in #2706.

There are two separate causes for this:

 1. Menu Areas were being created with both `constrain` _and_ `fixed_pos`. These two properties fight with each other as they are both trying to position the menu in a different position.
 2. `MenuState::area_contains` uses it's own logic to determine if the pointer is inside of the menu but this logic is not the same as `Context::layer_id_at`.
 
 (1) causes flickering when the submenu is constrained and ends up on top of the parent menu
 (2) causes flickering when the pointer is 5px away from the submenu

## Solution

(1) ~~seems fully solved, although there might be a better solution~~ see first comment below

(2) I hard-coded a value for `resize_grab_radius_side` for now, which fixes the issue unless someone tweaks this value. Feedback on how to properly solve this would be appreciated. Left some comments explaining the issue

Closes #2706 