### PR TITLE
egui-winit: Remove `android-activity` dependency + add `Activity` backend features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
 
-      - run: cargo check --features wgpu --target aarch64-linux-android
+      - run: cargo check --features wgpu,android-native-activity --target aarch64-linux-android
         working-directory: crates/eframe
 
   # ---------------------------------------------------------------------------

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,7 +1272,6 @@ name = "egui-winit"
 version = "0.21.1"
 dependencies = [
  "accesskit_winit",
- "android-activity",
  "arboard",
  "document-features",
  "egui",

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -69,6 +69,15 @@ __screenshot = ["dep:image"]
 ## This overrides the `glow` feature.
 wgpu = ["dep:wgpu", "dep:egui-wgpu", "dep:pollster"]
 
+# Allow crates to choose an android-activity backend via Winit
+# - It's important that most applications should not have to depend on android-activity directly, and can
+#   rely on Winit to pull in a suitable version (unlike most Rust crates, any version conflicts won't link)
+# - It's also important that we don't impose an android-activity backend by taking this choice away from applications.
+
+## Enable the `native-activity` backend via `egui-winit` on Android
+android-native-activity = [ "egui-winit/android-native-activity" ]
+## Enable the `game-activity` backend via `egui-winit` on Android
+android-game-activity = [ "egui-winit/android-game-activity" ]
 
 [dependencies]
 egui = { version = "0.21.0", path = "../egui", default-features = false, features = [

--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -42,6 +42,16 @@ serde = ["egui/serde", "dep:serde"]
 ## Enables Wayland support.
 wayland = ["winit/wayland"]
 
+# Allow crates to choose an android-activity backend via Winit
+# - It's important that most applications should not have to depend on android-activity directly, and can
+#   rely on Winit to pull in a suitable version (unlike most Rust crates, any version conflicts won't link)
+# - It's also important that we don't impose an android-activity backend by taking this choice away from applications.
+
+## Enable the `native-activity` backend via Winit on Android
+android-native-activity = [ "winit/android-native-activity" ]
+## Enable the `game-activity` backend via Winit on Android
+android-game-activity = [ "winit/android-game-activity" ]
+
 [dependencies]
 egui = { version = "0.21.0", path = "../egui", default-features = false, features = [
   "tracing",
@@ -76,6 +86,3 @@ smithay-clipboard = { version = "0.6.3", optional = true }
 [target.'cfg(not(target_os = "android"))'.dependencies]
 arboard = { version = "3.2", optional = true, default-features = false }
 
-[target.'cfg(target_os = "android")'.dependencies]
-# TODO(emilk): this is probably not the right place for specifying native-activity, but we need to do it somewhere for the CI
-android-activity = { version = "0.4", features = ["native-activity"] }


### PR DESCRIPTION
Instead of depending on `android-activity` directly, this exposes the `android-native-activity` and `android-game-activity` features from Winit (via `egui-winit` and `eframe`).

The overall issue here is that Android applications will very likely need to implement a subclass of `Activity` in Java or Kotlin and when using `android-activity` that means they will have to choose to subclass `NativeActivity` or `GameActivity`. Since there are significant pros and cons to each one it isn't really appropriate for Egui to force a choice here.

Conceptually the `android-activity` crate is the lowest-level, runtime crate for a native Android application written in Rust and then middleware like Winit and Egui sit on top of this. With the way Cargo features work then if we want make the low-level crate configurable for applications then we don't really have any choice but to expose equivalent features via middleware frameworks (such as Egui) that applications depend on.

This ensures that applications can choose what `android-activity` backend they use while also relying on Winit to decide what version of `android-activity` to use - without increasing the risk of a version conflict by having a direct dependency.

_(NB: Egui doesn't currently use the android-activity API itself)_

Since `android-activity` provides the `android_main()` entry point for Android applications it's not possible to link in multiple versions of the android-activity crate and so it's particularly important to avoid unnecessary direct dependencies that could cause a version conflict in the future.

To help avoid the need for applications to directly depend on `android-activity` the Winit crate re-exports the `android-activity` API and exposes features to configure the backend so that application crates can instead rely on Winit to pull in a compatible version of `android-activity`. (This way version bumps for `android-activity` only need to be synchronized with the Winit crate).

CI now enables the `android-native-activity` feature for testing.

Fixes: #2829
Fixes: #2720
Closes: #2834

Cc: @ardocrat

