### PR TITLE
eframe: Use `NativeOptions::AppId` for the persistance location

### DIFF
--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -105,11 +105,12 @@ pub trait App {
     ///
     /// On web the state is stored to "Local Storage".
     /// On native the path is picked using [`directories_next::ProjectDirs::data_dir`](https://docs.rs/directories-next/2.0.0/directories_next/struct.ProjectDirs.html#method.data_dir) which is:
-    /// * Linux:   `/home/UserName/.local/share/APPNAME`
-    /// * macOS:   `/Users/UserName/Library/Application Support/APPNAME`
-    /// * Windows: `C:\Users\UserName\AppData\Roaming\APPNAME`
+    /// * Linux:   `/home/UserName/.local/share/APP_ID`
+    /// * macOS:   `/Users/UserName/Library/Application Support/APP_ID`
+    /// * Windows: `C:\Users\UserName\AppData\Roaming\APP_ID`
     ///
-    /// where `APPNAME` is what is given to `eframe::run_native`.
+    /// where `APP_ID` is determined by either [`NativeOptions::app_id`] or
+    /// the title argument to [`eframe::run_native`].
     fn save(&mut self, _storage: &mut dyn Storage) {}
 
     /// Called when the user attempts to close the desktop window and/or quit the application.
@@ -384,7 +385,18 @@ pub struct NativeOptions {
     #[cfg(feature = "wgpu")]
     pub wgpu_options: egui_wgpu::WgpuConfiguration,
 
-    /// On Wayland: Application ID for the window.
+    /// The application id, used for determining the folder to persist the app to.
+    ///
+    /// On native the path is picked using [`directories_next::ProjectDirs::data_dir`](https://docs.rs/directories-next/2.0.0/directories_next/struct.ProjectDirs.html#method.data_dir) which is:
+    /// * Linux:   `/home/UserName/.local/share/APP_ID`
+    /// * macOS:   `/Users/UserName/Library/Application Support/APP_ID`
+    /// * Windows: `C:\Users\UserName\AppData\Roaming\APP_ID`
+    ///
+    /// If you don't set [`Self::app_id`], the title argument to [`eframe::run_native`]
+    /// will be used instead.
+    ///
+    /// ### On Wayland
+    /// On Wauland this sets the Application ID for the window.
     ///
     /// The application ID is used in several places of the compositor, e.g. for
     /// grouping windows of the same application. It is also important for
@@ -415,7 +427,6 @@ pub struct NativeOptions {
     ///     })
     /// }
     /// ```
-    #[cfg(all(feature = "wayland", target_os = "linux"))]
     pub app_id: Option<String>,
 }
 
@@ -431,7 +442,6 @@ impl Clone for NativeOptions {
             #[cfg(feature = "wgpu")]
             wgpu_options: self.wgpu_options.clone(),
 
-            #[cfg(all(feature = "wayland", target_os = "linux"))]
             app_id: self.app_id.clone(),
 
             ..*self
@@ -491,7 +501,6 @@ impl Default for NativeOptions {
             #[cfg(feature = "wgpu")]
             wgpu_options: egui_wgpu::WgpuConfiguration::default(),
 
-            #[cfg(all(feature = "wayland", target_os = "linux"))]
             app_id: None,
         }
     }

--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -110,7 +110,7 @@ pub trait App {
     /// * Windows: `C:\Users\UserName\AppData\Roaming\APP_ID`
     ///
     /// where `APP_ID` is determined by either [`NativeOptions::app_id`] or
-    /// the title argument to [`eframe::run_native`].
+    /// the title argument to [`crate::run_native`].
     fn save(&mut self, _storage: &mut dyn Storage) {}
 
     /// Called when the user attempts to close the desktop window and/or quit the application.
@@ -392,7 +392,7 @@ pub struct NativeOptions {
     /// * macOS:   `/Users/UserName/Library/Application Support/APP_ID`
     /// * Windows: `C:\Users\UserName\AppData\Roaming\APP_ID`
     ///
-    /// If you don't set [`Self::app_id`], the title argument to [`eframe::run_native`]
+    /// If you don't set [`Self::app_id`], the title argument to [`crate::run_native`]
     /// will be used instead.
     ///
     /// ### On Wayland

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -3,9 +3,6 @@ use winit::event_loop::EventLoopWindowTarget;
 #[cfg(target_os = "macos")]
 use winit::platform::macos::WindowBuilderExtMacOS as _;
 
-#[cfg(all(feature = "wayland", target_os = "linux"))]
-use winit::platform::wayland::WindowBuilderExtWayland as _;
-
 #[cfg(feature = "accesskit")]
 use egui::accesskit;
 use egui::NumExt as _;
@@ -123,6 +120,7 @@ pub fn window_builder<E>(
 
     #[cfg(all(feature = "wayland", target_os = "linux"))]
     if let Some(app_id) = &native_options.app_id {
+        use winit::platform::wayland::WindowBuilderExtWayland as _;
         window_builder = window_builder.with_name(app_id, "");
     }
 

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -682,7 +682,12 @@ mod glow_integration {
         }
 
         fn init_run_state(&mut self, event_loop: &EventLoopWindowTarget<UserEvent>) -> Result<()> {
-            let storage = epi_integration::create_storage(&self.app_name);
+            let storage = epi_integration::create_storage(
+                self.native_options
+                    .app_id
+                    .as_ref()
+                    .unwrap_or(&self.app_name),
+            );
 
             let (gl_window, gl) = Self::create_glutin_windowed_context(
                 event_loop,
@@ -1350,7 +1355,12 @@ mod wgpu_integration {
                             self.set_window(window)?;
                         }
                     } else {
-                        let storage = epi_integration::create_storage(&self.app_name);
+                        let storage = epi_integration::create_storage(
+                            self.native_options
+                                .app_id
+                                .as_ref()
+                                .unwrap_or(&self.app_name),
+                        );
                         let window = Self::create_window(
                             event_loop,
                             storage.as_deref(),

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -16,7 +16,7 @@ pub struct RawInput {
     /// Position and size of the area that egui should use, in points.
     /// Usually you would set this to
     ///
-    /// `Some(Rect::from_pos_size(Default::default(), screen_size_in_points))`.
+    /// `Some(Rect::from_min_size(Default::default(), screen_size_in_points))`.
     ///
     /// but you could also constrain egui to some smaller portion of your window if you like.
     ///

--- a/crates/egui_glow/src/lib.rs
+++ b/crates/egui_glow/src/lib.rs
@@ -1,6 +1,6 @@
 //! [`egui`] bindings for [`glow`](https://github.com/grovesNL/glow).
 //!
-//! The main types you want to look are are [`Painter`] and [`EguiGlow`].
+//! The main types you want to look are are [`Painter`].
 //!
 //! If you are writing an app, you may want to look at [`eframe`](https://docs.rs/eframe) instead.
 //!

--- a/crates/egui_glow/src/painter.rs
+++ b/crates/egui_glow/src/painter.rs
@@ -15,6 +15,7 @@ use crate::misc_util::{compile_shader, link_program};
 use crate::shader_version::ShaderVersion;
 use crate::vao;
 
+/// Re-exported [`glow::Context`].
 pub use glow::Context;
 
 const VERT_SRC: &str = include_str!("shader/vertex.glsl");


### PR DESCRIPTION
Follow-up to https://github.com/emilk/egui/pull/3007

This introduces `NativeOptions::app_id` as a way to control the storage location:

* Linux:   `/home/UserName/.local/share/APP_ID`
* macOS:   `/Users/UserName/Library/Application Support/APP_ID`
* Windows: `C:\Users\UserName\AppData\Roaming\APP_ID`

The fallback will be the window title, as in previous version of `eframe`.