### PR TITLE
Made the resize widget take into account cursor offset when clicked

### DIFF
--- a/crates/egui/src/containers/resize.rs
+++ b/crates/egui/src/containers/resize.rs
@@ -14,6 +14,9 @@ pub(crate) struct State {
 
     /// Externally requested size (e.g. by Window) for the next frame
     pub(crate) requested_size: Option<Vec2>,
+
+    /// Offset of the cursor when clicked
+    cursor_offset: Option<Vec2>,
 }
 
 impl State {
@@ -187,6 +190,7 @@ impl Resize {
                 desired_size: default_size,
                 last_content_size: vec2(0.0, 0.0),
                 requested_size: None,
+                cursor_offset: None,
             }
         });
 
@@ -205,8 +209,16 @@ impl Resize {
             let corner_response = ui.interact(corner_rect, id.with("corner"), Sense::drag());
 
             if let Some(pointer_pos) = corner_response.interact_pointer_pos() {
+                let offset = state
+                    .cursor_offset
+                    .get_or_insert(corner_rect.center() - pointer_pos);
+
                 user_requested_size =
-                    Some(pointer_pos - position + 0.5 * corner_response.rect.size());
+                    Some(pointer_pos - position + 0.5 * corner_response.rect.size() + *offset);
+            }
+
+            if corner_response.drag_released() {
+                state.cursor_offset = None;
             }
 
             Some(corner_response)


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* Unless this is a trivial change, add a line to the relevant `CHANGELOG.md` under "Unreleased".
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./sh/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Keeps track of cursor offset in resize state when mouse is clicked. This offset is then added to the new requested position. This prevents the resize view to jump when initially grabbing with the mouse.

Closes <https://github.com/emilk/egui/issues/2907>.
