### PR TITLE
Add an optional skip_taskbar field to eframe's NativeOptions for hide taskbar icon under windows

### DIFF
--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -479,6 +479,7 @@ impl Default for NativeOptions {
             mouse_passthrough: false,
 
             active: true,
+            skip_taskbar: false,
 
             vsync: true,
             multisampling: 0,

--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -294,6 +294,9 @@ pub struct NativeOptions {
     /// Whether grant focus when window initially opened. True by default.
     pub active: bool,
 
+    /// Hide taskbar icon under windows.
+    pub skip_taskbar: bool,
+
     /// Turn on vertical syncing, limiting the FPS to the display refresh rate.
     ///
     /// The default is `true`.

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -110,10 +110,11 @@ pub fn window_builder<E>(
         .with_transparent(*transparent)
         .with_window_icon(window_icon)
         .with_active(*active)
-        .with_skip_taskbar(*skip_taskbar)
         // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
         // We must also keep the window hidden until AccessKit is initialized.
         .with_visible(false);
+    #[cfg(target_os = "windows")]
+    window_builder = window_builder.with_skip_taskbar(*skip_taskbar);
 
     #[cfg(target_os = "macos")]
     if *fullsize_content {

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -3,6 +3,9 @@ use winit::event_loop::EventLoopWindowTarget;
 #[cfg(target_os = "macos")]
 use winit::platform::macos::WindowBuilderExtMacOS as _;
 
+#[cfg(target_os = "windows")]
+use winit::platform::windows::WindowBuilderExtWindows;
+
 #[cfg(feature = "accesskit")]
 use egui::accesskit;
 use egui::NumExt as _;
@@ -92,6 +95,7 @@ pub fn window_builder<E>(
         transparent,
         centered,
         active,
+        skip_taskbar,
         ..
     } = native_options;
 
@@ -106,6 +110,7 @@ pub fn window_builder<E>(
         .with_transparent(*transparent)
         .with_window_icon(window_icon)
         .with_active(*active)
+        .with_skip_taskbar(*skip_taskbar)
         // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
         // We must also keep the window hidden until AccessKit is initialized.
         .with_visible(false);

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -115,7 +115,9 @@ pub fn window_builder<E>(
         .with_visible(false);
 
     #[cfg(target_os = "windows")]
-    window_builder = window_builder.with_skip_taskbar(*skip_taskbar);
+    {
+        window_builder = window_builder.with_skip_taskbar(*skip_taskbar);
+    }
 
     #[cfg(target_os = "macos")]
     if *fullsize_content {

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -113,6 +113,7 @@ pub fn window_builder<E>(
         // Keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
         // We must also keep the window hidden until AccessKit is initialized.
         .with_visible(false);
+
     #[cfg(target_os = "windows")]
     window_builder = window_builder.with_skip_taskbar(*skip_taskbar);
 


### PR DESCRIPTION
Add support for `skip_taskbar` of winit to hide taskbar icon under windows.