### PR TITLE
Fix auto_bounds when only one axis has restricted navigation

### DIFF
--- a/crates/egui/src/widgets/plot/mod.rs
+++ b/crates/egui/src/widgets/plot/mod.rs
@@ -864,7 +864,7 @@ impl Plot {
                 delta.y = 0.0;
             }
             transform.translate_bounds(delta);
-            bounds_modified = true.into();
+            bounds_modified = allow_drag;
         }
 
         // Zooming
@@ -935,7 +935,7 @@ impl Plot {
                 }
                 if zoom_factor != Vec2::splat(1.0) {
                     transform.zoom(zoom_factor, hover_pos);
-                    bounds_modified = true.into();
+                    bounds_modified = allow_zoom;
                 }
             }
             if allow_scroll {


### PR DESCRIPTION
This fixes an issue with plots where the auto-bounds feature for the y-axis would not work if navigation in the y-axis was restricted, but moving the x-axis was allowed. Any dragging or scrolling would lead to the auto-bounding being disabled, meaning the y-axis was not rescaled when new data came into view.

If that explanation makes no sense:

before: https://i.imgur.com/2bwRFNr.mp4
after: https://i.imgur.com/5TtD9fp.mp4

The solution is to only consider an axis to be modified if modifying that axis is actually allowed.