### PR TITLE
Add `Pointer::is_decidedly_dragging` and `could_any_button_be_click`

### DIFF
--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -557,6 +557,7 @@ impl EpiIntegration {
         }
     }
 
+    #[allow(clippy::unused_self)]
     pub fn save(&mut self, _app: &mut dyn epi::App, _window: &winit::window::Window) {
         #[cfg(feature = "persistence")]
         if let Some(storage) = self.frame.storage_mut() {

--- a/crates/egui/src/input_state.rs
+++ b/crates/egui/src/input_state.rs
@@ -919,7 +919,7 @@ impl PointerState {
     /// But if the mouse is down long enough, or has moved far enough,
     /// then we consider it a drag.
     ///
-    /// This function can return true on the same frame the drag is relased,
+    /// This function can return true on the same frame the drag is released,
     /// but NOT on the first frame it was started.
     ///
     /// See also [`Self::could_any_button_be_click`].

--- a/crates/egui/src/input_state.rs
+++ b/crates/egui/src/input_state.rs
@@ -894,8 +894,9 @@ impl PointerState {
     }
 
     /// If the pointer button is down, will it register as a click when released?
-    #[inline(always)]
-    pub(crate) fn could_any_button_be_click(&self) -> bool {
+    ///
+    /// See also [`Self::is_decidedly_dragging`].
+    pub fn could_any_button_be_click(&self) -> bool {
         if !self.any_down() {
             return false;
         }
@@ -911,6 +912,22 @@ impl PointerState {
         }
 
         true
+    }
+
+    /// Just because the mouse is down doesn't mean we are dragging.
+    /// We could be at the start of a click.
+    /// But if the mouse is down long enough, or has moved far enough,
+    /// then we consider it a drag.
+    ///
+    /// This function can return true on the same frame the drag is relased,
+    /// but NOT on the first frame it was started.
+    ///
+    /// See also [`Self::could_any_button_be_click`].
+    pub fn is_decidedly_dragging(&self) -> bool {
+        (self.any_down() || self.any_released())
+            && !self.any_pressed()
+            && !self.could_any_button_be_click()
+            && !self.any_click()
     }
 
     /// Is the primary button currently down?

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -477,6 +477,11 @@ impl Memory {
         self.interaction.drag_id = Some(id);
     }
 
+    #[inline(always)]
+    pub fn stop_dragging(&mut self) {
+        self.interaction.drag_id = None;
+    }
+
     /// Forget window positions, sizes etc.
     /// Can be used to auto-layout windows.
     pub fn reset_areas(&mut self) {


### PR DESCRIPTION
This allows users to distinguish between click and drags while they are not yet done.