### PR TITLE
Add `ColorImage::from_gray_iter`

### DIFF
--- a/crates/epaint/src/image.rs
+++ b/crates/epaint/src/image.rs
@@ -120,6 +120,16 @@ impl ColorImage {
         Self { size, pixels }
     }
 
+    /// Alternative method to `from_gray`.
+    /// Create a [`ColorImage`] from iterator over flat opaque gray data.
+    /// 
+    /// Panics if `size[0] * size[1] != gray_iter.len()`.
+    pub fn from_gray_iter<'_>(size: [usize; 2], gray_iter: impl Iterator<Item = &'_ u8> + ExactSizeIterator) -> Self {
+        assert_eq!(size[0] * size[1], gray_iter.len());
+        let pixels = gray_iter.map(|p| Color32::from_gray(*p)).collect();
+        Self { size, pixels }
+    }
+
     /// A view of the underlying data as `&[u8]`
     #[cfg(feature = "bytemuck")]
     pub fn as_raw(&self) -> &[u8] {

--- a/crates/epaint/src/image.rs
+++ b/crates/epaint/src/image.rs
@@ -122,7 +122,7 @@ impl ColorImage {
 
     /// Alternative method to `from_gray`.
     /// Create a [`ColorImage`] from iterator over flat opaque gray data.
-    /// 
+    ///
     /// Panics if `size[0] * size[1] != gray_iter.len()`.
     pub fn from_gray_iter(size: [usize; 2], gray_iter: impl Iterator<Item = u8>) -> Self {
         let pixels: Vec<_> = gray_iter.map(Color32::from_gray).collect();

--- a/crates/epaint/src/image.rs
+++ b/crates/epaint/src/image.rs
@@ -125,7 +125,7 @@ impl ColorImage {
     /// 
     /// Panics if `size[0] * size[1] != gray_iter.len()`.
     pub fn from_gray_iter(size: [usize; 2], gray_iter: impl Iterator<Item = u8>) -> Self {
-        let pixels = gray_iter.map(Color32::from_gray).collect();
+        let pixels: Vec<_> = gray_iter.map(Color32::from_gray).collect();
         assert_eq!(size[0] * size[1], pixels.len());
         Self { size, pixels }
     }

--- a/crates/epaint/src/image.rs
+++ b/crates/epaint/src/image.rs
@@ -124,9 +124,9 @@ impl ColorImage {
     /// Create a [`ColorImage`] from iterator over flat opaque gray data.
     /// 
     /// Panics if `size[0] * size[1] != gray_iter.len()`.
-    pub fn from_gray_iter<'_>(size: [usize; 2], gray_iter: impl Iterator<Item = &'_ u8> + ExactSizeIterator) -> Self {
-        assert_eq!(size[0] * size[1], gray_iter.len());
-        let pixels = gray_iter.map(|p| Color32::from_gray(*p)).collect();
+    pub fn from_gray_iter(size: [usize; 2], gray_iter: impl Iterator<Item = u8>) -> Self {
+        let pixels = gray_iter.map(Color32::from_gray).collect();
+        assert_eq!(size[0] * size[1], pixels.len());
         Self { size, pixels }
     }
 


### PR DESCRIPTION
Add an alternative method for creating a [`ColorImage`] that accepts `Iterator` as the argument. It can be useful when `&[u8]` is not available but the iterator is.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review you PR, but my time is limited!
-->

