### PR TITLE
Fix rounding of `ImageButton`

### DIFF
--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -621,7 +621,7 @@ impl<'a> Widget for ImageButton<'a> {
                 let selection = ui.visuals().selection;
                 (
                     Vec2::ZERO,
-                    Rounding::ZERO,
+                    self.image.image_options().rounding,
                     selection.bg_fill,
                     selection.stroke,
                 )
@@ -630,7 +630,7 @@ impl<'a> Widget for ImageButton<'a> {
                 let expansion = Vec2::splat(visuals.expansion);
                 (
                     expansion,
-                    visuals.rounding,
+                    self.image.image_options().rounding,
                     visuals.weak_bg_fill,
                     visuals.bg_stroke,
                 )
@@ -647,7 +647,6 @@ impl<'a> Widget for ImageButton<'a> {
                 .align_size_within_rect(image_size, rect.shrink2(padding));
             // let image_rect = image_rect.expand2(expansion); // can make it blurry, so let's not
             let image_options = ImageOptions {
-                rounding, // apply rounding to the image
                 ..self.image.image_options().clone()
             };
             widgets::image::paint_texture_load_result(ui, &tlr, image_rect, None, &image_options);

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -596,7 +596,7 @@ impl<'a> ImageButton<'a> {
     }
 
     /// Set rounding for the `ImageButton`.
-    /// If the underlying image already had rounding, this
+    /// If the underlying image already has rounding, this
     /// will override that value.
     pub fn rounding(mut self, rounding: impl Into<Rounding>) -> Self {
         let image = self.image.rounding(rounding.into());

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -599,8 +599,7 @@ impl<'a> ImageButton<'a> {
     /// If the underlying image already has rounding, this
     /// will override that value.
     pub fn rounding(mut self, rounding: impl Into<Rounding>) -> Self {
-        let image = self.image.rounding(rounding.into());
-        self.image = image;
+        self.image = self.image.rounding(rounding.into());
         self
     }
 }

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -646,9 +646,8 @@ impl<'a> Widget for ImageButton<'a> {
                 .layout()
                 .align_size_within_rect(image_size, rect.shrink2(padding));
             // let image_rect = image_rect.expand2(expansion); // can make it blurry, so let's not
-            let image_options = ImageOptions {
-                ..self.image.image_options().clone()
-            };
+            let image_options = self.image.image_options().clone();
+
             widgets::image::paint_texture_load_result(ui, &tlr, image_rect, None, &image_options);
 
             // Draw frame outline:

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -594,6 +594,15 @@ impl<'a> ImageButton<'a> {
         self.sense = sense;
         self
     }
+
+    /// Set rounding for the `ImageButton`.
+    /// If the underlying image already had rounding, this
+    /// will override that value.
+    pub fn rounding(mut self, rounding: impl Into<Rounding>) -> Self {
+        let image = self.image.rounding(rounding.into());
+        self.image = image;
+        self
+    }
 }
 
 impl<'a> Widget for ImageButton<'a> {


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

Updated `ImageButton` to use rounding from the corresponding image via `self.image.image_options().rounding` and added a `rounding()` method to `ImageButton`.

Closes <https://github.com/emilk/egui/issues/3486> <s>if we agree the addition of a `rounding()` method on the `ImageButton` itself, which the issue also mentions, can be discussed and handled separately.</s>

This now fully closes #3486 