### PR TITLE
Allow temporarily preventing focusable widgets

### DIFF
--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -199,6 +199,9 @@ pub(crate) struct Focus {
 
     /// Set at the beginning of the frame, set to `false` when "used".
     pressed_shift_tab: bool,
+
+    /// If `true`, calls to [`Memory::interested_in_focus`] will be ignored.
+    prevent_focus: bool,
 }
 
 impl Interaction {
@@ -447,7 +450,22 @@ impl Memory {
     /// and rendered correctly in a single frame.
     #[inline(always)]
     pub fn interested_in_focus(&mut self, id: Id) {
-        self.interaction.focus.interested_in_focus(id);
+        if !self.interaction.focus.prevent_focus {
+            self.interaction.focus.interested_in_focus(id);
+        }
+    }
+
+    /// Prevent new widgets from being interested in focus, until a
+    /// subsequent call to [`Memory::allow_focus`].
+    ///
+    /// Works by turning [`Memory::interested_in_focus`] into a no-op.
+    pub fn prevent_focus(&mut self) {
+        self.interaction.focus.prevent_focus = true;
+    }
+
+    /// Allow new widgets to be focused. Used with [`Memory::prevent_focus`].
+    pub fn allow_focus(&mut self) {
+        self.interaction.focus.prevent_focus = false;
     }
 
     /// Stop editing of active [`TextEdit`](crate::TextEdit) (if any).


### PR DESCRIPTION
Currently there is no way to prevent focusing of widgets without locking focus to a particular widget. There are cases where it makes sense to disable focus for entire sections of widgets, particularly for modals. An outstanding issue in all of the modal implementations I've seen is that the tab key allows interacting with widgets behind the modal.

By calling `prevent_focus` before rendering all non-modal widgets, then `allow_focus` before a modal, it's possible to allow tab focus only within the modal's widgets. It's also necessary to reset focus when the modal opens by focusing some widget in the modal.

I don't think this is the ideal solution, since it might not work in a generic context like that of `egui-modal`.

I'm curious if there's other thoughts about how this can be achieved.

Related: https://github.com/n00kii/egui-modal/issues/4

Todo:
- [ ] Add to CHANGELOG.md