### PR TITLE
🧢 Expose `area::State`'s `Rect` in Memory

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -55,6 +55,8 @@ impl State {
 ///     });
 /// # });
 /// ```
+///
+/// The previous rectangle used by this area can be obtained through [`crate::Memory::area_rect()`].
 #[must_use = "You should call .show()"]
 #[derive(Clone, Copy, Debug)]
 pub struct Area {

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -21,6 +21,9 @@ use super::*;
 ///    ui.label("Hello World!");
 /// });
 /// # });
+/// ```
+///
+/// The previous rectangle used by this window can be obtained through [`crate::Memory::area_rect()`].
 #[must_use = "You should call .show()"]
 pub struct Window<'open> {
     title: WidgetText,

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -487,6 +487,11 @@ impl Memory {
     pub fn reset_areas(&mut self) {
         self.areas = Default::default();
     }
+
+    /// Obtain the previous rectangle of an area.
+    pub fn area_rect(&self, id: impl Into<Id>) -> Option<Rect> {
+        self.areas.get(id.into()).map(|state| state.rect())
+    }
 }
 
 /// ## Popups


### PR DESCRIPTION
Currently, there is no way of obtaining any information on windows from `Memory`, even though this is in fact stored in there. This PR exposes the `area::State` struct as public and adds a function to obtain said `State` for a window. 