### PR TITLE
eframe: read the state of native window's input focus and request it

### DIFF
--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -938,6 +938,9 @@ pub struct WindowInfo {
     /// Are we maximized?
     pub maximized: bool,
 
+    /// Is the window focused and able to receive input?
+    pub active: bool,
+
     /// Window inner size in egui points (logical pixels).
     pub size: egui::Vec2,
 

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -814,6 +814,15 @@ impl Frame {
         self.output.minimized = Some(minimized);
     }
 
+    /// Bring the window into focus (native only). Has no effect on Wayland, or if the window is minimized or invisible.
+    ///
+    /// This method puts the window on top of other applications and takes input focus away from them,
+    /// which, if unexpected, will disturb the user.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn focus(&mut self) {
+        self.output.focus = Some(true);
+    }
+
     /// Maximize or unmaximize window. (native only)
     #[cfg(not(target_arch = "wasm32"))]
     pub fn set_maximized(&mut self, maximized: bool) {
@@ -1131,6 +1140,10 @@ pub(crate) mod backend {
         /// Set to some bool to maximize or unmaximize window.
         #[cfg(not(target_arch = "wasm32"))]
         pub maximized: Option<bool>,
+
+        /// Set to some bool to focus window.
+        #[cfg(not(target_arch = "wasm32"))]
+        pub focus: Option<bool>,
 
         #[cfg(not(target_arch = "wasm32"))]
         pub screenshot_requested: bool,

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -232,6 +232,7 @@ pub fn handle_app_output(
         screenshot_requested: _, // handled by the rendering backend,
         minimized,
         maximized,
+        focus,
     } = app_output;
 
     if let Some(decorated) = decorated {
@@ -284,6 +285,10 @@ pub fn handle_app_output(
     if let Some(maximized) = maximized {
         window.set_maximized(maximized);
         window_state.maximized = maximized;
+    }
+
+    if focus == Some(true) {
+        window.focus_window();
     }
 }
 

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -61,6 +61,7 @@ pub fn read_window_info(
         fullscreen: window.fullscreen().is_some(),
         minimized: window_state.minimized,
         maximized: window_state.maximized,
+        active: window.has_focus(),
         size: egui::Vec2 {
             x: size.width,
             y: size.height,


### PR DESCRIPTION
allows to determine if the window is active, and make it gain focus if necessary.

while 7cbaafc38db298df22d7fe699b8ce8834c2ade0f *may* be not quite in spirit of the framework, I understand if you push back on it, but at least I found it useful for my purposes.