### PR TITLE
🏓 `egui-winit`: Document `State::on_event` from unconditionally consuming Tab keypresses 

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -307,6 +307,7 @@ impl State {
             }
             WindowEvent::KeyboardInput { input, .. } => {
                 self.on_keyboard_input(input);
+                // When pressing the Tab key, egui focuses the first focusable element, hence Tab always consumes.
                 let consumed = egui_ctx.wants_keyboard_input()
                     || input.virtual_keycode == Some(winit::event::VirtualKeyCode::Tab);
                 EventResponse {


### PR DESCRIPTION
In PR #735, the initial `egui-winit` version was added. That PR contains a check whether the `Tab` key was pressed within the `State::on_event` and returns `consumed = true`, regardless of `egui`'s `wants_keyboard_input`.

Since I could not find any reference or further logic that this is intended behavior and I'd like to handle the `Tab` key, similar to any other key, this PR removes the check.