### PR TITLE
Support multi-threaded Wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,12 +327,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic_refcell"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d6dc922a2792b006573f60b2648076355daeae5ce9cb59507e5908c9625d31"
-
-[[package]]
 name = "atspi"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,7 +1388,6 @@ version = "0.22.0"
 dependencies = [
  "ab_glyph",
  "ahash 0.8.3",
- "atomic_refcell",
  "backtrace",
  "bytemuck",
  "criterion",

--- a/crates/epaint/Cargo.toml
+++ b/crates/epaint/Cargo.toml
@@ -79,6 +79,7 @@ ahash = { version = "0.8.1", default-features = false, features = [
   "std",
 ] }
 nohash-hasher = "0.2"
+parking_lot = "0.12" # Using parking_lot over std::sync::Mutex gives 50% speedups in some real-world scenarios.
 
 #! ### Optional dependencies
 bytemuck = { version = "1.7.2", optional = true, features = ["derive"] }
@@ -94,11 +95,6 @@ serde = { version = "1", optional = true, features = ["derive", "rc"] }
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backtrace = { version = "0.3", optional = true }
-parking_lot = "0.12"                             # Using parking_lot over std::sync::Mutex gives 50% speedups in some real-world scenarios.
-
-# web:
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-atomic_refcell = "0.1" # Used instead of parking_lot on on wasm. See https://github.com/emilk/egui/issues/1401
 
 
 [dev-dependencies]


### PR DESCRIPTION
Replace `atomic_refcell` with `parking_lot` on wasm32.

`parking_lot` has had problems running on wasm32 before (https://github.com/emilk/egui/issues/1401) but it works these days.
If we have problems again we can always switch to `std::sync::Mutex`.

Closes https://github.com/emilk/egui/issues/3102
