### PR TITLE
Add a public API for overriding plot legend traces' visibilities

### DIFF
--- a/crates/egui_plot/src/legend.rs
+++ b/crates/egui_plot/src/legend.rs
@@ -73,6 +73,7 @@ impl Legend {
 
     /// Specifies hidden items in the legend configuration to override the existing ones. This
     /// allows the legend traces' visibility to be controlled from the application code.
+    #[inline]
     pub fn hidden_items<I>(mut self, hidden_items: I) -> Self
     where
         I: IntoIterator<Item = String>,

--- a/crates/egui_plot/src/legend.rs
+++ b/crates/egui_plot/src/legend.rs
@@ -32,6 +32,9 @@ pub struct Legend {
     pub text_style: TextStyle,
     pub background_alpha: f32,
     pub position: Corner,
+
+    /// Used for overriding the `hidden_items` set in [`LegendWidget`].
+    hidden_items: Option<ahash::HashSet<String>>,
 }
 
 impl Default for Legend {
@@ -40,6 +43,8 @@ impl Default for Legend {
             text_style: TextStyle::Body,
             background_alpha: 0.75,
             position: Corner::RightTop,
+
+            hidden_items: None,
         }
     }
 }
@@ -63,6 +68,16 @@ impl Legend {
     #[inline]
     pub fn position(mut self, corner: Corner) -> Self {
         self.position = corner;
+        self
+    }
+
+    /// Specifies hidden items in the legend configuration to override the existing ones. This
+    /// allows the legend traces' visibility to be controlled from the application code.
+    pub fn hidden_items<I>(mut self, hidden_items: I) -> Self
+    where
+        I: IntoIterator<Item = String>,
+    {
+        self.hidden_items = Some(hidden_items.into_iter().collect());
         self
     }
 }
@@ -167,8 +182,14 @@ impl LegendWidget {
         rect: Rect,
         config: Legend,
         items: &[Box<dyn PlotItem>],
-        hidden_items: &ahash::HashSet<String>,
+        hidden_items: &ahash::HashSet<String>, // Existing hiddent items in the plot memory.
     ) -> Option<Self> {
+        // If `config.hidden_items` is not `None`, it is used.
+        let hidden_items = match &config.hidden_items {
+            Some(h) => h,
+            None => hidden_items,
+        };
+
         // Collect the legend entries. If multiple items have the same name, they share a
         // checkbox. If their colors don't match, we pick a neutral color for the checkbox.
         let mut entries: BTreeMap<String, LegendEntry> = BTreeMap::new();

--- a/crates/egui_plot/src/legend.rs
+++ b/crates/egui_plot/src/legend.rs
@@ -186,10 +186,7 @@ impl LegendWidget {
         hidden_items: &ahash::HashSet<String>, // Existing hiddent items in the plot memory.
     ) -> Option<Self> {
         // If `config.hidden_items` is not `None`, it is used.
-        let hidden_items = match &config.hidden_items {
-            Some(h) => h,
-            None => hidden_items,
-        };
+        let hidden_items = config.hidden_items.as_ref().unwrap_or(hidden_items);
 
         // Collect the legend entries. If multiple items have the same name, they share a
         // checkbox. If their colors don't match, we pick a neutral color for the checkbox.

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -211,9 +211,6 @@ pub struct Plot {
     grid_spacers: [GridSpacer; 2],
     sharp_grid_lines: bool,
     clamp_grid: bool,
-
-    /// Used for overriding the `hidden_items` set in [`LegendWidget`].
-    hidden_items: Option<ahash::HashSet<String>>,
 }
 
 impl Plot {
@@ -256,8 +253,6 @@ impl Plot {
             grid_spacers: [log_grid_spacer(10), log_grid_spacer(10)],
             sharp_grid_lines: true,
             clamp_grid: false,
-
-            hidden_items: None,
         }
     }
 
@@ -698,16 +693,6 @@ impl Plot {
         self
     }
 
-    /// Overrides hidden items in the legend. This allows the legend traces' visibility to be
-    /// controlled from the application code.
-    pub fn override_hidden_items<I>(mut self, hidden_items: I) -> Self
-    where
-        I: IntoIterator<Item = String>,
-    {
-        self.hidden_items = Some(hidden_items.into_iter().collect());
-        self
-    }
-
     /// Interact with and add items to the plot and finally draw it.
     pub fn show<R>(self, ui: &mut Ui, build_fn: impl FnOnce(&mut PlotUi) -> R) -> PlotResponse<R> {
         self.show_dyn(ui, Box::new(build_fn))
@@ -752,8 +737,6 @@ impl Plot {
             clamp_grid,
             grid_spacers,
             sharp_grid_lines,
-
-            hidden_items: override_hidden_items,
         } = self;
 
         // Determine position of widget.
@@ -890,12 +873,6 @@ impl Plot {
             last_plot_transform,
             mut last_click_pos_for_zoom,
         } = memory;
-
-        // If `override_hidden_items` is not `None`, replace the `hidden_items` with
-        // `override_hidden_items`.
-        if let Some(override_hidden_items) = override_hidden_items {
-            hidden_items = override_hidden_items;
-        }
 
         // Call the plot build function.
         let mut plot_ui = PlotUi {


### PR DESCRIPTION
Added a public API in `egui_plot -> legend` to allow `hidden_items` to be overridden in the plot legend widget. This allows convenient control of traces' visibilities the selection of traces from the application code.

### Example
```rust
    let legend_config = if plot_selection_changed {
        let hidden_items = match plot_selection {
            PlotSelection::SelectAll => Vec::new(),
            PlotSelection::DeselectAll => all_trace_names,
        };

        Legend::default()
            .position(Corner::RightTop)
            .hidden_items(hidden_items) // Overrides `hidden_items`
    } else {
        Legend::default().position(Corner::RightTop)
    };

    Plot::new(id)
        .legend(legend_config)
        .show(ui, draw_plot);
```

Closes <https://github.com/emilk/egui/issues/3533>.
