### PR TITLE
Change force to be Option<f32> instead of f32

### DIFF
--- a/crates/eframe/src/web/input.rs
+++ b/crates/eframe/src/web/input.rs
@@ -68,7 +68,7 @@ pub fn push_touches(runner: &mut AppRunner, phase: egui::TouchPhase, event: &web
                 id: egui::TouchId::from(touch.identifier()),
                 phase,
                 pos: pos_from_touch(canvas_origin, &touch),
-                force: touch.force(),
+                force: Some(touch.force()),
             });
         }
     }

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -441,7 +441,7 @@ impl State {
                             id: egui::TouchId(0),
                             phase: egui::TouchPhase::Start,
                             pos,
-                            force: 0.0,
+                            force: None,
                         });
                     } else {
                         self.any_pointer_button_down = false;
@@ -453,7 +453,7 @@ impl State {
                             id: egui::TouchId(0),
                             phase: egui::TouchPhase::End,
                             pos,
-                            force: 0.0,
+                            force: None,
                         });
                     };
                 }
@@ -479,7 +479,7 @@ impl State {
                     id: egui::TouchId(0),
                     phase: egui::TouchPhase::Move,
                     pos: pos_in_points,
-                    force: 0.0,
+                    force: None,
                 });
             }
         } else {
@@ -505,13 +505,13 @@ impl State {
                 touch.location.y as f32 / self.pixels_per_point(),
             ),
             force: match touch.force {
-                Some(winit::event::Force::Normalized(force)) => force as f32,
+                Some(winit::event::Force::Normalized(force)) => Some(force as f32),
                 Some(winit::event::Force::Calibrated {
                     force,
                     max_possible_force,
                     ..
-                }) => (force / max_possible_force) as f32,
-                None => 0_f32,
+                }) => Some((force / max_possible_force) as f32),
+                None => None,
             },
         });
         // If we're not yet translating a touch or we're translating this very

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -274,10 +274,10 @@ pub enum Event {
         /// Position of the touch (or where the touch was last detected)
         pos: Pos2,
 
-        /// Describes how hard the touch device was pressed. May always be `0` if the platform does
+        /// Describes how hard the touch device was pressed. May always be `None` if the platform does
         /// not support pressure sensitivity.
         /// The value is in the range from 0.0 (no pressure) to 1.0 (maximum pressure).
-        force: f32,
+        force: Option<f32>,
     },
 
     /// A raw mouse wheel event as sent by the backend (minus the z coordinate),

--- a/crates/egui/src/input_state/touch_state.rs
+++ b/crates/egui/src/input_state/touch_state.rs
@@ -118,7 +118,7 @@ struct ActiveTouch {
     ///
     /// Note that a value of 0.0 either indicates a very light touch, or it means that the device
     /// is not capable of measuring the touch force.
-    force: f32,
+    force: Option<f32>,
 }
 
 impl TouchState {
@@ -249,7 +249,7 @@ impl TouchState {
 
             // first pass: calculate force and center of touch positions:
             for touch in self.active_touches.values() {
-                state.avg_force += touch.force;
+                state.avg_force += touch.force.unwrap_or(0.0);
                 state.avg_pos.x += touch.pos.x;
                 state.avg_pos.y += touch.pos.y;
             }


### PR DESCRIPTION
Force being 0 having two meanings makes it hard to tell whether it has just been a very light touch or whether no force is provided.

In my drawing app I draw a thick line when pressure is close to 1 or the device has no pressure and a thin line when pressure is close to 0. 

Not being able to tell between 0 and None causes bugs where faint strokes suddenly have thick blobs when pressure reaches 0. This could be avoided with some clever logic but the changes in this PR make it a lot easier.


There also is a force variable in `MultiTouchInfo` but I don't think that one needs to be changed to Option<f32> since it's an average. But I could also update it for consitency.