### PR TITLE
Added key mappings for `[`, `]`, `,` and `\`.

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1066,6 +1066,10 @@ fn key_from_key_code(key: winit::keyboard::KeyCode) -> Option<egui::Key> {
         KeyCode::Period => Key::Period,
         // KeyCode::Colon => Key::Colon, // NOTE: there is no physical colon key on an american keyboard
         KeyCode::Semicolon => Key::Semicolon,
+        KeyCode::Backslash => Key::Backslash,
+        KeyCode::BracketLeft => Key::OpenBracket,
+        KeyCode::BracketRight => Key::CloseBracket,
+        KeyCode::Backquote => Key::Backtick,
 
         KeyCode::Cut => Key::Cut,
         KeyCode::Copy => Key::Copy,

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -962,6 +962,18 @@ pub enum Key {
     /// `,`
     Comma,
 
+    /// '/'
+    Backslash,
+
+    // '['
+    OpenBracket,
+
+    // ']'
+    CloseBracket,
+
+    /// '`'
+    Backtick,
+
     /// `-`
     Minus,
 
@@ -1094,6 +1106,10 @@ impl Key {
         Self::Plus,
         Self::Equals,
         Self::Semicolon,
+        Self::OpenBracket,
+        Self::CloseBracket,
+        Self::Backtick,
+        Self::Backslash,
         // Digits:
         Self::Num0,
         Self::Num1,
@@ -1195,6 +1211,10 @@ impl Key {
             "Plus" | "+" => Self::Plus,
             "Equals" | "=" => Self::Equals,
             "Semicolon" | ";" => Self::Semicolon,
+            "Backslash" | "\\" => Self::Backslash,
+            "OpenBracket" | "[" => Self::OpenBracket,
+            "CloseBracket" | "]" => Self::CloseBracket,
+            "Backtick" | "`" => Self::Backtick,
 
             "0" => Self::Num0,
             "1" => Self::Num1,
@@ -1308,6 +1328,11 @@ impl Key {
             Key::Plus => "Plus",
             Key::Equals => "Equals",
             Key::Semicolon => "Semicolon",
+
+            Key::Backslash => "Backslash",
+            Key::OpenBracket => "OpenBracket",
+            Key::CloseBracket => "CloseBracket",
+            Key::Backtick => "Backtick",
 
             Key::Num0 => "0",
             Key::Num1 => "1",


### PR DESCRIPTION
Added key mappings for '[', ']', ',' and '\'.

* Closes https://github.com/emilk/egui/issues/3372

## Added keys

* egui::Key::Backslash
* egui::Key::OpenBracket
* egui::Key::CloseBracket
* egui::Key::Comma

