### PR TITLE
Change default scroll bar visibility to VisibleWhenNeeded

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -146,7 +146,7 @@ impl ScrollArea {
             auto_shrink: [true; 2],
             max_size: Vec2::INFINITY,
             min_scrolled_size: Vec2::splat(64.0),
-            scroll_bar_visibility: ScrollBarVisibility::AlwaysHidden,
+            scroll_bar_visibility: ScrollBarVisibility::VisibleWhenNeeded,
             id_source: None,
             offset_x: None,
             offset_y: None,


### PR DESCRIPTION
Believe this is a more sensible default than always hidden and also matches the behavior before ScrollBarVisibility was introduced.

Personally I noticed this because tables are always missing scroll bars currently.

Related PR: https://github.com/emilk/egui/pull/2729

Fixes #2826.
