### PR TITLE
Fix not taking clipping into account when calculating colum remainder

### DIFF
--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -648,7 +648,9 @@ impl<'a> Table<'a> {
                 // If the last column is 'remainder', then let it fill the remainder!
                 let eps = 0.1; // just to avoid some rounding errors.
                 *column_width = available_width - eps;
-                *column_width = column_width.at_least(max_used_widths[i]);
+                if !column.clip {
+                    *column_width = column_width.at_least(max_used_widths[i]);
+                }
                 *column_width = width_range.clamp(*column_width);
                 break;
             }


### PR DESCRIPTION
Currently there is a problem with [`Column::remainder()`](https://docs.rs/egui_extras/0.22.0/egui_extras/struct.Column.html#method.remainder) in that it can only grow but not shrink, even if [`Column::clip()`](https://docs.rs/egui_extras/0.22.0/egui_extras/struct.Column.html#method.clip) was set. It seemed to me that this simple check was missing, but maybe I've missed the reason why this check was not there in the first place?

See #2430 for more info and examples.

* Closes #2430.
