### PR TITLE
Menu State rect now uses menu frame rect instead of contents rect

### DIFF
--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -137,7 +137,6 @@ pub(crate) fn menu_ui<'c, R>(
 ) -> InnerResponse<R> {
     let pos = {
         let mut menu_state = menu_state_arc.write();
-
         menu_state.entry_count = 0;
         menu_state.rect.min
     };
@@ -149,7 +148,7 @@ pub(crate) fn menu_ui<'c, R>(
         .interactable(true)
         .drag_bounds(ctx.screen_rect());
 
-    let inner_response = area.show(ctx, |ui| {
+    inner_response = area.show(ctx, |ui| {
         set_menu_style(ui.style_mut());
 
         let frame = Frame::menu(ui.style()).show(ui, |ui| {
@@ -165,8 +164,6 @@ pub(crate) fn menu_ui<'c, R>(
 
         frame.inner
     });
-
-    inner_response
 }
 
 /// Build a top level menu with a button.


### PR DESCRIPTION
When a menu is opened near the edge of screen, the rect of the `add_contents` response is always `> cursor_pos` as expected during regular function, but not when the area moves itself to accommodate the screen edges.

As a solution I made the menu_state rect be the same as the menu frame, which fixes the issue. I am unsure if there is a better solution, such as making the `add_contents` aware that their parent has been moved.

I also removed a redundant call that set the menu_state rect a second time unnecessarily as it had already been set during  `MenuState::show`.

Closes #2862 .