### PR TITLE
fix unusable rgba constructor

### DIFF
--- a/crates/ecolor/src/rgba.rs
+++ b/crates/ecolor/src/rgba.rs
@@ -8,7 +8,7 @@ use crate::{
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
-pub struct Rgba(pub(crate) [f32; 4]);
+pub struct Rgba(pub [f32; 4]);
 
 impl std::ops::Index<usize> for Rgba {
     type Output = f32;


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->
The constructor was not usable, so this small change will make it usable. I receive a private fields error when pub(crate) is used inside a tuple. 