### PR TITLE
egui_extras: add `load_texture()` for `RetainedImage`

### DIFF
--- a/crates/egui_extras/CHANGELOG.md
+++ b/crates/egui_extras/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to the `egui_extras` integration will be noted in this file.
 
 
 ## Unreleased
+* Added `RetainedImage::load_texture` to preemptively load images into textures.
 
 
 ## 0.21.0 - 2023-02-08


### PR DESCRIPTION
Since `RetainedImage`'s are lazily loaded into textures, the GUI thread ends up being the one doing the work upon `.show()`.

With many images or high resolution ones (or both...!), it freezes the GUI for a few seconds.

This function allows some other thread to load them into textures.

The code is just `RetainedImage::texture_id()` but without the return value.