### PR TITLE
eframe: Fix building for iOS with wgpu

### DIFF
--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -91,6 +91,7 @@ fn create_event_loop_builder(
 ///
 /// We reuse the event-loop so we can support closing and opening an eframe window
 /// multiple times. This is just a limitation of winit.
+#[cfg(not(target_os = "ios"))]
 fn with_event_loop<R>(
     mut native_options: epi::NativeOptions,
     f: impl FnOnce(&mut EventLoop<UserEvent>, NativeOptions) -> R,
@@ -109,6 +110,7 @@ fn with_event_loop<R>(
     })
 }
 
+#[cfg(not(target_os = "ios"))]
 fn run_and_return(
     event_loop: &mut EventLoop<UserEvent>,
     mut winit_app: impl WinitApp,
@@ -1422,17 +1424,18 @@ mod wgpu_integration {
         mut native_options: epi::NativeOptions,
         app_creator: epi::AppCreator,
     ) -> Result<()> {
+        #[cfg(not(target_os = "ios"))]
         if native_options.run_and_return {
-            with_event_loop(native_options, |event_loop, native_options| {
+            return with_event_loop(native_options, |event_loop, native_options| {
                 let wgpu_eframe =
                     WgpuWinitApp::new(event_loop, app_name, native_options, app_creator);
                 run_and_return(event_loop, wgpu_eframe)
-            })
-        } else {
-            let event_loop = create_event_loop_builder(&mut native_options).build();
-            let wgpu_eframe = WgpuWinitApp::new(&event_loop, app_name, native_options, app_creator);
-            run_and_exit(event_loop, wgpu_eframe);
+            });
         }
+
+        let event_loop = create_event_loop_builder(&mut native_options).build();
+        let wgpu_eframe = WgpuWinitApp::new(&event_loop, app_name, native_options, app_creator);
+        run_and_exit(event_loop, wgpu_eframe);
     }
 }
 


### PR DESCRIPTION
This PR fixes a compile error when building an eframe app (using wgpu) for iOS due to winit's `run_return` function not being present.

As noted here [/winit/blob/master/src/platform/mod.rs#L12-L14](https://github.com/rust-windowing/winit/blob/master/src/platform/mod.rs#L12-L14)  in winit `run_return` is only available on specific platforms.

This PR contains the minimal changes required to build for IOS, I can envision a few other solutions such as:

- opt-ing in to using `run_and_return` only on the supported platforms
- Removing `native_options.run_and_return` on unsupported platforms
- Applying the same change to `run_glow` even though that appears to be unsupported (glutin fails to compile) on iOS.

I am just getting into rust so very much look forward to your feedback. Thanks in advance 👍 

See the following screenshot of the unmodifed (with wgpu eframe feature) hello world example running on ios:
<img width="561" alt="Screenshot 2023-04-01 at 22 13 14" src="https://user-images.githubusercontent.com/4324090/229314176-ff9511fb-6ff0-4e0d-86f7-6f71348e3324.png">
