### PR TITLE
Enable egui-winit to support wasm target

### DIFF
--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -58,6 +58,7 @@ egui = { version = "0.21.0", path = "../egui", default-features = false, feature
 ] }
 log = { version = "0.4", features = ["std"] }
 winit = { version = "0.28", default-features = false }
+raw-window-handle = "0.5.0"
 
 #! ### Optional dependencies
 
@@ -74,7 +75,6 @@ webbrowser = { version = "0.8.3", optional = true }
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
 instant = { version = "0.1" }
-raw-window-handle = "0.5.0"
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 instant = { version = "0.1", features = [


### PR DESCRIPTION
I am using `egui-winit` + `egui-wgpu` in my project, and when I compile the project to wasm, the following error occurs: 
```log
Running `target/release/run-wasm --bin simuverse`
Compiling egui-winit v0.21.1 (/Users/lijinlei/Rust/forks/egui/crates/egui-winit)
error[E0432]: unresolved import `raw_window_handle`
 --> /Users/lijinlei/Rust/forks/egui/crates/egui-winit/src/clipboard.rs:1:5
  |
1 | use raw_window_handle::HasRawDisplayHandle;
  |     ^^^^^^^^^^^^^^^^^ use of undeclared crate or module `raw_window_handle`

error[E0432]: unresolved import `raw_window_handle`
  --> /Users/lijinlei/Rust/forks/egui/crates/egui-winit/src/lib.rs:24:5
   |
24 | use raw_window_handle::HasRawDisplayHandle;
   |     ^^^^^^^^^^^^^^^^^ use of undeclared crate or module `raw_window_handle`
```
This PR should have no side effects, as `winit` already depends on `raw-window-handle` itself.

Tested via https://github.com/jinleili/simuverse/tree/wasm