### PR TITLE
Fix `DragValue` editing

### DIFF
--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -475,7 +475,7 @@ impl<'a> Widget for DragValue<'a> {
                     .desired_width(ui.spacing().interact_size.x)
                     .font(text_style),
             );
-            // Only update the value when the user presses enter, or clicks elsewhere. NOT every frame.
+            // Only update when the edit content has changed. NOT every frame.
             // See https://github.com/emilk/egui/issues/2687
             if response.changed() {
                 let parsed_value = match custom_parser {

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -477,7 +477,7 @@ impl<'a> Widget for DragValue<'a> {
             );
             // Only update the value when the user presses enter, or clicks elsewhere. NOT every frame.
             // See https://github.com/emilk/egui/issues/2687
-            if response.lost_focus() {
+            if response.changed() {
                 let parsed_value = match custom_parser {
                     Some(parser) => parser(&value_text),
                     None => value_text.parse().ok(),


### PR DESCRIPTION
Closes #2818.

Use `Response::changed` instead of `Response::lost_focus` (which is problematic).
