### PR TITLE
trivial: hide triple_clicked in docs

### DIFF
--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -57,6 +57,7 @@ pub struct Response {
     pub double_clicked: [bool; NUM_POINTER_BUTTONS],
 
     /// The thing was triple-clicked.
+    #[doc(hidden)]
     pub triple_clicked: [bool; NUM_POINTER_BUTTONS],
 
     /// The widgets is being dragged


### PR DESCRIPTION
Very trivial change to documentation

If `Response.clicked` and `Response.double_clicked` are hidden in the documentation, why isn't `Response.triple_clicked` also hidden?

![image](https://user-images.githubusercontent.com/19079506/229354363-03ae7961-b1d8-4c2d-a86b-f9aabe0cba05.png)