### PR TITLE
Fix inconsistent naming of constrain_to versus constraint_to

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -155,7 +155,7 @@ impl Area {
         self
     }
 
-    /// Constraint the movement of the window to the given rectangle.
+    /// Constrain the movement of the window to the given rectangle.
     ///
     /// For instance: `.constrain_to(ctx.screen_rect())`.
     pub fn constrain_to(mut self, constrain_rect: Rect) -> Self {

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -147,7 +147,7 @@ impl<'open> Window<'open> {
 
     /// Constrains this window to the screen bounds.
     ///
-    /// To change the area to constrain to, use [`Self::constraint_to`].
+    /// To change the area to constrain to, use [`Self::constrain_to`].
     ///
     /// Default: `true`.
     pub fn constrain(mut self, constrain: bool) -> Self {
@@ -155,10 +155,10 @@ impl<'open> Window<'open> {
         self
     }
 
-    /// Constraint the movement of the window to the given rectangle.
+    /// Constrain the movement of the window to the given rectangle.
     ///
     /// For instance: `.constrain_to(ctx.screen_rect())`.
-    pub fn constraint_to(mut self, constrain_rect: Rect) -> Self {
+    pub fn constrain_to(mut self, constrain_rect: Rect) -> Self {
         self.area = self.area.constrain_to(constrain_rect);
         self
     }


### PR DESCRIPTION

The changelog for 0.23.0 mentioned:

> * Add  `Area::constrain_to` and `Window::constrain_to` [#3396](https://github.com/emilk/egui/pull/3396)

However, the implementation for `Window` was called `constraint_to` (notice the extra 't'). I noticed this because the `deprecated` message points to the non-existing `constrain_to`.