### PR TITLE
Replace deprecated clippy option "derive_hash_xor_eq"

### DIFF
--- a/crates/ecolor/src/rgba.rs
+++ b/crates/ecolor/src/rgba.rs
@@ -38,7 +38,7 @@ pub(crate) fn f32_hash<H: std::hash::Hasher>(state: &mut H, f: f32) {
     }
 }
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl std::hash::Hash for Rgba {
     #[inline]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {

--- a/crates/eframe/src/web/input.rs
+++ b/crates/eframe/src/web/input.rs
@@ -35,7 +35,6 @@ pub fn pos_from_touch_event(
         // search for the touch we previously used for the position
         // (unfortunately, `event.touches()` is not a rust collection):
         (0..event.touches().length())
-            .into_iter()
             .map(|i| event.touches().get(i).unwrap())
             .find(|touch| egui::TouchId::from(touch.identifier()) == *touch_id_for_pos)
     } else {

--- a/crates/epaint/src/stroke.rs
+++ b/crates/epaint/src/stroke.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::derive_hash_xor_eq)] // We need to impl Hash for f32, but we don't implement Eq, which is fine
+#![allow(clippy::derived_hash_with_manual_eq)] // We need to impl Hash for f32, but we don't implement Eq, which is fine
 
 use super::*;
 

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -51,7 +51,7 @@ impl FontId {
     }
 }
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl std::hash::Hash for FontId {
     #[inline(always)]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
@@ -552,7 +552,7 @@ impl FontsAndCache {
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct HashableF32(f32);
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl std::hash::Hash for HashableF32 {
     #[inline(always)]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::derive_hash_xor_eq)] // We need to impl Hash for f32, but we don't implement Eq, which is fine
+#![allow(clippy::derived_hash_with_manual_eq)] // We need to impl Hash for f32, but we don't implement Eq, which is fine
 
 use std::ops::Range;
 use std::sync::Arc;


### PR DESCRIPTION
Replaces deprecated clippy option "derive_hash_xor_eq" with "derived_hash_with_manual_eq". More details can be found here:
https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#moves-and-deprecations-3

Also fixes single remaining clippy warning in `input.rs` while being at it.