### PR TITLE
Prune old egui memory data when reaching some limit

### DIFF
--- a/crates/egui/src/util/id_type_map.rs
+++ b/crates/egui/src/util/id_type_map.rs
@@ -360,7 +360,7 @@ impl Default for IdTypeMap {
     fn default() -> Self {
         Self {
             map: Default::default(),
-            max_bytes_per_type: 1_000_000,
+            max_bytes_per_type: 256 * 1024,
         }
     }
 }
@@ -530,9 +530,17 @@ impl IdTypeMap {
             .count()
     }
 
-    /// When serializing, try to not use up more than this many bytes for each type.
+    /// The maximum number of bytes that will be used to
+    /// store the persisted state of a single widget type.
     ///
-    /// The things that has most recently been read will be be prioritized during serialization.
+    /// Some egui widgets store persisted state that is
+    /// serialized to disk by some backends (e.g. `eframe`).
+    ///
+    /// Example of such widgets is `CollapsingHeader` and `Window`.
+    /// If you keep creating widgets with unique ids (e.g. `Windows` with many different names),
+    /// egui will use up more and more space for these widgets, until this limit is reached.
+    ///
+    /// Once this limit is reached, the state that was read the longest time ago will be dropped first.
     ///
     /// This value in itself will not be serialized.
     pub fn max_bytes_per_type(&self) -> usize {

--- a/crates/egui/src/util/id_type_map.rs
+++ b/crates/egui/src/util/id_type_map.rs
@@ -893,6 +893,7 @@ fn test_serialize_generations() {
     assert_eq!(map.get_generation::<A>(Id::new(1)), Some(3));
 }
 
+#[cfg(feature = "persistence")]
 #[test]
 fn test_serialize_gc() {
     use serde::{Deserialize, Serialize};

--- a/crates/egui/src/util/id_type_map.rs
+++ b/crates/egui/src/util/id_type_map.rs
@@ -3,8 +3,7 @@
 // For non-serializable types, these simply return `None`.
 // This will also allow users to pick their own serialization format per type.
 
-use std::sync::Arc;
-use std::{any::Any, collections::BTreeMap};
+use std::{any::Any, sync::Arc};
 
 // -----------------------------------------------------------------------------------------------
 
@@ -56,7 +55,6 @@ impl<T> SerializableAny for T where T: 'static + Any + Clone + for<'a> Send + Sy
 
 // -----------------------------------------------------------------------------------------------
 
-#[cfg(feature = "persistence")]
 #[cfg_attr(feature = "persistence", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Clone, Debug)]
 struct SerializedElement {
@@ -569,6 +567,8 @@ struct PersistedMap(Vec<(u64, SerializedElement)>);
 impl PersistedMap {
     fn from_map(map: &IdTypeMap) -> Self {
         crate::profile_function!();
+
+        use std::collections::BTreeMap;
 
         let mut types_map: nohash_hasher::IntMap<TypeId, TypeStats> = Default::default();
         #[derive(Default)]


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/2641

Previously egui would just accumulate state over time, growing its memory more and more if the user had unique `Id`s with persisted state, e.g. a lot of `CollapsingHeader`s or `Window`s with different names. This leads to slow load and save of `eframe` apps with persistence.

With this PR egui will now forget the oldest data of each type that hasn't been read in a while. That is, if you load and save your app state many times, egui will eventually drop the thing that never been read.

The limit can be set with `egui_ctx.memory_mut(|m| m.data.set_max_bytes_per_type(1_000_000));`

The default is 256 kiB per type. For reference, a `CollapsingHeader` takes around 200 bytes to store, so that's over a thousand different collapsing headers in your application.
