### PR TITLE
[egui-wgpu] Device configuration is now dependent on adapter

### DIFF
--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -499,17 +499,7 @@ impl Default for WebOptions {
             #[cfg(feature = "wgpu")]
             wgpu_options: egui_wgpu::WgpuConfiguration {
                 // Use WebGPU or WebGL. Note that WebGL needs to be opted in via a wgpu feature.
-                backends: wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL,
-                device_descriptor: wgpu::DeviceDescriptor {
-                    label: Some("egui wgpu device"),
-                    features: wgpu::Features::default(),
-                    limits: wgpu::Limits {
-                        // When using a depth buffer, we have to be able to create a texture
-                        // large enough for the entire surface, and we want to support 4k+ displays.
-                        max_texture_dimension_2d: 8192,
-                        ..wgpu::Limits::downlevel_webgl2_defaults()
-                    },
-                },
+                supported_backends: wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL,
                 ..Default::default()
             },
         }

--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -497,11 +497,7 @@ impl Default for WebOptions {
             webgl_context_option: WebGlContextOption::BestFirst,
 
             #[cfg(feature = "wgpu")]
-            wgpu_options: egui_wgpu::WgpuConfiguration {
-                // Use WebGPU or WebGL. Note that WebGL needs to be opted in via a wgpu feature.
-                supported_backends: wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL,
-                ..Default::default()
-            },
+            wgpu_options: egui_wgpu::WgpuConfiguration::default(),
         }
     }
 }

--- a/crates/eframe/src/web/web_painter_wgpu.rs
+++ b/crates/eframe/src/web/web_painter_wgpu.rs
@@ -159,9 +159,9 @@ impl WebPainter for WebPainterWgpu {
     }
 
     fn max_texture_side(&self) -> usize {
-        self.render_state
-            .as_ref()
-            .map_or(0, |state| state.device.limits().max_texture_dimension_2d as _)
+        self.render_state.as_ref().map_or(0, |state| {
+            state.device.limits().max_texture_dimension_2d as _
+        })
     }
 
     fn paint_and_update_textures(

--- a/crates/eframe/src/web/web_painter_wgpu.rs
+++ b/crates/eframe/src/web/web_painter_wgpu.rs
@@ -161,8 +161,7 @@ impl WebPainter for WebPainterWgpu {
     fn max_texture_side(&self) -> usize {
         self.render_state
             .as_ref()
-            .map(|state| state.device.limits().max_texture_dimension_2d as _)
-            .unwrap_or(0)
+            .map_or(0, |state| state.device.limits().max_texture_dimension_2d as _)
     }
 
     fn paint_and_update_textures(

--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -65,7 +65,8 @@ impl Default for WgpuConfiguration {
         Self {
             // Add GL backend, primarily because WebGPU is not stable enough yet.
             // (note however, that the GL backend needs to be opted-in via a wgpu feature flag)
-            supported_backends: wgpu::Backends::PRIMARY | wgpu::Backends::GL,
+            supported_backends: wgpu::util::backend_bits_from_env()
+                .unwrap_or(wgpu::Backends::PRIMARY | wgpu::Backends::GL),
             device_descriptor: Arc::new(|adapter| {
                 let base_limits = if adapter.get_info().backend == wgpu::Backend::Gl {
                     wgpu::Limits::downlevel_webgl2_defaults()

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -108,7 +108,7 @@ impl Painter {
         support_transparent_backbuffer: bool,
     ) -> Self {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-            backends: configuration.backends,
+            backends: configuration.supported_backends,
             dx12_shader_compiler: Default::default(), //
         });
 
@@ -141,7 +141,7 @@ impl Painter {
         target_format: wgpu::TextureFormat,
     ) -> Result<RenderState, wgpu::RequestDeviceError> {
         adapter
-            .request_device(&self.configuration.device_descriptor, None)
+            .request_device(&(*self.configuration.device_descriptor)(adapter), None)
             .await
             .map(|(device, queue)| {
                 let renderer =

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -109,7 +109,7 @@ impl Painter {
     ) -> Self {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: configuration.supported_backends,
-            dx12_shader_compiler: Default::default(), //
+            dx12_shader_compiler: Default::default(),
         });
 
         Self {


### PR DESCRIPTION
Additionally, renamed `backends` into `supported_backends` and improved & unified wgpu config defaults.