### PR TITLE
eframe: add call to save_and_destroy in Exit event of run_return

### DIFF
--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -8,6 +8,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 #### Desktop/Native:
 * Add `Frame::request_screenshot` and `Frame::screenshot` to communicate to the backend that a screenshot of the current frame should be exposed by `Frame` during `App::post_rendering` ([#2676](https://github.com/emilk/egui/pull/2676)).
 * Add `eframe::run_simple_native` - a simple API for simple apps ([#2453](https://github.com/emilk/egui/pull/2453)).
+* Fix bug where the eframe window is never destroyed on Linux when using `run_and_return` ([#2892](https://github.com/emilk/egui/issues/2892))
 
 #### Web:
 * Bug fix: modifiers keys getting stuck on alt-tab ([#2857](https://github.com/emilk/egui/pull/2857)).

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -190,6 +190,7 @@ fn run_and_return(
             }
             EventResult::Exit => {
                 tracing::debug!("Asking to exit event loop…");
+                winit_app.save_and_destroy();
                 *control_flow = ControlFlow::Exit;
                 return;
             }


### PR DESCRIPTION
`EventResult::Exit` is hit before `Event::LoopDestroyed` is, and due to possibly some order of operations or drops the window is never destroyed on Linux. Adding a call to `winit_app.save_and_destroy();` where `EventResult::Exit` is checked solves this.

Closes #2892
