### PR TITLE
Only show on-screen-keyboard and IME when editing text

### DIFF
--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -777,7 +777,6 @@ mod glow_integration {
             let theme = system_theme.unwrap_or(self.native_options.default_theme);
             integration.egui_ctx.set_visuals(theme.egui_visuals());
 
-            gl_window.window().set_ime_allowed(true);
             if self.native_options.mouse_passthrough {
                 gl_window.window().set_cursor_hittest(false).unwrap();
             }
@@ -1268,8 +1267,6 @@ mod wgpu_integration {
             }
             let theme = system_theme.unwrap_or(self.native_options.default_theme);
             integration.egui_ctx.set_visuals(theme.egui_visuals());
-
-            window.set_ime_allowed(true);
 
             {
                 let event_loop_proxy = self.repaint_proxy.clone();

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -9,8 +9,6 @@
 
 #![allow(clippy::manual_range_contains)]
 
-use std::sync::atomic::{AtomicBool, Ordering};
-
 #[cfg(feature = "accesskit")]
 pub use accesskit_winit;
 pub use egui;

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -83,7 +83,7 @@ pub struct State {
     #[cfg(feature = "accesskit")]
     accesskit: Option<accesskit_winit::Adapter>,
 
-    allow_ime: AtomicBool,
+    allow_ime: bool,
 }
 
 impl State {
@@ -112,7 +112,7 @@ impl State {
             #[cfg(feature = "accesskit")]
             accesskit: None,
 
-            allow_ime: AtomicBool::new(false),
+            allow_ime: false,
         }
     }
 
@@ -670,7 +670,8 @@ impl State {
         }
 
         let allow_ime = text_cursor_pos.is_some();
-        if self.allow_ime.swap(allow_ime, Ordering::Relaxed) != allow_ime {
+        if self.allow_ime != allow_ime {
+            self.allow_ime == allow_ime;
             window.set_ime_allowed(allow_ime);
         }
 

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -669,7 +669,7 @@ impl State {
 
         let allow_ime = text_cursor_pos.is_some();
         if self.allow_ime != allow_ime {
-            self.allow_ime == allow_ime;
+            self.allow_ime = allow_ime;
             window.set_ime_allowed(allow_ime);
         }
 

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -663,6 +663,7 @@ impl State {
             self.clipboard.set(copied_text);
         }
 
+        window.set_ime_allowed(text_cursor_pos.is_some());
         if let Some(egui::Pos2 { x, y }) = text_cursor_pos {
             window.set_ime_position(winit::dpi::LogicalPosition { x, y });
         }


### PR DESCRIPTION
* Closes #2614
* Closes #3057.

Allow IME if `PlatformOutput::text_cursor_pos` is `Some`.

* Hopefully this is a better approach than #3313.
