### PR TITLE
Refactor: Clarify os detection

### DIFF
--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -145,12 +145,12 @@ fn run_and_return(
             // Platform-dependent event handlers to workaround a winit bug
             // See: https://github.com/rust-windowing/winit/issues/987
             // See: https://github.com/rust-windowing/winit/issues/1619
-            #[cfg(windows)]
+            #[cfg(target_os = "windows")]
             winit::event::Event::RedrawEventsCleared => {
                 next_repaint_time = extremely_far_future();
                 winit_app.run_ui_and_paint()
             }
-            #[cfg(not(windows))]
+            #[cfg(not(target_os = "windows"))]
             winit::event::Event::RedrawRequested(_) => {
                 next_repaint_time = extremely_far_future();
                 winit_app.run_ui_and_paint()
@@ -196,7 +196,7 @@ fn run_and_return(
             EventResult::Wait => {}
             EventResult::RepaintNow => {
                 log::trace!("Repaint caused by winit::Event: {:?}", event);
-                if cfg!(windows) {
+                if cfg!(target_os = "windows") {
                     // Fix flickering on Windows, see https://github.com/emilk/egui/pull/2280
                     next_repaint_time = extremely_far_future();
                     winit_app.run_ui_and_paint();
@@ -245,7 +245,7 @@ fn run_and_return(
     //
     // Note that this approach may cause issues on macOS (emilk/egui#2768); therefore,
     // we only apply this approach on Windows to minimize the affect.
-    #[cfg(windows)]
+    #[cfg(target_os = "windows")]
     {
         event_loop.run_return(|_, _, control_flow| {
             control_flow.set_exit();
@@ -270,11 +270,11 @@ fn run_and_exit(event_loop: EventLoop<UserEvent>, mut winit_app: impl WinitApp +
             // Platform-dependent event handlers to workaround a winit bug
             // See: https://github.com/rust-windowing/winit/issues/987
             // See: https://github.com/rust-windowing/winit/issues/1619
-            winit::event::Event::RedrawEventsCleared if cfg!(windows) => {
+            winit::event::Event::RedrawEventsCleared if cfg!(target_os = "windows") => {
                 next_repaint_time = extremely_far_future();
                 winit_app.run_ui_and_paint()
             }
-            winit::event::Event::RedrawRequested(_) if !cfg!(windows) => {
+            winit::event::Event::RedrawRequested(_) if !cfg!(target_os = "windows") => {
                 next_repaint_time = extremely_far_future();
                 winit_app.run_ui_and_paint()
             }
@@ -302,7 +302,7 @@ fn run_and_exit(event_loop: EventLoop<UserEvent>, mut winit_app: impl WinitApp +
         match event_result {
             EventResult::Wait => {}
             EventResult::RepaintNow => {
-                if cfg!(windows) {
+                if cfg!(target_os = "windows") {
                     // Fix flickering on Windows, see https://github.com/emilk/egui/pull/2280
                     next_repaint_time = extremely_far_future();
                     winit_app.run_ui_and_paint();

--- a/crates/egui_glium/examples/native_texture.rs
+++ b/crates/egui_glium/examples/native_texture.rs
@@ -78,8 +78,8 @@ fn main() {
             // Platform-dependent event handlers to workaround a winit bug
             // See: https://github.com/rust-windowing/winit/issues/987
             // See: https://github.com/rust-windowing/winit/issues/1619
-            glutin::event::Event::RedrawEventsCleared if cfg!(windows) => redraw(),
-            glutin::event::Event::RedrawRequested(_) if !cfg!(windows) => redraw(),
+            glutin::event::Event::RedrawEventsCleared if cfg!(target_os = "windows") => redraw(),
+            glutin::event::Event::RedrawRequested(_) if !cfg!(target_os = "windows") => redraw(),
 
             glutin::event::Event::WindowEvent { event, .. } => {
                 use glutin::event::WindowEvent;

--- a/crates/egui_glium/examples/pure_glium.rs
+++ b/crates/egui_glium/examples/pure_glium.rs
@@ -65,8 +65,8 @@ fn main() {
             // Platform-dependent event handlers to workaround a winit bug
             // See: https://github.com/rust-windowing/winit/issues/987
             // See: https://github.com/rust-windowing/winit/issues/1619
-            glutin::event::Event::RedrawEventsCleared if cfg!(windows) => redraw(),
-            glutin::event::Event::RedrawRequested(_) if !cfg!(windows) => redraw(),
+            glutin::event::Event::RedrawEventsCleared if cfg!(target_os = "windows") => redraw(),
+            glutin::event::Event::RedrawRequested(_) if !cfg!(target_os = "windows") => redraw(),
 
             glutin::event::Event::WindowEvent { event, .. } => {
                 use glutin::event::WindowEvent;

--- a/crates/egui_glow/examples/pure_glow.rs
+++ b/crates/egui_glow/examples/pure_glow.rs
@@ -200,8 +200,8 @@ fn main() {
             // Platform-dependent event handlers to workaround a winit bug
             // See: https://github.com/rust-windowing/winit/issues/987
             // See: https://github.com/rust-windowing/winit/issues/1619
-            winit::event::Event::RedrawEventsCleared if cfg!(windows) => redraw(),
-            winit::event::Event::RedrawRequested(_) if !cfg!(windows) => redraw(),
+            winit::event::Event::RedrawEventsCleared if cfg!(target_os = "windows") => redraw(),
+            winit::event::Event::RedrawRequested(_) if !cfg!(target_os = "windows") => redraw(),
 
             winit::event::Event::WindowEvent { event, .. } => {
                 use winit::event::WindowEvent;


### PR DESCRIPTION
We had a bunch of `cfg!(windows)` which should have been `cfg!(target_os = "windows")`.

I wonder what the effects of this PR will be for Windows 😬


**EDIT**: Apparently I was confused. `cfg!(windows)` acts exactly like `cfg!(target_os = "windows")`.

However, `cfg!(macos)` is always `false` while `cfg!(target_os = "macos")` works :man-facepalming: 

https://twitter.com/ernerfeldt/status/1690010817415041024?s=20

I'll merge this anyway so I won't get confused again