### PR TITLE
Bug fix: arrow keys won't move focus away from TextEdit

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1276,7 +1276,7 @@ impl Context {
                     nodes,
                     tree: Some(accesskit::Tree::new(root_id)),
                     focus: has_focus.then(|| {
-                        let focus_id = self.memory(|mem| mem.interaction.focus.id);
+                        let focus_id = self.memory(|mem| mem.focus());
                         focus_id.map_or(root_id, |id| id.accesskit_id())
                     }),
                 });

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -1042,14 +1042,20 @@ impl From<u32> for TouchId {
 pub struct EventFilter {
     /// If `true`, pressing tab will act on the widget,
     /// and NOT move focus away from the focused widget.
+    ///
+    /// Default: `false`
     pub tab: bool,
 
     /// If `true`, pressing arrows will act on the widget,
     /// and NOT move focus away from the focused widget.
+    ///
+    /// Default: `false`
     pub arrows: bool,
 
     /// If `true`, pressing escape will act on the widget,
     /// and NOT surrender focus from the focused widget.
+    ///
+    /// Default: `false`
     pub escape: bool,
 }
 

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -1028,3 +1028,56 @@ impl From<u32> for TouchId {
         Self(id as u64)
     }
 }
+
+// ----------------------------------------------------------------------------
+
+// TODO(emilk): generalize this to a proper event filter.
+/// Controls which events that a focused widget will have exclusive access to.
+///
+/// Currently this only controls a few special keyboard events,
+/// but in the future this `struct` should be extended into a full callback thing.
+///
+/// Any events not covered by the filter are given to the widget, but are not exclusive.
+#[derive(Clone, Copy, Debug)]
+pub struct EventFilter {
+    /// If `true`, pressing tab will act on the widget,
+    /// and NOT move focus away from the focused widget.
+    pub tab: bool,
+
+    /// If `true`, pressing arrows will act on the widget,
+    /// and NOT move focus away from the focused widget.
+    pub arrows: bool,
+
+    /// If `true`, pressing escape will act on the widget,
+    /// and NOT surrender focus from the focused widget.
+    pub escape: bool,
+}
+
+#[allow(clippy::derivable_impls)] // let's be explicit
+impl Default for EventFilter {
+    fn default() -> Self {
+        Self {
+            tab: false,
+            arrows: false,
+            escape: false,
+        }
+    }
+}
+
+impl EventFilter {
+    pub fn matches(&self, event: &Event) -> bool {
+        if let Event::Key { key, .. } = event {
+            match key {
+                crate::Key::Tab => self.tab,
+                crate::Key::ArrowUp
+                | crate::Key::ArrowRight
+                | crate::Key::ArrowDown
+                | crate::Key::ArrowLeft => self.arrows,
+                crate::Key::Escape => self.escape,
+                _ => true,
+            }
+        } else {
+            true
+        }
+    }
+}

--- a/crates/egui/src/input_state.rs
+++ b/crates/egui/src/input_state.rs
@@ -461,6 +461,15 @@ impl InputState {
     pub fn num_accesskit_action_requests(&self, id: crate::Id, action: accesskit::Action) -> usize {
         self.accesskit_action_requests(id, action).count()
     }
+
+    /// Get all events that matches the given filter.
+    pub fn filtered_events(&self, filter: &EventFilter) -> Vec<Event> {
+        self.events
+            .iter()
+            .filter(|event| filter.matches(event))
+            .cloned()
+            .collect()
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -564,7 +564,7 @@ impl Memory {
 
     /// Set an event filter for a widget.
     ///
-    /// This allows you to control wether the widget will loose focus
+    /// This allows you to control whether the widget will loose focus
     /// when the user presses tab, arrow keys, or escape.
     ///
     /// You must first give focus to the widget before calling this.

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -570,6 +570,16 @@ impl<'a> Slider<'a> {
         let mut increment = 0usize;
 
         if response.has_focus() {
+            ui.ctx().memory_mut(|m| {
+                m.set_focus_lock_filter(
+                    response.id,
+                    EventFilter {
+                        arrows: true, // pressing arrows should not move focus to next widget
+                        ..Default::default()
+                    },
+                );
+            });
+
             let (dec_key, inc_key) = match self.orientation {
                 SliderOrientation::Horizontal => (Key::ArrowLeft, Key::ArrowRight),
                 // Note that this is for moving the slider position,

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -65,7 +65,7 @@ pub struct TextEdit<'t> {
     interactive: bool,
     desired_width: Option<f32>,
     desired_height_rows: usize,
-    lock_focus: bool,
+    event_filter: EventFilter,
     cursor_at_end: bool,
     min_size: Vec2,
     align: Align2,
@@ -115,7 +115,11 @@ impl<'t> TextEdit<'t> {
             interactive: true,
             desired_width: None,
             desired_height_rows: 4,
-            lock_focus: false,
+            event_filter: EventFilter {
+                arrows: true, // moving the cursor is really important
+                tab: false,   // tab is used to change focus, not to insert a tab character
+                ..Default::default()
+            },
             cursor_at_end: true,
             min_size: Vec2::ZERO,
             align: Align2::LEFT_TOP,
@@ -127,7 +131,7 @@ impl<'t> TextEdit<'t> {
     /// Build a [`TextEdit`] focused on code editing.
     /// By default it comes with:
     /// - monospaced font
-    /// - focus lock
+    /// - focus lock (tab will insert a tab character instead of moving focus)
     pub fn code_editor(self) -> Self {
         self.font(TextStyle::Monospace).lock_focus(true)
     }
@@ -266,8 +270,8 @@ impl<'t> TextEdit<'t> {
     ///
     /// When `true`, the widget will keep the focus and pressing TAB
     /// will insert the `'\t'` character.
-    pub fn lock_focus(mut self, b: bool) -> Self {
-        self.lock_focus = b;
+    pub fn lock_focus(mut self, tab_will_indent: bool) -> Self {
+        self.event_filter.tab = tab_will_indent;
         self
     }
 
@@ -352,7 +356,9 @@ impl<'t> TextEdit<'t> {
         let margin = self.margin;
         let max_rect = ui.available_rect_before_wrap().shrink2(margin);
         let mut content_ui = ui.child_ui(max_rect, *ui.layout());
+
         let mut output = self.show_content(&mut content_ui);
+
         let id = output.response.id;
         let frame_rect = output.response.rect.expand2(margin);
         ui.allocate_space(frame_rect.size());
@@ -413,7 +419,7 @@ impl<'t> TextEdit<'t> {
             interactive,
             desired_width,
             desired_height_rows,
-            lock_focus,
+            event_filter,
             cursor_at_end,
             min_size,
             align,
@@ -569,7 +575,7 @@ impl<'t> TextEdit<'t> {
         let mut cursor_range = None;
         let prev_cursor_range = state.cursor_range(&galley);
         if interactive && ui.memory(|mem| mem.has_focus(id)) {
-            ui.memory_mut(|mem| mem.lock_focus(id, lock_focus));
+            ui.memory_mut(|mem| mem.set_focus_lock_filter(id, event_filter));
 
             let default_cursor_range = if cursor_at_end {
                 CursorRange::one(galley.end())
@@ -589,6 +595,7 @@ impl<'t> TextEdit<'t> {
                 password,
                 default_cursor_range,
                 char_limit,
+                event_filter,
             );
 
             if changed {
@@ -880,6 +887,7 @@ fn events(
     password: bool,
     default_cursor_range: CursorRange,
     char_limit: usize,
+    event_filter: EventFilter,
 ) -> (bool, CursorRange) {
     let mut cursor_range = state.cursor_range(galley).unwrap_or(default_cursor_range);
 
@@ -898,7 +906,7 @@ fn events(
 
     let mut any_change = false;
 
-    let events = ui.input(|i| i.events.clone()); // avoid dead-lock by cloning. TODO(emilk): optimize
+    let events = ui.input(|i| i.filtered_events(&event_filter));
     for event in &events {
         let did_mutate_text = match event {
             Event::Copy => {
@@ -946,19 +954,15 @@ fn events(
                 pressed: true,
                 modifiers,
                 ..
-            } => {
-                if multiline && ui.memory(|mem| mem.has_lock_focus(id)) {
-                    let mut ccursor = delete_selected(text, &cursor_range);
-                    if modifiers.shift {
-                        // TODO(emilk): support removing indentation over a selection?
-                        decrease_indentation(&mut ccursor, text);
-                    } else {
-                        insert_text(&mut ccursor, text, "\t", char_limit);
-                    }
-                    Some(CCursorRange::one(ccursor))
+            } if multiline => {
+                let mut ccursor = delete_selected(text, &cursor_range);
+                if modifiers.shift {
+                    // TODO(emilk): support removing indentation over a selection?
+                    decrease_indentation(&mut ccursor, text);
                 } else {
-                    None
+                    insert_text(&mut ccursor, text, "\t", char_limit);
                 }
+                Some(CCursorRange::one(ccursor))
             }
             Event::Key {
                 key: Key::Enter,


### PR DESCRIPTION
* Caused by https://github.com/emilk/egui/pull/3272
* Closes https://github.com/emilk/egui/issues/3324

This PR introduces `Event::set_focus_lock_filter` which lets you tell egui what events a widget has exclusive access to:


```rs
/// Controls which events that a focused widget will have exclusive access to.
///
/// Currently this only controls a few special keyboard events,
/// but in the future this `struct` should be extended into a full callback thing.
///
/// Any events not covered by the filter are given to the widget, but are not exclusive.
#[derive(Clone, Copy, Debug)]
pub struct EventFilter {
    /// If `true`, pressing tab will act on the widget,
    /// and NOT move focus away from the focused widget.
    /// 
    /// Default: `false`
    pub tab: bool,

    /// If `true`, pressing arrows will act on the widget,
    /// and NOT move focus away from the focused widget.
    /// 
    /// Default: `false`
    pub arrows: bool,

    /// If `true`, pressing escape will act on the widget,
    /// and NOT surrender focus from the focused widget.
    /// 
    /// Default: `false`
    pub escape: bool,
}
```

### Future work
The event filter was the simplest possible for what is needed today. In the future we should replace it with some sort of callback.

### Alternatives
Another way to solve this would be that widgets mark events as handled/consumed. The widget-focus-move logic runs at the end of the frame, so it would just ignored consumed events.

One downside with that would be requiring attaching some `bool` to each event, which would require quite a bit of a refactor.

Another problem is that it won't handle the case when several widgets are interested in events, since there is no guarantee which orders widgets will be executed (it is immediate mode!). The only thing that could work in that case is an event filter.
