### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,13 +15,11 @@ jobs:
     name: Format + check + test
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: default
           toolchain: 1.65.0
-          override: true
 
       - name: Install packages (Linux)
         if: runner.os == 'Linux'
@@ -37,10 +35,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Install cargo-cranky
         uses: baptiste0928/cargo-install@v1
@@ -48,70 +43,37 @@ jobs:
           crate: cargo-cranky
 
       - name: check --all-features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --locked --all-features --all-targets
+        run: cargo check --locked --all-features --all-targets
 
       - name: check egui_extras --all-features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --locked --all-features --all-targets -p egui_extras
+        run: cargo check --locked --all-features --all-targets -p egui_extras
 
       - name: check default features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --locked --all-targets
+        run: cargo check --locked --all-targets
 
       - name: check --no-default-features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --locked --no-default-features --lib --all-targets
+        run: cargo check --locked --no-default-features --lib --all-targets
 
       - name: check epaint --no-default-features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --locked --no-default-features --lib --all-targets -p epaint
+        run: cargo check --locked --no-default-features --lib --all-targets -p epaint
 
       - name: check eframe --no-default-features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --locked --no-default-features --lib --all-targets -p eframe
+        run: cargo check --locked --no-default-features --lib --all-targets -p eframe
 
       - name: Test doc-tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --doc --all-features
+        run: cargo test --doc --all-features
 
       - name: cargo doc --lib
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --lib --no-deps --all-features
+        run: cargo doc --lib --no-deps --all-features
 
       - name: cargo doc --document-private-items
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --document-private-items --no-deps --all-features
+        run: cargo doc --document-private-items --no-deps --all-features
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
+        run: cargo test --all-features
 
       - name: Cranky
-        uses: actions-rs/cargo@v1
-        with:
-          command: cranky
-          args: --all-targets --all-features -- -D warnings
+        run: cargo cranky --all-targets --all-features -- -D warnings
 
   # ---------------------------------------------------------------------------
 
@@ -119,13 +81,11 @@ jobs:
     name: Check wasm32 + wasm-bindgen
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: 1.65.0
-          target: wasm32-unknown-unknown
-          override: true
+          targets: wasm32-unknown-unknown
 
       - run: sudo apt-get update && sudo apt-get install libgtk-3-dev
 
@@ -138,22 +98,13 @@ jobs:
           crate: cargo-cranky
 
       - name: Check wasm32 egui_demo_app
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: -p egui_demo_app --lib --target wasm32-unknown-unknown
+        run: cargo check -p egui_demo_app --lib --target wasm32-unknown-unknown
 
       - name: Check wasm32 egui_demo_app --all-features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: -p egui_demo_app --lib --target wasm32-unknown-unknown --all-features
+        run: cargo check -p egui_demo_app --lib --target wasm32-unknown-unknown --all-features
 
       - name: Check wasm32 eframe
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: -p eframe --lib --no-default-features --features glow,persistence --target wasm32-unknown-unknown
+        run: cargo check -p eframe --lib --no-default-features --features glow,persistence --target wasm32-unknown-unknown
 
       - name: wasm-bindgen
         uses: jetli/wasm-bindgen-action@v0.1.0
@@ -188,7 +139,7 @@ jobs:
     name: cargo-deny ${{ matrix.target }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           rust-version: "1.65.0"
@@ -202,14 +153,12 @@ jobs:
     name: android
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: 1.65.0
-          target: aarch64-linux-android
-          override: true
+          targets: aarch64-linux-android
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
@@ -223,18 +172,13 @@ jobs:
     name: Check Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: 1.65.0
-          override: true
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
 
       - name: Check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-targets --all-features
+        run: cargo check --all-targets --all-features

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check spelling of entire workspace
         uses: crate-ci/typos@master


### PR DESCRIPTION
The following updates are performed:
* update [`actions/checkout`](https://github.com/actions/checkout) to v3
* replace [unmaintained](https://github.com/actions-rs/toolchain/issues/216) `actions-rs/toolchain` by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)
* replace unmaintained `actions-rs/cargo` by direct invocation of `cargo`

Still using the outdated / unmaintained actions will generate several warnings in CI runs, for example in https://github.com/emilk/egui/actions/runs/5060562895:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions-rs/toolchain@v1, actions-rs/cargo@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings.