### PR TITLE
egui_extras datepicker: Add option to hide button calendar icon

### DIFF
--- a/crates/egui_extras/src/datepicker/button.rs
+++ b/crates/egui_extras/src/datepicker/button.rs
@@ -14,6 +14,7 @@ pub struct DatePickerButton<'a> {
     arrows: bool,
     calendar: bool,
     calendar_week: bool,
+    show_icon: bool,
 }
 
 impl<'a> DatePickerButton<'a> {
@@ -25,6 +26,7 @@ impl<'a> DatePickerButton<'a> {
             arrows: true,
             calendar: true,
             calendar_week: true,
+            show_icon: true,
         }
     }
 
@@ -58,6 +60,12 @@ impl<'a> DatePickerButton<'a> {
         self.calendar_week = week;
         self
     }
+
+    /// Show the calender icon on the button. (Default: true)
+    pub fn show_icon(mut self, show_icon: bool) -> Self {
+        self.show_icon = show_icon;
+        self
+    }
 }
 
 impl<'a> Widget for DatePickerButton<'a> {
@@ -67,7 +75,11 @@ impl<'a> Widget for DatePickerButton<'a> {
             .memory_mut(|mem| mem.data.get_persisted::<DatePickerButtonState>(id))
             .unwrap_or_default();
 
-        let mut text = RichText::new(format!("{} 📆", self.selection.format("%Y-%m-%d")));
+        let mut text = if self.show_icon {
+            RichText::new(format!("{} 📆", self.selection.format("%Y-%m-%d")))
+        } else {
+            RichText::new(format!("{}", self.selection.format("%Y-%m-%d")))
+        };
         let visuals = ui.visuals().widgets.open;
         if button_state.picker_visible {
             text = text.color(visuals.text_color());


### PR DESCRIPTION
Implement the ability to hide the button icon via a `show_icon` construction method.