### PR TITLE
Remove Function() invocation from eframe text_agent to bypass "unsafe-eval" restrictions in Chrome browser extensions.

### DIFF
--- a/crates/eframe/src/web/text_agent.rs
+++ b/crates/eframe/src/web/text_agent.rs
@@ -101,14 +101,13 @@ pub fn install_text_agent(runner_ref: &WebRunner) -> Result<(), JsValue> {
 
     // When input lost focus, focus on it again.
     // It is useful when user click somewhere outside canvas.
+    let input_refocus = input.clone();
     runner_ref.add_event_listener(&input, "focusout", move |_event: web_sys::MouseEvent, _| {
         // Delay 10 ms, and focus again.
-        let func = js_sys::Function::new_no_args(&format!(
-            "document.getElementById('{AGENT_ID}').focus()"
-        ));
-        window
-            .set_timeout_with_callback_and_timeout_and_arguments_0(&func, 10)
-            .unwrap();
+        let input_refocus = input_refocus.clone();
+        call_after_delay(std::time::Duration::from_millis(10), move || {
+            input_refocus.focus().ok();
+        });
     })?;
 
     body.append_child(&input)?;

--- a/crates/egui_demo_app/src/apps/image_viewer.rs
+++ b/crates/egui_demo_app/src/apps/image_viewer.rs
@@ -167,7 +167,7 @@ impl eframe::App for ImageViewer {
                     if !matches!(self.fit, ImageFit::Original { .. }) {
                         self.fit = ImageFit::Original { scale: 1.0 };
                     }
-                    let ImageFit::Original{scale} = &mut self.fit else {
+                    let ImageFit::Original { scale } = &mut self.fit else {
                         unreachable!()
                     };
                     ui.add(Slider::new(scale, 0.1..=4.0).text("scale"));


### PR DESCRIPTION
This is a small snippet that replaces `Function()` with `call_after_delay()` (which was conveniently present a few lines below).

Chrome browser extensions using the latest manifest v3 format do not allow invocation of `eval()`-like functions (`Function` belongs to this list of restrictions). As such, loading `eframe` WASM application within a Chrome browser extension popup will result in Chrome blocking the execution.

After this change, the resulting eframe WASM application powers up as a Chrome browser extension.

