### PR TITLE
Fix vertical `Slider` regression(?)

### DIFF
--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -703,7 +703,9 @@ impl<'a> Slider<'a> {
         let handle_radius = self.handle_radius(rect);
         match self.orientation {
             SliderOrientation::Horizontal => rect.x_range().shrink(handle_radius),
-            SliderOrientation::Vertical => rect.y_range().shrink(handle_radius),
+            SliderOrientation::Vertical => {
+                ((rect.bottom() - handle_radius)..=(rect.top() + handle_radius)).into()
+            }
         }
     }
 


### PR DESCRIPTION
## Regression(?)
In `egui 0.23.0`, [this commit and line exactly](https://github.com/emilk/egui/commit/8cdffc4e2d66d54f3059b3a31fac924f630dce8b#diff-8e09ca1b216ec1b61cfc347621f794d6dfba7bad08ea58822842ca560db058f1R693), the behavior of vertical `Slider`'s has been swapped.

I'm not sure if this was intentional (nothing in the `CHANGELOG.md`).

The base used to be the `bottom`, but it is now the `top`.

This PR reverts the code calculating the start position and uses `.into()` to convert to the new `Rangef`.

## `egui 0.23.0` Behavior
Horizontal sliders increment `left <-> right`, vertical sliders increment `top <-> bottom`:
```
 0 <-------> 100

       0
       ^
       |
       v
      100
```
`trailing_fill` behavior is incorrect here.

https://github.com/emilk/egui/assets/101352116/8530b50b-218c-4da1-a994-78c669e2affb


## Fixed(?) Behavior
Horizontal sliders increment `left <-> right` (same), vertical sliders increment `bottom <-> top` (old behavior):
```
 0 <-------> 100

      100
       ^
       |
       v
       0
```

https://github.com/emilk/egui/assets/101352116/a294b786-dc2f-4f20-963e-500c91eab5e4