### PR TITLE
Change focused widget with arrow keys

### DIFF
--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -428,8 +428,8 @@ impl Focus {
             return None;
         };
 
-        // Check if the widget has the right dot product and length.
-        let focus_direction = match self.focus_direction {
+        // In what direction we are looking for the next widget.
+        let search_direction = match self.focus_direction {
             FocusDirection::Up => Vec2::UP,
             FocusDirection::Right => Vec2::RIGHT,
             FocusDirection::Down => Vec2::DOWN,
@@ -459,17 +459,22 @@ impl Focus {
                 continue;
             }
 
+            // There is a lot of room for improvement here.
             let to_candidate = vec2(
                 range_diff(candidate_rect.x_range(), current_rect.x_range()),
                 range_diff(candidate_rect.y_range(), current_rect.y_range()),
             );
 
-            let acos_angle = to_candidate.normalized().dot(focus_direction);
+            let acos_angle = to_candidate.normalized().dot(search_direction);
 
-            // Only interested in widgets that fall in a 90° cone (+/- 45°)
-            if 0.5_f32.sqrt() <= acos_angle {
+            // Only interested in widgets that fall in a 90° cone (±45°)
+            // of the search direction.
+            let is_in_search_cone = 0.5_f32.sqrt() <= acos_angle;
+            if is_in_search_cone {
                 let distance = to_candidate.length();
-                let score = distance / acos_angle;
+
+                // There is a lot of room for improvement here.
+                let score = distance / (acos_angle * acos_angle);
 
                 if score < best_score {
                     best_score = score;

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -440,14 +440,14 @@ impl Focus {
                 continue;
             }
 
-            let x_overlaps = -current_focus_widget_rect
+            let x_similarity = -current_focus_widget_rect
                 .x_range()
-                .overlaps(widget_rect.x_range());
-            let y_overlaps = -current_focus_widget_rect
+                .similarity(widget_rect.x_range());
+            let y_similarity = -current_focus_widget_rect
                 .y_range()
-                .overlaps(widget_rect.y_range());
+                .similarity(widget_rect.y_range());
 
-            let current_to_candidate = vec2(x_overlaps, y_overlaps);
+            let current_to_candidate = vec2(x_similarity, y_similarity);
 
             let dot_current_candidate = current_to_candidate.normalized().dot(focus_direction);
             let distance_current_candidate = current_to_candidate.length();

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -93,22 +93,22 @@ pub struct Memory {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum FocusDirection {
-    // Select the widget closest above the current focused widget.
+    /// Select the widget closest above the current focused widget.
     Up,
 
-    // Select the widget to the right of the current focused widget.
+    /// Select the widget to the right of the current focused widget.
     Right,
 
-    // Select the widget below the current focused widget.
+    /// Select the widget below the current focused widget.
     Down,
 
-    // Select the widget to the left of the the current focused widget.
+    /// Select the widget to the left of the the current focused widget.
     Left,
 
-    // Select the previous widget that had focus.
+    /// Select the previous widget that had focus.
     Previous,
 
-    // Select the next widget that wants focus.
+    /// Select the next widget that wants focus.
     Next,
 
     /// Don't change focus.

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -92,7 +92,7 @@ pub struct Memory {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum FocusDirection {
+enum FocusDirection {
     /// Select the widget closest above the current focused widget.
     Up,
 
@@ -405,7 +405,7 @@ impl Focus {
         self.last_interested = Some(id);
     }
 
-    pub fn reset_focus(&mut self) {
+    fn reset_focus(&mut self) {
         self.focus_direction = FocusDirection::None;
     }
 

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -413,7 +413,6 @@ impl Focus {
         let mut focus_candidates: Vec<(&Id, f32, f32)> =
             Vec::with_capacity(self.focus_widgets_cache.len());
 
-        // The local cache is lagging behind the new rectangles so update them
         for (widget_id, widget_rect) in &mut self.focus_widgets_cache {
             if Some(*widget_id) == self.id {
                 continue;
@@ -461,7 +460,7 @@ impl Focus {
         }
 
         if !focus_candidates.is_empty() {
-            // Select widget based on highest dot product and than lowest distance.
+            // Select widget based on highest dot product and then lowest distance.
             focus_candidates.sort_by(|(_, dot1, _), (_, dot2, _)| dot2.partial_cmp(dot1).unwrap());
             focus_candidates.sort_by(|(_, _, len1), (_, _, len2)| len1.partial_cmp(len2).unwrap());
 

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -256,10 +256,6 @@ impl Interaction {
 }
 
 impl Focus {
-    pub fn set_id(&mut self, id: Id) {
-        self.id = Some(id);
-    }
-
     /// Which widget currently has keyboard focus?
     pub fn focused(&self) -> Option<Id> {
         self.id
@@ -268,7 +264,7 @@ impl Focus {
     fn begin_frame(&mut self, new_input: &crate::data::input::RawInput) {
         self.id_previous_frame = self.id;
         if let Some(id) = self.id_next_frame.take() {
-            self.set_id(id);
+            self.id = Some(id);
         }
 
         #[cfg(feature = "accesskit")]
@@ -333,7 +329,7 @@ impl Focus {
             FocusDirection::None | FocusDirection::Previous | FocusDirection::Next
         ) {
             if let Some(found_widget) = self.find_widget_in_direction(used_ids) {
-                self.set_id(found_widget);
+                self.id = Some(found_widget);
             }
         }
 
@@ -356,7 +352,7 @@ impl Focus {
         #[cfg(feature = "accesskit")]
         {
             if self.id_requested_by_accesskit == Some(id.accesskit_id()) {
-                self.set_id(id);
+                self.id = Some(id);
                 self.id_requested_by_accesskit = None;
                 self.give_to_next = false;
                 self.reset_focus();
@@ -369,7 +365,7 @@ impl Focus {
             .or_insert(Rect::EVERYTHING);
 
         if self.give_to_next && !self.had_focus_last_frame(id) {
-            self.set_id(id);
+            self.id = Some(id);
             self.give_to_next = false;
         } else if self.id == Some(id) {
             if matches!(self.focus_direction, FocusDirection::Next) && !self.is_focus_locked {
@@ -387,7 +383,7 @@ impl Focus {
             && !self.give_to_next
         {
             // nothing has focus and the user pressed tab - give focus to the first widgets that wants it:
-            self.set_id(id);
+            self.id = Some(id);
             self.reset_focus();
         }
 
@@ -558,7 +554,7 @@ impl Memory {
     /// See also [`crate::Response::request_focus`].
     #[inline(always)]
     pub fn request_focus(&mut self, id: Id) {
-        self.interaction.focus.set_id(id);
+        self.interaction.focus.id = Some(id);
         self.interaction.focus.is_focus_locked = false;
     }
 

--- a/crates/emath/src/range.rs
+++ b/crates/emath/src/range.rs
@@ -49,24 +49,10 @@ impl Rangef {
         self.max - self.min
     }
 
-    /// The length of the range, i.e. `max - min`.
+    /// The center of the range
     #[inline]
     pub fn center(self) -> f32 {
         self.min + (self.span() / 2.0)
-    }
-
-    /// Returns the similarity between `self` and `other`.
-    ///
-    ///  * negative if `a` is left of `b`
-    /// * positive if `a` is right of `b`
-    /// * zero if the ranges overlap significantly
-    #[inline]
-    pub fn similarity(self, other: Rangef) -> f32 {
-        if self.contains_range(other) || other.contains_range(self) {
-            0.0
-        } else {
-            -(other.center() - self.center())
-        }
     }
 
     #[inline]
@@ -78,17 +64,7 @@ impl Rangef {
     /// Returns if `self` contains `other` for at least 50%.
     #[inline]
     pub fn contains_range(&self, other: Rangef) -> bool {
-        let overlap_start = self.min.max(other.min);
-        let overlap_end = self.max.min(other.max);
-
-        if overlap_start >= overlap_end {
-            return false;
-        }
-
-        let overlap_length = overlap_end - overlap_start;
-        let other_length = other.max - other.min;
-
-        overlap_length >= 0.5 * other_length
+        self.contains(other.min) && self.contains(other.max)
     }
 
     /// Equivalent to `x.clamp(min, max)`

--- a/crates/emath/src/range.rs
+++ b/crates/emath/src/range.rs
@@ -96,6 +96,18 @@ impl Rangef {
             max: self.max + amnt,
         }
     }
+
+    /// The overlap of two ranges, i.e. the range that is contained by both.
+    ///
+    /// If the ranges do not overlap, returns a range with `span() < 0.0`.
+    #[inline]
+    #[must_use]
+    pub fn intersection(self, other: Self) -> Self {
+        Self {
+            min: self.min.max(other.min),
+            max: self.max.min(other.max),
+        }
+    }
 }
 
 impl From<Rangef> for RangeInclusive<f32> {

--- a/crates/emath/src/range.rs
+++ b/crates/emath/src/range.rs
@@ -61,12 +61,6 @@ impl Rangef {
         self.min <= x && x <= self.max
     }
 
-    /// Returns if `self` contains `other` for at least 50%.
-    #[inline]
-    pub fn contains_range(&self, other: Rangef) -> bool {
-        self.contains(other.min) && self.contains(other.max)
-    }
-
     /// Equivalent to `x.clamp(min, max)`
     #[inline]
     #[must_use]

--- a/crates/emath/src/range.rs
+++ b/crates/emath/src/range.rs
@@ -52,7 +52,7 @@ impl Rangef {
     /// The center of the range
     #[inline]
     pub fn center(self) -> f32 {
-        self.min + (self.span() / 2.0)
+        0.5 * (self.min + self.max)
     }
 
     #[inline]

--- a/crates/emath/src/range.rs
+++ b/crates/emath/src/range.rs
@@ -49,10 +49,46 @@ impl Rangef {
         self.max - self.min
     }
 
+    /// The length of the range, i.e. `max - min`.
+    #[inline]
+    pub fn center(self) -> f32 {
+        self.min + (self.span() / 2.0)
+    }
+
+    /// Returns the similarity between `self` and `other`.
+    ///
+    ///  * negative if `a` is left of `b`
+    /// * positive if `a` is right of `b`
+    /// * zero if the ranges overlap significantly
+    #[inline]
+    pub fn similarity(self, other: Rangef) -> f32 {
+        if self.contains_range(other) || other.contains_range(self) {
+            0.0
+        } else {
+            -(other.center() - self.center())
+        }
+    }
+
     #[inline]
     #[must_use]
     pub fn contains(self, x: f32) -> bool {
         self.min <= x && x <= self.max
+    }
+
+    /// Returns if `self` contains `other` for at least 50%.
+    #[inline]
+    pub fn contains_range(&self, other: Rangef) -> bool {
+        let overlap_start = self.min.max(other.min);
+        let overlap_end = self.max.min(other.max);
+
+        if overlap_start >= overlap_end {
+            return false;
+        }
+
+        let overlap_length = overlap_end - overlap_start;
+        let other_length = other.max - other.min;
+
+        overlap_length >= 0.5 * other_length
     }
 
     /// Equivalent to `x.clamp(min, max)`

--- a/crates/emath/src/range.rs
+++ b/crates/emath/src/range.rs
@@ -100,6 +100,13 @@ impl Rangef {
     /// The overlap of two ranges, i.e. the range that is contained by both.
     ///
     /// If the ranges do not overlap, returns a range with `span() < 0.0`.
+    ///
+    /// ```
+    /// # use emath::Rangef;
+    /// assert_eq!(Rangef::new(0.0, 10.0).intersection(Rangef::new(5.0, 15.0)), Rangef::new(5.0, 10.0));
+    /// assert_eq!(Rangef::new(0.0, 10.0).intersection(Rangef::new(10.0, 20.0)), Rangef::new(10.0, 10.0));
+    /// assert!(Rangef::new(0.0, 10.0).intersection(Rangef::new(20.0, 30.0)).span() < 0.0);
+    /// ```
     #[inline]
     #[must_use]
     pub fn intersection(self, other: Self) -> Self {

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -17,44 +17,32 @@ fn main() -> Result<(), eframe::Error> {
 
 struct MyApp {
     name: String,
-    name2: String,
     age: u32,
-    age2: u32,
 }
 
 impl Default for MyApp {
     fn default() -> Self {
         Self {
             name: "Arthur".to_owned(),
-            name2: "Afadsf".to_owned(),
             age: 42,
-            age2: 42,
         }
     }
 }
 
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        ctx.set_debug_on_hover(true);
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("My egui Application");
-
-            ui.vertical(|ui| {
-                ui.horizontal(|ui| {
-                    ui.text_edit_singleline(&mut self.name);
-                    ui.add(egui::Slider::new(&mut self.age, 0..=120).text("age 1"));
-                    if ui.button("First button").clicked() {
-                        self.age += 1;
-                    }
-                });
-                ui.horizontal(|ui| {
-                    ui.text_edit_singleline(&mut self.name2);
-                    ui.add(egui::Slider::new(&mut self.age2, 0..=120).text("age 2"));
-                    if ui.button("Second button").clicked() {
-                        self.age += 1;
-                    }
-                })
-            })
+            ui.horizontal(|ui| {
+                let name_label = ui.label("Your name: ");
+                ui.text_edit_singleline(&mut self.name)
+                    .labelled_by(name_label.id);
+            });
+            ui.add(egui::Slider::new(&mut self.age, 0..=120).text("age"));
+            if ui.button("Click each year").clicked() {
+                self.age += 1;
+            }
+            ui.label(format!("Hello '{}', age {}", self.name, self.age));
         });
     }
 }

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -17,14 +17,18 @@ fn main() -> Result<(), eframe::Error> {
 
 struct MyApp {
     name: String,
+    name2: String,
     age: u32,
+    age2: u32,
 }
 
 impl Default for MyApp {
     fn default() -> Self {
         Self {
             name: "Arthur".to_owned(),
+            name2: "Afadsf".to_owned(),
             age: 42,
+            age2: 42,
         }
     }
 }
@@ -33,16 +37,23 @@ impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("My egui Application");
-            ui.horizontal(|ui| {
-                let name_label = ui.label("Your name: ");
-                ui.text_edit_singleline(&mut self.name)
-                    .labelled_by(name_label.id);
-            });
-            ui.add(egui::Slider::new(&mut self.age, 0..=120).text("age"));
-            if ui.button("Click each year").clicked() {
-                self.age += 1;
-            }
-            ui.label(format!("Hello '{}', age {}", self.name, self.age));
+
+            ui.vertical(|ui| {
+                ui.horizontal(|ui| {
+                    ui.text_edit_singleline(&mut self.name);
+                    ui.add(egui::Slider::new(&mut self.age, 0..=120).text("age 1"));
+                    if ui.button("First button").clicked() {
+                        self.age += 1;
+                    }
+                });
+                ui.horizontal(|ui| {
+                    ui.text_edit_singleline(&mut self.name2);
+                    ui.add(egui::Slider::new(&mut self.age2, 0..=120).text("age 2"));
+                    if ui.button("Second button").clicked() {
+                        self.age += 1;
+                    }
+                })
+            })
         });
     }
 }

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -35,6 +35,7 @@ impl Default for MyApp {
 
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        ctx.set_debug_on_hover(true);
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("My egui Application");
 


### PR DESCRIPTION
We have the use case of gamepad control for a user-facing game menu. This PR makes it possible to change widget focus with the keyboard arrows. It allows integrations to convert joysticks to arrow keys in order to toggle between menu items. It does not add support for gamepad events in egui as this seems like a bigger topic that I desire not to touch. 

Initially, I examine the currently focused widget to determine the one with the highest dot product when compared to the desired focus direction. Subsequently, I identify the widget that is nearest to the current one. This process enables the selection of the widget in the desired direction which not only possesses the smallest angle relative to the current widget but also maintains the closest proximity.

The widget selection code can be improved over time ofcourse, there are some potential issues right now:
- This solution has no sense of the window it exists in, so if a focusable widget in another window is a better candidate it will pick that one.  
- If I click in an input box the `Focus::interested_in_focus` is not called and thus I do not know what the interactable widgets and their rectangles are. I only know this after using a key like arrow or tab (+shift). 

![2023-08-23 13-07-13](https://github.com/emilk/egui/assets/19969910/02170e68-d5be-4c75-8f3c-d7fddeff799c)



Closes #1250

