### PR TITLE
Changing `menu_image_button` to use `ImageButton` builder

### DIFF
--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -111,11 +111,10 @@ pub fn menu_button<R>(
 /// Returns `None` if the menu is not open.
 pub fn menu_image_button<R>(
     ui: &mut Ui,
-    texture_id: TextureId,
-    image_size: impl Into<Vec2>,
+    image_button: ImageButton,
     add_contents: impl FnOnce(&mut Ui) -> R,
 ) -> InnerResponse<Option<R>> {
-    stationary_menu_image_impl(ui, texture_id, image_size, Box::new(add_contents))
+    stationary_menu_image_impl(ui, image_button, Box::new(add_contents))
 }
 
 /// Construct a nested sub menu in another menu.
@@ -202,14 +201,13 @@ fn stationary_menu_impl<'c, R>(
 /// Responds to primary clicks.
 fn stationary_menu_image_impl<'c, R>(
     ui: &mut Ui,
-    texture_id: TextureId,
-    image_size: impl Into<Vec2>,
+    image_button: ImageButton,
     add_contents: Box<dyn FnOnce(&mut Ui) -> R + 'c>,
 ) -> InnerResponse<Option<R>> {
     let bar_id = ui.id();
 
     let mut bar_state = BarState::load(ui.ctx(), bar_id);
-    let button_response = ui.add(ImageButton::new(texture_id, image_size));
+    let button_response = ui.add(image_button);
     let inner = bar_state.bar_menu(&button_response, add_contents);
 
     bar_state.store(ui.ctx(), bar_id);

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2222,7 +2222,7 @@ impl Ui {
         if let Some(menu_state) = self.menu_state.clone() {
             menu::submenu_button(self, menu_state, String::new(), add_contents)
         } else {
-            menu::menu_image_button(self, texture_id, image_size, add_contents)
+            menu::menu_image_button(self, ImageButton::new(texture_id, image_size), add_contents)
         }
     }
 }


### PR DESCRIPTION
I'm changing `menu_image_button` to allow passing in an ImageButton so that I can modify the frame of the passed in ImageButton. It's a breaking API change but I kept the shorthand `ui` version the same.
