### PR TITLE
Log warning instead of error when failing to decode RON in storage

### DIFF
--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -1051,7 +1051,13 @@ impl Storage for DummyStorage {
 pub fn get_value<T: serde::de::DeserializeOwned>(storage: &dyn Storage, key: &str) -> Option<T> {
     storage
         .get_string(key)
-        .and_then(|value| ron::from_str(&value).ok())
+        .and_then(|value| match ron::from_str(&value) {
+            Ok(value) => Some(value),
+            Err(err) => {
+                log::warn!("Failed to decode RON: {err}");
+                None
+            }
+        })
 }
 
 /// Serialize the given value as [RON](https://github.com/ron-rs/ron) and store with the given key.

--- a/crates/eframe/src/web/backend.rs
+++ b/crates/eframe/src/web/backend.rs
@@ -529,7 +529,7 @@ impl AppRunnerRef {
             log::debug!("Unsubscribing from {} events", events_to_unsubscribe.len());
             for x in events_to_unsubscribe {
                 if let Err(err) = x.unsubscribe() {
-                    log::error!("Failed to unsubscribe from event: {err:?}");
+                    log::warn!("Failed to unsubscribe from event: {err:?}");
                 }
             }
         }

--- a/crates/eframe/src/web/backend.rs
+++ b/crates/eframe/src/web/backend.rs
@@ -560,7 +560,7 @@ impl AppRunnerRef {
         if self.has_panicked() {
             None
         } else {
-            let lock = self.runner.borrow_mut();
+            let lock = self.runner.try_borrow_mut().ok()?;
             if lock.is_destroyed.fetch() {
                 None
             } else {

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -192,7 +192,7 @@ pub fn set_clipboard_text(s: &str) {
             let future = wasm_bindgen_futures::JsFuture::from(promise);
             let future = async move {
                 if let Err(err) = future.await {
-                    log::error!("Copy/cut action denied: {:?}", err);
+                    log::error!("Copy/cut action failed: {err:?}");
                 }
             };
             wasm_bindgen_futures::spawn_local(future);

--- a/crates/eframe/src/web/storage.rs
+++ b/crates/eframe/src/web/storage.rs
@@ -18,7 +18,7 @@ pub fn load_memory(ctx: &egui::Context) {
                 ctx.memory_mut(|m| *m = memory);
             }
             Err(err) => {
-                log::error!("Failed to parse memory RON: {}", err);
+                log::warn!("Failed to parse memory RON: {err}");
             }
         }
     }
@@ -34,7 +34,7 @@ pub fn save_memory(ctx: &egui::Context) {
             local_storage_set("egui_memory_ron", &ron);
         }
         Err(err) => {
-            log::error!("Failed to serialize memory as RON: {}", err);
+            log::warn!("Failed to serialize memory as RON: {err}");
         }
     }
 }

--- a/crates/eframe/src/web/web_logger.rs
+++ b/crates/eframe/src/web/web_logger.rs
@@ -37,7 +37,11 @@ impl log::Log for WebLogger {
             log::Level::Debug => console::debug(&msg),
             log::Level::Info => console::info(&msg),
             log::Level::Warn => console::warn(&msg),
-            log::Level::Error => console::error(&msg),
+
+            // Using console.error causes crashes for unknown reason
+            // https://github.com/emilk/egui/pull/2961
+            // log::Level::Error => console::error(&msg),
+            log::Level::Error => console::warn(&format!("ERROR: {msg}")),
         }
     }
 
@@ -66,9 +70,11 @@ mod console {
         #[wasm_bindgen(js_namespace = console)]
         pub fn warn(s: &str);
 
-        /// `console.error`
-        #[wasm_bindgen(js_namespace = console)]
-        pub fn error(s: &str);
+        // Using console.error causes crashes for unknown reason
+        // https://github.com/emilk/egui/pull/2961
+        // /// `console.error`
+        // #[wasm_bindgen(js_namespace = console)]
+        // pub fn error(s: &str);
     }
 }
 

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -311,7 +311,7 @@ impl Painter {
                 height_in_pixels,
             );
         } else {
-            log::error!("Ignoring window resize notification with no surface created via Painter::set_window()");
+            log::warn!("Ignoring window resize notification with no surface created via Painter::set_window()");
         }
     }
 

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -21,8 +21,8 @@ impl EguiGlow {
         shader_version: Option<ShaderVersion>,
     ) -> Self {
         let painter = crate::Painter::new(gl, "", shader_version)
-            .map_err(|error| {
-                log::error!("error occurred in initializing painter:\n{}", error);
+            .map_err(|err| {
+                log::error!("error occurred in initializing painter:\n{err}");
             })
             .unwrap();
 

--- a/docs/egui_demo_app.js
+++ b/docs/egui_demo_app.js
@@ -1662,27 +1662,27 @@ function getImports() {
         const ret = wasm.memory;
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper2873 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper2874 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 981, __wbg_adapter_28);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper2874 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper2875 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 981, __wbg_adapter_31);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper2877 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper2878 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 981, __wbg_adapter_34);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper3275 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper3276 = function(arg0, arg1, arg2) {
         const ret = makeClosure(arg0, arg1, 1143, __wbg_adapter_37);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper3277 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper3278 = function(arg0, arg1, arg2) {
         const ret = makeClosure(arg0, arg1, 1143, __wbg_adapter_37);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper3320 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper3321 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 1166, __wbg_adapter_42);
         return addHeapObject(ret);
     };

--- a/docs/egui_demo_app.js
+++ b/docs/egui_demo_app.js
@@ -43,6 +43,7 @@ function getUint8Memory0() {
 }
 
 function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
     return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
 }
 
@@ -76,14 +77,14 @@ function passStringToWasm0(arg, malloc, realloc) {
 
     if (realloc === undefined) {
         const buf = cachedTextEncoder.encode(arg);
-        const ptr = malloc(buf.length);
+        const ptr = malloc(buf.length) >>> 0;
         getUint8Memory0().subarray(ptr, ptr + buf.length).set(buf);
         WASM_VECTOR_LEN = buf.length;
         return ptr;
     }
 
     let len = arg.length;
-    let ptr = malloc(len);
+    let ptr = malloc(len) >>> 0;
 
     const mem = getUint8Memory0();
 
@@ -99,7 +100,7 @@ function passStringToWasm0(arg, malloc, realloc) {
         if (offset !== 0) {
             arg = arg.slice(offset);
         }
-        ptr = realloc(ptr, len, len = offset + arg.length * 3);
+        ptr = realloc(ptr, len, len = offset + arg.length * 3) >>> 0;
         const view = getUint8Memory0().subarray(ptr + offset, ptr + len);
         const ret = encodeString(arg, view);
 
@@ -279,7 +280,7 @@ function handleError(f, args) {
         wasm.__wbindgen_exn_store(addHeapObject(e));
     }
 }
-function __wbg_adapter_586(arg0, arg1, arg2, arg3) {
+function __wbg_adapter_584(arg0, arg1, arg2, arg3) {
     wasm.wasm_bindgen__convert__closures__invoke2_mut__h125af29ab38d9781(arg0, arg1, addHeapObject(arg2), addHeapObject(arg3));
 }
 
@@ -288,6 +289,7 @@ function __wbg_adapter_586(arg0, arg1, arg2, arg3) {
 class WebHandle {
 
     static __wrap(ptr) {
+        ptr = ptr >>> 0;
         const obj = Object.create(WebHandle.prototype);
         obj.ptr = ptr;
 
@@ -468,13 +470,6 @@ function getImports() {
     };
     imports.wbg.__wbg_warn_8b4e19d4032139f0 = function(arg0, arg1) {
         console.warn(getStringFromWasm0(arg0, arg1));
-    };
-    imports.wbg.__wbg_error_e62b64b85c2bc545 = function(arg0, arg1) {
-        try {
-            console.error(getStringFromWasm0(arg0, arg1));
-        } finally {
-            wasm.__wbindgen_free(arg0, arg1);
-        }
     };
     imports.wbg.__wbg_new_40620131643ca1cf = function() {
         const ret = new Error();
@@ -1578,7 +1573,7 @@ function getImports() {
                 const a = state0.a;
                 state0.a = 0;
                 try {
-                    return __wbg_adapter_586(a, state0.b, arg0, arg1);
+                    return __wbg_adapter_584(a, state0.b, arg0, arg1);
                 } finally {
                     state0.a = a;
                 }
@@ -1662,27 +1657,27 @@ function getImports() {
         const ret = wasm.memory;
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper2874 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper2873 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 981, __wbg_adapter_28);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper2875 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper2874 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 981, __wbg_adapter_31);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper2878 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper2877 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 981, __wbg_adapter_34);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper3276 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper3272 = function(arg0, arg1, arg2) {
         const ret = makeClosure(arg0, arg1, 1143, __wbg_adapter_37);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper3278 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper3274 = function(arg0, arg1, arg2) {
         const ret = makeClosure(arg0, arg1, 1143, __wbg_adapter_37);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper3321 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper3317 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 1166, __wbg_adapter_42);
         return addHeapObject(ret);
     };

--- a/scripts/setup_web.sh
+++ b/scripts/setup_web.sh
@@ -5,4 +5,9 @@ cd "$script_path/.."
 
 # Pre-requisites:
 rustup target add wasm32-unknown-unknown
-cargo install wasm-bindgen-cli --version 0.2.84
+
+# For generating JS bindings:
+# cargo install wasm-bindgen-cli --version 0.2.84
+# We use a patched version containing this critical fix: https://github.com/rustwasm/wasm-bindgen/pull/3310
+# See https://github.com/rerun-io/wasm-bindgen/commits/0.2.84-patch
+cargo install wasm-bindgen-cli --git https://github.com/rerun-io/wasm-bindgen.git --rev 13283975ddf48c2d90758095e235b28d381c5762


### PR DESCRIPTION
I'm not sure why, but using `console.error` causes a hard crash.

![image](https://user-images.githubusercontent.com/1148717/234786364-2e4a70fc-67a3-4fb3-8acc-1ae1819ba6f6.png)

But this PR fixes it. I don't understand why.