### PR TITLE
Add `mime` field to `DroppedFile`

### DIFF
--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -473,6 +473,7 @@ pub fn install_canvas_events(runner_ref: &WebRunner) -> Result<(), JsValue> {
                     for i in 0..files.length() {
                         if let Some(file) = files.get(i) {
                             let name = file.name();
+                            let mime = file.type_();
                             let last_modified = std::time::UNIX_EPOCH
                                 + std::time::Duration::from_millis(file.last_modified() as u64);
 
@@ -491,6 +492,7 @@ pub fn install_canvas_events(runner_ref: &WebRunner) -> Result<(), JsValue> {
                                             runner_lock.input.raw.dropped_files.push(
                                                 egui::DroppedFile {
                                                     name,
+                                                    mime,
                                                     last_modified: Some(last_modified),
                                                     bytes: Some(bytes.into()),
                                                     ..Default::default()

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -155,6 +155,9 @@ pub struct DroppedFile {
     /// Name of the file. Set by the `eframe` web backend.
     pub name: String,
 
+    /// With the `eframe` web backend, this is set to the mime-type of the file (if available).
+    pub mime: String,
+
     /// Set by the `eframe` web backend.
     pub last_modified: Option<std::time::SystemTime>,
 

--- a/crates/egui_demo_app/src/wrap_app.rs
+++ b/crates/egui_demo_app/src/wrap_app.rs
@@ -460,9 +460,18 @@ impl WrapApp {
                         } else {
                             "???".to_owned()
                         };
-                        if let Some(bytes) = &file.bytes {
-                            write!(info, " ({} bytes)", bytes.len()).ok();
+
+                        let mut additional_info = vec![];
+                        if !file.mime.is_empty() {
+                            additional_info.push(format!("type: {}", file.mime));
                         }
+                        if let Some(bytes) = &file.bytes {
+                            additional_info.push(format!("{} bytes", bytes.len()));
+                        }
+                        if !additional_info.is_empty() {
+                            info += &format!(" ({})", additional_info.join(", "));
+                        }
+
                         ui.label(info);
                     }
                 });

--- a/examples/file_dialog/src/main.rs
+++ b/examples/file_dialog/src/main.rs
@@ -53,10 +53,18 @@ impl eframe::App for MyApp {
                         } else {
                             "???".to_owned()
                         };
-                        if let Some(bytes) = &file.bytes {
-                            use std::fmt::Write as _;
-                            write!(info, " ({} bytes)", bytes.len()).ok();
+
+                        let mut additional_info = vec![];
+                        if !file.mime.is_empty() {
+                            additional_info.push(format!("type: {}", file.mime));
                         }
+                        if let Some(bytes) = &file.bytes {
+                            additional_info.push(format!("{} bytes", bytes.len()));
+                        }
+                        if !additional_info.is_empty() {
+                            info += &format!(" ({})", additional_info.join(", "));
+                        }
+
                         ui.label(info);
                     }
                 });


### PR DESCRIPTION
Currently, `HoveredFile` has a `mime` field (which is only set on web by egui), but `DroppedFile` doesn't. This PR adds `mime` to `DroppedFile` with the same semantics and behaviour as `HoveredFile`'s. The demos are also updated to show the mime type when it's set (web-only, for known file paths only):

<img width="364" alt="image" src="https://github.com/emilk/egui/assets/49431240/b302e4df-5898-4da3-975f-565296bb2c4b">
