### PR TITLE
Add `TableRow::col_sense`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 
 
 ## Unreleased
-
+* Add `TableRow::col_sense` which does the same as `TableRow::col` but allows to specify a `Sense`. It allows for detecting clicks on rows ([Discussion #1519](https://github.com/emilk/egui/discussions/1519))
 
 ## 0.21.0 - 2023-02-08 - Deadlock fix and style customizability
 * ⚠️ BREAKING: `egui::Context` now use closures for locking ([#2625](https://github.com/emilk/egui/pull/2625)):

--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -119,7 +119,7 @@ impl<'l> StripLayout<'l> {
             max_rect.union(used_rect)
         };
 
-        let response = self.ui.allocate_rect(allocation_rect, Sense::hover());
+        let response = self.ui.allocate_rect(allocation_rect, Sense::click());
 
         (used_rect, response)
     }

--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -97,6 +97,7 @@ impl<'l> StripLayout<'l> {
         width: CellSize,
         height: CellSize,
         add_cell_contents: impl FnOnce(&mut Ui),
+        sense: Sense,
     ) -> (Rect, Response) {
         let max_rect = self.cell_rect(&width, &height);
 
@@ -119,7 +120,7 @@ impl<'l> StripLayout<'l> {
             max_rect.union(used_rect)
         };
 
-        let response = self.ui.allocate_rect(allocation_rect, Sense::click());
+        let response = self.ui.allocate_rect(allocation_rect, sense);
 
         (used_rect, response)
     }

--- a/crates/egui_extras/src/strip.rs
+++ b/crates/egui_extras/src/strip.rs
@@ -3,7 +3,7 @@ use crate::{
     sizing::Sizing,
     Size,
 };
-use egui::{Response, Ui};
+use egui::{Response, Sense, Ui};
 
 /// Builder for creating a new [`Strip`].
 ///
@@ -168,8 +168,14 @@ impl<'a, 'b> Strip<'a, 'b> {
     pub fn cell(&mut self, add_contents: impl FnOnce(&mut Ui)) {
         let (width, height) = self.next_cell_size();
         let striped = false;
-        self.layout
-            .add(self.clip, striped, width, height, add_contents);
+        self.layout.add(
+            self.clip,
+            striped,
+            width,
+            height,
+            add_contents,
+            Sense::hover(),
+        );
     }
 
     /// Add an empty cell.

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -3,7 +3,7 @@
 //! | fixed size | all available space/minimum | 30% of available width | fixed size |
 //! Takes all available height, so if you want something below the table, put it in a strip.
 
-use egui::{Align, NumExt as _, Rect, Response, ScrollArea, Ui, Vec2};
+use egui::{Align, NumExt as _, Rect, Response, ScrollArea, Sense, Ui, Vec2};
 
 use crate::{
     layout::{CellDirection, CellSize},
@@ -1026,6 +1026,18 @@ impl<'a, 'b> TableRow<'a, 'b> {
     /// Return the used space (`min_rect`) plus the [`Response`] of the whole cell.
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn col(&mut self, add_cell_contents: impl FnOnce(&mut Ui)) -> (Rect, Response) {
+        self.col_sense(Sense::hover(), add_cell_contents)
+    }
+
+    /// Add the contents of a column, also specifies which Sense is used to allocate the UI
+    ///
+    /// Return the used space (`min_rect`) plus the [`Response`] of the whole cell.
+    #[cfg_attr(debug_assertions, track_caller)]
+    pub fn col_sense(
+        &mut self,
+        sense: Sense,
+        add_cell_contents: impl FnOnce(&mut Ui),
+    ) -> (Rect, Response) {
         let col_index = self.col_index;
 
         let clip = self.columns.get(col_index).map_or(false, |c| c.clip);
@@ -1046,7 +1058,7 @@ impl<'a, 'b> TableRow<'a, 'b> {
 
         let (used_rect, response) =
             self.layout
-                .add(clip, self.striped, width, height, add_cell_contents);
+                .add(clip, self.striped, width, height, add_cell_contents, sense);
 
         if let Some(max_w) = self.max_used_widths.get_mut(col_index) {
             *max_w = max_w.max(used_rect.width());


### PR DESCRIPTION
Add `TableRow::col_sense` which does the same as `TableRow::col` but allows to specify a `Sense`. It allows for detecting clicks on rows

Closes [Discussion #1519](https://github.com/emilk/egui/discussions/1519)
