### PR TITLE
Fix copy and cut on Safari

### DIFF
--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -175,16 +175,30 @@ pub(crate) fn install_document_events(runner_ref: &WebRunner) -> Result<(), JsVa
     )?;
 
     #[cfg(web_sys_unstable_apis)]
-    runner_ref.add_event_listener(&document, "cut", |_: web_sys::ClipboardEvent, runner| {
-        runner.input.raw.events.push(egui::Event::Cut);
-        runner.needs_repaint.repaint_asap();
-    })?;
+    runner_ref.add_event_listener(
+        &document,
+        "cut",
+        |event: web_sys::ClipboardEvent, runner| {
+            runner.input.raw.events.push(egui::Event::Cut);
+            runner.logic();
+            runner.needs_repaint.repaint_asap();
+            event.stop_propagation();
+            event.prevent_default();
+        },
+    )?;
 
     #[cfg(web_sys_unstable_apis)]
-    runner_ref.add_event_listener(&document, "copy", |_: web_sys::ClipboardEvent, runner| {
-        runner.input.raw.events.push(egui::Event::Copy);
-        runner.needs_repaint.repaint_asap();
-    })?;
+    runner_ref.add_event_listener(
+        &document,
+        "copy",
+        |event: web_sys::ClipboardEvent, runner| {
+            runner.input.raw.events.push(egui::Event::Copy);
+            runner.logic();
+            runner.needs_repaint.repaint_asap();
+            event.stop_propagation();
+            event.prevent_default();
+        },
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
* Closes <https://github.com/emilk/egui/issues/3480>

I've tested this on Safari and Chrome on macOS Sonoma 14.0.

Could be improved to only call `event.preventDefault()` if `runner.logic()` actually performed a copy, but I don't see a way to get that information out with the current API.