### PR TITLE
Max window size & other size helpers

### DIFF
--- a/crates/egui/src/containers/resize.rs
+++ b/crates/egui/src/containers/resize.rs
@@ -123,6 +123,18 @@ impl Resize {
         self
     }
 
+    /// Won't expand to larger than this
+    pub fn max_width(mut self, max_width: f32) -> Self {
+        self.max_size.x = max_width;
+        self
+    }
+
+    /// Won't expand to larger than this
+    pub fn max_height(mut self, max_height: f32) -> Self {
+        self.max_size.y = max_height;
+        self
+    }
+
     /// Can you resize it with the mouse?
     ///
     /// Note that a window can still auto-resize.

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -126,6 +126,12 @@ impl<'open> Window<'open> {
         self
     }
 
+    /// Set minimum size of the window, equivalent to calling both `min_width` and `min_height`.
+    pub fn min_size(mut self, min_size: impl Into<Vec2>) -> Self {
+        self.resize = self.resize.min_size(min_size);
+        self
+    }
+
     /// Set maximum width of the window.
     pub fn max_width(mut self, max_width: f32) -> Self {
         self.resize = self.resize.max_width(max_width);
@@ -135,6 +141,12 @@ impl<'open> Window<'open> {
     /// Set maximum height of the window.
     pub fn max_height(mut self, max_height: f32) -> Self {
         self.resize = self.resize.max_height(max_height);
+        self
+    }
+
+    /// Set maximum size of the window, equivalent to calling both `max_width` and `max_height`.
+    pub fn max_size(mut self, max_size: impl Into<Vec2>) -> Self {
+        self.resize = self.resize.max_size(max_size);
         self
     }
 

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -126,6 +126,18 @@ impl<'open> Window<'open> {
         self
     }
 
+    /// Set maximum width of the window.
+    pub fn max_width(mut self, max_width: f32) -> Self {
+        self.resize = self.resize.max_width(max_width);
+        self
+    }
+
+    /// Set maximum height of the window.
+    pub fn max_height(mut self, max_height: f32) -> Self {
+        self.resize = self.resize.max_height(max_height);
+        self
+    }
+
     /// Set current position of the window.
     /// If the window is movable it is up to you to keep track of where it moved to!
     pub fn current_pos(mut self, current_pos: impl Into<Pos2>) -> Self {


### PR DESCRIPTION
Was a bit confused why the max_size API isn't exposed on `Window`, when it's perfectly functional in `Resize`. Anyway here's the main thing that it affects:

```rs
let screen = ctx.available_rect();
let size = screen.size();

egui::Window::new(self.name())
    .resizable(true)
    .resize(|resize| resize.max_size(size)) // Before
    .max_size(size)                         // After
    .show(ctx, |ui| todo!());
```

I also added some other relevant helpers for consistency.

This PR doesn't change any logic, only forwards along some helper functions that are already public for consistency.