### PR TITLE
egui: Plot Arrows add method to specify tip_size

### DIFF
--- a/crates/egui/src/widgets/plot/items/mod.rs
+++ b/crates/egui/src/widgets/plot/items/mod.rs
@@ -997,6 +997,7 @@ impl PlotItem for Points {
 pub struct Arrows {
     pub(super) origins: PlotPoints,
     pub(super) tips: PlotPoints,
+    pub(super) tip_length: Option<f32>,
     pub(super) color: Color32,
     pub(super) name: String,
     pub(super) highlight: bool,
@@ -1007,6 +1008,7 @@ impl Arrows {
         Self {
             origins: origins.into(),
             tips: tips.into(),
+            tip_length: None,
             color: Color32::TRANSPARENT,
             name: Default::default(),
             highlight: false,
@@ -1016,6 +1018,12 @@ impl Arrows {
     /// Highlight these arrows in the plot.
     pub fn highlight(mut self, highlight: bool) -> Self {
         self.highlight = highlight;
+        self
+    }
+
+    /// Set the length of the arrow tips
+    pub fn tip_length(mut self, tip_length: f32) -> Self {
+        self.tip_length = Some(tip_length);
         self
     }
 
@@ -1044,6 +1052,7 @@ impl PlotItem for Arrows {
         let Self {
             origins,
             tips,
+            tip_length,
             color,
             highlight,
             ..
@@ -1062,7 +1071,11 @@ impl PlotItem for Arrows {
             .for_each(|(origin, tip)| {
                 let vector = tip - origin;
                 let rot = Rot2::from_angle(std::f32::consts::TAU / 10.0);
-                let tip_length = vector.length() / 4.0;
+                let tip_length = if let Some(tip_length) = tip_length {
+                    *tip_length
+                } else {
+                    vector.length() / 4.0
+                };
                 let tip = origin + vector;
                 let dir = vector.normalized();
                 shapes.push(Shape::line_segment([origin, tip], stroke));


### PR DESCRIPTION
Hello everyone,

For my application I want the plot arrows to always have the same size and currently the tip size
depends on the length of the arrow. So this patch adds a method to explicitly set the arrow tip size.

If this needs more discussion, I can additionally open an issue.

Have a nice day everyone!

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do not open PR:s from your `master` branch, as thart makes it difficult for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->
