### PR TITLE
Replace instant with web_time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,12 +1206,12 @@ dependencies = [
  "arboard",
  "document-features",
  "egui",
- "instant",
  "log",
  "puffin",
  "raw-window-handle",
  "serde",
  "smithay-clipboard",
+ "web-time",
  "webbrowser",
  "winit",
 ]
@@ -4049,6 +4049,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa75ec260dcf59cc310827bae1d7f629809b173dbfe808a633e19754dd4282a5"
+dependencies = [
+ "js-sys",
+ "once_cell",
  "wasm-bindgen",
 ]
 

--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -60,8 +60,9 @@ egui = { version = "0.22.0", path = "../egui", default-features = false, feature
   "log",
 ] }
 log = { version = "0.4", features = ["std"] }
-winit = { version = "0.28", default-features = false }
 raw-window-handle = "0.5.0"
+web-time = { version = "0.1" } # We use web-time so we can (maybe) compile for web
+winit = { version = "0.28", default-features = false }
 
 #! ### Optional dependencies
 
@@ -73,16 +74,7 @@ document-features = { version = "0.2", optional = true }
 
 puffin = { version = "0.16", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
-
 webbrowser = { version = "0.8.3", optional = true }
-
-[target.'cfg(not(target_arch="wasm32"))'.dependencies]
-instant = { version = "0.1" }
-
-[target.'cfg(target_arch="wasm32")'.dependencies]
-instant = { version = "0.1", features = [
-  "wasm-bindgen",
-] } # We use instant so we can (maybe) compile for web
 
 [target.'cfg(any(target_os="linux", target_os="dragonfly", target_os="freebsd", target_os="netbsd", target_os="openbsd"))'.dependencies]
 smithay-clipboard = { version = "0.6.3", optional = true }

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -53,7 +53,7 @@ pub struct EventResponse {
 
 /// Handles the integration between egui and winit.
 pub struct State {
-    start_time: instant::Instant,
+    start_time: web_time::Instant,
     egui_input: egui::RawInput,
     pointer_pos_in_points: Option<egui::Pos2>,
     any_pointer_button_down: bool,
@@ -95,7 +95,7 @@ impl State {
         };
 
         Self {
-            start_time: instant::Instant::now(),
+            start_time: web_time::Instant::now(),
             egui_input,
             pointer_pos_in_points: None,
             any_pointer_button_down: false,


### PR DESCRIPTION
`instant` has at least one major bug:
- https://github.com/sebcrozet/instant/issues/49

It also hasn't been updated in 18 months.

`web-time`: https://github.com/daxpedda/web-time appears to achieve the same goals, but is under active development and notably doesn't have the bug that `instant` had.