### PR TITLE
Mention `store` in `TextEditState` doc comment

### DIFF
--- a/crates/egui/src/widgets/text_edit/state.rs
+++ b/crates/egui/src/widgets/text_edit/state.rs
@@ -9,6 +9,27 @@ use super::{CCursorRange, CursorRange};
 type Undoer = crate::util::undoer::Undoer<(CCursorRange, String)>;
 
 /// The text edit state stored between frames.
+///
+/// Attention: You also need to `store` the updated state.
+/// ```
+/// # use egui::text::CCursor;
+/// # use egui::text_edit::{CCursorRange, TextEditOutput};
+/// # use egui::TextEdit;
+/// # egui::__run_test_ui(|ui| {
+/// # let mut text = String::new();
+/// let mut output = TextEdit::singleline(&mut text).show(ui);
+///
+/// // Create a new selection range
+/// let min = CCursor::new(0);
+/// let max = CCursor::new(0);
+/// let new_range = CCursorRange::two(min, max);
+///
+/// // Update the state
+/// output.state.set_ccursor_range(Some(new_range));
+/// // Store the updated state
+/// output.state.store(ui.ctx(), output.response.id);
+/// # });
+/// ```
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]


### PR DESCRIPTION
To me it was confusing because I tried `set_cursor_range` and it didn't update the cursor range. After that, I found that the output is not a reference, nor a smart pointer, so I thought: "Ok, it might be for some internal use but not external." I didn't pay attention to the `store` method.
It would be good to have a comment that would have directed me to that method.

Closes https://github.com/emilk/egui/issues/2950
