### PR TITLE
Fix the "ever-growing height" problem of Strip and Table demos

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -426,7 +426,7 @@ impl Prepared {
             temporarily_invisible: _,
         } = self;
 
-        state.size = content_ui.min_rect().size();
+        state.size = content_ui.min_size();
 
         ctx.memory_mut(|m| m.areas.set_state(layer_id, state));
 

--- a/crates/egui_demo_lib/src/demo/strip_demo.rs
+++ b/crates/egui_demo_lib/src/demo/strip_demo.rs
@@ -37,7 +37,7 @@ impl super::View for StripDemo {
             .size(Size::exact(50.0))
             .size(Size::remainder())
             .size(Size::relative(0.5).at_least(60.0))
-            .size(Size::exact(10.0))
+            .size(Size::exact(10.5))
             .vertical(|mut strip| {
                 strip.cell(|ui| {
                     ui.painter().rect_filled(

--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -102,7 +102,7 @@ impl super::View for TableDemo {
         use egui_extras::{Size, StripBuilder};
         StripBuilder::new(ui)
             .size(Size::remainder().at_least(100.0)) // for the table
-            .size(Size::exact(10.0)) // for the source code link
+            .size(Size::exact(10.5)) // for the source code link
             .vertical(|mut strip| {
                 strip.cell(|ui| {
                     egui::ScrollArea::horizontal().show(ui, |ui| {

--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -38,7 +38,6 @@ impl super::Demo for TableDemo {
     fn show(&mut self, ctx: &egui::Context, open: &mut bool) {
         egui::Window::new(self.name())
             .open(open)
-            .resizable(true)
             .default_width(400.0)
             .show(ctx, |ui| {
                 use super::View as _;

--- a/crates/emath/src/rect.rs
+++ b/crates/emath/src/rect.rs
@@ -280,6 +280,7 @@ impl Rect {
         }
     }
 
+    /// `rect.size() == Vec2 { x: rect.width(), y: rect.height() }`
     #[inline(always)]
     pub fn size(&self) -> Vec2 {
         self.max - self.min


### PR DESCRIPTION
Problem
-------

The height of "Table Demo" or "Strip Demo" floating window grows
when the demo app is interacted with. If 'Continuous' mode is enabled
in 'Backend' settings, the window grows irrespectively of user interaction.

Observations
------------

I noticed that [`area_content_ui.min_rect().max.y`][1] is increasing
monotonically with speed 0.5 px/frame.

I also noticed that commenting out `ui.add(crate::egui_github_link_file!());`
[statement][2] in `table_demo.rs` makes the problem disappear.

The "Fix"
---------

I added 0.5 to the height of the row with GitHub link.
This solved the problem.

Before:

https://github.com/emilk/egui/assets/17462/1cb100b8-5fc8-4233-87eb-685d8a78650b

After:

https://github.com/emilk/egui/assets/17462/bd373d30-4775-4fa3-b8f7-425e13c6993c

Closes #3029.

Warning
-------

I failed to find the root cause of the problem.
I don't understand why this change makes the problem disappear.

[1]: https://github.com/emilk/egui/blob/9478e50d012c5138551c38cbee16b07bc1fcf283/crates/egui/src/containers/window.rs#L403
[2]: https://github.com/emilk/egui/blob/9478e50d012c5138551c38cbee16b07bc1fcf283/crates/egui_demo_lib/src/demo/table_demo.rs#L114