### PR TITLE
Fix a document: `eframe::start_web`

### DIFF
--- a/crates/eframe/src/lib.rs
+++ b/crates/eframe/src/lib.rs
@@ -7,7 +7,7 @@
 //! To learn how to set up `eframe` for web and native, go to <https://github.com/emilk/eframe_template/> and follow the instructions there!
 //!
 //! In short, you implement [`App`] (especially [`App::update`]) and then
-//! call [`crate::run_native`] from your `main.rs`, and/or call `eframe::start_web` from your `lib.rs`.
+//! call [`crate::run_native`] from your `main.rs`, and/or use `eframe::WebRunner` from your `lib.rs`.
 //!
 //! ## Usage, native:
 //! ``` no_run


### PR DESCRIPTION
In `0.22.0`, `eframe::start_web` has been replaced with `eframe::WebRunner`.

[But, there is a missed document in `eframe` `/lib.rs`.](https://github.com/emilk/egui/blob/307565efa55158cfa6b82d2e8fdc4c4914b954ed/crates/eframe/src/lib.rs#L10)

https://github.com/emilk/egui/blob/307565efa55158cfa6b82d2e8fdc4c4914b954ed/crates/eframe/src/lib.rs#L10

[I think it should be like:](https://github.com/ulagbulag/egui/blob/d9cf9e6f3a4c85b7029fb36abf3e85ac7afcf9df/crates/eframe/src/lib.rs#L10)

```rust
//! call [`crate::run_native`] from your `main.rs`, and/or use `eframe::WebRunner` from your `lib.rs`.
```

And thanks for driving the artistic Rust GUI framework!

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do not open PR:s from your `master` branch, as thart makes it difficult for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->
