### PR TITLE
Migrate to `mime_guess2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ dependencies = [
  "enum-map",
  "image",
  "log",
- "mime_guess",
+ "mime_guess2",
  "puffin",
  "resvg",
  "serde",
@@ -2445,10 +2445,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.4"
+name = "mime_guess2"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+checksum = "25a3333bb1609500601edc766a39b4c1772874a4ce26022f4d866854dc020c41"
 dependencies = [
  "mime",
  "unicase",

--- a/crates/egui_extras/Cargo.toml
+++ b/crates/egui_extras/Cargo.toml
@@ -24,7 +24,7 @@ all-features = true
 
 
 [features]
-default = ["dep:mime_guess"]
+default = ["dep:mime_guess2"]
 
 ## Shorthand for enabling the different types of image loaders (`file`, `http`, `image`, `svg`).
 all_loaders = ["file", "http", "image", "svg"]
@@ -33,7 +33,7 @@ all_loaders = ["file", "http", "image", "svg"]
 datepicker = ["chrono"]
 
 ## Add support for loading images from `file://` URIs.
-file = ["dep:mime_guess"]
+file = ["dep:mime_guess2"]
 
 ## Add support for loading images via HTTP.
 http = ["dep:ehttp"]
@@ -83,7 +83,7 @@ document-features = { version = "0.2", optional = true }
 image = { version = "0.24", optional = true, default-features = false }
 
 # file feature
-mime_guess = { version = "2.0.4", optional = true, default-features = false }
+mime_guess2 = { version = "2", optional = true, default-features = false }
 
 puffin = { version = "0.16", optional = true }
 

--- a/crates/egui_extras/src/loaders/file_loader.rs
+++ b/crates/egui_extras/src/loaders/file_loader.rs
@@ -68,7 +68,7 @@ impl BytesLoader for FileLoader {
                         let result = match std::fs::read(&path) {
                             Ok(bytes) => {
                                 #[cfg(feature = "mime_guess")]
-                                let mime = mime_guess::from_path(&path)
+                                let mime = mime_guess2::from_path(&path)
                                     .first_raw()
                                     .map(|v| v.to_owned());
 


### PR DESCRIPTION
`mime_guess` is unmaintained.

- Related: https://github.com/rerun-io/rerun/issues/3774
