### PR TITLE
eframe: sleep a bit only when minimized

### DIFF
--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -914,12 +914,9 @@ mod glow_integration {
 
                 integration.maybe_autosave(app.as_mut(), window);
 
-                if !self.is_focused {
-                    // On Mac, a minimized Window uses up all CPU: https://github.com/emilk/egui/issues/325
-                    // We can't know if we are minimized: https://github.com/rust-windowing/winit/issues/208
-                    // But we know if we are focused (in foreground). When minimized, we are not focused.
-                    // However, a user may want an egui with an animation in the background,
-                    // so we still need to repaint quite fast.
+                if window.is_minimized() == Some(true) {
+                    // On Mac, a minimized Window uses up all CPU:
+                    // https://github.com/emilk/egui/issues/325
                     crate::profile_scope!("bg_sleep");
                     std::thread::sleep(std::time::Duration::from_millis(10));
                 }
@@ -1335,12 +1332,9 @@ mod wgpu_integration {
 
                 integration.maybe_autosave(app.as_mut(), window);
 
-                if !self.is_focused {
-                    // On Mac, a minimized Window uses up all CPU: https://github.com/emilk/egui/issues/325
-                    // We can't know if we are minimized: https://github.com/rust-windowing/winit/issues/208
-                    // But we know if we are focused (in foreground). When minimized, we are not focused.
-                    // However, a user may want an egui with an animation in the background,
-                    // so we still need to repaint quite fast.
+                if window.is_minimized() == Some(true) {
+                    // On Mac, a minimized Window uses up all CPU:
+                    // https://github.com/emilk/egui/issues/325
                     crate::profile_scope!("bg_sleep");
                     std::thread::sleep(std::time::Duration::from_millis(10));
                 }


### PR DESCRIPTION
The current eframe implementation sleeps 10ms for each frame when the window is not focused. This is likely due to the fact that when this feature was added, winit was not a dependency package, so there was no way to check if the window was minimized.

While this behavior has its advantages, it's frustrating for developers who want a smooth UI experience, so it would be nice to add an optional frame limit feature in each situation in the future instead.

Related Issue: #325