### PR TITLE
fix scroll bars not appearing (#2826)

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -146,7 +146,7 @@ impl ScrollArea {
             auto_shrink: [true; 2],
             max_size: Vec2::INFINITY,
             min_scrolled_size: Vec2::splat(64.0),
-            scroll_bar_visibility: ScrollBarVisibility::AlwaysHidden,
+            scroll_bar_visibility: ScrollBarVisibility::VisibleWhenNeeded,
             id_source: None,
             offset_x: None,
             offset_y: None,


### PR DESCRIPTION
This fixes a scroll bar visibility default regression introduced by https://github.com/emilk/egui/pull/2729.

Closes <https://github.com/emilk/egui/issues/2826>.
