### PR TITLE
[DragValue] Use rounded values for checking if value needs setting

### DIFF
--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -440,7 +440,10 @@ impl<'a> Widget for DragValue<'a> {
         }
 
         value = clamp_to_range(value, clamp_range.clone());
-        if old_value != value {
+
+        let old_rounded = emath::round_to_decimals(old_value, auto_decimals);
+        let new_rounded = emath::round_to_decimals(value, auto_decimals);
+        if old_rounded != new_rounded {
             set(&mut get_set_value, value);
             ui.memory_mut(|mem| mem.drag_value.edit_string = None);
         }


### PR DESCRIPTION
If `old_value` is not rounded, the modified if-expression would always trigger clearing the edit memory, and hence making editing by keyboard impossible -- the edit buffer would only last a single frame.

Alternatively, `old_value` could abe always rounded if we rounded the result of parsing the keyboard inpu and accesskit input, but this prevents the user from inputting values more precise than allowed by default, which is a behavior I've personally found useful. Regardless of that, this solution is more likely to prevent this bug from being reintroduced if new input methods are added and don't respect rounding.
