### PR TITLE
📜 Replace ComboBox::show_index String with Into<TextWidget>

### DIFF
--- a/crates/egui/src/containers/combo_box.rs
+++ b/crates/egui/src/containers/combo_box.rs
@@ -198,16 +198,16 @@ impl ComboBox {
     ///     ui,
     ///     &mut selected,
     ///     alternatives.len(),
-    ///     |i| alternatives[i].to_owned()
+    ///     |i| alternatives[i]
     /// );
     /// # });
     /// ```
-    pub fn show_index(
+    pub fn show_index<Text: Into<WidgetText>>(
         self,
         ui: &mut Ui,
         selected: &mut usize,
         len: usize,
-        get: impl Fn(usize) -> String,
+        get: impl Fn(usize) -> Text,
     ) -> Response {
         let slf = self.selected_text(get(*selected));
 


### PR DESCRIPTION
The `ComboBox::show_index` function currently takes a `impl Fn(usize) -> String` and passes that `String` to functions taking a `impl Into<WidgetText>`. We can make the `show_index` function more generic by using `Into<WidgetText>` as well.