### PR TITLE
Fix consistency of lost_focus and gained_focus

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1250,7 +1250,7 @@ impl Context {
                     nodes,
                     tree: Some(accesskit::Tree::new(root_id)),
                     focus: has_focus.then(|| {
-                        let focus_id = self.memory(|mem| mem.interaction.focus.id);
+                        let focus_id = self.memory(|mem| mem.interaction.focus.focused());
                         focus_id.map_or(root_id, |id| id.accesskit_id())
                     }),
                 });

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -179,7 +179,7 @@ pub(crate) struct Interaction {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct Focus {
     /// The widget with keyboard focus (i.e. a text input field).
-    pub(crate) id: Option<Id>,
+    id: Option<Id>,
 
     /// What had keyboard focus previous frame?
     id_previous_frame: Option<Id>,
@@ -240,6 +240,7 @@ impl Interaction {
 
 impl Focus {
     /// Which widget currently has keyboard focus?
+    #[inline(always)]
     pub fn focused(&self) -> Option<Id> {
         self.id
     }
@@ -404,12 +405,12 @@ impl Memory {
     /// from the window and back.
     #[inline(always)]
     pub fn has_focus(&self, id: Id) -> bool {
-        self.interaction.focus.id == Some(id)
+        self.interaction.focus.focused() == Some(id)
     }
 
     /// Which widget has keyboard focus?
     pub fn focus(&self) -> Option<Id> {
-        self.interaction.focus.id
+        self.interaction.focus.focused()
     }
 
     /// Prevent keyboard focus from moving away from this widget even if users presses the tab key.


### PR DESCRIPTION
This PR aims to make `focus.id` stay consistent throughout the entire frame.

Otherwise `gained_focus` and `lost_focus` can sometimes produce inconsistent results as new widgets are added.

In my testing, this fixes #2142, where `lost_focus` on TextEdit widgets wouldn't fire if you clicked on a TextEdit widget that was added to the ui later than the currently focused widget. I suspect it fixes other weird bugs too.

Closes <https://github.com/emilk/egui/issues/2142>.
