### PR TITLE
Changed logic for submenus closing

### DIFF
--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -616,8 +616,6 @@ impl MenuState {
         } else if !open && button.hovered() {
             let pos = button.rect.right_top();
             self.open_submenu(sub_id, pos);
-        } else if open && !button.hovered() && !self.hovering_current_submenu(&pointer) {
-            self.close_submenu();
         }
     }
 

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -640,16 +640,6 @@ impl MenuState {
         false
     }
 
-    /// Check if pointer is hovering current submenu.
-    fn hovering_current_submenu(&self, pointer: &PointerState) -> bool {
-        if let Some(sub_menu) = self.current_submenu() {
-            if let Some(pos) = pointer.hover_pos() {
-                return sub_menu.read().area_contains(pos);
-            }
-        }
-        false
-    }
-
     /// Cascade close response to menu root.
     fn cascade_close_response(&mut self, response: MenuResponse) {
         if response.is_close() {
@@ -680,9 +670,5 @@ impl MenuState {
         if !self.is_open(id) {
             self.sub_menu = Some((id, Arc::new(RwLock::new(MenuState::new(pos)))));
         }
-    }
-
-    fn close_submenu(&mut self) {
-        self.sub_menu = None;
     }
 }


### PR DESCRIPTION
This tiny change removes the trigger for a submenu to close if the mouse is no longer hovering over it or one of its children. Now, the menu stays open until a different menu item is selected. This aims to address <https://github.com/emilk/egui/issues/2853>.

I suspected that a new trigger would need to be implemented so that multiple menu items don't remain open simultaneously, but after some testing, this does not appear to occur.

This change leaves `MenuState::hovering_current_submenu` and `MenuState::close_submenu` as dead code in case they might be useful later.