### PR TITLE
Fix documentation for TextureId::Managed(0)

### DIFF
--- a/crates/epaint/src/lib.rs
+++ b/crates/epaint/src/lib.rs
@@ -65,13 +65,13 @@ pub const WHITE_UV: emath::Pos2 = emath::pos2(0.0, 0.0);
 
 /// What texture to use in a [`Mesh`] mesh.
 ///
-/// If you don't want to use a texture, use `TextureId::Epaint(0)` and the [`WHITE_UV`] for uv-coord.
+/// If you don't want to use a texture, use `TextureId::Managed(0)` and the [`WHITE_UV`] for uv-coord.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum TextureId {
     /// Textures allocated using [`TextureManager`].
     ///
-    /// The first texture (`TextureId::Epaint(0)`) is used for the font data.
+    /// The first texture (`TextureId::Managed(0)`) is used for the font data.
     Managed(u64),
 
     /// Your own texture, defined in any which way you want.


### PR DESCRIPTION
`TextureId::Epaint` was renamed to `TextureId::Managed` during the development of #1110. Update the documentation to match.