### PR TITLE
Prefer the client width/height for the canvas parent

### DIFF
--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -113,8 +113,10 @@ pub fn resize_canvas_to_screen_size(canvas_id: &str, max_size_points: egui::Vec2
     let canvas = canvas_element(canvas_id)?;
     let parent = canvas.parent_element()?;
 
-    let width = parent.scroll_width();
-    let height = parent.scroll_height();
+    // Prefer the client width and height so that if the parent
+    // element is resized that the egui canvas resizes appropriately.
+    let width = parent.client_width();
+    let height = parent.client_height();
 
     let canvas_real_size = Vec2 {
         x: width as f32,


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Normally, `eframe` takes over the entire webpage, but sometimes, you
would like it to "play nice" and keep its canvas to a finite area.  This mostly
works as long as the containing `div` has the right style properties. 
However, the use of `scrollheight` and `scrollwidth` breaks the responsive case in which the page is resized.  The canvas will grow, but it will not shrink.

This PR resolves https://github.com/emilk/egui/issues/2805