### PR TITLE
Stop pulling instant with wasm-bindgen when not building for wasm32

### DIFF
--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -46,9 +46,6 @@ wayland = ["winit/wayland"]
 egui = { version = "0.21.0", path = "../egui", default-features = false, features = [
   "tracing",
 ] }
-instant = { version = "0.1", features = [
-  "wasm-bindgen",
-] } # We use instant so we can (maybe) compile for web
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 winit = { version = "0.28", default-features = false }
 
@@ -64,6 +61,14 @@ puffin = { version = "0.14", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 webbrowser = { version = "0.8.3", optional = true }
+
+[target.'cfg(not(target_arch="wasm32"))'.dependencies]
+instant = { version = "0.1" }
+
+[target.'cfg(target_arch="wasm32")'.dependencies]
+instant = { version = "0.1", features = [
+  "wasm-bindgen",
+] } # We use instant so we can (maybe) compile for web
 
 [target.'cfg(any(target_os="linux", target_os="dragonfly", target_os="freebsd", target_os="netbsd", target_os="openbsd"))'.dependencies]
 smithay-clipboard = { version = "0.6.3", optional = true }


### PR DESCRIPTION
This had the side-effect to build `instant `with the `js-sys,wasm-bindgen,wasm-bindgen_rs,web-sys` features, which somehow doesn't bother `cargo` but fails to compile with `bazel`.