### PR TITLE
Set the correct unicode character for "ctrl" shortcuts

### DIFF
--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -610,11 +610,11 @@ pub struct ModifierNames<'a> {
 }
 
 impl ModifierNames<'static> {
-    /// ⌥ ^ ⇧ ⌘ - NOTE: not supported by the default egui font.
+    /// ⌥ ⌃ ⇧ ⌘ - NOTE: not supported by the default egui font.
     pub const SYMBOLS: Self = Self {
         is_short: true,
         alt: "⌥",
-        ctrl: "^",
+        ctrl: "⌃",
         shift: "⇧",
         mac_cmd: "⌘",
         mac_alt: "⌥",
@@ -906,7 +906,7 @@ fn format_kb_shortcut() {
         cmd_shift_f.format(&ModifierNames::NAMES, true),
         "Shift+Cmd+F"
     );
-    assert_eq!(cmd_shift_f.format(&ModifierNames::SYMBOLS, false), "^⇧F");
+    assert_eq!(cmd_shift_f.format(&ModifierNames::SYMBOLS, false), "⌃⇧F");
     assert_eq!(cmd_shift_f.format(&ModifierNames::SYMBOLS, true), "⇧⌘F");
 }
 


### PR DESCRIPTION
This PR change the character used to display "ctrl" shortcuts from `^` to `⌃`, which is the proper unicode char for that.

Before:

<img width="242" alt="image" src="https://github.com/emilk/egui/assets/49431240/3bcc1ef0-b68e-440b-b135-f494fc9f33d1">

After:

<img width="244" alt="image" src="https://github.com/emilk/egui/assets/49431240/a947c7a4-ad8c-4c16-bb78-44bab6d6c854">


Fixes rerun-io/rerun#2862
