### PR TITLE
Derive Default for Rect

### DIFF
--- a/crates/emath/src/rect.rs
+++ b/crates/emath/src/rect.rs
@@ -15,7 +15,7 @@ use crate::*;
 ///
 /// Normally the unit is points (logical pixels) in screen space coordinates.
 #[repr(C)]
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 pub struct Rect {


### PR DESCRIPTION
Makes it slightly nicer to work with and I don't see a reason against the derive. `Pos2` already is Default.