### PR TITLE
`eframe::Frame::info` returns a reference

### DIFF
--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -774,6 +774,10 @@ impl Frame {
         self.info.clone()
     }
 
+    pub fn info_ref(&self) -> &IntegrationInfo {
+        &self.info
+    }
+
     /// A place where you can store custom data in a way that persists when you restart the app.
     pub fn storage(&self) -> Option<&dyn Storage> {
         self.storage.as_deref()

--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -774,6 +774,7 @@ impl Frame {
         self.info.clone()
     }
 
+    /// Get `IntegrationInfo` as a reference.
     pub fn info_ref(&self) -> &IntegrationInfo {
         &self.info
     }

--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -770,12 +770,7 @@ impl Frame {
     }
 
     /// Information about the integration.
-    pub fn info(&self) -> IntegrationInfo {
-        self.info.clone()
-    }
-
-    /// Get `IntegrationInfo` as a reference.
-    pub fn info_ref(&self) -> &IntegrationInfo {
+    pub fn info(&self) -> &IntegrationInfo {
         &self.info
     }
 

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -1215,7 +1215,7 @@ mod wgpu_integration {
                 .expect("Single-use AppCreator has unexpectedly already been taken");
             let mut app = app_creator(&epi::CreationContext {
                 egui_ctx: integration.egui_ctx.clone(),
-                integration_info: integration.frame.info(),
+                integration_info: integration.frame.info().clone(),
                 storage: integration.frame.storage(),
                 #[cfg(feature = "glow")]
                 gl: None,

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -753,7 +753,7 @@ mod glow_integration {
                 .expect("Single-use AppCreator has unexpectedly already been taken");
             let mut app = app_creator(&epi::CreationContext {
                 egui_ctx: integration.egui_ctx.clone(),
-                integration_info: integration.frame.info(),
+                integration_info: integration.frame.info().clone(),
                 storage: integration.frame.storage(),
                 gl: Some(gl.clone()),
                 #[cfg(feature = "wgpu")]

--- a/crates/egui_demo_app/src/backend_panel.rs
+++ b/crates/egui_demo_app/src/backend_panel.rs
@@ -155,7 +155,7 @@ impl BackendPanel {
         // On web, the browser controls `pixels_per_point`.
         let integration_controls_pixels_per_point = frame.is_web();
         if !integration_controls_pixels_per_point {
-            self.pixels_per_point_ui(ui, &frame.info());
+            self.pixels_per_point_ui(ui, frame.info());
         }
 
         #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
Add a way to get `IntegrationInfo` as a reference in order to avoid a deep copy.