### PR TITLE
Fix panic on wgpu GL backend due to new screenshot capability

### DIFF
--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -798,7 +798,8 @@ impl Frame {
     /// Returns None if:
     /// * Called in [`App::update`]
     /// * [`Frame::request_screenshot`] wasn't called on this frame during [`App::update`]
-    /// * The rendering backend doesn't support this feature (yet). Currently implemented for wgpu and glow, but not with wasm as target or gl as backend in the case of wgpu.
+    /// * The rendering backend doesn't support this feature (yet). Currently implemented for wgpu and glow, but not with wasm as target.
+    /// * Wgpu's GL target is active (not yet supported)
     /// * Retrieving the data was unsuccessful in some way.
     ///
     /// See also [`egui::ColorImage::region`]

--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -798,7 +798,7 @@ impl Frame {
     /// Returns None if:
     /// * Called in [`App::update`]
     /// * [`Frame::request_screenshot`] wasn't called on this frame during [`App::update`]
-    /// * The rendering backend doesn't support this feature (yet). Currently implemented for wgpu and glow, but not with wasm as target.
+    /// * The rendering backend doesn't support this feature (yet). Currently implemented for wgpu and glow, but not with wasm as target or gl as backend in the case of wgpu.
     /// * Retrieving the data was unsuccessful in some way.
     ///
     /// See also [`egui::ColorImage::region`]

--- a/crates/egui-wgpu/CHANGELOG.md
+++ b/crates/egui-wgpu/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to the `egui-wgpu` integration will be noted in this file.
 
 
 ## Unreleased
+* Fix panic on wgpu GL backend due to new screenshot capability ([#3068](https://github.com/emilk/egui/issues/3068), [#3078](https://github.com/emilk/egui/pull/3078)
 
 
 ## 0.22.0 - 2023-05-23

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -581,7 +581,7 @@ impl Painter {
                 Self::read_screen_rgba(screen_capture_state, render_state, &output_frame)
             }
             (true, false) => {
-                log::error!("Screenshots are not supported on backend that don't allow the render surface to have the TextureUsages::COPY_DST flag");
+                log::error!("The active render surface doesn't support taking screenshots.");
                 None
             }
             (false, _) => None,

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -136,7 +136,7 @@ impl Painter {
         render_state: &RenderState,
         present_mode: wgpu::PresentMode,
     ) {
-        let usage = match render_state.adapter.get_info().backend{
+        let usage = match render_state.adapter.get_info().backend {
             wgpu::Backend::Gl => wgpu::TextureUsages::RENDER_ATTACHMENT,
             _ => wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_DST,
         };
@@ -491,7 +491,12 @@ impl Painter {
 
         {
             let renderer = render_state.renderer.read();
-            let frame_view = if capture & output_frame.texture.usage().contains(wgpu::TextureUsages::COPY_DST) {
+            let frame_view = if capture
+                & output_frame
+                    .texture
+                    .usage()
+                    .contains(wgpu::TextureUsages::COPY_DST)
+            {
                 Self::update_capture_state(
                     &mut self.screen_capture_state,
                     &output_frame,
@@ -564,15 +569,21 @@ impl Painter {
                 .submit(user_cmd_bufs.into_iter().chain(std::iter::once(encoded)));
         };
 
-        let screenshot = match (capture, output_frame.texture.usage().contains(wgpu::TextureUsages::COPY_DST)){
+        let screenshot = match (
+            capture,
+            output_frame
+                .texture
+                .usage()
+                .contains(wgpu::TextureUsages::COPY_DST),
+        ) {
             (true, true) => {
                 let screen_capture_state = self.screen_capture_state.as_ref()?;
                 Self::read_screen_rgba(screen_capture_state, render_state, &output_frame)
-            },
+            }
             (true, false) => {
                 log::error!("Screenshots are not supported on backend that don't allow the render surface to have the TextureUsages::COPY_DST flag");
                 None
-            },
+            }
             (false, _) => None,
         };
 

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -224,7 +224,8 @@ impl Painter {
                     wgpu::CompositeAlphaMode::Auto
                 };
 
-                let supports_screenshot = !matches!(render_state.adapter.get_info().backend, wgpu::Backend::Gl);
+                let supports_screenshot =
+                    !matches!(render_state.adapter.get_info().backend, wgpu::Backend::Gl);
 
                 let size = window.inner_size();
                 self.surface_state = Some(SurfaceState {

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -224,10 +224,7 @@ impl Painter {
                     wgpu::CompositeAlphaMode::Auto
                 };
 
-                let supports_screenshot = match render_state.adapter.get_info().backend {
-                    wgpu::Backend::Gl => false,
-                    _ => true,
-                };
+                let supports_screenshot = !matches!(render_state.adapter.get_info().backend, wgpu::Backend::Gl);
 
                 let size = window.inner_size();
                 self.surface_state = Some(SurfaceState {


### PR DESCRIPTION
This is a first-pass triage for https://github.com/emilk/egui/issues/3068. The fix involves simply disabling the screen shot feature when using the GL backend with wgpu. If a screenshot is requested on this backend, None will be provided and an error is logged out. The docs have been updated with an small comment on how the feature isn't available with the GL backend.

The reason that the feature is incompatible with the GL backend is that this backend doesn't allow the surface to have the TextureUsages::COPY_DST flag, and so the approach of rendering to a texture and subsequently copying the result to the surface and a buffer for extracting to the CPU is fundamentally incompatible.

Perhaps @Wumpf can help with ideas on how to circumvent this?
