### PR TITLE
Replace `tracing` with `log`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -1223,6 +1223,7 @@ dependencies = [
  "glutin-winit",
  "image",
  "js-sys",
+ "log",
  "percent-encoding",
  "pollster",
  "puffin",
@@ -1230,7 +1231,6 @@ dependencies = [
  "ron",
  "serde",
  "thiserror",
- "tracing",
  "tts",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1247,10 +1247,10 @@ dependencies = [
  "ahash 0.8.3",
  "document-features",
  "epaint",
+ "log",
  "nohash-hasher",
  "ron",
  "serde",
- "tracing",
 ]
 
 [[package]]
@@ -1260,8 +1260,8 @@ dependencies = [
  "bytemuck",
  "document-features",
  "epaint",
+ "log",
  "puffin",
- "tracing",
  "type-map",
  "wgpu",
  "winit",
@@ -1276,10 +1276,10 @@ dependencies = [
  "document-features",
  "egui",
  "instant",
+ "log",
  "puffin",
  "serde",
  "smithay-clipboard",
- "tracing",
  "webbrowser",
  "winit",
 ]
@@ -1296,12 +1296,11 @@ dependencies = [
  "egui_demo_lib",
  "egui_extras",
  "ehttp",
+ "env_logger",
  "image",
+ "log",
  "poll-promise",
  "serde",
- "tracing",
- "tracing-subscriber",
- "tracing-wasm",
  "wasm-bindgen-futures",
 ]
 
@@ -1315,9 +1314,9 @@ dependencies = [
  "egui",
  "egui_extras",
  "enum-map",
+ "log",
  "serde",
  "syntect",
- "tracing",
  "unicode_names2",
 ]
 
@@ -1329,10 +1328,10 @@ dependencies = [
  "document-features",
  "egui",
  "image",
+ "log",
  "resvg",
  "serde",
  "tiny-skia",
- "tracing",
  "usvg",
 ]
 
@@ -1347,10 +1346,10 @@ dependencies = [
  "glow",
  "glutin",
  "glutin-winit",
+ "log",
  "memoffset",
  "puffin",
  "raw-window-handle",
- "tracing",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1438,6 +1437,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "epaint"
 version = "0.21.0"
 dependencies = [
@@ -1450,6 +1462,7 @@ dependencies = [
  "document-features",
  "ecolor",
  "emath",
+ "log",
  "nohash-hasher",
  "parking_lot",
  "serde",
@@ -1464,6 +1477,17 @@ dependencies = [
  "errno-dragonfly",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1932,7 +1956,7 @@ name = "hello_world"
 version = "0.1.0"
 dependencies = [
  "eframe",
- "tracing-subscriber",
+ "env_logger",
 ]
 
 [[package]]
@@ -1947,7 +1971,7 @@ name = "hello_world_simple"
 version = "0.1.0"
 dependencies = [
  "eframe",
- "tracing-subscriber",
+ "env_logger",
 ]
 
 [[package]]
@@ -1960,6 +1984,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,6 +2000,12 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -2065,6 +2101,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix 0.37.3",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2128,7 +2176,7 @@ name = "keyboard_events"
 version = "0.1.0"
 dependencies = [
  "eframe",
- "tracing-subscriber",
+ "env_logger",
 ]
 
 [[package]]
@@ -2214,6 +2262,12 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f508063cc7bb32987c71511216bd5a32be15bccb6a80b52df8b9d7f01fc3aa2"
 
 [[package]]
 name = "litrs"
@@ -2450,16 +2504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2633,12 +2677,6 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owned_ttf_parser"
@@ -3102,10 +3140,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
  "bitflags",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
+dependencies = [
+ "bitflags",
+ "errno 0.3.1",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.2",
  "windows-sys 0.45.0",
 ]
 
@@ -3261,15 +3313,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]
@@ -3503,7 +3546,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.2.16",
- "rustix",
+ "rustix 0.36.9",
  "windows-sys 0.42.0",
 ]
 
@@ -3540,15 +3583,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.107",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
-dependencies = [
- "once_cell",
 ]
 
 [[package]]
@@ -3695,43 +3729,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
-dependencies = [
- "nu-ansi-term",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing-core",
- "tracing-log",
-]
-
-[[package]]
-name = "tracing-wasm"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
-dependencies = [
- "tracing",
- "tracing-subscriber",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3890,12 +3887,6 @@ dependencies = [
  "strict-num",
  "svgtypes",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vec_map"
@@ -4313,13 +4304,13 @@ version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
@@ -4330,7 +4321,7 @@ checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-targets",
+ "windows-targets 0.42.1",
 ]
 
 [[package]]
@@ -4361,13 +4352,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
@@ -4376,7 +4367,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -4385,13 +4385,28 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -4401,10 +4416,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4413,10 +4440,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4425,16 +4464,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winit"

--- a/bacon.toml
+++ b/bacon.toml
@@ -6,23 +6,50 @@ default_job = "cranky"
 [jobs]
 
 [jobs.cranky]
-command = ["cargo", "cranky", "--all-targets", "--all-features", "--color", "always"]
+command = [
+    "cargo",
+    "cranky",
+    "--all-targets",
+    "--all-features",
+    "--color=always",
+]
+need_stdout = false
+watch = ["tests", "benches", "examples"]
+
+[jobs.wasm]
+command = [
+    "cargo",
+    "cranky",
+    "-p=egui_demo_app",
+    "--lib",
+    "--target=wasm32-unknown-unknown",
+    "--target-dir=target_wasm",
+    "--all-features",
+    "--color=always",
+]
 need_stdout = false
 watch = ["tests", "benches", "examples"]
 
 [jobs.test]
-command = ["cargo", "test", "--color", "always"]
+command = ["cargo", "test", "--color=always"]
 need_stdout = true
 watch = ["tests"]
 
 [jobs.doc]
-command = ["cargo", "doc", "--color", "always", "--all-features", "--no-deps"]
+command = ["cargo", "doc", "--color=always", "--all-features", "--no-deps"]
 need_stdout = false
 
 # if the doc compiles, then it opens in your browser and bacon switches
 # to the previous job
 [jobs.doc-open]
-command = ["cargo", "doc", "--color", "always", "--all-features", "--no-deps", "--open"]
+command = [
+    "cargo",
+    "doc",
+    "--color=always",
+    "--all-features",
+    "--no-deps",
+    "--open",
+]
 need_stdout = false
 on_success = "back" # so that we don't open the browser at each change
 
@@ -31,7 +58,7 @@ on_success = "back" # so that we don't open the browser at each change
 # way. Don't forget the `--color always` part or the errors won't be
 # properly parsed.
 [jobs.run]
-command = ["cargo", "run", "--color", "always"]
+command = ["cargo", "run", "--color=always"]
 need_stdout = true
 
 # You may define here keybindings that would be specific to
@@ -41,6 +68,7 @@ need_stdout = true
 [keybindings]
 i = "job:initial"
 c = "job:cranky"
+w = "job:wasm"
 d = "job:doc-open"
 t = "job:test"
 r = "job:run"

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -75,17 +75,17 @@ wgpu = ["dep:wgpu", "dep:egui-wgpu", "dep:pollster"]
 # - It's also important that we don't impose an android-activity backend by taking this choice away from applications.
 
 ## Enable the `native-activity` backend via `egui-winit` on Android
-android-native-activity = [ "egui-winit/android-native-activity" ]
+android-native-activity = ["egui-winit/android-native-activity"]
 ## Enable the `game-activity` backend via `egui-winit` on Android
-android-game-activity = [ "egui-winit/android-game-activity" ]
+android-game-activity = ["egui-winit/android-game-activity"]
 
 [dependencies]
 egui = { version = "0.21.0", path = "../egui", default-features = false, features = [
   "bytemuck",
-  "tracing",
+  "log",
 ] }
+log = { version = "0.4", features = ["std"] }
 thiserror = "1.0.37"
-tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 #! ### Optional dependencies
 ## Enable this when generating docs.

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -810,7 +810,7 @@ impl Frame {
     #[doc(alias = "exit")]
     #[doc(alias = "quit")]
     pub fn close(&mut self) {
-        tracing::debug!("eframe::Frame::close called");
+        log::debug!("eframe::Frame::close called");
         self.output.close = true;
     }
 
@@ -1088,7 +1088,7 @@ pub fn get_value<T: serde::de::DeserializeOwned>(storage: &dyn Storage, key: &st
 pub fn set_value<T: serde::Serialize>(storage: &mut dyn Storage, key: &str, value: &T) {
     match ron::ser::to_string(value) {
         Ok(string) => storage.set_string(key, string),
-        Err(err) => tracing::error!("eframe failed to encode data using ron: {}", err),
+        Err(err) => log::error!("eframe failed to encode data using ron: {}", err),
     }
 }
 

--- a/crates/eframe/src/lib.rs
+++ b/crates/eframe/src/lib.rs
@@ -201,13 +201,13 @@ pub fn run_native(
     match renderer {
         #[cfg(feature = "glow")]
         Renderer::Glow => {
-            tracing::debug!("Using the glow renderer");
+            log::debug!("Using the glow renderer");
             native::run::run_glow(app_name, native_options, app_creator)
         }
 
         #[cfg(feature = "wgpu")]
         Renderer::Wgpu => {
-            tracing::debug!("Using the wgpu renderer");
+            log::debug!("Using the wgpu renderer");
             native::run::run_wgpu(app_name, native_options, app_creator)
         }
     }

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -425,12 +425,12 @@ impl EpiIntegration {
 
         match event {
             WindowEvent::CloseRequested => {
-                tracing::debug!("Received WindowEvent::CloseRequested");
+                log::debug!("Received WindowEvent::CloseRequested");
                 self.close = app.on_close_event();
-                tracing::debug!("App::on_close_event returned {}", self.close);
+                log::debug!("App::on_close_event returned {}", self.close);
             }
             WindowEvent::Destroyed => {
-                tracing::debug!("Received WindowEvent::Destroyed");
+                log::debug!("Received WindowEvent::Destroyed");
                 self.close = true;
             }
             WindowEvent::MouseInput {
@@ -483,7 +483,7 @@ impl EpiIntegration {
             self.can_drag_window = false;
             if app_output.close {
                 self.close = app.on_close_event();
-                tracing::debug!("App::on_close_event returned {}", self.close);
+                log::debug!("App::on_close_event returned {}", self.close);
             }
             self.frame.output.visible = app_output.visible; // this is handled by post_present
             self.frame.output.screenshot_requested = app_output.screenshot_requested;

--- a/crates/eframe/src/native/file_storage.rs
+++ b/crates/eframe/src/native/file_storage.rs
@@ -26,7 +26,7 @@ impl FileStorage {
     /// Store the state in this .ron file.
     pub fn from_ron_filepath(ron_filepath: impl Into<PathBuf>) -> Self {
         let ron_filepath: PathBuf = ron_filepath.into();
-        tracing::debug!("Loading app state from {:?}…", ron_filepath);
+        log::debug!("Loading app state from {:?}…", ron_filepath);
         Self {
             kv: read_ron(&ron_filepath).unwrap_or_default(),
             ron_filepath,
@@ -40,7 +40,7 @@ impl FileStorage {
         if let Some(proj_dirs) = directories_next::ProjectDirs::from("", "", app_name) {
             let data_dir = proj_dirs.data_dir().to_path_buf();
             if let Err(err) = std::fs::create_dir_all(&data_dir) {
-                tracing::warn!(
+                log::warn!(
                     "Saving disabled: Failed to create app path at {:?}: {}",
                     data_dir,
                     err
@@ -50,7 +50,7 @@ impl FileStorage {
                 Some(Self::from_ron_filepath(data_dir.join("app.ron")))
             }
         } else {
-            tracing::warn!("Saving disabled: Failed to find path to data_dir.");
+            log::warn!("Saving disabled: Failed to find path to data_dir.");
             None
         }
     }
@@ -84,7 +84,7 @@ impl crate::Storage for FileStorage {
                 let file = std::fs::File::create(&file_path).unwrap();
                 let config = Default::default();
                 ron::ser::to_writer_pretty(file, &kv, config).unwrap();
-                tracing::trace!("Persisted to {:?}", file_path);
+                log::trace!("Persisted to {:?}", file_path);
             });
 
             self.last_save_join_handle = Some(join_handle);
@@ -104,7 +104,7 @@ where
             match ron::de::from_reader(reader) {
                 Ok(value) => Some(value),
                 Err(err) => {
-                    tracing::warn!("Failed to parse RON: {}", err);
+                    log::warn!("Failed to parse RON: {}", err);
                     None
                 }
             }

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -115,7 +115,7 @@ fn run_and_return(
 ) -> Result<()> {
     use winit::platform::run_return::EventLoopExtRunReturn as _;
 
-    tracing::debug!("Entering the winit event loop (run_return)…");
+    log::debug!("Entering the winit event loop (run_return)…");
 
     let mut next_repaint_time = Instant::now();
 
@@ -126,7 +126,7 @@ fn run_and_return(
             winit::event::Event::LoopDestroyed => {
                 // On Mac, Cmd-Q we get here and then `run_return` doesn't return (despite its name),
                 // so we need to save state now:
-                tracing::debug!("Received Event::LoopDestroyed - saving app state…");
+                log::debug!("Received Event::LoopDestroyed - saving app state…");
                 winit_app.save_and_destroy();
                 *control_flow = ControlFlow::Exit;
                 return;
@@ -161,7 +161,7 @@ fn run_and_return(
             event => match winit_app.on_event(event_loop, event) {
                 Ok(event_result) => event_result,
                 Err(err) => {
-                    tracing::error!("Exiting because of error: {err:?} on event {event:?}");
+                    log::error!("Exiting because of error: {err:?} on event {event:?}");
                     returned_result = Err(err);
                     EventResult::Exit
                 }
@@ -171,7 +171,7 @@ fn run_and_return(
         match event_result {
             EventResult::Wait => {}
             EventResult::RepaintNow => {
-                tracing::trace!("Repaint caused by winit::Event: {:?}", event);
+                log::trace!("Repaint caused by winit::Event: {:?}", event);
                 if cfg!(windows) {
                     // Fix flickering on Windows, see https://github.com/emilk/egui/pull/2280
                     next_repaint_time = Instant::now() + Duration::from_secs(1_000_000_000);
@@ -182,14 +182,14 @@ fn run_and_return(
                 }
             }
             EventResult::RepaintNext => {
-                tracing::trace!("Repaint caused by winit::Event: {:?}", event);
+                log::trace!("Repaint caused by winit::Event: {:?}", event);
                 next_repaint_time = Instant::now();
             }
             EventResult::RepaintAt(repaint_time) => {
                 next_repaint_time = next_repaint_time.min(repaint_time);
             }
             EventResult::Exit => {
-                tracing::debug!("Asking to exit event loop…");
+                log::debug!("Asking to exit event loop…");
                 winit_app.save_and_destroy();
                 *control_flow = ControlFlow::Exit;
                 return;
@@ -210,7 +210,7 @@ fn run_and_return(
         }
     });
 
-    tracing::debug!("eframe window closed");
+    log::debug!("eframe window closed");
 
     drop(winit_app);
 
@@ -224,14 +224,14 @@ fn run_and_return(
 }
 
 fn run_and_exit(event_loop: EventLoop<UserEvent>, mut winit_app: impl WinitApp + 'static) -> ! {
-    tracing::debug!("Entering the winit event loop (run)…");
+    log::debug!("Entering the winit event loop (run)…");
 
     let mut next_repaint_time = Instant::now();
 
     event_loop.run(move |event, event_loop, control_flow| {
         let event_result = match event {
             winit::event::Event::LoopDestroyed => {
-                tracing::debug!("Received Event::LoopDestroyed");
+                log::debug!("Received Event::LoopDestroyed");
                 EventResult::Exit
             }
 
@@ -279,7 +279,7 @@ fn run_and_exit(event_loop: EventLoop<UserEvent>, mut winit_app: impl WinitApp +
                 next_repaint_time = next_repaint_time.min(repaint_time);
             }
             EventResult::Exit => {
-                tracing::debug!("Quitting - saving app state…");
+                log::debug!("Quitting - saving app state…");
                 winit_app.save_and_destroy();
                 #[allow(clippy::exit)]
                 std::process::exit(0);
@@ -410,7 +410,7 @@ mod glow_integration {
                 config_template_builder
             };
 
-            tracing::debug!(
+            log::debug!(
                 "trying to create glutin Display with config: {:?}",
                 &config_template_builder
             );
@@ -426,7 +426,7 @@ mod glow_integration {
                         let config = config_iterator.next().expect(
                             "failed to find a matching configuration for creating glutin config",
                         );
-                        tracing::debug!(
+                        log::debug!(
                             "using the first config from config picker closure. config: {:?}",
                             &config
                         );
@@ -436,13 +436,13 @@ mod glow_integration {
                 .map_err(|e| crate::Error::NoGlutinConfigs(config_template_builder.build(), e))?;
 
             let gl_display = gl_config.display();
-            tracing::debug!(
+            log::debug!(
                 "successfully created GL Display with version: {} and supported features: {:?}",
                 gl_display.version_string(),
                 gl_display.supported_features()
             );
             let raw_window_handle = window.as_ref().map(|w| w.raw_window_handle());
-            tracing::debug!(
+            log::debug!(
                 "creating gl context using raw window handle: {:?}",
                 raw_window_handle
             );
@@ -459,8 +459,8 @@ mod glow_integration {
             {
                 Ok(it) => it,
                 Err(err) => {
-                    tracing::warn!("failed to create context using default context attributes {context_attributes:?} due to error: {err}");
-                    tracing::debug!("retrying with fallback context attributes: {fallback_context_attributes:?}");
+                    log::warn!("failed to create context using default context attributes {context_attributes:?} due to error: {err}");
+                    log::debug!("retrying with fallback context attributes: {fallback_context_attributes:?}");
                     gl_config
                         .display()
                         .create_context(&gl_config, &fallback_context_attributes)?
@@ -494,15 +494,13 @@ mod glow_integration {
         #[allow(unsafe_code)]
         fn on_resume(&mut self, event_loop: &EventLoopWindowTarget<UserEvent>) -> Result<()> {
             if self.gl_surface.is_some() {
-                tracing::warn!(
-                    "on_resume called even thought we already have a surface. early return"
-                );
+                log::warn!("on_resume called even thought we already have a surface. early return");
                 return Ok(());
             }
-            tracing::debug!("running on_resume fn.");
+            log::debug!("running on_resume fn.");
             // make sure we have a window or create one.
             let window = self.window.take().unwrap_or_else(|| {
-                tracing::debug!("window doesn't exist yet. creating one now with finalize_window");
+                log::debug!("window doesn't exist yet. creating one now with finalize_window");
                 glutin_winit::finalize_window(event_loop, self.builder.clone(), &self.gl_config)
                     .expect("failed to finalize glutin window")
             });
@@ -513,7 +511,7 @@ mod glow_integration {
             let surface_attributes =
                 glutin::surface::SurfaceAttributesBuilder::<glutin::surface::WindowSurface>::new()
                     .build(window.raw_window_handle(), width, height);
-            tracing::debug!(
+            log::debug!(
                 "creating surface with attributes: {:?}",
                 &surface_attributes
             );
@@ -523,7 +521,7 @@ mod glow_integration {
                     .display()
                     .create_window_surface(&self.gl_config, &surface_attributes)?
             };
-            tracing::debug!("surface created successfully: {gl_surface:?}.making context current");
+            log::debug!("surface created successfully: {gl_surface:?}.making context current");
             // make surface and context current.
             let not_current_gl_context = self
                 .not_current_gl_context
@@ -531,9 +529,9 @@ mod glow_integration {
                 .expect("failed to get not current context after resume event. impossible!");
             let current_gl_context = not_current_gl_context.make_current(&gl_surface)?;
             // try setting swap interval. but its not absolutely necessary, so don't panic on failure.
-            tracing::debug!("made context current. setting swap interval for surface");
+            log::debug!("made context current. setting swap interval for surface");
             if let Err(e) = gl_surface.set_swap_interval(&current_gl_context, self.swap_interval) {
-                tracing::error!("failed to set swap interval due to error: {e:?}");
+                log::error!("failed to set swap interval due to error: {e:?}");
             }
             // we will reach this point only once in most platforms except android.
             // create window/surface/make context current once and just use them forever.
@@ -545,16 +543,14 @@ mod glow_integration {
 
         /// only applies for android. but we basically drop surface + window and make context not current
         fn on_suspend(&mut self) -> Result<()> {
-            tracing::debug!("received suspend event. dropping window and surface");
+            log::debug!("received suspend event. dropping window and surface");
             self.gl_surface.take();
             self.window.take();
             if let Some(current) = self.current_gl_context.take() {
-                tracing::debug!("context is current, so making it non-current");
+                log::debug!("context is current, so making it non-current");
                 self.not_current_gl_context = Some(current.make_not_current()?);
             } else {
-                tracing::debug!(
-                    "context is already not current??? could be duplicate suspend event"
-                );
+                log::debug!("context is already not current??? could be duplicate suspend event");
             }
             Ok(())
         }
@@ -952,7 +948,7 @@ mod glow_integration {
                             winit::event::WindowEvent::CloseRequested
                                 if running.integration.should_close() =>
                             {
-                                tracing::debug!("Received WindowEvent::CloseRequested");
+                                log::debug!("Received WindowEvent::CloseRequested");
                                 return Ok(EventResult::Exit);
                             }
                             _ => {}
@@ -1375,7 +1371,7 @@ mod wgpu_integration {
                             winit::event::WindowEvent::CloseRequested
                                 if running.integration.should_close() =>
                             {
-                                tracing::debug!("Received WindowEvent::CloseRequested");
+                                log::debug!("Received WindowEvent::CloseRequested");
                                 return Ok(EventResult::Exit);
                             }
                             _ => {}

--- a/crates/eframe/src/web/backend.rs
+++ b/crates/eframe/src/web/backend.rs
@@ -187,7 +187,7 @@ pub struct AppRunner {
 
 impl Drop for AppRunner {
     fn drop(&mut self) {
-        tracing::debug!("AppRunner has fully dropped");
+        log::debug!("AppRunner has fully dropped");
     }
 }
 
@@ -334,10 +334,10 @@ impl AppRunner {
         let is_destroyed_already = self.is_destroyed.fetch();
 
         if is_destroyed_already {
-            tracing::warn!("App was destroyed already");
+            log::warn!("App was destroyed already");
             Ok(())
         } else {
-            tracing::debug!("Destroying");
+            log::debug!("Destroying");
             for x in self.events_to_unsubscribe.drain(..) {
                 x.unsubscribe()?;
             }
@@ -534,7 +534,7 @@ pub async fn start(
     app_creator: epi::AppCreator,
 ) -> Result<AppRunnerRef, JsValue> {
     #[cfg(not(web_sys_unstable_apis))]
-    tracing::warn!(
+    log::warn!(
         "eframe compiled without RUSTFLAGS='--cfg=web_sys_unstable_apis'. Copying text won't work."
     );
     let follow_system_theme = web_options.follow_system_theme;
@@ -570,7 +570,7 @@ fn start_runner(app_runner: AppRunner, follow_system_theme: bool) -> Result<AppR
     runner_container.runner.lock().events_to_unsubscribe = runner_container.events;
 
     std::panic::set_hook(Box::new(move |panic_info| {
-        tracing::info!("egui disabled all event handlers due to panic");
+        log::info!("egui disabled all event handlers due to panic");
         runner_container.panicked.store(true, SeqCst);
 
         // Propagate panic info to the previously registered panic hook

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -63,7 +63,7 @@ pub fn install_document_events(runner_container: &mut AppRunnerContainer) -> Res
                     let has_focus = event_name == "focus";
                     runner_lock.input.on_web_page_focus_change(has_focus);
                     runner_lock.egui_ctx().request_repaint();
-                    // tracing::debug!("{event_name:?}");
+                    // log::debug!("{event_name:?}");
                 };
 
             runner_container.add_event_listener(&document, event_name, closure)?;
@@ -131,7 +131,7 @@ pub fn install_document_events(runner_container: &mut AppRunnerContainer) -> Res
                 false
             };
 
-            // tracing::debug!(
+            // log::debug!(
             //     "On key-down {:?}, egui_wants_keyboard: {}, prevent_default: {}",
             //     event.key().as_str(),
             //     egui_wants_keyboard,
@@ -269,7 +269,7 @@ pub fn install_canvas_events(runner_container: &mut AppRunnerContainer) -> Resul
                       mut _runner_lock: egui::mutex::MutexGuard<'_, AppRunner>| {
                     event.prevent_default();
                     // event.stop_propagation();
-                    // tracing::debug!("Preventing event {event_name:?}");
+                    // log::debug!("Preventing event {event_name:?}");
                 };
 
             runner_container.add_event_listener(&canvas, event_name, closure)?;
@@ -551,7 +551,7 @@ pub fn install_canvas_events(runner_container: &mut AppRunnerContainer) -> Resul
                             let last_modified = std::time::UNIX_EPOCH
                                 + std::time::Duration::from_millis(file.last_modified() as u64);
 
-                            tracing::debug!("Loading {:?} ({} bytes)…", name, file.size());
+                            log::debug!("Loading {:?} ({} bytes)…", name, file.size());
 
                             let future = wasm_bindgen_futures::JsFuture::from(file.array_buffer());
 
@@ -560,11 +560,7 @@ pub fn install_canvas_events(runner_container: &mut AppRunnerContainer) -> Resul
                                 match future.await {
                                     Ok(array_buffer) => {
                                         let bytes = js_sys::Uint8Array::new(&array_buffer).to_vec();
-                                        tracing::debug!(
-                                            "Loaded {:?} ({} bytes).",
-                                            name,
-                                            bytes.len()
-                                        );
+                                        log::debug!("Loaded {:?} ({} bytes).", name, bytes.len());
 
                                         // Re-lock the mutex on the other side of the await point
                                         let mut runner_lock = runner_ref.lock();
@@ -579,7 +575,7 @@ pub fn install_canvas_events(runner_container: &mut AppRunnerContainer) -> Resul
                                         runner_lock.needs_repaint.repaint_asap();
                                     }
                                     Err(err) => {
-                                        tracing::error!("Failed to read file: {:?}", err);
+                                        log::error!("Failed to read file: {:?}", err);
                                     }
                                 }
                             };

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -135,7 +135,7 @@ pub fn resize_canvas_to_screen_size(canvas_id: &str, max_size_points: egui::Vec2
     };
 
     if width <= 0 || height <= 0 {
-        tracing::error!("egui canvas parent size is {}x{}. Try adding `html, body {{ height: 100%; width: 100% }}` to your CSS!", width, height);
+        log::error!("egui canvas parent size is {}x{}. Try adding `html, body {{ height: 100%; width: 100% }}` to your CSS!", width, height);
     }
 
     let pixels_per_point = native_pixels_per_point();
@@ -192,7 +192,7 @@ pub fn set_clipboard_text(s: &str) {
             let future = wasm_bindgen_futures::JsFuture::from(promise);
             let future = async move {
                 if let Err(err) = future.await {
-                    tracing::error!("Copy/cut action denied: {:?}", err);
+                    log::error!("Copy/cut action denied: {:?}", err);
                 }
             };
             wasm_bindgen_futures::spawn_local(future);

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -8,6 +8,9 @@ mod input;
 pub mod screen_reader;
 pub mod storage;
 mod text_agent;
+mod web_logger;
+
+pub use web_logger::WebLogger;
 
 #[cfg(not(any(feature = "glow", feature = "wgpu")))]
 compile_error!("You must enable either the 'glow' or 'wgpu' feature");

--- a/crates/eframe/src/web/screen_reader.rs
+++ b/crates/eframe/src/web/screen_reader.rs
@@ -16,11 +16,11 @@ impl Default for ScreenReader {
     fn default() -> Self {
         let tts = match tts::Tts::default() {
             Ok(screen_reader) => {
-                tracing::debug!("Initialized screen reader.");
+                log::debug!("Initialized screen reader.");
                 Some(screen_reader)
             }
             Err(err) => {
-                tracing::warn!("Failed to load screen reader: {}", err);
+                log::warn!("Failed to load screen reader: {}", err);
                 None
             }
         };
@@ -39,10 +39,10 @@ impl ScreenReader {
             return;
         }
         if let Some(tts) = &mut self.tts {
-            tracing::debug!("Speaking: {:?}", text);
+            log::debug!("Speaking: {:?}", text);
             let interrupt = true;
             if let Err(err) = tts.speak(text, interrupt) {
-                tracing::warn!("Failed to read: {}", err);
+                log::warn!("Failed to read: {}", err);
             }
         }
     }

--- a/crates/eframe/src/web/storage.rs
+++ b/crates/eframe/src/web/storage.rs
@@ -18,7 +18,7 @@ pub fn load_memory(ctx: &egui::Context) {
                 ctx.memory_mut(|m| *m = memory);
             }
             Err(err) => {
-                tracing::error!("Failed to parse memory RON: {}", err);
+                log::error!("Failed to parse memory RON: {}", err);
             }
         }
     }
@@ -34,7 +34,7 @@ pub fn save_memory(ctx: &egui::Context) {
             local_storage_set("egui_memory_ron", &ron);
         }
         Err(err) => {
-            tracing::error!("Failed to serialize memory as RON: {}", err);
+            log::error!("Failed to serialize memory as RON: {}", err);
         }
     }
 }

--- a/crates/eframe/src/web/web_logger.rs
+++ b/crates/eframe/src/web/web_logger.rs
@@ -1,0 +1,110 @@
+/// Implements [`log::Log`] to log messages to `console.log`, `console.warn`, etc.
+pub struct WebLogger {
+    filter: log::LevelFilter,
+}
+
+impl WebLogger {
+    /// Pipe all [`log`] events to the web console.
+    pub fn init(filter: log::LevelFilter) -> Result<(), log::SetLoggerError> {
+        log::set_max_level(filter);
+        log::set_boxed_logger(Box::new(WebLogger::new(filter)))
+    }
+
+    pub fn new(filter: log::LevelFilter) -> Self {
+        Self { filter }
+    }
+}
+
+impl log::Log for WebLogger {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        metadata.level() <= self.filter
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let msg = if let (Some(file), Some(line)) = (record.file(), record.line()) {
+            let file = shorten_file_path(file);
+            format!("[{}] {file}:{line}: {}", record.target(), record.args())
+        } else {
+            format!("[{}] {}", record.target(), record.args())
+        };
+
+        match record.level() {
+            log::Level::Trace => console::trace(&msg),
+            log::Level::Debug => console::debug(&msg),
+            log::Level::Info => console::info(&msg),
+            log::Level::Warn => console::warn(&msg),
+            log::Level::Error => console::error(&msg),
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+/// js-bindings for console.log, console.warn, etc
+mod console {
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen]
+    extern "C" {
+        /// `console.trace`
+        #[wasm_bindgen(js_namespace = console)]
+        pub fn trace(s: &str);
+
+        /// `console.debug`
+        #[wasm_bindgen(js_namespace = console)]
+        pub fn debug(s: &str);
+
+        /// `console.info`
+        #[wasm_bindgen(js_namespace = console)]
+        pub fn info(s: &str);
+
+        /// `console.warn`
+        #[wasm_bindgen(js_namespace = console)]
+        pub fn warn(s: &str);
+
+        /// `console.error`
+        #[wasm_bindgen(js_namespace = console)]
+        pub fn error(s: &str);
+    }
+}
+
+/// Shorten a path to a Rust source file.
+///
+/// Example input:
+/// * `/Users/emilk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.1/src/runtime/runtime.rs`
+/// * `crates/rerun/src/main.rs`
+/// * `/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/ops/function.rs`
+///
+/// Example output:
+/// * `tokio-1.24.1/src/runtime/runtime.rs`
+/// * `rerun/src/main.rs`
+/// * `core/src/ops/function.rs`
+#[allow(dead_code)] // only used on web and in tests
+fn shorten_file_path(file_path: &str) -> &str {
+    if let Some(i) = file_path.rfind("/src/") {
+        if let Some(prev_slash) = file_path[..i].rfind('/') {
+            &file_path[prev_slash + 1..]
+        } else {
+            file_path
+        }
+    } else {
+        file_path
+    }
+}
+
+#[test]
+fn test_shorten_file_path() {
+    for (before, after) in [
+        ("/Users/emilk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.1/src/runtime/runtime.rs", "tokio-1.24.1/src/runtime/runtime.rs"),
+        ("crates/rerun/src/main.rs", "rerun/src/main.rs"),
+        ("/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/ops/function.rs", "core/src/ops/function.rs"),
+        ("/weird/path/file.rs", "/weird/path/file.rs"),
+        ]
+    {
+        assert_eq!(shorten_file_path(before), after);
+    }
+}

--- a/crates/eframe/src/web/web_painter_glow.rs
+++ b/crates/eframe/src/web/web_painter_glow.rs
@@ -106,14 +106,14 @@ fn init_webgl1(canvas: &HtmlCanvasElement) -> Option<(glow::Context, &'static st
         .expect("Failed to query about WebGL2 context");
 
     let gl1_ctx = gl1_ctx?;
-    tracing::debug!("WebGL1 selected.");
+    log::debug!("WebGL1 selected.");
 
     let gl1_ctx = gl1_ctx
         .dyn_into::<web_sys::WebGlRenderingContext>()
         .unwrap();
 
     let shader_prefix = if webgl1_requires_brightening(&gl1_ctx) {
-        tracing::debug!("Enabling webkitGTK brightening workaround.");
+        log::debug!("Enabling webkitGTK brightening workaround.");
         "#define APPLY_BRIGHTENING_GAMMA"
     } else {
         ""
@@ -130,7 +130,7 @@ fn init_webgl2(canvas: &HtmlCanvasElement) -> Option<(glow::Context, &'static st
         .expect("Failed to query about WebGL2 context");
 
     let gl2_ctx = gl2_ctx?;
-    tracing::debug!("WebGL2 selected.");
+    log::debug!("WebGL2 selected.");
 
     let gl2_ctx = gl2_ctx
         .dyn_into::<web_sys::WebGl2RenderingContext>()

--- a/crates/eframe/src/web/web_painter_wgpu.rs
+++ b/crates/eframe/src/web/web_painter_wgpu.rs
@@ -57,7 +57,7 @@ impl WebPainterWgpu {
 
     #[allow(unused)] // only used if `wgpu` is the only active feature.
     pub async fn new(canvas_id: &str, options: &WebOptions) -> Result<Self, String> {
-        tracing::debug!("Creating wgpu painter");
+        log::debug!("Creating wgpu painter");
 
         let canvas = super::canvas_element_or_die(canvas_id);
 
@@ -108,7 +108,7 @@ impl WebPainterWgpu {
             view_formats: vec![target_format],
         };
 
-        tracing::debug!("wgpu painter initialized.");
+        log::debug!("wgpu painter initialized.");
 
         Ok(Self {
             canvas,

--- a/crates/egui-wgpu/Cargo.toml
+++ b/crates/egui-wgpu/Cargo.toml
@@ -41,7 +41,7 @@ epaint = { version = "0.21.0", path = "../epaint", default-features = false, fea
 ] }
 
 bytemuck = "1.7"
-tracing = { version = "0.1", default-features = false, features = ["std"] }
+log = { version = "0.4", features = ["std"] }
 type-map = "0.5.0"
 wgpu = "0.15.0"
 

--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -79,7 +79,7 @@ impl Default for WgpuConfiguration {
                     // Silently return here to prevent spamming the console with:
                     // "The underlying surface has changed, and therefore the swap chain must be updated"
                 } else {
-                    tracing::warn!("Dropped frame with error: {err}");
+                    log::warn!("Dropped frame with error: {err}");
                 }
                 SurfaceErrorAction::SkipFrame
             }),

--- a/crates/egui-wgpu/src/renderer.rs
+++ b/crates/egui-wgpu/src/renderer.rs
@@ -296,7 +296,7 @@ impl Renderer {
             fragment: Some(wgpu::FragmentState {
                 module: &module,
                 entry_point: if output_color_format.describe().srgb {
-                    tracing::warn!("Detected a linear (sRGBA aware) framebuffer {:?}. egui prefers Rgba8Unorm or Bgra8Unorm", output_color_format);
+                    log::warn!("Detected a linear (sRGBA aware) framebuffer {:?}. egui prefers Rgba8Unorm or Bgra8Unorm", output_color_format);
                     "fs_main_linear_framebuffer"
                 } else {
                     "fs_main_gamma_framebuffer" // this is what we prefer
@@ -428,7 +428,7 @@ impl Renderer {
                         );
                         render_pass.draw_indexed(0..mesh.indices.len() as u32, 0, 0..1);
                     } else {
-                        tracing::warn!("Missing texture: {:?}", mesh.texture_id);
+                        log::warn!("Missing texture: {:?}", mesh.texture_id);
                     }
                 }
                 Primitive::Callback(callback) => {
@@ -871,9 +871,7 @@ impl Renderer {
                         let cbfn = if let Some(c) = callback.callback.downcast_ref::<CallbackFn>() {
                             c
                         } else {
-                            tracing::warn!(
-                                "Unknown paint callback: expected `egui_wgpu::CallbackFn`"
-                            );
+                            log::warn!("Unknown paint callback: expected `egui_wgpu::CallbackFn`");
                             continue;
                         };
 

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -2,8 +2,6 @@ use std::sync::Arc;
 
 use epaint::{self, mutex::RwLock};
 
-use tracing::error;
-
 use crate::{renderer, RenderState, Renderer, SurfaceErrorAction, WgpuConfiguration};
 
 struct SurfaceState {
@@ -260,7 +258,7 @@ impl Painter {
                     {
                         wgpu::CompositeAlphaMode::PostMultiplied
                     } else {
-                        tracing::warn!("Transparent window was requested, but the active wgpu surface does not support a `CompositeAlphaMode` with transparency.");
+                        log::warn!("Transparent window was requested, but the active wgpu surface does not support a `CompositeAlphaMode` with transparency.");
                         wgpu::CompositeAlphaMode::Auto
                     }
                 } else {
@@ -360,7 +358,7 @@ impl Painter {
                 height_in_pixels,
             );
         } else {
-            error!("Ignoring window resize notification with no surface created via Painter::set_window()");
+            log::error!("Ignoring window resize notification with no surface created via Painter::set_window()");
         }
     }
 
@@ -435,7 +433,7 @@ impl Painter {
             wgpu::TextureFormat::Rgba8Unorm => [0, 1, 2, 3],
             wgpu::TextureFormat::Bgra8Unorm => [2, 1, 0, 3],
             _ => {
-                tracing::error!("Screen can't be captured unless the surface format is Rgba8Unorm or Bgra8Unorm. Current surface format is {:?}", tex.format());
+                log::error!("Screen can't be captured unless the surface format is Rgba8Unorm or Bgra8Unorm. Current surface format is {:?}", tex.format());
                 return None;
             }
         };

--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -48,15 +48,15 @@ wayland = ["winit/wayland"]
 # - It's also important that we don't impose an android-activity backend by taking this choice away from applications.
 
 ## Enable the `native-activity` backend via Winit on Android
-android-native-activity = [ "winit/android-native-activity" ]
+android-native-activity = ["winit/android-native-activity"]
 ## Enable the `game-activity` backend via Winit on Android
-android-game-activity = [ "winit/android-game-activity" ]
+android-game-activity = ["winit/android-game-activity"]
 
 [dependencies]
 egui = { version = "0.21.0", path = "../egui", default-features = false, features = [
-  "tracing",
+  "log",
 ] }
-tracing = { version = "0.1", default-features = false, features = ["std"] }
+log = { version = "0.4", features = ["std"] }
 winit = { version = "0.28", default-features = false }
 
 #! ### Optional dependencies
@@ -85,4 +85,3 @@ smithay-clipboard = { version = "0.6.3", optional = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 arboard = { version = "3.2", optional = true, default-features = false }
-

--- a/crates/egui-winit/src/clipboard.rs
+++ b/crates/egui-winit/src/clipboard.rs
@@ -66,7 +66,7 @@ impl Clipboard {
             return match clipboard.load() {
                 Ok(text) => Some(text),
                 Err(err) => {
-                    tracing::error!("smithay paste error: {err}");
+                    log::error!("smithay paste error: {err}");
                     None
                 }
             };
@@ -77,7 +77,7 @@ impl Clipboard {
             return match clipboard.get_text() {
                 Ok(text) => Some(text),
                 Err(err) => {
-                    tracing::error!("arboard paste error: {err}");
+                    log::error!("arboard paste error: {err}");
                     None
                 }
             };
@@ -105,7 +105,7 @@ impl Clipboard {
         #[cfg(all(feature = "arboard", not(target_os = "android")))]
         if let Some(clipboard) = &mut self.arboard {
             if let Err(err) = clipboard.set_text(text) {
-                tracing::error!("arboard copy/cut error: {err}");
+                log::error!("arboard copy/cut error: {err}");
             }
             return;
         }
@@ -116,11 +116,11 @@ impl Clipboard {
 
 #[cfg(all(feature = "arboard", not(target_os = "android")))]
 fn init_arboard() -> Option<arboard::Clipboard> {
-    tracing::debug!("Initializing arboard clipboard…");
+    log::debug!("Initializing arboard clipboard…");
     match arboard::Clipboard::new() {
         Ok(clipboard) => Some(clipboard),
         Err(err) => {
-            tracing::warn!("Failed to initialize arboard clipboard: {err}");
+            log::warn!("Failed to initialize arboard clipboard: {err}");
             None
         }
     }
@@ -144,18 +144,18 @@ fn init_smithay_clipboard<T>(
     {
         use winit::platform::wayland::EventLoopWindowTargetExtWayland as _;
         if let Some(display) = _event_loop.wayland_display() {
-            tracing::debug!("Initializing smithay clipboard…");
+            log::debug!("Initializing smithay clipboard…");
             #[allow(unsafe_code)]
             Some(unsafe { smithay_clipboard::Clipboard::new(display) })
         } else {
-            tracing::debug!("Cannot initialize smithay clipboard without a display handle");
+            log::debug!("Cannot initialize smithay clipboard without a display handle");
             None
         }
     }
 
     #[cfg(not(feature = "wayland"))]
     {
-        tracing::debug!(
+        log::debug!(
             "You need to enable the 'wayland' feature of 'egui-winit' to get a working clipboard"
         );
         None

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -700,12 +700,12 @@ impl State {
 fn open_url_in_browser(_url: &str) {
     #[cfg(feature = "webbrowser")]
     if let Err(err) = webbrowser::open(_url) {
-        tracing::warn!("Failed to open url: {}", err);
+        log::warn!("Failed to open url: {}", err);
     }
 
     #[cfg(not(feature = "webbrowser"))]
     {
-        tracing::warn!("Cannot open url - feature \"links\" not enabled.");
+        log::warn!("Cannot open url - feature \"links\" not enabled.");
     }
 }
 

--- a/crates/egui/Cargo.toml
+++ b/crates/egui/Cargo.toml
@@ -45,6 +45,9 @@ extra_debug_asserts = ["epaint/extra_debug_asserts"]
 ## Always enable additional checks.
 extra_asserts = ["epaint/extra_asserts"]
 
+## Turn on the `log` feature, that makes egui log some errors using the [`log`](https://docs.rs/log) crate.
+log = ["dep:log", "epaint/log"]
+
 ## [`mint`](https://docs.rs/mint) enables interoperability with other math libraries such as [`glam`](https://docs.rs/glam) and [`nalgebra`](https://docs.rs/nalgebra).
 mint = ["epaint/mint"]
 
@@ -75,10 +78,6 @@ accesskit = { version = "0.10.1", optional = true }
 ## Enable this when generating docs.
 document-features = { version = "0.2", optional = true }
 
+log = { version = "0.4", optional = true, features = ["std"] }
 ron = { version = "0.8", optional = true }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
-
-# egui doesn't log much, but when it does, it uses [`tracing`](https://docs.rs/tracing).
-tracing = { version = "0.1", optional = true, default-features = false, features = [
-    "std",
-] }

--- a/crates/egui/src/os.rs
+++ b/crates/egui/src/os.rs
@@ -65,8 +65,8 @@ impl OperatingSystem {
         {
             Self::Nix
         } else {
-            #[cfg(feature = "tracing")]
-            tracing::warn!(
+            #[cfg(feature = "log")]
+            log::warn!(
                 "egui: Failed to guess operating system from User-Agent {:?}. Please file an issue at https://github.com/emilk/egui/issues",
                 user_agent);
 

--- a/crates/egui/src/util/id_type_map.rs
+++ b/crates/egui/src/util/id_type_map.rs
@@ -286,8 +286,8 @@ fn from_ron_str<T: serde::de::DeserializeOwned>(ron: &str) -> Option<T> {
     match ron::from_str::<T>(ron) {
         Ok(value) => Some(value),
         Err(_err) => {
-            #[cfg(feature = "tracing")]
-            tracing::warn!(
+            #[cfg(feature = "log")]
+            log::warn!(
                 "egui: Failed to deserialize {} from memory: {}, ron error: {:?}",
                 std::any::type_name::<T>(),
                 _err,

--- a/crates/egui_demo_app/Cargo.toml
+++ b/crates/egui_demo_app/Cargo.toml
@@ -37,7 +37,7 @@ egui = { version = "0.21.0", path = "../egui", features = [
 egui_demo_lib = { version = "0.21.0", path = "../egui_demo_lib", features = [
   "chrono",
 ] }
-tracing = "0.1"
+log = { version = "0.4", features = ["std"] }
 
 # Optional dependencies:
 
@@ -58,10 +58,9 @@ serde = { version = "1", optional = true, features = ["derive"] }
 
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tracing-subscriber = "0.3"
+env_logger = "0.10"
 
 # web:
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.6"
-tracing-wasm = "0.2"
 wasm-bindgen-futures = "0.4"

--- a/crates/egui_demo_app/src/apps/custom3d_glow.rs
+++ b/crates/egui_demo_app/src/apps/custom3d_glow.rs
@@ -89,7 +89,7 @@ impl RotatingTriangle {
             let program = gl.create_program().expect("Cannot create program");
 
             if !shader_version.is_new_shader_interface() {
-                tracing::warn!(
+                log::warn!(
                     "Custom 3D painting hasn't been ported to {:?}",
                     shader_version
                 );

--- a/crates/egui_demo_app/src/lib.rs
+++ b/crates/egui_demo_app/src/lib.rs
@@ -52,7 +52,7 @@ pub fn init_wasm_hooks() {
     console_error_panic_hook::set_once();
 
     // Redirect tracing to console.log and friends:
-    tracing_wasm::set_as_global_default();
+    eframe::web::WebLogger::init(log::LevelFilter::Debug).ok();
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/egui_demo_app/src/main.rs
+++ b/crates/egui_demo_app/src/main.rs
@@ -15,8 +15,8 @@ fn main() -> Result<(), eframe::Error> {
         std::env::set_var("RUST_LOG", rust_log);
     }
 
-    // Log to stdout (if you run with `RUST_LOG=debug`).
-    tracing_subscriber::fmt::init();
+    // Log to stderr (if you run with `RUST_LOG=debug`).
+    env_logger::init();
 
     let options = eframe::NativeOptions {
         drag_and_drop_support: true,

--- a/crates/egui_demo_lib/Cargo.toml
+++ b/crates/egui_demo_lib/Cargo.toml
@@ -33,7 +33,7 @@ syntax_highlighting = ["syntect"]
 egui = { version = "0.21.0", path = "../egui", default-features = false }
 egui_extras = { version = "0.21.0", path = "../egui_extras" }
 enum-map = { version = "2", features = ["serde"] }
-tracing = { version = "0.1", default-features = false, features = ["std"] }
+log = { version = "0.4", features = ["std"] }
 unicode_names2 = { version = "0.6.0", default-features = false }
 
 #! ### Optional dependencies

--- a/crates/egui_extras/Cargo.toml
+++ b/crates/egui_extras/Cargo.toml
@@ -32,8 +32,8 @@ datepicker = ["chrono"]
 ## Support loading svg images.
 svg = ["resvg", "tiny-skia", "usvg"]
 
-## Log warnings using `tracing` crate.
-tracing = ["dep:tracing", "egui/tracing"]
+## Log warnings using [`log`](https://docs.rs/log) crate.
+log = ["dep:log", "egui/log"]
 
 
 [dependencies]
@@ -57,12 +57,10 @@ document-features = { version = "0.2", optional = true }
 ## ```
 image = { version = "0.24", optional = true, default-features = false }
 
+# feature "log"
+log = { version = "0.4", optional = true, features = ["std"] }
+
 # svg feature
 resvg = { version = "0.28", optional = true, default-features = false }
 tiny-skia = { version = "0.8", optional = true, default-features = false } # must be updated in lock-step with resvg
 usvg = { version = "0.28", optional = true, default-features = false }
-
-# feature "tracing"
-tracing = { version = "0.1", optional = true, default-features = false, features = [
-  "std",
-] }

--- a/crates/egui_extras/src/lib.rs
+++ b/crates/egui_extras/src/lib.rs
@@ -28,13 +28,13 @@ pub use crate::sizing::Size;
 pub use crate::strip::*;
 pub use crate::table::*;
 
-/// Log an error with either `tracing` or `eprintln`
+/// Log an error with either `log` or `eprintln`
 macro_rules! log_err {
     ($fmt: literal, $($arg: tt)*) => {{
-        #[cfg(feature = "tracing")]
-        tracing::error!($fmt, $($arg)*);
+        #[cfg(feature = "log")]
+        log::error!($fmt, $($arg)*);
 
-        #[cfg(not(feature = "tracing"))]
+        #[cfg(not(feature = "log"))]
         eprintln!(
             concat!("egui_extras: ", $fmt), $($arg)*
         );

--- a/crates/egui_glow/Cargo.toml
+++ b/crates/egui_glow/Cargo.toml
@@ -50,8 +50,8 @@ egui = { version = "0.21.0", path = "../egui", default-features = false, feature
 
 bytemuck = "1.7"
 glow = "0.12"
+log = { version = "0.4", features = ["std"] }
 memoffset = "0.6"
-tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 #! ### Optional dependencies
 ## Enable this when generating docs.

--- a/crates/egui_glow/examples/pure_glow.rs
+++ b/crates/egui_glow/examples/pure_glow.rs
@@ -39,7 +39,7 @@ impl GlutinWindowContext {
             .with_stencil_size(0)
             .with_transparency(false);
 
-        tracing::debug!("trying to get gl_config");
+        log::debug!("trying to get gl_config");
         let (mut window, gl_config) =
             glutin_winit::DisplayBuilder::new() // let glutin-winit helper crate handle the complex parts of opengl context creation
                 .with_preference(glutin_winit::ApiPrefence::FallbackEgl) // https://github.com/emilk/egui/issues/2520#issuecomment-1367841150
@@ -55,10 +55,10 @@ impl GlutinWindowContext {
                 )
                 .expect("failed to create gl_config");
         let gl_display = gl_config.display();
-        tracing::debug!("found gl_config: {:?}", &gl_config);
+        log::debug!("found gl_config: {:?}", &gl_config);
 
         let raw_window_handle = window.as_ref().map(|w| w.raw_window_handle());
-        tracing::debug!("raw window handle: {:?}", raw_window_handle);
+        log::debug!("raw window handle: {:?}", raw_window_handle);
         let context_attributes =
             glutin::context::ContextAttributesBuilder::new().build(raw_window_handle);
         // by default, glutin will try to create a core opengl context. but, if it is not available, try to create a gl-es context using this fallback attributes
@@ -69,7 +69,7 @@ impl GlutinWindowContext {
             gl_display
                     .create_context(&gl_config, &context_attributes)
                     .unwrap_or_else(|_| {
-                        tracing::debug!("failed to create gl_context with attributes: {:?}. retrying with fallback context attributes: {:?}",
+                        log::debug!("failed to create gl_context with attributes: {:?}. retrying with fallback context attributes: {:?}",
                             &context_attributes,
                             &fallback_context_attributes);
                         gl_config
@@ -81,7 +81,7 @@ impl GlutinWindowContext {
 
         // this is where the window is created, if it has not been created while searching for suitable gl_config
         let window = window.take().unwrap_or_else(|| {
-            tracing::debug!("window doesn't exist yet. creating one now with finalize_window");
+            log::debug!("window doesn't exist yet. creating one now with finalize_window");
             glutin_winit::finalize_window(event_loop, winit_window_builder.clone(), &gl_config)
                 .expect("failed to finalize glutin window")
         });
@@ -91,7 +91,7 @@ impl GlutinWindowContext {
         let surface_attributes =
             glutin::surface::SurfaceAttributesBuilder::<glutin::surface::WindowSurface>::new()
                 .build(window.raw_window_handle(), width, height);
-        tracing::debug!(
+        log::debug!(
             "creating surface with attributes: {:?}",
             &surface_attributes
         );
@@ -100,7 +100,7 @@ impl GlutinWindowContext {
                 .create_window_surface(&gl_config, &surface_attributes)
                 .unwrap()
         };
-        tracing::debug!("surface created successfully: {gl_surface:?}.making context current");
+        log::debug!("surface created successfully: {gl_surface:?}.making context current");
         let gl_context = not_current_gl_context.make_current(&gl_surface).unwrap();
 
         gl_surface

--- a/crates/egui_glow/src/lib.rs
+++ b/crates/egui_glow/src/lib.rs
@@ -25,7 +25,7 @@ pub mod winit;
 #[cfg(all(not(target_arch = "wasm32"), feature = "winit"))]
 pub use winit::*;
 
-/// Check for OpenGL error and report it using `tracing::error`.
+/// Check for OpenGL error and report it using `log::error`.
 ///
 /// Only active in debug builds!
 ///
@@ -49,7 +49,7 @@ macro_rules! check_for_gl_error {
     }};
 }
 
-/// Check for OpenGL error and report it using `tracing::error`.
+/// Check for OpenGL error and report it using `log::error`.
 ///
 /// WARNING: slow! Only use during setup!
 ///
@@ -90,7 +90,7 @@ pub fn check_for_gl_error_impl(gl: &glow::Context, file: &str, line: u32, contex
         };
 
         if context.is_empty() {
-            tracing::error!(
+            log::error!(
                 "GL error, at {}:{}: {} (0x{:X}). Please file a bug at https://github.com/emilk/egui/issues",
                 file,
                 line,
@@ -98,7 +98,7 @@ pub fn check_for_gl_error_impl(gl: &glow::Context, file: &str, line: u32, contex
                 error_code,
             );
         } else {
-            tracing::error!(
+            log::error!(
                 "GL error, at {}:{} ({}): {} (0x{:X}). Please file a bug at https://github.com/emilk/egui/issues",
                 file,
                 line,

--- a/crates/egui_glow/src/painter.rs
+++ b/crates/egui_glow/src/painter.rs
@@ -111,7 +111,7 @@ impl Painter {
             let version = gl.get_parameter_string(glow::VERSION);
             let renderer = gl.get_parameter_string(glow::RENDERER);
             let vendor = gl.get_parameter_string(glow::VENDOR);
-            tracing::debug!(
+            log::debug!(
                 "\nopengl version: {version}\nopengl renderer: {renderer}\nopengl vendor: {vendor}"
             );
         }
@@ -127,16 +127,16 @@ impl Painter {
         let shader_version = shader_version.unwrap_or_else(|| ShaderVersion::get(&gl));
         let is_webgl_1 = shader_version == ShaderVersion::Es100;
         let shader_version_declaration = shader_version.version_declaration();
-        tracing::debug!("Shader header: {:?}.", shader_version_declaration);
+        log::debug!("Shader header: {:?}.", shader_version_declaration);
 
         let supported_extensions = gl.supported_extensions();
-        tracing::trace!("OpenGL extensions: {supported_extensions:?}");
+        log::trace!("OpenGL extensions: {supported_extensions:?}");
         let srgb_textures = shader_version == ShaderVersion::Es300 // WebGL2 always support sRGB
             || supported_extensions.iter().any(|extension| {
                 // EXT_sRGB, GL_ARB_framebuffer_sRGB, GL_EXT_sRGB, GL_EXT_texture_sRGB_decode, …
                 extension.contains("sRGB")
             });
-        tracing::debug!("SRGB texture Support: {:?}", srgb_textures);
+        log::debug!("SRGB texture Support: {:?}", srgb_textures);
 
         unsafe {
             let vert = compile_shader(
@@ -399,7 +399,7 @@ impl Painter {
                         if let Some(callback) = callback.callback.downcast_ref::<CallbackFn>() {
                             (callback.f)(info, self);
                         } else {
-                            tracing::warn!("Warning: Unsupported render callback. Expected egui_glow::CallbackFn");
+                            log::warn!("Warning: Unsupported render callback. Expected egui_glow::CallbackFn");
                         }
 
                         check_for_gl_error!(&self.gl, "callback");
@@ -455,7 +455,7 @@ impl Painter {
 
             check_for_gl_error!(&self.gl, "paint_mesh");
         } else {
-            tracing::warn!("Failed to find texture {:?}", mesh.texture_id);
+            log::warn!("Failed to find texture {:?}", mesh.texture_id);
         }
     }
 
@@ -713,7 +713,7 @@ pub fn clear(gl: &glow::Context, screen_size_in_pixels: [u32; 2], clear_color: [
 impl Drop for Painter {
     fn drop(&mut self) {
         if !self.destroyed {
-            tracing::warn!(
+            log::warn!(
                 "You forgot to call destroy() on the egui glow painter. Resources will leak!"
             );
         }

--- a/crates/egui_glow/src/shader_version.rs
+++ b/crates/egui_glow/src/shader_version.rs
@@ -24,7 +24,7 @@ impl ShaderVersion {
         let shading_lang_string =
             unsafe { gl.get_parameter_string(glow::SHADING_LANGUAGE_VERSION) };
         let shader_version = Self::parse(&shading_lang_string);
-        tracing::debug!(
+        log::debug!(
             "Shader version: {:?} ({:?}).",
             shader_version,
             shading_lang_string

--- a/crates/egui_glow/src/vao.rs
+++ b/crates/egui_glow/src/vao.rs
@@ -59,7 +59,7 @@ impl VertexArrayObject {
 
             Some(vao)
         } else {
-            tracing::debug!("VAO not supported");
+            log::debug!("VAO not supported");
             None
         };
 
@@ -113,7 +113,7 @@ fn supports_vao(gl: &glow::Context) -> bool {
     const OPENGL_ES_PREFIX: &str = "OpenGL ES ";
 
     let version_string = unsafe { gl.get_parameter_string(glow::VERSION) };
-    tracing::debug!("GL version: {:?}.", version_string);
+    log::debug!("GL version: {:?}.", version_string);
 
     // Examples:
     // * "WebGL 2.0 (OpenGL ES 3.0 Chromium)"
@@ -124,7 +124,7 @@ fn supports_vao(gl: &glow::Context) -> bool {
         if version_str.contains("1.0") {
             // need to test OES_vertex_array_object .
             let supported_extensions = gl.supported_extensions();
-            tracing::debug!("Supported OpenGL extensions: {:?}", supported_extensions);
+            log::debug!("Supported OpenGL extensions: {:?}", supported_extensions);
             supported_extensions.contains("OES_vertex_array_object")
                 || supported_extensions.contains("GL_OES_vertex_array_object")
         } else {
@@ -135,7 +135,7 @@ fn supports_vao(gl: &glow::Context) -> bool {
         if version_string.contains("2.0") {
             // need to test OES_vertex_array_object .
             let supported_extensions = gl.supported_extensions();
-            tracing::debug!("Supported OpenGL extensions: {:?}", supported_extensions);
+            log::debug!("Supported OpenGL extensions: {:?}", supported_extensions);
             supported_extensions.contains("OES_vertex_array_object")
                 || supported_extensions.contains("GL_OES_vertex_array_object")
         } else {
@@ -147,7 +147,7 @@ fn supports_vao(gl: &glow::Context) -> bool {
             // I found APPLE_vertex_array_object , GL_ATI_vertex_array_object ,ARB_vertex_array_object
             // but APPLE's and ATI's very old extension.
             let supported_extensions = gl.supported_extensions();
-            tracing::debug!("Supported OpenGL extensions: {:?}", supported_extensions);
+            log::debug!("Supported OpenGL extensions: {:?}", supported_extensions);
             supported_extensions.contains("ARB_vertex_array_object")
                 || supported_extensions.contains("GL_ARB_vertex_array_object")
         } else {

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -22,7 +22,7 @@ impl EguiGlow {
     ) -> Self {
         let painter = crate::Painter::new(gl, "", shader_version)
             .map_err(|error| {
-                tracing::error!("error occurred in initializing painter:\n{}", error);
+                log::error!("error occurred in initializing painter:\n{}", error);
             })
             .unwrap();
 

--- a/crates/epaint/Cargo.toml
+++ b/crates/epaint/Cargo.toml
@@ -57,6 +57,9 @@ extra_debug_asserts = [
 ## Always enable additional checks.
 extra_asserts = ["emath/extra_asserts", "ecolor/extra_asserts"]
 
+## Turn on the `log` feature, that makes egui log some errors using the [`log`](https://docs.rs/log) crate.
+log = ["dep:log"]
+
 ## [`mint`](https://docs.rs/mint) enables interoperability with other math libraries such as [`glam`](https://docs.rs/glam) and [`nalgebra`](https://docs.rs/nalgebra).
 mint = ["emath/mint"]
 
@@ -82,6 +85,8 @@ bytemuck = { version = "1.7.2", optional = true, features = ["derive"] }
 
 ## Enable this when generating docs.
 document-features = { version = "0.2", optional = true }
+
+log = { version = "0.4", optional = true, features = ["std"] }
 
 ## Allow serialization using [`serde`](https://docs.rs/serde) .
 serde = { version = "1", optional = true, features = ["derive", "rc"] }

--- a/crates/epaint/src/texture_atlas.rs
+++ b/crates/epaint/src/texture_atlas.rs
@@ -217,8 +217,8 @@ impl TextureAtlas {
         if required_height > self.max_height() {
             // This is a bad place to be - we need to start reusing space :/
 
-            #[cfg(feature = "tracing")]
-            tracing::wan!("epaint texture atlas overflowed!");
+            #[cfg(feature = "log")]
+            log::warn!("epaint texture atlas overflowed!");
 
             self.cursor = (0, self.image.height() / 3); // Restart a bit down - the top of the atlas has too many important things in it
             self.overflowed = true; // this will signal the user that we need to recreate the texture atlas next frame.

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -12,4 +12,4 @@ publish = false
 eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-tracing-subscriber = "0.3"
+env_logger = "0.10"

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -3,8 +3,8 @@
 use eframe::egui;
 
 fn main() -> Result<(), eframe::Error> {
-    // Log to stdout (if you run with `RUST_LOG=debug`).
-    tracing_subscriber::fmt::init();
+    // Log to stderr (if you run with `RUST_LOG=debug`).
+    env_logger::init();
 
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(320.0, 240.0)),

--- a/examples/hello_world_simple/Cargo.toml
+++ b/examples/hello_world_simple/Cargo.toml
@@ -12,4 +12,4 @@ publish = false
 eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-tracing-subscriber = "0.3"
+env_logger = "0.10"

--- a/examples/hello_world_simple/src/main.rs
+++ b/examples/hello_world_simple/src/main.rs
@@ -3,8 +3,8 @@
 use eframe::egui;
 
 fn main() -> Result<(), eframe::Error> {
-    // Log to stdout (if you run with `RUST_LOG=debug`).
-    tracing_subscriber::fmt::init();
+    // Log to stderr (if you run with `RUST_LOG=debug`).
+    env_logger::init();
 
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(320.0, 240.0)),

--- a/examples/keyboard_events/Cargo.toml
+++ b/examples/keyboard_events/Cargo.toml
@@ -12,4 +12,4 @@ publish = false
 eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-tracing-subscriber = "0.3"
+env_logger = "0.10"

--- a/examples/keyboard_events/src/main.rs
+++ b/examples/keyboard_events/src/main.rs
@@ -4,8 +4,8 @@ use eframe::egui;
 use egui::*;
 
 fn main() -> Result<(), eframe::Error> {
-    // Log to stdout (if you run with `RUST_LOG=debug`).
-    tracing_subscriber::fmt::init();
+    // Log to stderr (if you run with `RUST_LOG=debug`).
+    env_logger::init();
 
     let options = eframe::NativeOptions::default();
     eframe::run_native(


### PR DESCRIPTION
Why? Writing backends for `log` is so much nicer than for `tracing`, and we don't use any of `tracing`s advanced features anyway.

For native apps:

```diff
-    tracing_subscriber::fmt::init();
+    env_logger::init();
```

For web apps:

```diff
-    tracing_wasm::set_as_global_default();
+    eframe::web::WebLogger::init(log::LevelFilter::Debug).ok();
```


For those of you who use `tracing` and want to see `log` events, just use `tracing = { version = "0.1", features = ["log"] }`
