### PR TITLE
Remove problematic clip code from `ScrollArea`

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -439,20 +439,12 @@ impl ScrollArea {
         {
             // Clip the content, but only when we really need to:
             let clip_rect_margin = ui.visuals().clip_rect_margin;
-            let scroll_bar_inner_margin = ui.spacing().scroll_bar_inner_margin;
             let mut content_clip_rect = ui.clip_rect();
             for d in 0..2 {
                 if has_bar[d] {
                     if state.content_is_too_large[d] {
                         content_clip_rect.min[d] = inner_rect.min[d] - clip_rect_margin;
                         content_clip_rect.max[d] = inner_rect.max[d] + clip_rect_margin;
-                    }
-
-                    if state.show_scroll[d] {
-                        // Make sure content doesn't cover scroll bars
-                        let tiny_gap = 1.0;
-                        content_clip_rect.max[1 - d] =
-                            inner_rect.max[1 - d] + scroll_bar_inner_margin - tiny_gap;
                     }
                 } else {
                     // Nice handling of forced resizing beyond the possible:


### PR DESCRIPTION
Closes <https://github.com/emilk/egui/issues/2811>.

This code causes incorrect clipping. It also uses incorrect indexing (1 - d instead of just d). With this code removed, I have not been able to find a case where the scroll area contents invade the scroll bar area.

Because this was asked about in the original PR (#2839), here is a simple project with embedded `ScrollArea`s. I cannot see any difference between this branch and  master.
[scroll_test.zip](https://github.com/emilk/egui/files/11125180/scroll_test.zip)
