### PR TITLE
Fix TextEdit's character limit

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -1185,7 +1185,7 @@ fn insert_text(
     if char_limit < usize::MAX {
         let mut new_string = text_to_insert;
         // Avoid subtract with overflow panic
-        let cutoff = char_limit.saturating_sub(text.as_str().len());
+        let cutoff = char_limit.saturating_sub(text.as_str().chars().count());
 
         new_string = match new_string.char_indices().nth(cutoff) {
             None => new_string,


### PR DESCRIPTION
# Objective
Fixes a issue with `TextEdit`'s character limit. Currently, the character limit is using bytes instead of chars to count the existing length of the text, which causes incorrect behavior with non-ASCII text. This small PR fixes the issue.

## Issue example
If I set a character limit to 8, `TextEdit` will not allow me to write anything after

- "Language" (8 bytes, 8 chars)
- "Морж" (8 bytes, 4 chars)
- "冰淇淋" (9 bytes, 3 chars)

While still not being at the character limit.