### PR TITLE
Add an optional app_id field to eframe's NativeOptions for Wayland

### DIFF
--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -8,6 +8,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 #### Desktop/Native:
 * Add `Frame::request_screenshot` and `Frame::screenshot` to communicate to the backend that a screenshot of the current frame should be exposed by `Frame` during `App::post_rendering` ([#2676](https://github.com/emilk/egui/pull/2676)).
 * Add `eframe::run_simple_native` - a simple API for simple apps ([#2453](https://github.com/emilk/egui/pull/2453)).
+* Add `NativeOptions::app_id` which allows to set the Wayland application ID ([#1600](https://github.com/emilk/egui/issues/1600)).
 * Fix bug where the eframe window is never destroyed on Linux when using `run_and_return` ([#2892](https://github.com/emilk/egui/issues/2892))
 
 #### Web:

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -8,7 +8,7 @@ NOTE: [`egui-winit`](../egui-winit/CHANGELOG.md), [`egui_glium`](../egui_glium/C
 #### Desktop/Native:
 * Add `Frame::request_screenshot` and `Frame::screenshot` to communicate to the backend that a screenshot of the current frame should be exposed by `Frame` during `App::post_rendering` ([#2676](https://github.com/emilk/egui/pull/2676)).
 * Add `eframe::run_simple_native` - a simple API for simple apps ([#2453](https://github.com/emilk/egui/pull/2453)).
-* Add `NativeOptions::app_id` which allows to set the Wayland application ID ([#1600](https://github.com/emilk/egui/issues/1600)).
+* Add `NativeOptions::app_id` which allows to set the Wayland application ID under Linux ([#1600](https://github.com/emilk/egui/issues/1600)).
 * Fix bug where the eframe window is never destroyed on Linux when using `run_and_return` ([#2892](https://github.com/emilk/egui/issues/2892))
 
 #### Web:

--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -383,6 +383,21 @@ pub struct NativeOptions {
     /// Configures wgpu instance/device/adapter/surface creation and renderloop.
     #[cfg(feature = "wgpu")]
     pub wgpu_options: egui_wgpu::WgpuConfiguration,
+
+    /// On Wayland: Application ID for the window.
+    ///
+    /// The application ID is used in several places of the compositor, e.g. for
+    /// grouping windows of the same application. It is also important for
+    /// connecting the configuration of a `.desktop` file with the window, by
+    /// using the application ID as file name. This allows e.g. a proper icon
+    /// handling under Wayland.
+    ///
+    /// See [Waylands XDG shell documentation][xdg-shell] for more information
+    /// on this Wayland-specific option.
+    ///
+    /// [xdg-shell]: https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id
+    #[cfg(feature = "wayland")]
+    pub app_id: Option<String>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -396,6 +411,9 @@ impl Clone for NativeOptions {
 
             #[cfg(feature = "wgpu")]
             wgpu_options: self.wgpu_options.clone(),
+
+            #[cfg(feature = "wayland")]
+            app_id: self.app_id.clone(),
 
             ..*self
         }
@@ -453,6 +471,9 @@ impl Default for NativeOptions {
 
             #[cfg(feature = "wgpu")]
             wgpu_options: egui_wgpu::WgpuConfiguration::default(),
+
+            #[cfg(feature = "wayland")]
+            app_id: None,
         }
     }
 }

--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -396,6 +396,25 @@ pub struct NativeOptions {
     /// on this Wayland-specific option.
     ///
     /// [xdg-shell]: https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id
+    ///
+    /// # Example
+    /// ``` no_run
+    /// fn main() -> eframe::Result<()> {
+    ///
+    ///     let mut options = eframe::NativeOptions::default();
+    ///     // Set the application ID for Wayland only on Linux
+    ///     #[cfg(target_os = "linux")]
+    ///     {
+    ///         options.app_id = Some("egui-example".to_string());
+    ///     }
+    ///
+    ///     eframe::run_simple_native("My egui App", options, move |ctx, _frame| {
+    ///         egui::CentralPanel::default().show(ctx, |ui| {
+    ///             ui.heading("My egui Application");
+    ///         });
+    ///     })
+    /// }
+    /// ```
     #[cfg(all(feature = "wayland", target_os = "linux"))]
     pub app_id: Option<String>,
 }

--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -396,7 +396,7 @@ pub struct NativeOptions {
     /// on this Wayland-specific option.
     ///
     /// [xdg-shell]: https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id
-    #[cfg(feature = "wayland")]
+    #[cfg(all(feature = "wayland", target_os = "linux"))]
     pub app_id: Option<String>,
 }
 
@@ -412,7 +412,7 @@ impl Clone for NativeOptions {
             #[cfg(feature = "wgpu")]
             wgpu_options: self.wgpu_options.clone(),
 
-            #[cfg(feature = "wayland")]
+            #[cfg(all(feature = "wayland", target_os = "linux"))]
             app_id: self.app_id.clone(),
 
             ..*self
@@ -472,7 +472,7 @@ impl Default for NativeOptions {
             #[cfg(feature = "wgpu")]
             wgpu_options: egui_wgpu::WgpuConfiguration::default(),
 
-            #[cfg(feature = "wayland")]
+            #[cfg(all(feature = "wayland", target_os = "linux"))]
             app_id: None,
         }
     }

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -3,6 +3,9 @@ use winit::event_loop::EventLoopWindowTarget;
 #[cfg(target_os = "macos")]
 use winit::platform::macos::WindowBuilderExtMacOS as _;
 
+#[cfg(feature = "wayland")]
+use winit::platform::wayland::WindowBuilderExtWayland as _;
+
 #[cfg(feature = "accesskit")]
 use egui::accesskit;
 use egui::NumExt as _;
@@ -116,6 +119,12 @@ pub fn window_builder<E>(
             .with_title_hidden(true)
             .with_titlebar_transparent(true)
             .with_fullsize_content_view(true);
+    }
+
+    #[cfg(feature = "wayland")]
+    {
+        window_builder =
+            window_builder.with_name(native_options.app_id.as_deref().unwrap_or(title), "");
     }
 
     if let Some(min_size) = *min_window_size {

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -122,7 +122,7 @@ pub fn window_builder<E>(
     }
 
     #[cfg(all(feature = "wayland", target_os = "linux"))]
-    if let Some(app_id) = native_options.app_id.as_deref() {
+    if let Some(app_id) = &native_options.app_id {
         window_builder = window_builder.with_name(app_id, "");
     }
 

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -3,7 +3,7 @@ use winit::event_loop::EventLoopWindowTarget;
 #[cfg(target_os = "macos")]
 use winit::platform::macos::WindowBuilderExtMacOS as _;
 
-#[cfg(feature = "wayland")]
+#[cfg(all(feature = "wayland", target_os = "linux"))]
 use winit::platform::wayland::WindowBuilderExtWayland as _;
 
 #[cfg(feature = "accesskit")]
@@ -121,7 +121,7 @@ pub fn window_builder<E>(
             .with_fullsize_content_view(true);
     }
 
-    #[cfg(feature = "wayland")]
+    #[cfg(all(feature = "wayland", target_os = "linux"))]
     {
         window_builder =
             window_builder.with_name(native_options.app_id.as_deref().unwrap_or(title), "");

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -122,9 +122,8 @@ pub fn window_builder<E>(
     }
 
     #[cfg(all(feature = "wayland", target_os = "linux"))]
-    {
-        window_builder =
-            window_builder.with_name(native_options.app_id.as_deref().unwrap_or(title), "");
+    if let Some(app_id) = native_options.app_id.as_deref() {
+        window_builder = window_builder.with_name(app_id, "");
     }
 
     if let Some(min_size) = *min_window_size {


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do not open PR:s from your `master` branch, as thart makes it difficult for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Closes <https://github.com/emilk/egui/issues/1600>.

The new `app_id` is used in the window builder to set the Wayland application ID using the [winit API](https://docs.rs/winit/latest/winit/platform/wayland/trait.WindowBuilderExtWayland.html#tymethod.with_name), which is e.g. important for a proper configuration in `.desktop` files.
There should not be any changes in the behavior for existing applications.

The new field is only available when the `target_os` is set to "linux"  and the "wayland" feature is enabled  (similar to the `fullsize_content` field in macOS). The limitation to `target_os = "linux"` is needed because the winit crate does not export the needed trait on Windows and other Non-Unix systems (causing compilation issues otherwise). 
Because this makes the configuration a little bit more difficult to use, I added an example in its documentation.
