### PR TITLE
feat: change to PointingHand when hovering over a button

### DIFF
--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -2,7 +2,9 @@
 
 #![allow(clippy::if_same_then_else)]
 
-use crate::{ecolor::*, emath::*, FontFamily, FontId, Response, RichText, WidgetText};
+use crate::{
+    ecolor::*, emath::*, ComboBox, CursorIcon, FontFamily, FontId, Response, RichText, WidgetText,
+};
 use epaint::{Rounding, Shadow, Stroke};
 use std::collections::BTreeMap;
 
@@ -545,12 +547,12 @@ pub struct Visuals {
     /// Enabling this will affect ALL sliders, and can be enabled/disabled per slider with [`Slider::trailing_fill`].
     pub slider_trailing_fill: bool,
 
-    /// Should the cursor change into a [`CursorIcon::PointingHand`][crate::CursorIcon::PointingHand]
-    /// if the user hovers over an interactive/clickable item?
+    /// Should the cursor change when the user hovers over an interactive/clickable item?
     ///
-    /// This is consistent with web browser behaviour, but inconsistent with native
-    /// UI toolkits.
-    pub pointinghand_if_interactive: bool,
+    /// This is consistent with a lot of browser-based applications (vscode, github
+    /// all turn your cursor into [`CursorIcon::PointingHand`] when a button is
+    /// hovered) but it is inconsistent with native UI toolkits.
+    pub interact_cursor: Option<CursorIcon>,
 }
 
 impl Visuals {
@@ -814,7 +816,7 @@ impl Visuals {
 
             slider_trailing_fill: false,
 
-            pointinghand_if_interactive: false,
+            interact_cursor: None,
         }
     }
 
@@ -1385,7 +1387,7 @@ impl Visuals {
             striped,
 
             slider_trailing_fill,
-            pointinghand_if_interactive,
+            interact_cursor,
         } = self;
 
         ui.collapsing("Background Colors", |ui| {
@@ -1451,10 +1453,15 @@ impl Visuals {
 
         ui.checkbox(slider_trailing_fill, "Add trailing color to sliders");
 
-        ui.checkbox(
-            pointinghand_if_interactive,
-            "Change cursor to PointingHand when an interactive item is hovered.",
-        );
+        ComboBox::from_label("Interact Cursor")
+            .selected_text(format!("{interact_cursor:?}"))
+            .show_ui(ui, |ui| {
+                ui.selectable_value(interact_cursor, None, "None");
+
+                for icon in CursorIcon::ALL {
+                    ui.selectable_value(interact_cursor, Some(icon), format!("{icon:?}"));
+                }
+            });
 
         ui.vertical_centered(|ui| reset_button(ui, self));
     }

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -544,6 +544,13 @@ pub struct Visuals {
     ///
     /// Enabling this will affect ALL sliders, and can be enabled/disabled per slider with [`Slider::trailing_fill`].
     pub slider_trailing_fill: bool,
+
+    /// Should the cursor change into a [`CursorIcon::PointingHand`][crate::CursorIcon::PointingHand]
+    /// if the user hovers over an interactive/clickable item?
+    ///
+    /// This is consistent with web browser behaviour, but inconsistent with native
+    /// UI toolkits.
+    pub pointinghand_if_interactable: bool,
 }
 
 impl Visuals {
@@ -806,6 +813,8 @@ impl Visuals {
             striped: false,
 
             slider_trailing_fill: false,
+
+            pointinghand_if_interactable: false,
         }
     }
 
@@ -1376,6 +1385,7 @@ impl Visuals {
             striped,
 
             slider_trailing_fill,
+            pointinghand_if_interactable,
         } = self;
 
         ui.collapsing("Background Colors", |ui| {
@@ -1440,6 +1450,11 @@ impl Visuals {
         ui.checkbox(striped, "By default, add stripes to grids and tables?");
 
         ui.checkbox(slider_trailing_fill, "Add trailing color to sliders");
+
+        ui.checkbox(
+            pointinghand_if_interactable,
+            "Change cursor to PointingHand when an interactive item is hovered.",
+        );
 
         ui.vertical_centered(|ui| reset_button(ui, self));
     }

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -550,7 +550,7 @@ pub struct Visuals {
     ///
     /// This is consistent with web browser behaviour, but inconsistent with native
     /// UI toolkits.
-    pub pointinghand_if_interactable: bool,
+    pub pointinghand_if_interactive: bool,
 }
 
 impl Visuals {
@@ -814,7 +814,7 @@ impl Visuals {
 
             slider_trailing_fill: false,
 
-            pointinghand_if_interactable: false,
+            pointinghand_if_interactive: false,
         }
     }
 
@@ -1385,7 +1385,7 @@ impl Visuals {
             striped,
 
             slider_trailing_fill,
-            pointinghand_if_interactable,
+            pointinghand_if_interactive,
         } = self;
 
         ui.collapsing("Background Colors", |ui| {
@@ -1452,7 +1452,7 @@ impl Visuals {
         ui.checkbox(slider_trailing_fill, "Add trailing color to sliders");
 
         ui.checkbox(
-            pointinghand_if_interactable,
+            pointinghand_if_interactive,
             "Change cursor to PointingHand when an interactive item is hovered.",
         );
 

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -238,7 +238,7 @@ impl Widget for Button {
             }
         }
 
-        if response.hovered && ui.visuals().pointinghand_if_interactable {
+        if response.hovered && ui.visuals().pointinghand_if_interactive {
             ui.ctx().set_cursor_icon(CursorIcon::PointingHand);
         }
 

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -238,6 +238,10 @@ impl Widget for Button {
             }
         }
 
+        if response.hovered {
+            ui.ctx().set_cursor_icon(CursorIcon::PointingHand);
+        }
+
         response
     }
 }

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -238,8 +238,11 @@ impl Widget for Button {
             }
         }
 
-        if response.hovered && ui.visuals().pointinghand_if_interactive {
-            ui.ctx().set_cursor_icon(CursorIcon::PointingHand);
+        // n.b. no let chains here...
+        if let Some(cursor) = ui.visuals().interact_cursor {
+            if response.hovered {
+                ui.ctx().set_cursor_icon(cursor);
+            }
         }
 
         response

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -238,7 +238,6 @@ impl Widget for Button {
             }
         }
 
-        // n.b. no let chains here...
         if let Some(cursor) = ui.visuals().interact_cursor {
             if response.hovered {
                 ui.ctx().set_cursor_icon(cursor);

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -238,7 +238,7 @@ impl Widget for Button {
             }
         }
 
-        if response.hovered {
+        if response.hovered && ui.visuals().pointinghand_if_interactable {
             ui.ctx().set_cursor_icon(CursorIcon::PointingHand);
         }
 


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

When hovering over an `egui::Button`, the cursor should change to a PointingHand. This is consistent with the buttons in most other UIs (the browser, etc.)

Closes <https://github.com/emilk/egui/issues/3311>.
