### PR TITLE
Add raw_window_handle to WindowInfo

### DIFF
--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -985,6 +985,9 @@ pub struct WindowInfo {
 
     /// Current monitor size in egui points (logical pixels)
     pub monitor_size: Option<egui::Vec2>,
+
+    /// The raw window handle for the main window
+    pub raw_handle: raw_window_handle::RawWindowHandle,
 }
 
 /// Information about the URL.

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -1,3 +1,4 @@
+use raw_window_handle::HasRawWindowHandle;
 use winit::event_loop::EventLoopWindowTarget;
 
 #[cfg(target_os = "macos")]
@@ -54,6 +55,8 @@ pub fn read_window_info(
         .inner_size()
         .to_logical::<f32>(pixels_per_point.into());
 
+    let window_handle = window.raw_window_handle();
+
     // NOTE: calling window.is_minimized() or window.is_maximized() deadlocks on Mac.
 
     WindowInfo {
@@ -67,6 +70,7 @@ pub fn read_window_info(
             y: size.height,
         },
         monitor_size,
+        raw_handle: window_handle
     }
 }
 

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -70,7 +70,7 @@ pub fn read_window_info(
             y: size.height,
         },
         monitor_size,
-        raw_handle: window_handle
+        raw_handle: window_handle,
     }
 }
 

--- a/crates/egui_demo_app/src/backend_panel.rs
+++ b/crates/egui_demo_app/src/backend_panel.rs
@@ -300,6 +300,7 @@ fn window_info_ui(ui: &mut egui::Ui, window_info: &eframe::WindowInfo) {
         focused,
         size,
         monitor_size,
+        raw_handle,
     } = window_info;
 
     egui::Grid::new("window_info_grid")
@@ -336,6 +337,10 @@ fn window_info_ui(ui: &mut egui::Ui, window_info: &eframe::WindowInfo) {
                 ui.monospace(format!("{x:.0} x {y:.0}"));
                 ui.end_row();
             }
+
+            ui.label("Window handle:");
+            ui.label(format!("{raw_handle:?}"));
+            ui.end_row();
         });
 }
 


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

All this does is expose the winit window raw_window_handle and put it into the WindowInfo so it can be accessed through the Frame's or CreationContexts's IntegrationInfo.

I'm a bit uncertain about the safety of this since most of `raw_window_handle`'s structs are wrapping `*mut c_void`, but I think it's fine? Any input there would be appreciated.

Closes #3050
