### PR TITLE
Return `TableOutput` struct from `TableBuilder::body()`

### DIFF
--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -539,6 +539,7 @@ pub struct Table<'a> {
     cell_layout: egui::Layout,
 
     scroll_options: TableScrollOptions,
+
     /// The `header_response` is passed down from [`TableBuilder::header()`] so that it can be returned to the user after the body is built.
     /// If no header is specified, it is `None`.
     header_response: Option<Response>,


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do not open PR:s from your `master` branch, as thart makes it difficult for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Currently it appears to be impossible, or very difficult, to receive information about the table that will be drawn to the window. This PR adds a barebones solution to this by returning a `TableOutput` struct from `fn body()` which describes the basic details about the header and the content body of the table.

I'm ok with spending the extra time to expand this further to cover more of the data about the table, such as being able to return values from the header and body functions, or being able to specify the sense on them. However, I want to verify this is the preferred way of doing this beforehand.