### PR TITLE
Add method to RichText making it easier to construct layout jobs

### DIFF
--- a/crates/egui/src/widget_text.rs
+++ b/crates/egui/src/widget_text.rs
@@ -269,6 +269,35 @@ impl RichText {
         fonts.row_height(&font_id)
     }
 
+    /// Append to an existing [`LayoutJob`]
+    ///
+    /// Note that the color of the [`RichText`] must be set, or may default to an undesirable color.
+    ///
+    /// ### Example
+    /// ```
+    /// use egui::{Style, RichText, text::LayoutJob, Color32, FontSelection, Align};
+    ///
+    /// let style = Style::default();
+    /// let mut layout_job = LayoutJob::default();
+    /// RichText::new("Normal")
+    ///     .color(style.visuals.text_color())
+    ///     .append_to(
+    ///         &mut layout_job,
+    ///         &style,
+    ///         FontSelection::Default,
+    ///         Align::Center,
+    ///     );
+    /// RichText::new("Large and underlined")
+    ///     .color(style.visuals.text_color())
+    ///     .size(20.0)
+    ///     .underline()
+    ///     .append_to(
+    ///         &mut layout_job,
+    ///         &style,
+    ///         FontSelection::Default,
+    ///         Align::Center,
+    ///     );
+    /// ```
     pub fn append_to(
         self,
         layout_job: &mut LayoutJob,

--- a/crates/egui/src/widget_text.rs
+++ b/crates/egui/src/widget_text.rs
@@ -269,12 +269,34 @@ impl RichText {
         fonts.row_height(&font_id)
     }
 
+    pub fn append_to(self,
+        layout_job: &mut LayoutJob,
+        style: &Style,
+        fallback_font: FontSelection,
+        default_valign: Align) {
+        let (text, format) = self.into_text_and_format(style, fallback_font, default_valign);
+
+        layout_job.append(&text, 0.0, format);
+    }
+
     fn into_text_job(
         self,
         style: &Style,
         fallback_font: FontSelection,
         default_valign: Align,
     ) -> WidgetTextJob {
+        let job_has_color = self.get_text_color(&style.visuals).is_some();
+        let (text, text_format) = self.into_text_and_format(style, fallback_font, default_valign);
+
+        let job = LayoutJob::single_section(text, text_format);
+        WidgetTextJob { job, job_has_color }
+    }
+
+    fn into_text_and_format(self,
+        style: &Style,
+        fallback_font: FontSelection,
+        default_valign: Align,
+    ) -> (String, crate::text::TextFormat) {
         let text_color = self.get_text_color(&style.visuals);
 
         let Self {
@@ -295,7 +317,6 @@ impl RichText {
             raised,
         } = self;
 
-        let job_has_color = text_color.is_some();
         let line_color = text_color.unwrap_or_else(|| style.visuals.text_color());
         let text_color = text_color.unwrap_or(crate::Color32::TEMPORARY_COLOR);
 
@@ -336,7 +357,7 @@ impl RichText {
             default_valign
         };
 
-        let text_format = crate::text::TextFormat {
+        (text, crate::text::TextFormat {
             font_id,
             extra_letter_spacing,
             line_height,
@@ -346,10 +367,7 @@ impl RichText {
             underline,
             strikethrough,
             valign,
-        };
-
-        let job = LayoutJob::single_section(text, text_format);
-        WidgetTextJob { job, job_has_color }
+        })
     }
 
     fn get_text_color(&self, visuals: &Visuals) -> Option<Color32> {

--- a/crates/egui/src/widget_text.rs
+++ b/crates/egui/src/widget_text.rs
@@ -269,11 +269,13 @@ impl RichText {
         fonts.row_height(&font_id)
     }
 
-    pub fn append_to(self,
+    pub fn append_to(
+        self,
         layout_job: &mut LayoutJob,
         style: &Style,
         fallback_font: FontSelection,
-        default_valign: Align) {
+        default_valign: Align,
+    ) {
         let (text, format) = self.into_text_and_format(style, fallback_font, default_valign);
 
         layout_job.append(&text, 0.0, format);
@@ -292,7 +294,8 @@ impl RichText {
         WidgetTextJob { job, job_has_color }
     }
 
-    fn into_text_and_format(self,
+    fn into_text_and_format(
+        self,
         style: &Style,
         fallback_font: FontSelection,
         default_valign: Align,
@@ -357,17 +360,20 @@ impl RichText {
             default_valign
         };
 
-        (text, crate::text::TextFormat {
-            font_id,
-            extra_letter_spacing,
-            line_height,
-            color: text_color,
-            background: background_color,
-            italics,
-            underline,
-            strikethrough,
-            valign,
-        })
+        (
+            text,
+            crate::text::TextFormat {
+                font_id,
+                extra_letter_spacing,
+                line_height,
+                color: text_color,
+                background: background_color,
+                italics,
+                underline,
+                strikethrough,
+                valign,
+            },
+        )
     }
 
     fn get_text_color(&self, visuals: &Visuals) -> Option<Color32> {


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->
Closes #3318

This refactors the existing code that was used inside `RichText.into_text_job()` to generate a `LayoutJob` to also expose a method that appends to a `LayoutJob` passed in from the outside. This makes it possible to construct a `LayoutJob` using only `RichText`s, without having to manually touch `TextFormat`.

In my code I added an extension method to UI (which didn't seem fitting for core egui) that looks like this:
```rust
fn create_default_layout_job(&self, rich_texts: Vec<RichText>) -> LayoutJob {
    let mut layout_job = LayoutJob::default();
    for rich_text in rich_texts.into_iter() {
        rich_text.append_to(
            &mut layout_job,
            self.style(),
            egui::FontSelection::Default,
            egui::Align::Center,
        )
    }

    layout_job
}
```

which can be used like so:
```rust
let layout_job = ui.create_default_layout_job(vec![
    RichText::new("Using: ").color(ui.style().visuals.text_color()),
    RichText::new(format!("{} ", self.current_window.app_name)).strong(),
    RichText::new(format!("(started using {})", time_using_current))
        .color(ui.style().visuals.text_color()),
]);
```

This, in my opinion, is a much more ergonomic API that was available previously. Compare the above code to the code inside the linked #3318.

Note that the color of text must be specified in the RichText since `WidgetText.into_text_job()` always sets `WidgetTextJob::job_has_color` to true when converting from a LayoutJob, or the text will show up as green.

I'm not sure if this change is appropriate for core `egui`, but since it helped me, I thought I'd share and see.
