### PR TITLE
Make the demo app's "Scale" slider responsive to text editing

### DIFF
--- a/crates/egui_demo_app/src/backend_panel.rs
+++ b/crates/egui_demo_app/src/backend_panel.rs
@@ -218,12 +218,9 @@ impl BackendPanel {
                 )
                 .on_hover_text("Physical pixels per point.");
 
-            if response.drag_released() {
+            if !response.dragged() {
                 // We wait until mouse release to activate:
                 ui.ctx().set_pixels_per_point(*pixels_per_point);
-                reset = true;
-            } else if !response.is_pointer_button_down_on() {
-                // When not dragging, show the current pixels_per_point so others can change it.
                 reset = true;
             }
 


### PR DESCRIPTION
Currently, the "Scale" slider in the demo app only syncs scale changes on mouse-up. This means that editing the text field has no effect.

This commit changes that slider to sync every scale change, as long as the slider isn't currently being dragged.