### PR TITLE
`std::borrow::Cow<'_, str>` now implements `TextBuffer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 * Plot widget - allow disabling zoom and drag for x and y separately [#2901](https://github.com/emilk/egui/pull/2901) (thanks [@OmegaJak](https://github.com/OmegaJak)!)
 * Add character limit to `TextEdit` [#2816](https://github.com/emilk/egui/pull/2816) (thanks [@wzid](https://github.com/wzid)!)
 * Add `egui::Modifiers::contains` [#2989](https://github.com/emilk/egui/pull/2989) (thanks [@Wumpf](https://github.com/Wumpf)!)
-* `std::borrow::Cow<'_, str>` now implements `TextBuffer` [#3164](https://github.com/emilk/pull/3164)
 
 ### 🔧 Changed
 * Improve vertical alignment of fonts [#2724](https://github.com/emilk/egui/pull/2724) (thanks [@lictex](https://github.com/lictex)!)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 * Plot widget - allow disabling zoom and drag for x and y separately [#2901](https://github.com/emilk/egui/pull/2901) (thanks [@OmegaJak](https://github.com/OmegaJak)!)
 * Add character limit to `TextEdit` [#2816](https://github.com/emilk/egui/pull/2816) (thanks [@wzid](https://github.com/wzid)!)
 * Add `egui::Modifiers::contains` [#2989](https://github.com/emilk/egui/pull/2989) (thanks [@Wumpf](https://github.com/Wumpf)!)
-* `std::borrow::Cow<'_, str>` now implements `TextBuffer` [#____](https://github.com/emilk/pull/____)
+* `std::borrow::Cow<'_, str>` now implements `TextBuffer` [#3164](https://github.com/emilk/pull/3164)
 
 ### 🔧 Changed
 * Improve vertical alignment of fonts [#2724](https://github.com/emilk/egui/pull/2724) (thanks [@lictex](https://github.com/lictex)!)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`eframe`](crates/eframe/CHANGELOG
 * Plot widget - allow disabling zoom and drag for x and y separately [#2901](https://github.com/emilk/egui/pull/2901) (thanks [@OmegaJak](https://github.com/OmegaJak)!)
 * Add character limit to `TextEdit` [#2816](https://github.com/emilk/egui/pull/2816) (thanks [@wzid](https://github.com/wzid)!)
 * Add `egui::Modifiers::contains` [#2989](https://github.com/emilk/egui/pull/2989) (thanks [@Wumpf](https://github.com/Wumpf)!)
+* `std::borrow::Cow<'_, str>` now implements `TextBuffer` [#____](https://github.com/emilk/pull/____)
 
 ### 🔧 Changed
 * Improve vertical alignment of fonts [#2724](https://github.com/emilk/egui/pull/2724) (thanks [@lictex](https://github.com/lictex)!)

--- a/crates/egui/src/widgets/text_edit/text_buffer.rs
+++ b/crates/egui/src/widgets/text_edit/text_buffer.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use std::{borrow::Cow, ops::Range};
 
 /// Trait constraining what types [`crate::TextEdit`] may use as
 /// an underlying buffer.
@@ -97,6 +97,36 @@ impl TextBuffer for String {
 
     fn take(&mut self) -> String {
         std::mem::take(self)
+    }
+}
+
+impl<'a> TextBuffer for Cow<'a, str> {
+    fn is_mutable(&self) -> bool {
+        true
+    }
+
+    fn as_str(&self) -> &str {
+        self.as_ref()
+    }
+
+    fn insert_text(&mut self, text: &str, char_index: usize) -> usize {
+        <String as TextBuffer>::insert_text(self.to_mut(), text, char_index)
+    }
+
+    fn delete_char_range(&mut self, char_range: Range<usize>) {
+        <String as TextBuffer>::delete_char_range(self.to_mut(), char_range)
+    }
+
+    fn clear(&mut self) {
+        <String as TextBuffer>::clear(self.to_mut());
+    }
+
+    fn replace(&mut self, text: &str) {
+        *self = Cow::Owned(text.to_owned());
+    }
+
+    fn take(&mut self) -> String {
+        std::mem::take(self).into_owned()
     }
 }
 

--- a/crates/egui/src/widgets/text_edit/text_buffer.rs
+++ b/crates/egui/src/widgets/text_edit/text_buffer.rs
@@ -110,7 +110,7 @@ impl<'a> TextBuffer for Cow<'a, str> {
     }
 
     fn insert_text(&mut self, text: &str, char_index: usize) -> usize {
-        <String as TextBuffer>::insert_text(self.to_mut(), text, char_index);
+        <String as TextBuffer>::insert_text(self.to_mut(), text, char_index)
     }
 
     fn delete_char_range(&mut self, char_range: Range<usize>) {

--- a/crates/egui/src/widgets/text_edit/text_buffer.rs
+++ b/crates/egui/src/widgets/text_edit/text_buffer.rs
@@ -110,11 +110,11 @@ impl<'a> TextBuffer for Cow<'a, str> {
     }
 
     fn insert_text(&mut self, text: &str, char_index: usize) -> usize {
-        <String as TextBuffer>::insert_text(self.to_mut(), text, char_index)
+        <String as TextBuffer>::insert_text(self.to_mut(), text, char_index);
     }
 
     fn delete_char_range(&mut self, char_range: Range<usize>) {
-        <String as TextBuffer>::delete_char_range(self.to_mut(), char_range)
+        <String as TextBuffer>::delete_char_range(self.to_mut(), char_range);
     }
 
     fn clear(&mut self) {


### PR DESCRIPTION
This allows `Cow<'_, str>` to be editable in `TextEdit` widgets. This allows a small optimisation where an immutable value can be provided by default, but then cloned and edited when it is modified using a text edit.

Please let me know if there are any tests or anything else I should add. Thanks for your time.