### PR TITLE
Fix typo in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/
 * Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
 * When you have addressed a PR comment, mark it as resolved.
 
-Please be patient! I will review you PR, but my time is limited!
+Please be patient! I will review your PR, but my time is limited!
 -->
 
 Closes <https://github.com/emilk/egui/issues/THE_RELEVANT_ISSUE>.


### PR DESCRIPTION
This fixes a minor grammar issue I noticed in the template while submitting my previous PR.