### PR TITLE
Add  `Area::constrain_to` and `Window::constrain_to`

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -65,12 +65,12 @@ pub struct Area {
     interactable: bool,
     enabled: bool,
     constrain: bool,
+    constrain_rect: Option<Rect>,
     order: Order,
     default_pos: Option<Pos2>,
     pivot: Align2,
     anchor: Option<(Align2, Vec2)>,
     new_pos: Option<Pos2>,
-    drag_bounds: Option<Rect>,
 }
 
 impl Area {
@@ -80,13 +80,13 @@ impl Area {
             movable: true,
             interactable: true,
             constrain: false,
+            constrain_rect: None,
             enabled: true,
             order: Order::Middle,
             default_pos: None,
             new_pos: None,
             pivot: Align2::LEFT_TOP,
             anchor: None,
-            drag_bounds: None,
         }
     }
 
@@ -155,6 +155,21 @@ impl Area {
         self
     }
 
+    /// Constraint the movement of the window to the given rectangle.
+    ///
+    /// For instance: `.constrain_to(ctx.screen_rect())`.
+    pub fn constrain_to(mut self, constrain_rect: Rect) -> Self {
+        self.constrain = true;
+        self.constrain_rect = Some(constrain_rect);
+        self
+    }
+
+    #[deprecated = "Use `constrain_to` instead"]
+    pub fn drag_bounds(mut self, constrain_rect: Rect) -> Self {
+        self.constrain_rect = Some(constrain_rect);
+        self
+    }
+
     /// Where the "root" of the area is.
     ///
     /// For instance, if you set this to [`Align2::RIGHT_TOP`]
@@ -189,12 +204,6 @@ impl Area {
         self.movable(false)
     }
 
-    /// Constrain the area up to which the window can be dragged.
-    pub fn drag_bounds(mut self, bounds: Rect) -> Self {
-        self.drag_bounds = Some(bounds);
-        self
-    }
-
     pub(crate) fn get_pivot(&self) -> Align2 {
         if let Some((pivot, _)) = self.anchor {
             pivot
@@ -209,7 +218,8 @@ pub(crate) struct Prepared {
     state: State,
     move_response: Response,
     enabled: bool,
-    drag_bounds: Option<Rect>,
+    constrain: bool,
+    constrain_rect: Option<Rect>,
 
     /// We always make windows invisible the first frame to hide "first-frame-jitters".
     ///
@@ -243,8 +253,8 @@ impl Area {
             new_pos,
             pivot,
             anchor,
-            drag_bounds,
             constrain,
+            constrain_rect,
         } = self;
 
         let layer_id = LayerId::new(order, id);
@@ -308,7 +318,7 @@ impl Area {
 
         if constrain {
             state.set_left_top_pos(
-                ctx.constrain_window_rect_to_area(state.rect(), drag_bounds)
+                ctx.constrain_window_rect_to_area(state.rect(), constrain_rect)
                     .min,
             );
         }
@@ -323,7 +333,8 @@ impl Area {
             state,
             move_response,
             enabled,
-            drag_bounds,
+            constrain,
+            constrain_rect,
             temporarily_invisible: is_new,
         }
     }
@@ -366,15 +377,19 @@ impl Prepared {
         &mut self.state
     }
 
-    pub(crate) fn drag_bounds(&self) -> Option<Rect> {
-        self.drag_bounds
+    pub(crate) fn constrain(&self) -> bool {
+        self.constrain
+    }
+
+    pub(crate) fn constrain_rect(&self) -> Option<Rect> {
+        self.constrain_rect
     }
 
     pub(crate) fn content_ui(&self, ctx: &Context) -> Ui {
         let screen_rect = ctx.screen_rect();
 
-        let bounds = if let Some(bounds) = self.drag_bounds {
-            bounds.intersect(screen_rect) // protect against infinite bounds
+        let constrain_rect = if let Some(constrain_rect) = self.constrain_rect {
+            constrain_rect.intersect(screen_rect) // protect against infinite bounds
         } else {
             let central_area = ctx.available_rect();
 
@@ -388,7 +403,7 @@ impl Prepared {
 
         let max_rect = Rect::from_min_max(
             self.state.left_top_pos(),
-            bounds
+            constrain_rect
                 .max
                 .at_least(self.state.left_top_pos() + Vec2::splat(32.0)),
         );
@@ -396,9 +411,9 @@ impl Prepared {
         let shadow_radius = ctx.style().visuals.window_shadow.extrusion; // hacky
         let clip_rect_margin = ctx.style().visuals.clip_rect_margin.max(shadow_radius);
 
-        let clip_rect = Rect::from_min_max(self.state.left_top_pos(), bounds.max)
+        let clip_rect = Rect::from_min_max(self.state.left_top_pos(), constrain_rect.max)
             .expand(clip_rect_margin)
-            .intersect(bounds);
+            .intersect(constrain_rect);
 
         let mut ui = Ui::new(
             ctx.clone(),
@@ -419,7 +434,8 @@ impl Prepared {
             mut state,
             move_response,
             enabled: _,
-            drag_bounds: _,
+            constrain: _,
+            constrain_rect: _,
             temporarily_invisible: _,
         } = self;
 

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -260,9 +260,8 @@ fn show_tooltip_area_dyn<'c, R>(
     Area::new(area_id)
         .order(Order::Tooltip)
         .fixed_pos(window_pos)
-        .constrain(true)
+        .constrain_to(ctx.screen_rect())
         .interactable(false)
-        .drag_bounds(ctx.screen_rect())
         .show(ctx, |ui| {
             Frame::popup(&ctx.style())
                 .show(ui, |ui| {

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -146,10 +146,9 @@ pub(crate) fn menu_ui<'c, R>(
 
     let area = Area::new(menu_id)
         .order(Order::Foreground)
-        .constrain(true)
         .fixed_pos(pos)
-        .interactable(true)
-        .drag_bounds(ctx.screen_rect());
+        .constrain_to(ctx.screen_rect())
+        .interactable(true);
 
     area.show(ctx, |ui| {
         set_menu_style(ui.style_mut());

--- a/crates/egui_demo_lib/src/demo/window_options.rs
+++ b/crates/egui_demo_lib/src/demo/window_options.rs
@@ -105,7 +105,7 @@ impl super::View for WindowOptions {
                     ui.checkbox(collapsible, "collapsible");
                     ui.checkbox(resizable, "resizable");
                     ui.checkbox(constrain, "constrain")
-                        .on_hover_text("Contrain window to the screen");
+                        .on_hover_text("Constrain window to the screen");
                     ui.checkbox(&mut scroll2[0], "hscroll");
                     ui.checkbox(&mut scroll2[1], "vscroll");
                 });

--- a/crates/egui_demo_lib/src/demo/window_options.rs
+++ b/crates/egui_demo_lib/src/demo/window_options.rs
@@ -6,6 +6,7 @@ pub struct WindowOptions {
     closable: bool,
     collapsible: bool,
     resizable: bool,
+    constrain: bool,
     scroll2: [bool; 2],
     disabled_time: f64,
 
@@ -22,6 +23,7 @@ impl Default for WindowOptions {
             closable: true,
             collapsible: true,
             resizable: true,
+            constrain: true,
             scroll2: [true; 2],
             disabled_time: f64::NEG_INFINITY,
             anchored: false,
@@ -43,6 +45,7 @@ impl super::Demo for WindowOptions {
             closable,
             collapsible,
             resizable,
+            constrain,
             scroll2,
             disabled_time,
             anchored,
@@ -59,6 +62,7 @@ impl super::Demo for WindowOptions {
         let mut window = egui::Window::new(title)
             .id(egui::Id::new("demo_window_options")) // required since we change the title
             .resizable(resizable)
+            .constrain(constrain)
             .collapsible(collapsible)
             .title_bar(title_bar)
             .scroll2(scroll2)
@@ -81,6 +85,7 @@ impl super::View for WindowOptions {
             closable,
             collapsible,
             resizable,
+            constrain,
             scroll2,
             disabled_time: _,
             anchored,
@@ -99,6 +104,8 @@ impl super::View for WindowOptions {
                     ui.checkbox(closable, "closable");
                     ui.checkbox(collapsible, "collapsible");
                     ui.checkbox(resizable, "resizable");
+                    ui.checkbox(constrain, "constrain")
+                        .on_hover_text("Contrain window to the screen");
                     ui.checkbox(&mut scroll2[0], "hscroll");
                     ui.checkbox(&mut scroll2[1], "vscroll");
                 });

--- a/crates/egui_extras/src/datepicker/button.rs
+++ b/crates/egui_extras/src/datepicker/button.rs
@@ -117,6 +117,7 @@ impl<'a> Widget for DatePickerButton<'a> {
             } = Area::new(ui.make_persistent_id(self.id_source))
                 .order(Order::Foreground)
                 .fixed_pos(pos)
+                .constrain_to(ui.ctx().screen_rect())
                 .show(ui.ctx(), |ui| {
                     let frame = Frame::popup(ui.style());
                     frame


### PR DESCRIPTION
`constrain_to` takes a rect, and will constrain the area/window to that rectangle.

This acts the same as `.constrain(true).drag_bounds(rect)`, but `drag_bounds` has now been deprecated.

This also fixes a bug where a `Window` could not be unconstrained.