### PR TITLE
Apply 'with_active' option to winit

### DIFF
--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -284,6 +284,10 @@ pub struct NativeOptions {
     /// Generally you would use this in conjunction with always_on_top
     pub mouse_passthrough: bool,
 
+    /// Whether grant focus when window initially opened. True by default.
+    #[cfg(target_os = "windows")]
+    pub active: bool,
+
     /// Turn on vertical syncing, limiting the FPS to the display refresh rate.
     ///
     /// The default is `true`.
@@ -419,6 +423,10 @@ impl Default for NativeOptions {
             resizable: true,
             transparent: false,
             mouse_passthrough: false,
+
+            #[cfg(target_os = "windows")]
+            active: true,
+
             vsync: true,
             multisampling: 0,
             depth_buffer: 0,

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -423,7 +423,6 @@ impl Default for NativeOptions {
             transparent: false,
             mouse_passthrough: false,
 
-            #[cfg(target_os = "windows")]
             active: true,
 
             vsync: true,

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -285,7 +285,6 @@ pub struct NativeOptions {
     pub mouse_passthrough: bool,
 
     /// Whether grant focus when window initially opened. True by default.
-    #[cfg(target_os = "windows")]
     pub active: bool,
 
     /// Turn on vertical syncing, limiting the FPS to the display refresh rate.

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -90,6 +90,7 @@ pub fn window_builder<E>(
         resizable,
         transparent,
         centered,
+        active,
         ..
     } = native_options;
 
@@ -103,6 +104,7 @@ pub fn window_builder<E>(
         .with_resizable(*resizable)
         .with_transparent(*transparent)
         .with_window_icon(window_icon)
+        .with_active(*active)
         // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
         // We must also keep the window hidden until AccessKit is initialized.
         .with_visible(false);


### PR DESCRIPTION
There is a option in winit's WindowBuilder called `with_active` which allow to avoid granting focus when window initially opened. This PR is tend to add this option into `NativeOptions` of eframe.
