### PR TITLE
epaint: Add `ColorImage::from_gray`

### DIFF
--- a/crates/epaint/src/image.rs
+++ b/crates/epaint/src/image.rs
@@ -110,10 +110,10 @@ impl ColorImage {
         Self { size, pixels }
     }
 
-    /// Create a [`ColorImage`] from flat un-multiplied gray data.
+    /// Create a [`ColorImage`] from flat opaque gray data.
     ///
     /// Panics if `size[0] * size[1] != gray.len()`.
-    pub fn from_gray_unmultiplied(size: [usize; 2], gray: &[u8]) -> Self {
+    pub fn from_gray(size: [usize; 2], gray: &[u8]) -> Self {
         assert_eq!(size[0] * size[1], gray.len());
         let pixels = gray.iter().map(|p| Color32::from_gray(*p)).collect();
         Self { size, pixels }

--- a/crates/epaint/src/image.rs
+++ b/crates/epaint/src/image.rs
@@ -110,6 +110,15 @@ impl ColorImage {
         Self { size, pixels }
     }
 
+    /// Create a [`ColorImage`] from flat un-multiplied gray data.
+    ///
+    /// Panics if `size[0] * size[1] != gray.len()`.
+    pub fn from_gray_unmultiplied(size: [usize; 2], gray: &[u8]) -> Self {
+        assert_eq!(size[0] * size[1], gray.len());
+        let pixels = gray.iter().map(|p| Color32::from_gray(*p)).collect();
+        Self { size, pixels }
+    }
+
     /// A view of the underlying data as `&[u8]`
     #[cfg(feature = "bytemuck")]
     pub fn as_raw(&self) -> &[u8] {


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do not open PR:s from your `master` branch, as thart makes it difficult for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

This PR adds a new function `from_gray_unmultiplied()` . This allows programs working with grayscale source images to load the images directly as grayscale. 

Previously, an application working with grayscale images would have load the image as rgba. By providing a way to load images in grayscale, the size of the copy is reduced by 4x and the caller no longer needs to perform a conversion from grayscale to rgba. This has resulted in significant performance improvements in my application. It seems likely that anyone working with grayscale source imagery in the future would find this functionality useful.