### PR TITLE
Add remove method for CollapsingState.

### DIFF
--- a/crates/egui/src/containers/collapsing_header.rs
+++ b/crates/egui/src/containers/collapsing_header.rs
@@ -36,6 +36,10 @@ impl CollapsingState {
         ctx.data_mut(|d| d.insert_persisted(self.id, self.state));
     }
 
+    pub fn remove(&self, ctx: &Context) {
+        ctx.data_mut(|d| d.remove::<InnerState>(self.id));
+    }
+
     pub fn id(&self) -> Id {
         self.id
     }


### PR DESCRIPTION
This PR adds a removal method for `CollapsingState` to remove its persisted `InnerState` from memory.

Closes <https://github.com/emilk/egui/issues/3250>.
