### PR TITLE
Menu State rect now uses menu frame rect instead of contents rect.

### DIFF
--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -147,21 +147,22 @@ pub(crate) fn menu_ui<'c, R>(
         .fixed_pos(pos)
         .interactable(true)
         .drag_bounds(ctx.screen_rect());
-    let inner_response = area.show(ctx, |ui| {
+
+    area.show(ctx, |ui| {
         set_menu_style(ui.style_mut());
 
-        Frame::menu(ui.style())
-            .show(ui, |ui| {
-                const DEFAULT_MENU_WIDTH: f32 = 150.0; // TODO(emilk): add to ui.spacing
-                ui.set_max_width(DEFAULT_MENU_WIDTH);
-                ui.set_menu_state(Some(menu_state_arc.clone()));
-                ui.with_layout(Layout::top_down_justified(Align::LEFT), add_contents)
-                    .inner
-            })
-            .inner
-    });
-    menu_state_arc.write().rect = inner_response.response.rect;
-    inner_response
+        let frame = Frame::menu(ui.style()).show(ui, |ui| {
+            const DEFAULT_MENU_WIDTH: f32 = 150.0; // TODO(emilk): add to ui.spacing
+            ui.set_max_width(DEFAULT_MENU_WIDTH);
+            ui.set_menu_state(Some(menu_state_arc.clone()));
+            ui.with_layout(Layout::top_down_justified(Align::LEFT), add_contents)
+                .inner
+        });
+
+        menu_state_arc.write().rect = frame.response.rect;
+
+        frame.inner
+    })
 }
 
 /// Build a top level menu with a button.
@@ -293,8 +294,7 @@ impl MenuRoot {
         if self.id == response.id {
             let inner_response =
                 MenuState::show(&response.ctx, &self.menu_state, self.id, add_contents);
-            let mut menu_state = self.menu_state.write();
-            menu_state.rect = inner_response.response.rect;
+            let menu_state = self.menu_state.read();
 
             if menu_state.response.is_close() {
                 return (MenuResponse::Close, Some(inner_response));


### PR DESCRIPTION
When a menu is opened near the edge of screen, the rect of the `add_contents` response is always `> cursor_pos` as expected during regular function, but not when the area moves itself to accommodate the screen edges.

As a solution I made the menu_state rect be the same as the menu frame, which fixes the issue. I am unsure if there is a better solution, such as making the `add_contents` aware that their parent has been moved.

I also removed a redundant call that set the menu_state rect a second time unnecessarily as it had already been set during  `MenuState::show`.

Closes #2862 .