### PR TITLE
Implement `Frame::allow_ime` method

### DIFF
--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -455,6 +455,9 @@ pub struct NativeOptions {
     /// }
     /// ```
     pub app_id: Option<String>,
+
+    /// Enable/disable IME at startup.
+    pub allow_ime: bool,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -529,6 +532,7 @@ impl Default for NativeOptions {
             wgpu_options: egui_wgpu::WgpuConfiguration::default(),
 
             app_id: None,
+            allow_ime: false,
         }
     }
 }

--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -730,6 +730,9 @@ pub struct Frame {
     /// Raw platform display handle for window
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) raw_display_handle: RawDisplayHandle,
+
+    /// Option for enabling/disabling IME.
+    pub(crate) allow_ime: Option<bool>,
 }
 
 // Implementing `Clone` would violate the guarantees of `HasRawWindowHandle` and `HasRawDisplayHandle`.
@@ -976,6 +979,11 @@ impl Frame {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn set_always_on_top(&mut self, always_on_top: bool) {
         self.output.always_on_top = Some(always_on_top);
+    }
+
+    /// Enable/disable IME.
+    pub fn allow_ime(&mut self, allow: bool) {
+        self.allow_ime = Some(allow);
     }
 
     /// On desktop: Set the window to be centered.

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -400,6 +400,7 @@ impl EpiIntegration {
             screenshot: std::cell::Cell::new(None),
             raw_display_handle: window.raw_display_handle(),
             raw_window_handle: window.raw_window_handle(),
+            allow_ime: None,
         };
 
         let mut egui_winit = egui_winit::State::new(event_loop);
@@ -519,6 +520,10 @@ impl EpiIntegration {
             crate::profile_scope!("App::update");
             app.update(egui_ctx, &mut self.frame);
         });
+
+        if let Some(allow_ime) = self.frame.allow_ime.take() {
+            window.set_ime_allowed(allow_ime);
+        }
 
         self.pending_full_output.append(full_output);
         let full_output = std::mem::take(&mut self.pending_full_output);

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -744,7 +744,6 @@ mod glow_integration {
             let theme = system_theme.unwrap_or(self.native_options.default_theme);
             integration.egui_ctx.set_visuals(theme.egui_visuals());
 
-            gl_window.window().set_ime_allowed(true);
             if self.native_options.mouse_passthrough {
                 gl_window.window().set_cursor_hittest(false).unwrap();
             }
@@ -1221,8 +1220,6 @@ mod wgpu_integration {
             }
             let theme = system_theme.unwrap_or(self.native_options.default_theme);
             integration.egui_ctx.set_visuals(theme.egui_visuals());
-
-            window.set_ime_allowed(true);
 
             {
                 let event_loop_proxy = self.repaint_proxy.clone();

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -744,6 +744,10 @@ mod glow_integration {
             let theme = system_theme.unwrap_or(self.native_options.default_theme);
             integration.egui_ctx.set_visuals(theme.egui_visuals());
 
+            gl_window
+                .window()
+                .set_ime_allowed(self.native_options.allow_ime);
+
             if self.native_options.mouse_passthrough {
                 gl_window.window().set_cursor_hittest(false).unwrap();
             }
@@ -1220,6 +1224,8 @@ mod wgpu_integration {
             }
             let theme = system_theme.unwrap_or(self.native_options.default_theme);
             integration.egui_ctx.set_visuals(theme.egui_visuals());
+
+            window.set_ime_allowed(self.native_options.allow_ime);
 
             {
                 let event_loop_proxy = self.repaint_proxy.clone();

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -87,6 +87,7 @@ impl AppRunner {
             wgpu_render_state: painter.render_state(),
             #[cfg(all(feature = "wgpu", feature = "glow"))]
             wgpu_render_state: None,
+            allow_ime: None,
         };
 
         let needs_repaint: std::sync::Arc<NeedRepaint> = Default::default();


### PR DESCRIPTION
Blindly enabling IME is problematic for Phosh (and probably other Linux desktops that use touch) as it brings up the on-screen keyboard when the app starts. A better solution would be to enable IME when a text edit gains focus and disable IME when it looses focus (which actually shows and hides the on-screen keyboard nicely in Phosh). In order to facilitate this, I have added an `allow_ime` method to `Frame`.

I also added an `allow_ime` member to `NativeOptions` in order to enable IME at startup.
