### PR TITLE
Adjust menu shadows

### DIFF
--- a/crates/egui/src/widgets/mod.rs
+++ b/crates/egui/src/widgets/mod.rs
@@ -125,16 +125,33 @@ pub fn stroke_ui(ui: &mut crate::Ui, stroke: &mut epaint::Stroke, text: &str) {
 }
 
 pub(crate) fn shadow_ui(ui: &mut Ui, shadow: &mut epaint::Shadow, text: &str) {
-    let epaint::Shadow { extrusion, color } = shadow;
-    ui.horizontal(|ui| {
+    let epaint::Shadow {
+        extrusion,
+        color,
+        top_offset,
+    } = shadow;
+    ui.group(|ui| {
         ui.label(text);
-        ui.add(
-            DragValue::new(extrusion)
-                .speed(1.0)
-                .clamp_range(0.0..=100.0),
-        )
-        .on_hover_text("Extrusion");
-        ui.color_edit_button_srgba(color);
+        ui.horizontal(|ui| {
+            ui.add(
+                DragValue::new(extrusion)
+                    .speed(1.0)
+                    .clamp_range(0.0..=100.0),
+            );
+            ui.label("Extrusion");
+        });
+        ui.horizontal(|ui| {
+            ui.color_edit_button_srgba(color);
+            ui.label("Color");
+        });
+        ui.horizontal(|ui| {
+            ui.add(
+                DragValue::new(top_offset)
+                    .speed(1.0)
+                    .clamp_range(0.0..=100.0),
+            );
+            ui.label("Top edge offset");
+        });
     });
 }
 

--- a/crates/epaint/src/shadow.rs
+++ b/crates/epaint/src/shadow.rs
@@ -11,27 +11,34 @@ pub struct Shadow {
 
     /// Color of the opaque center of the shadow.
     pub color: Color32,
+
+    /// Y-offset for the top edge of the rectangle. Positive values make the shadow
+    /// smaller, negative values make the shadow larger. The bottom edge is unchanged.
+    pub top_offset: f32,
 }
 
 impl Shadow {
     pub const NONE: Self = Self {
         extrusion: 0.0,
         color: Color32::TRANSPARENT,
+        top_offset: 0.0,
     };
 
     /// Tooltips, menus, …, for dark mode.
     pub fn small_dark() -> Self {
         Self {
-            extrusion: 16.0,
-            color: Color32::from_black_alpha(96),
+            extrusion: 12.0,
+            color: Color32::from_black_alpha(72),
+            top_offset: 6.0,
         }
     }
 
     /// Tooltips, menus, …, for light mode.
     pub fn small_light() -> Self {
         Self {
-            extrusion: 16.0,
-            color: Color32::from_black_alpha(20),
+            extrusion: 12.0,
+            color: Color32::from_black_alpha(15),
+            top_offset: 6.0,
         }
     }
 
@@ -40,6 +47,7 @@ impl Shadow {
         Self {
             extrusion: 32.0,
             color: Color32::from_black_alpha(96),
+            top_offset: 0.0,
         }
     }
 
@@ -48,13 +56,20 @@ impl Shadow {
         Self {
             extrusion: 32.0,
             color: Color32::from_black_alpha(16),
+            top_offset: 0.0,
         }
     }
 
-    pub fn tessellate(&self, rect: Rect, rounding: impl Into<Rounding>) -> Mesh {
+    pub fn tessellate(&self, mut rect: Rect, rounding: impl Into<Rounding>) -> Mesh {
         // tessellator.clip_rect = clip_rect; // TODO(emilk): culling
 
-        let Self { extrusion, color } = *self;
+        let Self {
+            extrusion,
+            color,
+            top_offset,
+        } = *self;
+
+        rect.set_top(f32::min(rect.top() + top_offset, rect.bottom()));
 
         let rounding: Rounding = rounding.into();
         let half_ext = 0.5 * extrusion;


### PR DESCRIPTION
This commit makes menu and tooltip shadows slightly fainter and smaller.

It also introduces the option for shadows' top edges to be slightly inset relative to their parent window. This causes menus and tooltips to cast less of a shadow over the widget which opened them.

Closes <https://github.com/emilk/egui/issues/3046>.