### PR TITLE
Revert "DragValue: when keyboard editing, only update the value on focus lost"

### DIFF
--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -475,17 +475,13 @@ impl<'a> Widget for DragValue<'a> {
                     .desired_width(ui.spacing().interact_size.x)
                     .font(text_style),
             );
-            // Only update the value when the user presses enter, or clicks elsewhere. NOT every frame.
-            // See https://github.com/emilk/egui/issues/2687
-            if response.lost_focus() {
-                let parsed_value = match custom_parser {
-                    Some(parser) => parser(&value_text),
-                    None => value_text.parse().ok(),
-                };
-                if let Some(parsed_value) = parsed_value {
-                    let parsed_value = clamp_to_range(parsed_value, clamp_range.clone());
-                    set(&mut get_set_value, parsed_value);
-                }
+            let parsed_value = match custom_parser {
+                Some(parser) => parser(&value_text),
+                None => value_text.parse().ok(),
+            };
+            if let Some(parsed_value) = parsed_value {
+                let parsed_value = clamp_to_range(parsed_value, clamp_range.clone());
+                set(&mut get_set_value, parsed_value);
             }
             ui.memory_mut(|mem| mem.drag_value.edit_string = Some(value_text));
             response


### PR DESCRIPTION
Reverts emilk/egui#2688, which causes  a lot of problems with `DragValue` editing (see #2818).