### PR TITLE
Make `Table` min/max_scroll_height Optional by default

### DIFF
--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -160,8 +160,8 @@ struct TableScrollOptions {
     stick_to_bottom: bool,
     scroll_to_row: Option<(usize, Option<Align>)>,
     scroll_offset_y: Option<f32>,
-    min_scrolled_height: f32,
-    max_scroll_height: f32,
+    min_scrolled_height: Option<f32>,
+    max_scroll_height: Option<f32>,
     auto_shrink: [bool; 2],
 }
 
@@ -172,8 +172,8 @@ impl Default for TableScrollOptions {
             stick_to_bottom: false,
             scroll_to_row: None,
             scroll_offset_y: None,
-            min_scrolled_height: 200.0,
-            max_scroll_height: 800.0,
+            min_scrolled_height: None,
+            max_scroll_height: None,
             auto_shrink: [true; 2],
         }
     }
@@ -306,7 +306,7 @@ impl<'a> TableBuilder<'a> {
     ///
     /// Default: `200.0`.
     pub fn min_scrolled_height(mut self, min_scrolled_height: f32) -> Self {
-        self.scroll_options.min_scrolled_height = min_scrolled_height;
+        self.scroll_options.min_scrolled_height = Some(min_scrolled_height);
         self
     }
 
@@ -315,7 +315,7 @@ impl<'a> TableBuilder<'a> {
     /// In other words: add scroll-bars when this height is reached.
     /// Default: `800.0`.
     pub fn max_scroll_height(mut self, max_scroll_height: f32) -> Self {
-        self.scroll_options.max_scroll_height = max_scroll_height;
+        self.scroll_options.max_scroll_height = Some(max_scroll_height);
         self
     }
 
@@ -564,9 +564,15 @@ impl<'a> Table<'a> {
         let mut scroll_area = ScrollArea::new([false, vscroll])
             .auto_shrink([true; 2])
             .stick_to_bottom(stick_to_bottom)
-            .min_scrolled_height(min_scrolled_height)
-            .max_height(max_scroll_height)
             .auto_shrink(auto_shrink);
+
+        if let Some(min_scrolled_height) = min_scrolled_height {
+            scroll_area = scroll_area.min_scrolled_height(min_scrolled_height);
+        }
+
+        if let Some(max_scroll_height) = max_scroll_height {
+            scroll_area = scroll_area.max_height(max_scroll_height);
+        }
 
         if let Some(scroll_offset_y) = scroll_offset_y {
             scroll_area = scroll_area.vertical_scroll_offset(scroll_offset_y);


### PR DESCRIPTION
Changes the `TableScrollOptions` to use Optional values for `min_scroll_height` and `max_scroll_height`, requiring the user to call the respective builder functions if they desire those behaviors.

This addresses the surprising effect that by default Tables limit themselves to a maximum height of 800px (#3114).

Closes <https://github.com/emilk/egui/issues/3114>.
