### PR TITLE
Fix resizable columns option in the table demo

### DIFF
--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -126,15 +126,11 @@ impl TableDemo {
 
         let mut table = TableBuilder::new(ui)
             .striped(self.striped)
+            .resizable(self.resizable)
             .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
             .column(Column::auto())
-            .column(Column::initial(100.0).range(40.0..=300.0).resizable(true))
-            .column(
-                Column::initial(100.0)
-                    .at_least(40.0)
-                    .resizable(true)
-                    .clip(true),
-            )
+            .column(Column::initial(100.0).range(40.0..=300.0))
+            .column(Column::initial(100.0).at_least(40.0).clip(true))
             .column(Column::remainder())
             .min_scrolled_height(0.0);
 


### PR DESCRIPTION
The "Resizable columns" check box wasn't doing anything in the table demo before.