### PR TITLE
Improve text truncation: always include elision character

### DIFF
--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -879,41 +879,46 @@ fn is_cjk_break_allowed(c: char) -> bool {
 
 // ----------------------------------------------------------------------------
 
-#[test]
-fn test_zero_max_width() {
-    let mut fonts = FontsImpl::new(1.0, 1024, super::FontDefinitions::default());
-    let mut layout_job = LayoutJob::single_section("W".into(), super::TextFormat::default());
-    layout_job.wrap.max_width = 0.0;
-    let galley = super::layout(&mut fonts, layout_job.into());
-    assert_eq!(galley.rows.len(), 1);
-}
+#[cfg(test)]
+mod tests {
+    use super::{super::*, *};
 
-#[test]
-fn test_cjk() {
-    let mut fonts = FontsImpl::new(1.0, 1024, super::FontDefinitions::default());
-    let mut layout_job = LayoutJob::single_section(
-        "日本語とEnglishの混在した文章".into(),
-        super::TextFormat::default(),
-    );
-    layout_job.wrap.max_width = 90.0;
-    let galley = super::layout(&mut fonts, layout_job.into());
-    assert_eq!(
-        galley.rows.iter().map(|row| row.text()).collect::<Vec<_>>(),
-        vec!["日本語と", "Englishの混在", "した文章"]
-    );
-}
+    #[test]
+    fn test_zero_max_width() {
+        let mut fonts = FontsImpl::new(1.0, 1024, FontDefinitions::default());
+        let mut layout_job = LayoutJob::single_section("W".into(), TextFormat::default());
+        layout_job.wrap.max_width = 0.0;
+        let galley = layout(&mut fonts, layout_job.into());
+        assert_eq!(galley.rows.len(), 1);
+    }
 
-#[test]
-fn test_pre_cjk() {
-    let mut fonts = FontsImpl::new(1.0, 1024, super::FontDefinitions::default());
-    let mut layout_job = LayoutJob::single_section(
-        "日本語とEnglishの混在した文章".into(),
-        super::TextFormat::default(),
-    );
-    layout_job.wrap.max_width = 110.0;
-    let galley = super::layout(&mut fonts, layout_job.into());
-    assert_eq!(
-        galley.rows.iter().map(|row| row.text()).collect::<Vec<_>>(),
-        vec!["日本語とEnglish", "の混在した文章"]
-    );
+    #[test]
+    fn test_cjk() {
+        let mut fonts = FontsImpl::new(1.0, 1024, FontDefinitions::default());
+        let mut layout_job = LayoutJob::single_section(
+            "日本語とEnglishの混在した文章".into(),
+            TextFormat::default(),
+        );
+        layout_job.wrap.max_width = 90.0;
+        let galley = layout(&mut fonts, layout_job.into());
+        assert_eq!(
+            galley.rows.iter().map(|row| row.text()).collect::<Vec<_>>(),
+            vec!["日本語と", "Englishの混在", "した文章"]
+        );
+    }
+
+    #[test]
+    fn test_pre_cjk() {
+        let mut fonts = FontsImpl::new(1.0, 1024, FontDefinitions::default());
+        let mut layout_job = LayoutJob::single_section(
+            "日本語とEnglishの混在した文章".into(),
+            TextFormat::default(),
+        );
+        layout_job.wrap.max_width = 110.0;
+        let galley = layout(&mut fonts, layout_job.into());
+        assert_eq!(
+            galley.rows.iter().map(|row| row.text()).collect::<Vec<_>>(),
+            vec!["日本語とEnglish", "の混在した文章"]
+        );
+    }
 }

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -898,11 +898,7 @@ fn test_cjk() {
     layout_job.wrap.max_width = 90.0;
     let galley = super::layout(&mut fonts, layout_job.into());
     assert_eq!(
-        galley
-            .rows
-            .iter()
-            .map(|row| row.glyphs.iter().map(|g| g.chr).collect::<String>())
-            .collect::<Vec<_>>(),
+        galley.rows.iter().map(|row| row.text()).collect::<Vec<_>>(),
         vec!["日本語と", "Englishの混在", "した文章"]
     );
 }
@@ -917,11 +913,7 @@ fn test_pre_cjk() {
     layout_job.wrap.max_width = 110.0;
     let galley = super::layout(&mut fonts, layout_job.into());
     assert_eq!(
-        galley
-            .rows
-            .iter()
-            .map(|row| row.glyphs.iter().map(|g| g.chr).collect::<String>())
-            .collect::<Vec<_>>(),
+        galley.rows.iter().map(|row| row.text()).collect::<Vec<_>>(),
         vec!["日本語とEnglish", "の混在した文章"]
     );
 }

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -494,6 +494,13 @@ pub struct Row {
     pub ends_with_newline: bool,
 }
 
+impl Row {
+    /// The text on this row, excluding the implicit `\n` if any.
+    pub fn text(&self) -> String {
+        self.glyphs.iter().map(|g| g.chr).collect()
+    }
+}
+
 /// The tessellated output of a row.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -480,6 +480,9 @@ pub struct Galley {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Row {
+    /// This is included in case there are no glyphs
+    pub section_index_at_start: u32,
+
     /// One for each `char`.
     pub glyphs: Vec<Glyph>,
 

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -394,7 +394,7 @@ impl Default for TextWrapping {
 }
 
 impl TextWrapping {
-    /// A row can be as long as it need to be
+    /// A row can be as long as it need to be.
     pub fn no_max_width() -> Self {
         Self {
             max_width: f32::INFINITY,
@@ -402,14 +402,19 @@ impl TextWrapping {
         }
     }
 
-    /// Elide text that doesn't fit within the given width.
-    pub fn elide_at_width(max_width: f32) -> Self {
+    /// Elide text that doesn't fit within the given width, replaced with `…`.
+    pub fn truncate_at_width(max_width: f32) -> Self {
         Self {
             max_width,
             max_rows: 1,
             break_anywhere: true,
             ..Default::default()
         }
+    }
+
+    #[deprecated = "Renamed `truncate_at_width`"]
+    pub fn elide_at_width(max_width: f32) -> Self {
+        Self::truncate_at_width(max_width)
     }
 }
 

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -411,11 +411,6 @@ impl TextWrapping {
             ..Default::default()
         }
     }
-
-    #[deprecated = "Renamed `truncate_at_width`"]
-    pub fn elide_at_width(max_width: f32) -> Self {
-        Self::truncate_at_width(max_width)
-    }
 }
 
 // ----------------------------------------------------------------------------
@@ -502,13 +497,6 @@ pub struct Row {
     pub ends_with_newline: bool,
 }
 
-impl Row {
-    /// The text on this row, excluding the implicit `\n` if any.
-    pub fn text(&self) -> String {
-        self.glyphs.iter().map(|g| g.chr).collect()
-    }
-}
-
 /// The tessellated output of a row.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -576,6 +564,11 @@ impl Glyph {
 // ----------------------------------------------------------------------------
 
 impl Row {
+    /// The text on this row, excluding the implicit `\n` if any.
+    pub fn text(&self) -> String {
+        self.glyphs.iter().map(|g| g.chr).collect()
+    }
+
     /// Excludes the implicit `\n` after the [`Row`], if any.
     #[inline]
     pub fn char_count_excluding_newline(&self) -> usize {


### PR DESCRIPTION
There were cases where the elision character (e.g. `…`) was not included, even though the text was elided. This PR fixed that.

* Follow-up to https://github.com/emilk/egui/pull/3244