### PR TITLE
Add option to truncate text at wrap width

### DIFF
--- a/crates/egui/src/widget_text.rs
+++ b/crates/egui/src/widget_text.rs
@@ -676,7 +676,7 @@ impl WidgetTextGalley {
         self.galley.size()
     }
 
-    /// Size of the laid out text.
+    /// The full, non-elided text of the input job.
     #[inline]
     pub fn text(&self) -> &str {
         self.galley.text()

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -194,8 +194,12 @@ impl Label {
 
 impl Widget for Label {
     fn ui(self, ui: &mut Ui) -> Response {
-        let (pos, text_galley, response) = self.layout_in_ui(ui);
+        let (pos, text_galley, mut response) = self.layout_in_ui(ui);
         response.widget_info(|| WidgetInfo::labeled(WidgetType::Label, text_galley.text()));
+
+        if text_galley.galley.elided {
+            response = response.on_hover_text(text_galley.text());
+        }
 
         if ui.is_rect_visible(response.rect) {
             let response_color = ui.style().interact(&response).text_color();

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -19,7 +19,7 @@ use crate::{widget_text::WidgetTextGalley, *};
 pub struct Label {
     text: WidgetText,
     wrap: Option<bool>,
-    elide: bool,
+    truncate: bool,
     sense: Option<Sense>,
 }
 
@@ -28,7 +28,7 @@ impl Label {
         Self {
             text: text.into(),
             wrap: None,
-            elide: false,
+            truncate: false,
             sense: None,
         }
     }
@@ -39,7 +39,7 @@ impl Label {
 
     /// If `true`, the text will wrap to stay within the max width of the [`Ui`].
     ///
-    /// Calling `wrap` will override [`Self::elide`].
+    /// Calling `wrap` will override [`Self::truncate`].
     ///
     /// By default [`Self::wrap`] will be `true` in vertical layouts
     /// and horizontal layouts with wrapping,
@@ -51,21 +51,23 @@ impl Label {
     #[inline]
     pub fn wrap(mut self, wrap: bool) -> Self {
         self.wrap = Some(wrap);
-        self.elide = false;
+        self.truncate = false;
         self
     }
 
     /// If `true`, the text will stop at the max width of the [`Ui`],
     /// and what doesn't fit will be elided, replaced with `…`.
     ///
+    /// If the text is truncated, the full text will be shown on hover as a tool-tip.
+    ///
     /// Default is `false`, which means the text will expand the parent [`Ui`],
     /// or wrap if [`Self::wrap`] is set.
     ///
-    /// Calling `elide` will override [`Self::wrap`].
+    /// Calling `truncate` will override [`Self::wrap`].
     #[inline]
-    pub fn elide(mut self, elide: bool) -> Self {
+    pub fn truncate(mut self, truncate: bool) -> Self {
         self.wrap = None;
-        self.elide = elide;
+        self.truncate = truncate;
         self
     }
 
@@ -120,8 +122,8 @@ impl Label {
             .text
             .into_text_job(ui.style(), FontSelection::Default, valign);
 
-        let elide = self.elide;
-        let wrap = !elide && self.wrap.unwrap_or_else(|| ui.wrap_text());
+        let truncate = self.truncate;
+        let wrap = !truncate && self.wrap.unwrap_or_else(|| ui.wrap_text());
         let available_width = ui.available_width();
 
         if wrap
@@ -161,7 +163,7 @@ impl Label {
             }
             (pos, text_galley, response)
         } else {
-            if elide {
+            if truncate {
                 text_job.job.wrap.max_width = available_width;
                 text_job.job.wrap.max_rows = 1;
                 text_job.job.wrap.break_anywhere = true;

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -198,6 +198,7 @@ impl Widget for Label {
         response.widget_info(|| WidgetInfo::labeled(WidgetType::Label, text_galley.text()));
 
         if text_galley.galley.elided {
+            // Show the full (non-elided) text on hover:
             response = response.on_hover_text(text_galley.text());
         }
 

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -56,8 +56,14 @@ impl View for MiscDemoWindow {
     fn ui(&mut self, ui: &mut Ui) {
         ui.set_min_width(250.0);
 
-        CollapsingHeader::new("Widgets")
+        CollapsingHeader::new("Label")
             .default_open(true)
+            .show(ui, |ui| {
+                label_ui(ui);
+            });
+
+        CollapsingHeader::new("Misc widgets")
+            .default_open(false)
             .show(ui, |ui| {
                 self.widgets.ui(ui);
             });
@@ -172,6 +178,43 @@ impl View for MiscDemoWindow {
 
 // ----------------------------------------------------------------------------
 
+fn label_ui(ui: &mut egui::Ui) {
+    ui.vertical_centered(|ui| {
+        ui.add(crate::egui_github_link_file_line!());
+    });
+
+    ui.horizontal_wrapped(|ui| {
+            // Trick so we don't have to add spaces in the text below:
+            let width = ui.fonts(|f|f.glyph_width(&TextStyle::Body.resolve(ui.style()), ' '));
+            ui.spacing_mut().item_spacing.x = width;
+
+            ui.label(RichText::new("Text can have").color(Color32::from_rgb(110, 255, 110)));
+            ui.colored_label(Color32::from_rgb(128, 140, 255), "color"); // Shortcut version
+            ui.label("and tooltips.").on_hover_text(
+                "This is a multiline tooltip that demonstrates that you can easily add tooltips to any element.\nThis is the second line.\nThis is the third.",
+            );
+
+            ui.label("You can mix in other widgets into text, like");
+            let _ = ui.small_button("this button");
+            ui.label(".");
+
+            ui.label("The default font supports all latin and cyrillic characters (ИÅđ…), common math symbols (∫√∞²⅓…), and many emojis (💓🌟🖩…).")
+                .on_hover_text("There is currently no support for right-to-left languages.");
+            ui.label("See the 🔤 Font Book for more!");
+
+            ui.monospace("There is also a monospace font.");
+        });
+
+    ui.add(
+        egui::Label::new(
+            "Labels containing long text can be set to elide the text that doesn't fit on a single line using `Label::elide`. When hovered, the label will show the full text.",
+        )
+        .elide(true),
+    );
+}
+
+// ----------------------------------------------------------------------------
+
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct Widgets {
@@ -193,28 +236,6 @@ impl Widgets {
         let Self { angle, password } = self;
         ui.vertical_centered(|ui| {
             ui.add(crate::egui_github_link_file_line!());
-        });
-
-        ui.horizontal_wrapped(|ui| {
-            // Trick so we don't have to add spaces in the text below:
-            let width = ui.fonts(|f|f.glyph_width(&TextStyle::Body.resolve(ui.style()), ' '));
-            ui.spacing_mut().item_spacing.x = width;
-
-            ui.label(RichText::new("Text can have").color(Color32::from_rgb(110, 255, 110)));
-            ui.colored_label(Color32::from_rgb(128, 140, 255), "color"); // Shortcut version
-            ui.label("and tooltips.").on_hover_text(
-                "This is a multiline tooltip that demonstrates that you can easily add tooltips to any element.\nThis is the second line.\nThis is the third.",
-            );
-
-            ui.label("You can mix in other widgets into text, like");
-            let _ = ui.small_button("this button");
-            ui.label(".");
-
-            ui.label("The default font supports all latin and cyrillic characters (ИÅđ…), common math symbols (∫√∞²⅓…), and many emojis (💓🌟🖩…).")
-                .on_hover_text("There is currently no support for right-to-left languages.");
-            ui.label("See the 🔤 Font Book for more!");
-
-            ui.monospace("There is also a monospace font.");
         });
 
         let tooltip_ui = |ui: &mut Ui| {

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -628,7 +628,7 @@ fn text_layout_demo(ui: &mut Ui) {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 struct TextBreakDemo {
-    clip_to_max_width: bool,
+    elide_at_max_width: bool,
     break_anywhere: bool,
     max_rows: usize,
     overflow_character: Option<char>,
@@ -637,7 +637,7 @@ struct TextBreakDemo {
 impl Default for TextBreakDemo {
     fn default() -> Self {
         Self {
-            clip_to_max_width: true,
+            elide_at_max_width: true,
             max_rows: 2,
             break_anywhere: false,
             overflow_character: Some('…'),
@@ -648,7 +648,7 @@ impl Default for TextBreakDemo {
 impl TextBreakDemo {
     pub fn ui(&mut self, ui: &mut Ui) {
         let Self {
-            clip_to_max_width,
+            elide_at_max_width,
             break_anywhere,
             max_rows,
             overflow_character,
@@ -657,11 +657,11 @@ impl TextBreakDemo {
         use egui::text::LayoutJob;
 
         ui.horizontal(|ui| {
-            ui.radio_value(clip_to_max_width, false, "Wrap");
-            ui.radio_value(clip_to_max_width, true, "Clip");
+            ui.radio_value(elide_at_max_width, false, "Wrap");
+            ui.radio_value(elide_at_max_width, true, "Clip");
         });
 
-        if !*clip_to_max_width {
+        if !*elide_at_max_width {
             ui.horizontal(|ui| {
                 ui.add(DragValue::new(max_rows));
                 ui.label("Max rows");
@@ -680,7 +680,7 @@ impl TextBreakDemo {
         let mut job = LayoutJob::single_section(LOREM_IPSUM.to_owned(), TextFormat::default());
         job.wrap = TextWrapping {
             max_rows: *max_rows,
-            clip_to_max_width: *clip_to_max_width,
+            elide_at_max_width: *elide_at_max_width,
             break_anywhere: *break_anywhere,
             overflow_character: *overflow_character,
             ..Default::default()

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -679,7 +679,7 @@ impl TextBreakDemo {
         });
 
         ui.horizontal(|ui| {
-            ui.label("Break:");
+            ui.label("Line-break:");
             ui.radio_value(break_anywhere, false, "word boundaries");
             ui.radio_value(break_anywhere, true, "anywhere");
         });

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::LOREM_IPSUM;
 use egui::{epaint::text::TextWrapping, *};
 
 /// Showcase some ui code
@@ -628,7 +627,6 @@ fn text_layout_demo(ui: &mut Ui) {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 struct TextBreakDemo {
-    elide_at_max_width: bool,
     break_anywhere: bool,
     max_rows: usize,
     overflow_character: Option<char>,
@@ -637,9 +635,8 @@ struct TextBreakDemo {
 impl Default for TextBreakDemo {
     fn default() -> Self {
         Self {
-            elide_at_max_width: true,
-            max_rows: 2,
-            break_anywhere: false,
+            max_rows: 1,
+            break_anywhere: true,
             overflow_character: Some('…'),
         }
     }
@@ -648,7 +645,6 @@ impl Default for TextBreakDemo {
 impl TextBreakDemo {
     pub fn ui(&mut self, ui: &mut Ui) {
         let Self {
-            elide_at_max_width,
             break_anywhere,
             max_rows,
             overflow_character,
@@ -657,17 +653,15 @@ impl TextBreakDemo {
         use egui::text::LayoutJob;
 
         ui.horizontal(|ui| {
-            ui.radio_value(elide_at_max_width, false, "Wrap");
-            ui.radio_value(elide_at_max_width, true, "Clip");
+            ui.add(DragValue::new(max_rows));
+            ui.label("Max rows");
         });
 
-        if !*elide_at_max_width {
-            ui.horizontal(|ui| {
-                ui.add(DragValue::new(max_rows));
-                ui.label("Max rows");
-            });
-            ui.checkbox(break_anywhere, "Break anywhere");
-        }
+        ui.horizontal(|ui| {
+            ui.label("Break:");
+            ui.radio_value(break_anywhere, false, "word boundaries");
+            ui.radio_value(break_anywhere, true, "anywhere");
+        });
 
         ui.horizontal(|ui| {
             ui.selectable_value(overflow_character, None, "None");
@@ -677,10 +671,10 @@ impl TextBreakDemo {
             ui.label("Overflow character");
         });
 
-        let mut job = LayoutJob::single_section(LOREM_IPSUM.to_owned(), TextFormat::default());
+        let mut job =
+            LayoutJob::single_section(crate::LOREM_IPSUM_LONG.to_owned(), TextFormat::default());
         job.wrap = TextWrapping {
             max_rows: *max_rows,
-            elide_at_max_width: *elide_at_max_width,
             break_anywhere: *break_anywhere,
             overflow_character: *overflow_character,
             ..Default::default()

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -679,6 +679,7 @@ impl TextBreakDemo {
             overflow_character: *overflow_character,
             ..Default::default()
         };
-        ui.label(job);
+
+        ui.label(job); // `Label` overrides some of the wrapping settings, e.g. wrap width
     }
 }

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -209,7 +209,7 @@ fn label_ui(ui: &mut egui::Ui) {
         egui::Label::new(
             "Labels containing long text can be set to elide the text that doesn't fit on a single line using `Label::elide`. When hovered, the label will show the full text.",
         )
-        .elide(true),
+        .truncate(true),
     );
 }
 

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -1,9 +1,11 @@
 use std::ops::RangeInclusive;
 use std::sync::Arc;
 
-use super::{FontsImpl, Galley, Glyph, LayoutJob, LayoutSection, Row, RowVisuals};
-use crate::{Color32, Mesh, Stroke, Vertex};
 use emath::*;
+
+use crate::{Color32, Mesh, Stroke, Vertex};
+
+use super::{FontsImpl, Galley, Glyph, LayoutJob, LayoutSection, Row, RowVisuals};
 
 // ----------------------------------------------------------------------------
 
@@ -54,6 +56,20 @@ struct Paragraph {
 /// In most cases you should use [`crate::Fonts::layout_job`] instead
 /// since that memoizes the input, making subsequent layouting of the same text much faster.
 pub fn layout(fonts: &mut FontsImpl, job: Arc<LayoutJob>) -> Galley {
+    if job.wrap.max_rows == 0 {
+        // Early-out: no text
+        return Galley {
+            job,
+            rows: Default::default(),
+            rect: Rect::from_min_max(Pos2::ZERO, Pos2::ZERO),
+            mesh_bounds: Rect::NOTHING,
+            num_vertices: 0,
+            num_indices: 0,
+            pixels_per_point: fonts.pixels_per_point(),
+            elided: true,
+        };
+    }
+
     let mut paragraphs = vec![Paragraph::default()];
     for (section_index, section) in job.sections.iter().enumerate() {
         layout_section(fonts, &job, section_index as u32, section, &mut paragraphs);
@@ -61,7 +77,8 @@ pub fn layout(fonts: &mut FontsImpl, job: Arc<LayoutJob>) -> Galley {
 
     let point_scale = PointScale::new(fonts.pixels_per_point());
 
-    let mut rows = rows_from_paragraphs(fonts, paragraphs, &job);
+    let mut elided = false;
+    let mut rows = rows_from_paragraphs(fonts, paragraphs, &job, &mut elided);
 
     let justify = job.justify && job.wrap.max_width.is_finite();
 
@@ -80,7 +97,7 @@ pub fn layout(fonts: &mut FontsImpl, job: Arc<LayoutJob>) -> Galley {
         }
     }
 
-    galley_from_rows(point_scale, job, rows)
+    galley_from_rows(point_scale, job, rows, elided)
 }
 
 fn layout_section(
@@ -145,6 +162,7 @@ fn rows_from_paragraphs(
     fonts: &mut FontsImpl,
     paragraphs: Vec<Paragraph>,
     job: &LayoutJob,
+    elided: &mut bool,
 ) -> Vec<Row> {
     let num_paragraphs = paragraphs.len();
 
@@ -175,7 +193,7 @@ fn rows_from_paragraphs(
                     ends_with_newline: !is_last_paragraph,
                 });
             } else {
-                line_break(fonts, &paragraph, job, &mut rows);
+                line_break(fonts, &paragraph, job, &mut rows, elided);
                 rows.last_mut().unwrap().ends_with_newline = !is_last_paragraph;
             }
         }
@@ -189,6 +207,7 @@ fn line_break(
     paragraph: &Paragraph,
     job: &LayoutJob,
     out_rows: &mut Vec<Row>,
+    elided: &mut bool,
 ) {
     // Keeps track of good places to insert row break if we exceed `wrap_width`.
     let mut row_break_candidates = RowBreakCandidates::default();
@@ -201,12 +220,12 @@ fn line_break(
     for i in 0..paragraph.glyphs.len() {
         let potential_row_width = paragraph.glyphs[i].max_x() - row_start_x;
 
-        if job.wrap.max_rows != 0 && non_empty_rows >= job.wrap.max_rows {
+        if non_empty_rows >= job.wrap.max_rows {
             break;
         }
 
         if potential_row_width > job.wrap.max_width {
-            if job.wrap.clip_to_max_width {
+            if job.wrap.elide_at_max_width {
                 assert_eq!(row_start_x, 0.0);
                 assert_eq!(row_start_idx, 0);
                 assert_eq!(non_empty_rows, 0);
@@ -228,6 +247,7 @@ fn line_break(
 
                 // Add the trailing overflow character (e.g. `…`):
                 replace_last_glyph_with_overflow_character(fonts, job, &mut row);
+                *elided = true;
 
                 out_rows.push(row);
 
@@ -284,9 +304,10 @@ fn line_break(
     }
 
     if row_start_idx < paragraph.glyphs.len() {
-        if job.wrap.max_rows != 0 && non_empty_rows == job.wrap.max_rows {
+        if non_empty_rows == job.wrap.max_rows {
             if let Some(last_row) = out_rows.last_mut() {
                 replace_last_glyph_with_overflow_character(fonts, job, last_row);
+                *elided = true;
             }
         } else {
             let glyphs: Vec<Glyph> = paragraph.glyphs[row_start_idx..]
@@ -465,7 +486,12 @@ fn halign_and_justify_row(
 }
 
 /// Calculate the Y positions and tessellate the text.
-fn galley_from_rows(point_scale: PointScale, job: Arc<LayoutJob>, mut rows: Vec<Row>) -> Galley {
+fn galley_from_rows(
+    point_scale: PointScale,
+    job: Arc<LayoutJob>,
+    mut rows: Vec<Row>,
+    elided: bool,
+) -> Galley {
     let mut first_row_min_height = job.first_row_min_height;
     let mut cursor_y = 0.0;
     let mut min_x: f32 = 0.0;
@@ -526,6 +552,7 @@ fn galley_from_rows(point_scale: PointScale, job: Arc<LayoutJob>, mut rows: Vec<
     Galley {
         job,
         rows,
+        elided,
         rect,
         mesh_bounds,
         num_vertices,

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -225,78 +225,48 @@ fn line_break(
         }
 
         if potential_row_width > job.wrap.max_width {
-            if job.wrap.elide_at_max_width {
-                assert_eq!(row_start_x, 0.0);
-                assert_eq!(row_start_idx, 0);
-                assert_eq!(non_empty_rows, 0);
+            // Row break:
 
-                let glyphs: Vec<Glyph> = paragraph.glyphs[..i].to_vec();
+            if first_row_indentation > 0.0
+                && !row_break_candidates.has_good_candidate(job.wrap.break_anywhere)
+            {
+                // Allow the first row to be completely empty, because we know there will be more space on the next row:
+                // TODO(emilk): this records the height of this first row as zero, though that is probably fine since first_row_indentation usually comes with a first_row_min_height.
+                out_rows.push(Row {
+                    glyphs: vec![],
+                    visuals: Default::default(),
+                    rect: rect_from_x_range(first_row_indentation..=first_row_indentation),
+                    ends_with_newline: false,
+                });
+                row_start_x += first_row_indentation;
+                first_row_indentation = 0.0;
+            } else if let Some(last_kept_index) = row_break_candidates.get(job.wrap.break_anywhere)
+            {
+                let glyphs: Vec<Glyph> = paragraph.glyphs[row_start_idx..=last_kept_index]
+                    .iter()
+                    .copied()
+                    .map(|mut glyph| {
+                        glyph.pos.x -= row_start_x;
+                        glyph
+                    })
+                    .collect();
 
-                let x_range = if let (Some(first), Some(last)) = (glyphs.first(), glyphs.last()) {
-                    first.pos.x..=last.max_x()
-                } else {
-                    0.0..=0.0
-                };
+                let paragraph_min_x = glyphs[0].pos.x;
+                let paragraph_max_x = glyphs.last().unwrap().max_x();
 
-                let mut row = Row {
+                out_rows.push(Row {
                     glyphs,
                     visuals: Default::default(),
-                    rect: rect_from_x_range(x_range),
+                    rect: rect_from_x_range(paragraph_min_x..=paragraph_max_x),
                     ends_with_newline: false,
-                };
+                });
 
-                // Add the trailing overflow character (e.g. `…`):
-                replace_last_glyph_with_overflow_character(fonts, job, &mut row);
-                *elided = true;
-
-                out_rows.push(row);
-
-                return;
+                row_start_idx = last_kept_index + 1;
+                row_start_x = paragraph.glyphs[row_start_idx].pos.x;
+                row_break_candidates = Default::default();
+                non_empty_rows += 1;
             } else {
-                // Row break:
-
-                if first_row_indentation > 0.0
-                    && !row_break_candidates.has_good_candidate(job.wrap.break_anywhere)
-                {
-                    // Allow the first row to be completely empty, because we know there will be more space on the next row:
-                    // TODO(emilk): this records the height of this first row as zero, though that is probably fine since first_row_indentation usually comes with a first_row_min_height.
-                    out_rows.push(Row {
-                        glyphs: vec![],
-                        visuals: Default::default(),
-                        rect: rect_from_x_range(first_row_indentation..=first_row_indentation),
-                        ends_with_newline: false,
-                    });
-                    row_start_x += first_row_indentation;
-                    first_row_indentation = 0.0;
-                } else if let Some(last_kept_index) =
-                    row_break_candidates.get(job.wrap.break_anywhere)
-                {
-                    let glyphs: Vec<Glyph> = paragraph.glyphs[row_start_idx..=last_kept_index]
-                        .iter()
-                        .copied()
-                        .map(|mut glyph| {
-                            glyph.pos.x -= row_start_x;
-                            glyph
-                        })
-                        .collect();
-
-                    let paragraph_min_x = glyphs[0].pos.x;
-                    let paragraph_max_x = glyphs.last().unwrap().max_x();
-
-                    out_rows.push(Row {
-                        glyphs,
-                        visuals: Default::default(),
-                        rect: rect_from_x_range(paragraph_min_x..=paragraph_max_x),
-                        ends_with_newline: false,
-                    });
-
-                    row_start_idx = last_kept_index + 1;
-                    row_start_x = paragraph.glyphs[row_start_idx].pos.x;
-                    row_break_candidates = Default::default();
-                    non_empty_rows += 1;
-                } else {
-                    // Found no place to break, so we have to overrun wrap_width.
-                }
+                // Found no place to break, so we have to overrun wrap_width.
             }
         }
 

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -297,7 +297,7 @@ pub struct TextWrapping {
     /// If set to `1`, a single row will be outputted,
     /// eliding the text after [`Self::max_width`] is reached.
     ///
-    /// Wether or not a word can be cut in half is decided by [`Self::break_anywhere`].
+    /// Whether or not a word can be cut in half is decided by [`Self::break_anywhere`].
     ///
     /// Default value: `usize::MAX`.
     pub max_rows: usize,
@@ -305,7 +305,7 @@ pub struct TextWrapping {
     /// If `true`: Allow breaking between any characters.
     /// If `false` (default): prefer breaking between words, etc.
     ///
-    /// This also aplies to elision: when `true`, a word may be cut in half.
+    /// This also applies to elision: when `true`, a word may be cut in half.
     pub break_anywhere: bool,
 
     /// Character to use to represent elided text, `…` for example, which is the default.
@@ -351,7 +351,7 @@ impl TextWrapping {
     }
 
     /// Elide text that doesn't fit within the given width.
-    pub fn ellide_at_width(max_width: f32) -> Self {
+    pub fn elide_at_width(max_width: f32) -> Self {
         Self {
             max_width,
             max_rows: 1,

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -384,7 +384,7 @@ pub struct Galley {
     /// Rows of text, from top to bottom.
     ///
     /// The number of characters in all rows sum up to `job.text.chars().count()`
-    /// unless [`self::elided`] is `true`.
+    /// unless [`Self::elided`] is `true`.
     ///
     /// Note that a paragraph (a piece of text separated with `\n`)
     /// can be split up into multiple rows.

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -277,10 +277,9 @@ impl TextFormat {
 pub struct TextWrapping {
     /// Wrap text so that no row is wider than this.
     ///
-    /// If you would rather elide text that doesn't fit,
-    /// set [`Self::max_rows`] to `1`.
+    /// If you would rather elide text that doesn't fit, set [`Self::max_rows`] to `1`.
     ///
-    /// Set `max_width` to [`f32::INFINITY`] to turn off wrapping/clipping.
+    /// Set `max_width` to [`f32::INFINITY`] to turn off wrapping and elision.
     ///
     /// Note that `\n` always produces a new row
     /// if [`LayoutJob::break_on_newline`] is `true`.
@@ -308,9 +307,11 @@ pub struct TextWrapping {
     /// This also applies to elision: when `true`, a word may be cut in half.
     pub break_anywhere: bool,
 
-    /// Character to use to represent elided text, `…` for example, which is the default.
+    /// Character to use to represent elided text.
     ///
-    /// If not set, no character will be used (but the text will still be clipped).
+    /// The default is `…`.
+    ///
+    /// If not set, no character will be used (but the text will still be elided).
     pub overflow_character: Option<char>,
 }
 

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -561,6 +561,7 @@ impl Galley {
         self.job.is_empty()
     }
 
+    /// The full, non-elided text of the input job.
     #[inline(always)]
     pub fn text(&self) -> &str {
         &self.job.text

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -295,8 +295,7 @@ pub struct TextWrapping {
     ///
     /// If set to `1`, a single row will be outputted,
     /// eliding the text after [`Self::max_width`] is reached.
-    ///
-    /// Whether or not a word can be cut in half is decided by [`Self::break_anywhere`].
+    /// When you set `max_rows = 1`, it is recommended you also set [`Self::break_anywhere`] to `true`.
     ///
     /// Default value: `usize::MAX`.
     pub max_rows: usize,
@@ -304,7 +303,11 @@ pub struct TextWrapping {
     /// If `true`: Allow breaking between any characters.
     /// If `false` (default): prefer breaking between words, etc.
     ///
-    /// This also applies to elision: when `true`, a word may be cut in half.
+    /// NOTE: Due to limitations in the current implementation,
+    /// when truncating text using [`Self::max_rows`] the text may be truncated
+    /// in the middle of a word even if [`Self::break_anywhere`] is `false`.
+    /// Therefore it is recommended to set [`Self::break_anywhere`] to `true`
+    /// whenever [`Self::max_rows`] is set to `1`.
     pub break_anywhere: bool,
 
     /// Character to use to represent elided text.

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -282,14 +282,16 @@ pub struct TextWrapping {
 
     /// If `true`, the text that doesn't fit within [`Self::max_width`]
     /// will be elided and replaced with [`Self::overflow_character`].
+    /// You can detect this by checking [`Galley::elided`].
     ///
     /// Default: `false`.
     pub elide_at_max_width: bool,
 
-    /// Maximum amount of rows the text should have.
+    /// Maximum amount of rows the text galley should have.
     ///
-    /// If the full text requires more rows than this,
-    /// the last rows will be clipped, and [`Self::overflow_character`] appended.
+    /// If this limit is reach, text will be elided and
+    /// and [`Self::overflow_character`] appended to the final row.
+    /// You can detect this by checking [`Galley::elided`].
     ///
     /// If set to `0`, no text will be shown.
     ///

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -49,7 +49,7 @@ pub struct LayoutJob {
     /// The different section, which can have different fonts, colors, etc.
     pub sections: Vec<LayoutSection>,
 
-    /// Controls the text wrapping.
+    /// Controls the text wrapping and elision.
     pub wrap: TextWrapping,
 
     /// The first row must be at least this high.
@@ -59,8 +59,12 @@ pub struct LayoutJob {
     /// In other cases, set this to `0.0`.
     pub first_row_min_height: f32,
 
-    /// If `false`, all newlines characters will be ignored
+    /// If `true`, all `\n` characters will result in a new _paragraph_,
+    /// starting on a new row.
+    ///
+    /// If `false`, all `\n` characters will be ignored
     /// and show up as the replacement character.
+    ///
     /// Default: `true`.
     pub break_on_newline: bool,
 
@@ -154,7 +158,7 @@ impl LayoutJob {
         });
     }
 
-    /// The height of the tallest used font in the job.
+    /// The height of the tallest font used in the job.
     pub fn font_height(&self, fonts: &crate::Fonts) -> f32 {
         let mut max_height = 0.0_f32;
         for section in &self.sections {
@@ -267,17 +271,18 @@ impl TextFormat {
 
 // ----------------------------------------------------------------------------
 
+/// Controls the text wrapping and elision of a [`LayoutJob`].
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct TextWrapping {
     /// Wrap text so that no row is wider than this.
     ///
-    /// If you would rather elide text that is too wide,
+    /// If you would rather elide text that doesn't fit,
     /// set [`Self::max_rows`] to `1`.
     ///
-    /// Set to [`f32::INFINITY`] to turn off wrapping/clipping.
+    /// Set `max_width` to [`f32::INFINITY`] to turn off wrapping/clipping.
     ///
-    /// Note that `\n` always produces a new line
+    /// Note that `\n` always produces a new row
     /// if [`LayoutJob::break_on_newline`] is `true`.
     pub max_width: f32,
 
@@ -290,7 +295,7 @@ pub struct TextWrapping {
     /// If set to `0`, no text will be outputted.
     ///
     /// If set to `1`, a single row will be outputted,
-    /// eliding the text at [`Self::max_width`].
+    /// eliding the text after [`Self::max_width`] is reached.
     ///
     /// Wether or not a word can be cut in half is decided by [`Self::break_anywhere`].
     ///
@@ -303,7 +308,7 @@ pub struct TextWrapping {
     /// This also aplies to elision: when `true`, a word may be cut in half.
     pub break_anywhere: bool,
 
-    /// Character to use to represent clipped text, `…` for example, which is the default.
+    /// Character to use to represent elided text, `…` for example, which is the default.
     ///
     /// If not set, no character will be used (but the text will still be clipped).
     pub overflow_character: Option<char>,

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -277,7 +277,7 @@ impl TextFormat {
 pub struct TextWrapping {
     /// Wrap text so that no row is wider than this.
     ///
-    /// If you would rather elide text that doesn't fit, set [`Self::max_rows`] to `1`.
+    /// If you would rather truncate text that doesn't fit, set [`Self::max_rows`] to `1`.
     ///
     /// Set `max_width` to [`f32::INFINITY`] to turn off wrapping and elision.
     ///
@@ -287,7 +287,7 @@ pub struct TextWrapping {
 
     /// Maximum amount of rows the text galley should have.
     ///
-    /// If this limit is reached, text will be elided and
+    /// If this limit is reached, text will be truncated and
     /// and [`Self::overflow_character`] appended to the final row.
     /// You can detect this by checking [`Galley::elided`].
     ///
@@ -394,7 +394,7 @@ pub struct Galley {
     /// can be split up into multiple rows.
     pub rows: Vec<Row>,
 
-    /// Set to true if some text was elided due to [`TextWrapping::max_rows`].
+    /// Set to true the text was truncated due to [`TextWrapping::max_rows`].
     pub elided: bool,
 
     /// Bounding rect.

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -272,7 +272,7 @@ impl TextFormat {
 pub struct TextWrapping {
     /// Try to wrap or clip text so that no row is wider than this.
     ///
-    /// Wether the text is wrapped or clipped depends on [`Self::clip_to_max_width`].
+    /// Whether the text is wrapped or clipped depends on [`Self::clip_to_max_width`].
     ///
     /// Set to [`f32::INFINITY`] to turn off wrapping/clipping.
     ///
@@ -281,7 +281,7 @@ pub struct TextWrapping {
     pub max_width: f32,
 
     /// If `true`, the text that doesn't fit within [`Self::max_width`]
-    /// will be ellided and replaced with [`Self::overflow_character`].
+    /// will be elided and replaced with [`Self::overflow_character`].
     ///
     /// Default: `false`.
     pub clip_to_max_width: bool,


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/1727

You can now easily elide text that doesn't fit a certain max width.

This is done using `Label::new(long_text).truncate(true)`. The text will be truncated to fit the max width of the parent `Ui`, and the [`…` ellipsis](https://www.compart.com/en/unicode/U+2026) will replace the omitted text. The text may get truncated in the middle of a word. When hovering a label with elided text, the full non-elided text will be shown in a tool-tip.

You can use the options in `TextWrapping` for finer control.

⚠️ BREAKING: `TextWrapping::max_rows == 0` will now output zero rows. Use `usize::MAX` to set no limit.
⚠️ BREAKING: `TextWrapping::max_rows` will now count total rows (not rows per paragraph, as previous).
ADDED: `Galley::elided`, to see if the text layout elided the input text

Most of the implementation had already be done by @awaken1ng in https://github.com/emilk/egui/pull/1291

### Future work
There are normally three modes of elision that can be desired:

* Start:  `… jumps over the lazy dog`
* Middle: `The quick … the lazy dog`
* End: `The quick brown fox jumps… `

This PR only adds support for the latter kind.

It would also be good to have an option to only omit whole words, never breaking them.

Finally, being able to set the truncate character to a string (e.g. ` …` with a leading space) would be nice.
