### PR TITLE
Fix iOS support in `eframe`

### DIFF
--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -139,7 +139,7 @@ pub fn window_builder<E>(
     window_builder = window_builder_drag_and_drop(window_builder, *drag_and_drop_support);
 
     // Always use the default window size / position on iOS. Trying to restore the previous position
-    // causes the window to be shown to small.
+    // causes the window to be shown too small.
     #[cfg(not(target_os = "ios"))]
     let inner_size_points = if let Some(mut window_settings) = window_settings {
         // Restore pos/size from previous session

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -138,6 +138,9 @@ pub fn window_builder<E>(
 
     window_builder = window_builder_drag_and_drop(window_builder, *drag_and_drop_support);
 
+    // Always use the default window size / position on iOS. Trying to restore the previous position
+    // causes the window to be shown to small.
+    #[cfg(not(target_os = "ios"))]
     let inner_size_points = if let Some(mut window_settings) = window_settings {
         // Restore pos/size from previous session
 
@@ -163,6 +166,7 @@ pub fn window_builder<E>(
         *initial_window_size
     };
 
+    #[cfg(not(target_os = "ios"))]
     if *centered {
         if let Some(monitor) = event_loop.available_monitors().next() {
             let monitor_size = monitor.size().to_logical::<f64>(monitor.scale_factor());

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -1057,6 +1057,7 @@ mod glow_integration {
         mut native_options: epi::NativeOptions,
         app_creator: epi::AppCreator,
     ) -> Result<()> {
+        #[cfg(not(target_os = "ios"))]
         if native_options.run_and_return {
             with_event_loop(native_options, |event_loop, native_options| {
                 let glow_eframe =
@@ -1064,6 +1065,13 @@ mod glow_integration {
                 run_and_return(event_loop, glow_eframe)
             })
         } else {
+            let event_loop = create_event_loop_builder(&mut native_options).build();
+            let glow_eframe = GlowWinitApp::new(&event_loop, app_name, native_options, app_creator);
+            run_and_exit(event_loop, glow_eframe);
+        }
+
+        #[cfg(target_os = "ios")]
+        {
             let event_loop = create_event_loop_builder(&mut native_options).build();
             let glow_eframe = GlowWinitApp::new(&event_loop, app_name, native_options, app_creator);
             run_and_exit(event_loop, glow_eframe);

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -119,6 +119,7 @@ fn with_event_loop<R>(
     })
 }
 
+#[cfg(not(target_os = "ios"))]
 fn run_and_return(
     event_loop: &mut EventLoop<UserEvent>,
     mut winit_app: impl WinitApp,
@@ -1494,6 +1495,7 @@ mod wgpu_integration {
         mut native_options: epi::NativeOptions,
         app_creator: epi::AppCreator,
     ) -> Result<()> {
+        #[cfg(not(target_os = "ios"))]
         if native_options.run_and_return {
             with_event_loop(native_options, |event_loop, native_options| {
                 let wgpu_eframe =
@@ -1501,6 +1503,13 @@ mod wgpu_integration {
                 run_and_return(event_loop, wgpu_eframe)
             })
         } else {
+            let event_loop = create_event_loop_builder(&mut native_options).build();
+            let wgpu_eframe = WgpuWinitApp::new(&event_loop, app_name, native_options, app_creator);
+            run_and_exit(event_loop, wgpu_eframe);
+        }
+
+        #[cfg(target_os = "ios")]
+        {
             let event_loop = create_event_loop_builder(&mut native_options).build();
             let wgpu_eframe = WgpuWinitApp::new(&event_loop, app_name, native_options, app_creator);
             run_and_exit(event_loop, wgpu_eframe);

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -280,6 +280,10 @@ fn run_and_exit(event_loop: EventLoop<UserEvent>, mut winit_app: impl WinitApp +
             }
 
             winit::event::Event::UserEvent(UserEvent::RequestRepaint { when, frame_nr }) => {
+                // WaitUntil seems to not work on iOS
+                #[cfg(target_os = "ios")]
+                winit_app.window().unwrap().request_redraw();
+
                 if winit_app.frame_nr() == frame_nr {
                     EventResult::RepaintAt(when)
                 } else {

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -281,10 +281,6 @@ fn run_and_exit(event_loop: EventLoop<UserEvent>, mut winit_app: impl WinitApp +
             }
 
             winit::event::Event::UserEvent(UserEvent::RequestRepaint { when, frame_nr }) => {
-                // WaitUntil seems to not work on iOS
-                #[cfg(target_os = "ios")]
-                winit_app.window().unwrap().request_redraw();
-
                 if winit_app.frame_nr() == frame_nr {
                     EventResult::RepaintAt(when)
                 } else {
@@ -337,6 +333,11 @@ fn run_and_exit(event_loop: EventLoop<UserEvent>, mut winit_app: impl WinitApp +
             next_repaint_time = extremely_far_future();
             ControlFlow::Poll
         } else {
+            // WaitUntil seems to not work on iOS
+            #[cfg(target_os = "ios")]
+            if let Some(window) = winit_app.window() {
+                window.request_redraw();
+            }
             ControlFlow::WaitUntil(next_repaint_time)
         };
     })


### PR DESCRIPTION
This allows egui and eframe to work correctly on iOS. 

Without these changes it wouldn't compile because winit doesn't support run_and_return on iOS. 
Also request_redraw was not working, seems like WaitUntil was not working correctly, I'm not sure why though. My fix is to repaint immideately but that might need to be investigated some more.

Then, after changing screen orientation, the screen wouldn't return to full size, because egui was trying to restore the previous window size. I've disabled this behaviour for iOS since it doesn't seem like it would make sense there anyways.