### PR TITLE
Add tooltip_delay option

### DIFF
--- a/crates/egui/src/input_state.rs
+++ b/crates/egui/src/input_state.rs
@@ -566,6 +566,10 @@ pub struct PointerState {
     /// Used to check for triple-clicks.
     last_last_click_time: f64,
 
+    /// When was the pointer last moved?
+    /// Used for things like showing hover ui/tooltip with a delay.
+    last_move_time: f64,
+
     /// All button events that occurred this frame
     pub(crate) pointer_events: Vec<PointerEvent>,
 }
@@ -585,6 +589,7 @@ impl Default for PointerState {
             has_moved_too_much_for_a_click: false,
             last_click_time: std::f64::NEG_INFINITY,
             last_last_click_time: std::f64::NEG_INFINITY,
+            last_move_time: std::f64::NEG_INFINITY,
             pointer_events: vec![],
         }
     }
@@ -709,6 +714,9 @@ impl PointerState {
         } else {
             Vec2::default()
         };
+        if self.velocity != Vec2::ZERO {
+            self.last_move_time = time;
+        }
 
         self
     }
@@ -786,6 +794,12 @@ impl PointerState {
     #[inline]
     pub fn is_moving(&self) -> bool {
         self.velocity != Vec2::ZERO
+    }
+
+    /// How long has it been (in seconds) since the pointer was last moved?
+    #[inline(always)]
+    pub fn time_since_last_movement(&self) -> f64 {
+        self.time - self.last_move_time
     }
 
     /// Was any pointer button pressed (`!down -> down`) this frame?
@@ -1033,6 +1047,7 @@ impl PointerState {
             last_click_time,
             last_last_click_time,
             pointer_events,
+            last_move_time,
         } = self;
 
         ui.label(format!("latest_pos: {latest_pos:?}"));
@@ -1050,6 +1065,7 @@ impl PointerState {
         ));
         ui.label(format!("last_click_time: {last_click_time:#?}"));
         ui.label(format!("last_last_click_time: {last_last_click_time:#?}"));
+        ui.label(format!("last_move_time: {last_move_time:#?}"));
         ui.label(format!("pointer_events: {pointer_events:?}"));
     }
 }

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -435,14 +435,11 @@ impl Response {
             }
         }
 
-        if self.ctx.style().interaction.tooltip_delay > 0.0
-            && self.ctx.style().interaction.tooltip_delay
-                > self.ctx.input(|i| i.pointer.time_since_last_movement())
+        if !self.is_tooltip_open()
+            && self.ctx.input(|i| i.pointer.time_since_last_movement())
+                < self.ctx.style().interaction.tooltip_delay
         {
-            // If a non-zero delay was specified, we only show the tooltip if the mouse has been
-            // still for the specified amount of time. If the mouse is moved, the tooltip
-            // disappears.
-
+            // Keep waiting until the mouse has been still for a while
             self.ctx.request_repaint();
             return false;
         }

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -435,6 +435,18 @@ impl Response {
             }
         }
 
+        if self.ctx.style().interaction.tooltip_delay > 0.0
+            && self.ctx.style().interaction.tooltip_delay
+                > self.ctx.input(|i| i.pointer.time_since_last_movement())
+        {
+            // If a non-zero delay was specified, we only show the tooltip if the mouse has been
+            // still for the specified amount of time. If the mouse is moved, the tooltip
+            // disappears.
+
+            self.ctx.request_repaint();
+            return false;
+        }
+
         // We don't want tooltips of things while we are dragging them,
         // but we do want tooltips while holding down on an item on a touch screen.
         if self

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -434,6 +434,9 @@ pub struct Interaction {
 
     /// If `false`, tooltips will show up anytime you hover anything, even is mouse is still moving
     pub show_tooltips_only_when_still: bool,
+
+    /// Delay in seconds before showing tooltips after the mouse stops moving
+    pub tooltip_delay: f64,
 }
 
 /// Controls the visual style (colors etc) of egui.
@@ -755,6 +758,7 @@ impl Default for Interaction {
             resize_grab_radius_side: 5.0,
             resize_grab_radius_corner: 10.0,
             show_tooltips_only_when_still: true,
+            tooltip_delay: 0.0,
         }
     }
 }
@@ -1211,6 +1215,7 @@ impl Interaction {
             resize_grab_radius_side,
             resize_grab_radius_corner,
             show_tooltips_only_when_still,
+            tooltip_delay,
         } = self;
         ui.add(Slider::new(resize_grab_radius_side, 0.0..=20.0).text("resize_grab_radius_side"));
         ui.add(
@@ -1220,6 +1225,7 @@ impl Interaction {
             show_tooltips_only_when_still,
             "Only show tooltips if mouse is still",
         );
+        ui.add(Slider::new(tooltip_delay, 0.0..=1.0).text("tooltip_delay"));
 
         ui.vertical_centered(|ui| reset_button(ui, self));
     }


### PR DESCRIPTION
Similar to the show_tooltips_only_when_still option, but allows the user to configure a specific delay in seconds, and also makes the tooltip disappear if the mouse is moved again.

Closes #3232

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->
