### PR TITLE
Use `env_logger` in all examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,6 +764,7 @@ name = "confirm_exit"
 version = "0.1.0"
 dependencies = [
  "eframe",
+ "env_logger",
 ]
 
 [[package]]
@@ -910,6 +911,7 @@ version = "0.1.0"
 dependencies = [
  "eframe",
  "egui_glow",
+ "env_logger",
  "glow",
 ]
 
@@ -918,6 +920,7 @@ name = "custom_font"
 version = "0.1.0"
 dependencies = [
  "eframe",
+ "env_logger",
 ]
 
 [[package]]
@@ -925,6 +928,7 @@ name = "custom_font_style"
 version = "0.1.0"
 dependencies = [
  "eframe",
+ "env_logger",
 ]
 
 [[package]]
@@ -932,6 +936,7 @@ name = "custom_window_frame"
 version = "0.1.0"
 dependencies = [
  "eframe",
+ "env_logger",
 ]
 
 [[package]]
@@ -1129,6 +1134,7 @@ dependencies = [
  "eframe",
  "egui_extras",
  "ehttp",
+ "env_logger",
  "image",
  "poll-promise",
 ]
@@ -1505,6 +1511,7 @@ name = "file_dialog"
 version = "0.1.0"
 dependencies = [
  "eframe",
+ "env_logger",
  "rfd",
 ]
 
@@ -1929,6 +1936,7 @@ name = "hello_world_par"
 version = "0.1.0"
 dependencies = [
  "eframe",
+ "env_logger",
 ]
 
 [[package]]
@@ -2851,6 +2859,7 @@ name = "puffin_profiler"
 version = "0.1.0"
 dependencies = [
  "eframe",
+ "env_logger",
  "puffin",
  "puffin_http",
 ]
@@ -2996,6 +3005,7 @@ version = "0.1.0"
 dependencies = [
  "eframe",
  "egui_extras",
+ "env_logger",
  "image",
 ]
 
@@ -3173,6 +3183,7 @@ name = "screenshot"
 version = "0.1.0"
 dependencies = [
  "eframe",
+ "env_logger",
  "image",
  "itertools",
 ]
@@ -3247,6 +3258,7 @@ name = "serial_windows"
 version = "0.1.0"
 dependencies = [
  "eframe",
+ "env_logger",
 ]
 
 [[package]]
@@ -3413,6 +3425,7 @@ version = "0.1.0"
 dependencies = [
  "eframe",
  "egui_extras",
+ "env_logger",
 ]
 
 [[package]]
@@ -3818,6 +3831,7 @@ name = "user_attention"
 version = "0.1.0"
 dependencies = [
  "eframe",
+ "env_logger",
 ]
 
 [[package]]

--- a/crates/egui_demo_app/src/main.rs
+++ b/crates/egui_demo_app/src/main.rs
@@ -15,8 +15,7 @@ fn main() -> Result<(), eframe::Error> {
         std::env::set_var("RUST_LOG", rust_log);
     }
 
-    // Log to stderr (if you run with `RUST_LOG=debug`).
-    env_logger::init();
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
 
     let options = eframe::NativeOptions {
         drag_and_drop_support: true,

--- a/examples/confirm_exit/Cargo.toml
+++ b/examples/confirm_exit/Cargo.toml
@@ -12,3 +12,4 @@ publish = false
 eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
+env_logger = "0.10"

--- a/examples/confirm_exit/src/main.rs
+++ b/examples/confirm_exit/src/main.rs
@@ -3,6 +3,7 @@
 use eframe::egui;
 
 fn main() -> Result<(), eframe::Error> {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(320.0, 240.0)),
         ..Default::default()

--- a/examples/custom_3d_glow/Cargo.toml
+++ b/examples/custom_3d_glow/Cargo.toml
@@ -13,4 +13,5 @@ eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 egui_glow = { path = "../../crates/egui_glow" }
+env_logger = "0.10"
 glow = "0.12"

--- a/examples/custom_3d_glow/src/main.rs
+++ b/examples/custom_3d_glow/src/main.rs
@@ -7,6 +7,7 @@ use egui::mutex::Mutex;
 use std::sync::Arc;
 
 fn main() -> Result<(), eframe::Error> {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(350.0, 380.0)),
         multisampling: 4,

--- a/examples/custom_font/Cargo.toml
+++ b/examples/custom_font/Cargo.toml
@@ -12,3 +12,4 @@ publish = false
 eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
+env_logger = "0.10"

--- a/examples/custom_font/src/main.rs
+++ b/examples/custom_font/src/main.rs
@@ -3,6 +3,7 @@
 use eframe::egui;
 
 fn main() -> Result<(), eframe::Error> {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(320.0, 240.0)),
         ..Default::default()

--- a/examples/custom_font_style/Cargo.toml
+++ b/examples/custom_font_style/Cargo.toml
@@ -12,3 +12,4 @@ publish = false
 eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
+env_logger = "0.10"

--- a/examples/custom_font_style/src/main.rs
+++ b/examples/custom_font_style/src/main.rs
@@ -3,6 +3,17 @@
 use eframe::egui;
 use egui::{FontFamily, FontId, RichText, TextStyle};
 
+fn main() -> Result<(), eframe::Error> {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
+    let options = eframe::NativeOptions::default();
+
+    eframe::run_native(
+        "egui example: global font style",
+        options,
+        Box::new(|cc| Box::new(MyApp::new(cc))),
+    )
+}
+
 #[inline]
 fn heading2() -> TextStyle {
     TextStyle::Name("Heading2".into())
@@ -56,16 +67,6 @@ impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, content);
     }
-}
-
-fn main() -> Result<(), eframe::Error> {
-    let options = eframe::NativeOptions::default();
-
-    eframe::run_native(
-        "egui example: global font style",
-        options,
-        Box::new(|cc| Box::new(MyApp::new(cc))),
-    )
 }
 
 pub const LOREM_IPSUM: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";

--- a/examples/custom_window_frame/Cargo.toml
+++ b/examples/custom_window_frame/Cargo.toml
@@ -12,3 +12,4 @@ publish = false
 eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
+env_logger = "0.10"

--- a/examples/custom_window_frame/src/main.rs
+++ b/examples/custom_window_frame/src/main.rs
@@ -5,6 +5,7 @@
 use eframe::egui;
 
 fn main() -> Result<(), eframe::Error> {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
     let options = eframe::NativeOptions {
         // Hide the OS-specific "chrome" around the window:
         decorated: false,

--- a/examples/download_image/Cargo.toml
+++ b/examples/download_image/Cargo.toml
@@ -14,5 +14,6 @@ eframe = { path = "../../crates/eframe", features = [
 ] }
 egui_extras = { path = "../../crates/egui_extras", features = ["image"] }
 ehttp = "0.2"
+env_logger = "0.10"
 image = { version = "0.24", default-features = false, features = ["jpeg"] }
 poll-promise = "0.2"

--- a/examples/download_image/src/main.rs
+++ b/examples/download_image/src/main.rs
@@ -5,6 +5,7 @@ use egui_extras::RetainedImage;
 use poll_promise::Promise;
 
 fn main() -> Result<(), eframe::Error> {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
     let options = eframe::NativeOptions::default();
     eframe::run_native(
         "Download and show an image with eframe/egui",

--- a/examples/file_dialog/Cargo.toml
+++ b/examples/file_dialog/Cargo.toml
@@ -12,4 +12,5 @@ publish = false
 eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
+env_logger = "0.10"
 rfd = "0.11"

--- a/examples/file_dialog/src/main.rs
+++ b/examples/file_dialog/src/main.rs
@@ -3,6 +3,7 @@
 use eframe::egui;
 
 fn main() -> Result<(), eframe::Error> {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
     let options = eframe::NativeOptions {
         drag_and_drop_support: true,
         initial_window_size: Some(egui::vec2(320.0, 240.0)),

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -3,9 +3,7 @@
 use eframe::egui;
 
 fn main() -> Result<(), eframe::Error> {
-    // Log to stderr (if you run with `RUST_LOG=debug`).
-    env_logger::init();
-
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(320.0, 240.0)),
         ..Default::default()

--- a/examples/hello_world_par/Cargo.toml
+++ b/examples/hello_world_par/Cargo.toml
@@ -14,3 +14,4 @@ eframe = { path = "../../crates/eframe", default-features = false, features = [
     "default_fonts",
     "wgpu",
 ] }
+env_logger = "0.10"

--- a/examples/hello_world_par/src/main.rs
+++ b/examples/hello_world_par/src/main.rs
@@ -8,6 +8,7 @@ use std::thread::JoinHandle;
 use eframe::egui;
 
 fn main() -> Result<(), eframe::Error> {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(1024.0, 768.0)),
         ..Default::default()

--- a/examples/hello_world_simple/src/main.rs
+++ b/examples/hello_world_simple/src/main.rs
@@ -3,8 +3,7 @@
 use eframe::egui;
 
 fn main() -> Result<(), eframe::Error> {
-    // Log to stderr (if you run with `RUST_LOG=debug`).
-    env_logger::init();
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
 
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(320.0, 240.0)),

--- a/examples/keyboard_events/src/main.rs
+++ b/examples/keyboard_events/src/main.rs
@@ -4,9 +4,7 @@ use eframe::egui;
 use egui::*;
 
 fn main() -> Result<(), eframe::Error> {
-    // Log to stderr (if you run with `RUST_LOG=debug`).
-    env_logger::init();
-
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
     let options = eframe::NativeOptions::default();
     eframe::run_native(
         "Keyboard events",

--- a/examples/puffin_profiler/Cargo.toml
+++ b/examples/puffin_profiler/Cargo.toml
@@ -13,5 +13,6 @@ eframe = { path = "../../crates/eframe", features = [
     "puffin",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
+env_logger = "0.10"
 puffin = "0.14"
 puffin_http = "0.11"

--- a/examples/puffin_profiler/src/main.rs
+++ b/examples/puffin_profiler/src/main.rs
@@ -3,8 +3,8 @@
 use eframe::egui;
 
 fn main() -> Result<(), eframe::Error> {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
     start_puffin_server(); // NOTE: you may only want to call this if the users specifies some flag or clicks a button!
-
     let options = eframe::NativeOptions::default();
     eframe::run_native(
         "My egui App",

--- a/examples/retained_image/Cargo.toml
+++ b/examples/retained_image/Cargo.toml
@@ -13,4 +13,5 @@ eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 egui_extras = { path = "../../crates/egui_extras", features = ["image"] }
+env_logger = "0.10"
 image = { version = "0.24", default-features = false, features = ["png"] }

--- a/examples/retained_image/src/main.rs
+++ b/examples/retained_image/src/main.rs
@@ -4,11 +4,11 @@ use eframe::egui;
 use egui_extras::RetainedImage;
 
 fn main() -> Result<(), eframe::Error> {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(300.0, 900.0)),
         ..Default::default()
     };
-
     eframe::run_native(
         "Show an image with eframe/egui",
         options,

--- a/examples/screenshot/Cargo.toml
+++ b/examples/screenshot/Cargo.toml
@@ -16,5 +16,6 @@ eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
     "wgpu",
 ] }
+env_logger = "0.10"
 itertools = "0.10.3"
 image = { version = "0.24", default-features = false, features = ["png"] }

--- a/examples/screenshot/src/main.rs
+++ b/examples/screenshot/src/main.rs
@@ -3,6 +3,7 @@
 use eframe::egui::{self, ColorImage};
 
 fn main() -> Result<(), eframe::Error> {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
     let options = eframe::NativeOptions {
         renderer: eframe::Renderer::Wgpu,
         ..Default::default()

--- a/examples/serial_windows/Cargo.toml
+++ b/examples/serial_windows/Cargo.toml
@@ -12,3 +12,4 @@ publish = false
 eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
+env_logger = "0.10"

--- a/examples/serial_windows/src/main.rs
+++ b/examples/serial_windows/src/main.rs
@@ -3,6 +3,8 @@
 use eframe::egui;
 
 fn main() -> Result<(), eframe::Error> {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
+
     if cfg!(target_os = "macos") {
         eprintln!("WARNING: this example does not work on Mac! See https://github.com/emilk/egui/issues/1918");
     }

--- a/examples/svg/Cargo.toml
+++ b/examples/svg/Cargo.toml
@@ -13,3 +13,4 @@ eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 egui_extras = { path = "../../crates/egui_extras", features = ["svg"] }
+env_logger = "0.10"

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -7,6 +7,7 @@
 use eframe::egui;
 
 fn main() -> Result<(), eframe::Error> {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(1000.0, 700.0)),
         ..Default::default()

--- a/examples/user_attention/Cargo.toml
+++ b/examples/user_attention/Cargo.toml
@@ -8,4 +8,7 @@ rust-version = "1.65"
 publish = false
 
 [dependencies]
-eframe = { path = "../../crates/eframe" }
+eframe = { path = "../../crates/eframe", features = [
+    "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
+] }
+env_logger = "0.10"

--- a/examples/user_attention/src/main.rs
+++ b/examples/user_attention/src/main.rs
@@ -1,7 +1,22 @@
-use eframe::egui::{Button, CentralPanel, Context, UserAttentionType};
-use eframe::{CreationContext, NativeOptions};
+use eframe::{
+    egui::{Button, CentralPanel, Context, UserAttentionType},
+    CreationContext, NativeOptions,
+};
 
 use std::time::{Duration, SystemTime};
+
+fn main() -> eframe::Result<()> {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
+    let native_options = NativeOptions {
+        initial_window_size: Some(eframe::egui::vec2(400., 200.)),
+        ..Default::default()
+    };
+    eframe::run_native(
+        "User attention test",
+        native_options,
+        Box::new(|cc| Box::new(Application::new(cc))),
+    )
+}
 
 fn repr(attention: UserAttentionType) -> String {
     format!("{:?}", attention)
@@ -115,16 +130,4 @@ impl eframe::App for Application {
 
         ctx.request_repaint_after(Self::repaint_max_timeout());
     }
-}
-
-fn main() -> eframe::Result<()> {
-    let native_options = NativeOptions {
-        initial_window_size: Some(eframe::egui::vec2(400., 200.)),
-        ..Default::default()
-    };
-    eframe::run_native(
-        "User attention test",
-        native_options,
-        Box::new(|cc| Box::new(Application::new(cc))),
-    )
 }


### PR DESCRIPTION
Nice to get logging with `RUST_LOG=info` for all examples