### PR TITLE
Tiny PR: Document available_width() and available_height()

### DIFF
--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -556,6 +556,7 @@ impl Ui {
     // Layout related measures:
 
     /// The available space at the moment, given the current cursor.
+    ///
     /// This how much more space we can take up without overflowing our parent.
     /// Shrinks as widgets allocate space and the cursor moves.
     /// A small size should be interpreted as "as little as possible".
@@ -564,19 +565,30 @@ impl Ui {
         self.placer.available_size()
     }
 
+    /// The available width at the moment, given the current cursor.
+    ///
+    /// See [available_size()] for mor information.
     pub fn available_width(&self) -> f32 {
         self.available_size().x
     }
 
+    /// The available height at the moment, given the current cursor.
+    ///
+    /// See [available_size()] for mor information.
     pub fn available_height(&self) -> f32 {
         self.available_size().y
     }
 
     /// In case of a wrapping layout, how much space is left on this row/column?
+    ///
+    /// If the layout does not wrap, this will return the same value as [available_size()].
     pub fn available_size_before_wrap(&self) -> Vec2 {
         self.placer.available_rect_before_wrap().size()
     }
 
+    /// In case of a wrapping layout, how much space is left on this row/column?
+    ///
+    /// If the layout does not wrap, this will return the same value as [available_size()].
     pub fn available_rect_before_wrap(&self) -> Rect {
         self.placer.available_rect_before_wrap()
     }


### PR DESCRIPTION
Added some quick docs to the available_width() and available_height() methods. 

Also a quick note about the wrapping versions of the methods as well.