### PR TITLE
Fix: allow using the full Private Use Area for custom fonts

### DIFF
--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -139,6 +139,12 @@ impl FontImpl {
     ///
     /// See also [`invisible_char`].
     fn ignore_character(&self, chr: char) -> bool {
+        use crate::text::FontDefinitions;
+
+        if !FontDefinitions::builtin_font_names().contains(&self.name.as_str()) {
+            return false;
+        }
+
         if self.name == "emoji-icon-font" {
             // HACK: https://github.com/emilk/egui/issues/1284 https://github.com/jslegers/emoji-icon-font/issues/18
             // Don't show the wrong fullwidth capital letters:

--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -141,7 +141,7 @@ impl FontImpl {
     fn ignore_character(&self, chr: char) -> bool {
         use crate::text::FontDefinitions;
 
-        if !FontDefinitions::builtin_font_names().contains(&self.name.as_str()) {
+        if !FontDefinitions::builtin_font_names().contains(&self.name) {
             return false;
         }
 

--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -141,7 +141,7 @@ impl FontImpl {
     fn ignore_character(&self, chr: char) -> bool {
         use crate::text::FontDefinitions;
 
-        if !FontDefinitions::builtin_font_names().contains(&self.name) {
+        if !FontDefinitions::builtin_font_names().contains(&self.name.as_str()) {
             return false;
         }
 

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -335,6 +335,23 @@ impl FontDefinitions {
             families,
         }
     }
+
+    /// List of all the builtin font names used by `epaint`.
+    #[cfg(feature = "default_fonts")]
+    pub fn builtin_font_names() -> &'static [&'static str] {
+        &[
+            "Ubuntu-Light",
+            "NotoEmoji-Regular",
+            "emoji-icon-font",
+            "Hack",
+        ]
+    }
+
+    /// List of all the builtin font names used by `epaint`.
+    #[cfg(not(feature = "default_fonts"))]
+    pub fn builtin_font_names() -> &'static [&'static str] {
+        &[]
+    }
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
The ignored characters are used in some custom fonts.

for example: the \u{F0FF} is used as `cleaning_services` in MaterialIcons-Regular.ttf

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Closes <https://github.com/emilk/egui/issues/THE_RELEVANT_ISSUE>.
