### PR TITLE
Fix a typo

### DIFF
--- a/crates/egui_extras/src/datepicker/button.rs
+++ b/crates/egui_extras/src/datepicker/button.rs
@@ -61,7 +61,7 @@ impl<'a> DatePickerButton<'a> {
         self
     }
 
-    /// Show the calender icon on the button. (Default: true)
+    /// Show the calendar icon on the button. (Default: true)
     pub fn show_icon(mut self, show_icon: bool) -> Self {
         self.show_icon = show_icon;
         self


### PR DESCRIPTION
Fixes a small typo in `DatePickerButton`.