### PR TITLE
Floating scroll bars

### DIFF
--- a/crates/egui/src/animation_manager.rs
+++ b/crates/egui/src/animation_manager.rs
@@ -25,7 +25,7 @@ struct ValueAnim {
 }
 
 impl AnimationManager {
-    /// See `Context::animate_bool` for documentation
+    /// See [`crate::Context::animate_bool`] for documentation
     pub fn animate_bool(
         &mut self,
         input: &InputState,

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -152,22 +152,26 @@ pub struct ScrollArea {
 
 impl ScrollArea {
     /// Create a horizontal scroll area.
+    #[inline]
     pub fn horizontal() -> Self {
         Self::new([true, false])
     }
 
     /// Create a vertical scroll area.
+    #[inline]
     pub fn vertical() -> Self {
         Self::new([false, true])
     }
 
     /// Create a bi-directional (horizontal and vertical) scroll area.
+    #[inline]
     pub fn both() -> Self {
         Self::new([true, true])
     }
 
     /// Create a scroll area where both direction of scrolling is disabled.
     /// It's unclear why you would want to do this.
+    #[inline]
     pub fn neither() -> Self {
         Self::new([false, false])
     }
@@ -195,6 +199,7 @@ impl ScrollArea {
     /// Use `f32::INFINITY` if you want the scroll area to expand to fit the surrounding [`Ui`] (default).
     ///
     /// See also [`Self::auto_shrink`].
+    #[inline]
     pub fn max_width(mut self, max_width: f32) -> Self {
         self.max_size.x = max_width;
         self
@@ -205,6 +210,7 @@ impl ScrollArea {
     /// Use `f32::INFINITY` if you want the scroll area to expand to fit the surrounding [`Ui`] (default).
     ///
     /// See also [`Self::auto_shrink`].
+    #[inline]
     pub fn max_height(mut self, max_height: f32) -> Self {
         self.max_size.y = max_height;
         self
@@ -216,6 +222,7 @@ impl ScrollArea {
     /// (and so we don't require scroll bars).
     ///
     /// Default: `64.0`.
+    #[inline]
     pub fn min_scrolled_width(mut self, min_scrolled_width: f32) -> Self {
         self.min_scrolled_size.x = min_scrolled_width;
         self
@@ -227,6 +234,7 @@ impl ScrollArea {
     /// (and so we don't require scroll bars).
     ///
     /// Default: `64.0`.
+    #[inline]
     pub fn min_scrolled_height(mut self, min_scrolled_height: f32) -> Self {
         self.min_scrolled_size.y = min_scrolled_height;
         self
@@ -235,12 +243,14 @@ impl ScrollArea {
     /// Set the visibility of both horizontal and vertical scroll bars.
     ///
     /// With `ScrollBarVisibility::VisibleWhenNeeded` (default), the scroll bar will be visible only when needed.
+    #[inline]
     pub fn scroll_bar_visibility(mut self, scroll_bar_visibility: ScrollBarVisibility) -> Self {
         self.scroll_bar_visibility = scroll_bar_visibility;
         self
     }
 
     /// A source for the unique [`Id`], e.g. `.id_source("second_scroll_area")` or `.id_source(loop_index)`.
+    #[inline]
     pub fn id_source(mut self, id_source: impl std::hash::Hash) -> Self {
         self.id_source = Some(Id::new(id_source));
         self
@@ -253,6 +263,7 @@ impl ScrollArea {
     /// See also: [`Self::vertical_scroll_offset`], [`Self::horizontal_scroll_offset`],
     /// [`Ui::scroll_to_cursor`](crate::ui::Ui::scroll_to_cursor) and
     /// [`Response::scroll_to_me`](crate::Response::scroll_to_me)
+    #[inline]
     pub fn scroll_offset(mut self, offset: Vec2) -> Self {
         self.offset_x = Some(offset.x);
         self.offset_y = Some(offset.y);
@@ -265,6 +276,7 @@ impl ScrollArea {
     ///
     /// See also: [`Self::scroll_offset`], [`Ui::scroll_to_cursor`](crate::ui::Ui::scroll_to_cursor) and
     /// [`Response::scroll_to_me`](crate::Response::scroll_to_me)
+    #[inline]
     pub fn vertical_scroll_offset(mut self, offset: f32) -> Self {
         self.offset_y = Some(offset);
         self
@@ -276,24 +288,28 @@ impl ScrollArea {
     ///
     /// See also: [`Self::scroll_offset`], [`Ui::scroll_to_cursor`](crate::ui::Ui::scroll_to_cursor) and
     /// [`Response::scroll_to_me`](crate::Response::scroll_to_me)
+    #[inline]
     pub fn horizontal_scroll_offset(mut self, offset: f32) -> Self {
         self.offset_x = Some(offset);
         self
     }
 
     /// Turn on/off scrolling on the horizontal axis.
+    #[inline]
     pub fn hscroll(mut self, hscroll: bool) -> Self {
         self.has_bar[0] = hscroll;
         self
     }
 
     /// Turn on/off scrolling on the vertical axis.
+    #[inline]
     pub fn vscroll(mut self, vscroll: bool) -> Self {
         self.has_bar[1] = vscroll;
         self
     }
 
     /// Turn on/off scrolling on the horizontal/vertical axes.
+    #[inline]
     pub fn scroll2(mut self, has_bar: [bool; 2]) -> Self {
         self.has_bar = has_bar;
         self
@@ -308,6 +324,7 @@ impl ScrollArea {
     /// is typing text in a [`TextEdit`] widget contained within the scroll area.
     ///
     /// This controls both scrolling directions.
+    #[inline]
     pub fn enable_scrolling(mut self, enable: bool) -> Self {
         self.scrolling_enabled = enable;
         self
@@ -320,6 +337,7 @@ impl ScrollArea {
     /// If `true`, the [`ScrollArea`] will sense drags.
     ///
     /// Default: `true`.
+    #[inline]
     pub fn drag_to_scroll(mut self, drag_to_scroll: bool) -> Self {
         self.drag_to_scroll = drag_to_scroll;
         self
@@ -331,6 +349,7 @@ impl ScrollArea {
     /// * If `false`, egui will add blank space inside the scroll area.
     ///
     /// Default: `[true; 2]`.
+    #[inline]
     pub fn auto_shrink(mut self, auto_shrink: [bool; 2]) -> Self {
         self.auto_shrink = auto_shrink;
         self
@@ -346,6 +365,7 @@ impl ScrollArea {
     /// it will remain focused on whatever content viewport the user left it on. If the scroll
     /// handle is dragged all the way to the right it will again become stuck and remain there
     /// until manually pulled from the end position.
+    #[inline]
     pub fn stick_to_right(mut self, stick: bool) -> Self {
         self.stick_to_end[0] = stick;
         self
@@ -357,6 +377,7 @@ impl ScrollArea {
     /// it will remain focused on whatever content viewport the user left it on. If the scroll
     /// handle is dragged to the bottom it will again become stuck and remain there until manually
     /// pulled from the end position.
+    #[inline]
     pub fn stick_to_bottom(mut self, stick: bool) -> Self {
         self.stick_to_end[1] = stick;
         self

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -1038,7 +1038,7 @@ impl Prepared {
                     1.0
                 };
 
-                let handle_color = if scroll_style.floating {
+                let handle_color = if scroll_style.foreground_color {
                     visuals.fg_stroke.color
                 } else {
                     visuals.bg_fill

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -743,8 +743,8 @@ impl Prepared {
             }
 
             // margin on either side of the scroll bar
-            let inner_margin = animation_t * ui.spacing().scroll_bar_inner_margin;
-            let outer_margin = animation_t * ui.spacing().scroll_bar_outer_margin;
+            let inner_margin = animation_t * ui.spacing().scroll.bar_inner_margin;
+            let outer_margin = animation_t * ui.spacing().scroll.bar_outer_margin;
             let mut min_cross = inner_rect.max[1 - d] + inner_margin; // left of vertical scroll (d == 1)
             let mut max_cross = outer_rect.max[1 - d] - outer_margin; // right of vertical scroll (d == 1)
             let min_main = inner_rect.min[d]; // top of vertical scroll (d == 1)
@@ -855,7 +855,7 @@ impl Prepared {
                         ),
                     )
                 };
-                let min_handle_size = ui.spacing().scroll_handle_min_length;
+                let min_handle_size = ui.spacing().scroll.handle_min_length;
                 if handle_rect.size()[d] < min_handle_size {
                     handle_rect = Rect::from_center_size(
                         handle_rect.center(),
@@ -920,7 +920,7 @@ impl Prepared {
 
 /// Width of a vertical scrollbar, or height of a horizontal scroll bar
 fn max_scroll_bar_width_with_margin(ui: &Ui) -> f32 {
-    ui.spacing().scroll_bar_inner_margin
-        + ui.spacing().scroll_bar_width
-        + ui.spacing().scroll_bar_outer_margin
+    ui.spacing().scroll.bar_inner_margin
+        + ui.spacing().scroll.bar_width
+        + ui.spacing().scroll.bar_outer_margin
 }

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -853,7 +853,7 @@ impl Prepared {
                     || state.scroll_bar_interaction[d];
                 let is_hovering_bar_area_t = ui
                     .ctx()
-                    .animate_bool(id.with("bar_hover"), is_hovering_bar_area);
+                    .animate_bool(id.with((d, "bar_hover")), is_hovering_bar_area);
                 let width = show_factor
                     * lerp(
                         scroll_style.floating_width..=scroll_style.bar_width,
@@ -1013,7 +1013,7 @@ impl Prepared {
                         scroll_style.interact_handle_opacity
                     } else {
                         let is_hovering_outer_rect_t = ui.ctx().animate_bool(
-                            id.with("is_hovering_outer_rect"),
+                            id.with((d, "is_hovering_outer_rect")),
                             is_hovering_outer_rect,
                         );
                         lerp(

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -411,7 +411,7 @@ struct Prepared {
     /// Does this `ScrollArea` have horizontal/vertical scrolling enabled?
     scroll_enabled: [bool; 2],
 
-    /// Smoothly interpolated boolean of wether or not to show the scroll bars.
+    /// Smoothly interpolated boolean of whether or not to show the scroll bars.
     show_bars_factor: Vec2,
 
     /// How much horizontal and vertical space are used up by the

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -411,7 +411,7 @@ struct Prepared {
     /// Does this `ScrollArea` have horizontal/vertical scrolling enabled?
     scroll_enabled: [bool; 2],
 
-    /// Like [`Self::show_bars`], but smoothly interpolated
+    /// Smoothly interpolated boolean of wether or not to show the scroll bars.
     show_bars_factor: Vec2,
 
     /// How much horizontal and vertical space are used up by the

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -80,11 +80,40 @@ pub struct ScrollAreaOutput<R> {
 }
 
 /// Indicate whether the horizontal and vertical scroll bars must be always visible, hidden or visible when needed.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum ScrollBarVisibility {
-    AlwaysVisible,
-    VisibleWhenNeeded,
+    /// Hide scroll bar even if they are needed.
+    ///
+    /// You can still scroll, with the scroll-wheel
+    /// and by dragging the contents, but there is no
+    /// visual indication of how far you have scrolled.
     AlwaysHidden,
+
+    /// Show scroll bars only when the content size exceeds the container,
+    /// i.e. when there is any need to scroll.
+    ///
+    /// This is the default.
+    VisibleWhenNeeded,
+
+    /// Always show the scroll bar, even if the contents fit in the container
+    /// and there is no need to scroll.
+    AlwaysVisible,
+}
+
+impl Default for ScrollBarVisibility {
+    #[inline]
+    fn default() -> Self {
+        Self::VisibleWhenNeeded
+    }
+}
+
+impl ScrollBarVisibility {
+    pub const ALL: [Self; 3] = [
+        Self::AlwaysHidden,
+        Self::VisibleWhenNeeded,
+        Self::AlwaysVisible,
+    ];
 }
 
 /// Add vertical and/or horizontal scrolling to a contained [`Ui`].
@@ -151,7 +180,7 @@ impl ScrollArea {
             auto_shrink: [true; 2],
             max_size: Vec2::INFINITY,
             min_scrolled_size: Vec2::splat(64.0),
-            scroll_bar_visibility: ScrollBarVisibility::VisibleWhenNeeded,
+            scroll_bar_visibility: Default::default(),
             id_source: None,
             offset_x: None,
             offset_y: None,

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -124,19 +124,7 @@ impl ScrollBarVisibility {
 /// There are two flavors of scroll areas: solid and floating.
 /// Solid scroll bars use up space, reducing the amount of space available
 /// to the contents. Floating scroll bars float on top of the contents, covering it.
-/// You can control with with [`ScrollSpacing::floating`].
-///
-/// ### Floating scroll baers
-/// Floating scroll bars are _dormant_ by default, meaning they are
-/// tranlucent and thin.
-/// Exactly how tranlucent is controlled by [`ScrollSpacing::floating_dormant_opacity`].
-///
-/// When the user hovers the scroll _area_, the scroll bars become opaque, but stay thin.
-/// Their thickness is controlled by [`ScrollSpacing::floating_thickness`].
-///
-/// When the user hovers the scroll _bars_, they become wider so
-/// the user can more easily grab onto them.
-/// How wide is controlled by [`ScrollSpacing::bar_width`].
+/// You can change the scroll style by changing the [`crate::style::Spacing::scroll`].
 ///
 /// ### Coordinate system
 /// * content: size of contents (generally large; that's why we want scroll bars)

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -419,7 +419,7 @@ impl<'open> Window<'open> {
                             ui.add_space(title_content_spacing);
                         }
 
-                        if scroll.has_any_bar() {
+                        if scroll.is_any_scroll_enabled() {
                             scroll.show(ui, add_contents).inner
                         } else {
                             add_contents(ui)

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -367,6 +367,9 @@ pub struct ScrollStyle {
     /// so as to always show a thin scroll bar.
     pub floating_allocated_width: f32,
 
+    /// If true, use colors with more contrast. Good for floating scroll bars.
+    pub foreground_color: bool,
+
     /// The opaqueness of the background when the user is neither scrolling
     /// nor hovering the scroll area.
     ///
@@ -412,14 +415,23 @@ pub struct ScrollStyle {
 
 impl Default for ScrollStyle {
     fn default() -> Self {
+        Self::solid()
+    }
+}
+
+impl ScrollStyle {
+    /// Solid scroll bars that always use up space
+    pub fn solid() -> Self {
         Self {
             floating: false,
-            bar_width: 8.0,
+            bar_width: 6.0,
             handle_min_length: 12.0,
             bar_inner_margin: 4.0,
             bar_outer_margin: 0.0,
             floating_width: 2.0,
             floating_allocated_width: 0.0,
+
+            foreground_color: false,
 
             dormant_background_opacity: 0.0,
             active_background_opacity: 0.4,
@@ -430,9 +442,44 @@ impl Default for ScrollStyle {
             interact_handle_opacity: 1.0,
         }
     }
-}
 
-impl ScrollStyle {
+    /// Thin scroll bars that expand on hover
+    pub fn thin() -> Self {
+        Self {
+            floating: true,
+            bar_width: 12.0,
+            floating_allocated_width: 6.0,
+            foreground_color: false,
+
+            dormant_background_opacity: 1.0,
+            dormant_handle_opacity: 1.0,
+
+            active_background_opacity: 1.0,
+            active_handle_opacity: 1.0,
+
+            // Be tranlucent when expanded so we can see the content
+            interact_background_opacity: 0.6,
+            interact_handle_opacity: 0.6,
+
+            ..Self::solid()
+        }
+    }
+
+    /// No scroll bars until you hover the scroll area,
+    /// at which time they appear faintly, and then expand
+    /// when you hover the scroll bars.
+    pub fn floating() -> Self {
+        Self {
+            floating: true,
+            bar_width: 12.0,
+            foreground_color: true,
+            floating_allocated_width: 0.0,
+            dormant_background_opacity: 0.0,
+            dormant_handle_opacity: 0.0,
+            ..Self::solid()
+        }
+    }
+
     /// Width of a solid vertical scrollbar, or height of a horizontal scroll bar, when it is at its widest.
     pub fn allocated_width(&self) -> f32 {
         if self.floating {
@@ -443,6 +490,13 @@ impl ScrollStyle {
     }
 
     pub fn ui(&mut self, ui: &mut Ui) {
+        ui.horizontal(|ui| {
+            ui.label("Presets:");
+            ui.selectable_value(self, Self::solid(), "Solid");
+            ui.selectable_value(self, Self::thin(), "Thin");
+            ui.selectable_value(self, Self::floating(), "Floating");
+        });
+
         let Self {
             floating,
             bar_width,
@@ -451,6 +505,8 @@ impl ScrollStyle {
             bar_outer_margin,
             floating_width,
             floating_allocated_width,
+
+            foreground_color,
 
             dormant_background_opacity,
             active_background_opacity,
@@ -489,6 +545,13 @@ impl ScrollStyle {
             ui.add(DragValue::new(bar_outer_margin).clamp_range(0.0..=32.0));
             ui.label("Outer margin");
         });
+
+        ui.horizontal(|ui| {
+            ui.label("Color:");
+            ui.selectable_value(foreground_color, false, "Background");
+            ui.selectable_value(foreground_color, true, "Foreground");
+        });
+
         if *floating {
             crate::Grid::new("opacity").show(ui, |ui| {
                 fn opacity_ui(ui: &mut Ui, opacity: &mut f32) {

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -306,7 +306,7 @@ pub struct Spacing {
     pub combo_height: f32,
 
     /// Controls the spacing of a [`crate::ScrollArea`].
-    pub scroll: ScrollSpacing,
+    pub scroll: ScrollStyle,
 }
 
 impl Spacing {
@@ -331,11 +331,14 @@ impl Spacing {
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
-pub struct ScrollSpacing {
+pub struct ScrollStyle {
     /// If `true`, scroll bars float above the content, partially covering it.
     ///
     /// If `false`, the scroll bars allocate space, shrinking the area
     /// available to the contents.
+    ///
+    /// This also changes the colors of the scroll-handle to make
+    /// it more promiment.
     pub floating: bool,
 
     /// The width of the scroll bars at it largest.
@@ -356,18 +359,6 @@ pub struct ScrollSpacing {
     /// When the user hovers the scroll bars they expand to [`Self::bar_width`].
     pub floating_width: f32,
 
-    /// The opaqueness of the handle when the user is neither scrolling
-    /// nor hovering the scroll area.
-    pub dormant_handle_opacity: f32,
-
-    /// The opaqueness of the handle when the user is hovering
-    /// the scroll area, but not the scroll bar.
-    pub active_handle_opacity: f32,
-
-    /// The opaqueness of the handle when the user is hovering
-    /// over the scroll bars.
-    pub interact_handle_opacity: f32,
-
     /// The opaqueness of the background when the user is neither scrolling
     /// nor hovering the scroll area.
     pub dormant_background_opacity: f32,
@@ -379,9 +370,21 @@ pub struct ScrollSpacing {
     /// The opaqueness of the background when the user is hovering
     /// over the scroll bars.
     pub interact_background_opacity: f32,
+
+    /// The opaqueness of the handle when the user is neither scrolling
+    /// nor hovering the scroll area.
+    pub dormant_handle_opacity: f32,
+
+    /// The opaqueness of the handle when the user is hovering
+    /// the scroll area, but not the scroll bar.
+    pub active_handle_opacity: f32,
+
+    /// The opaqueness of the handle when the user is hovering
+    /// over the scroll bars.
+    pub interact_handle_opacity: f32,
 }
 
-impl Default for ScrollSpacing {
+impl Default for ScrollStyle {
     fn default() -> Self {
         Self {
             floating: false,
@@ -391,18 +394,18 @@ impl Default for ScrollSpacing {
             bar_outer_margin: 0.0,
             floating_width: 3.0,
 
-            dormant_handle_opacity: 0.0,
-            active_handle_opacity: 0.9,
-            interact_handle_opacity: 1.0,
-
             dormant_background_opacity: 0.0,
             active_background_opacity: 0.4,
             interact_background_opacity: 0.7,
+
+            dormant_handle_opacity: 0.0,
+            active_handle_opacity: 0.6,
+            interact_handle_opacity: 1.0,
         }
     }
 }
 
-impl ScrollSpacing {
+impl ScrollStyle {
     /// Width of a solid vertical scrollbar, or height of a horizontal scroll bar, when it is at its widest.
     pub fn max_width_with_margin(&self) -> f32 {
         self.bar_inner_margin + self.bar_width + self.bar_outer_margin
@@ -417,12 +420,12 @@ impl ScrollSpacing {
             bar_outer_margin,
             floating_width,
 
-            dormant_handle_opacity,
-            active_handle_opacity,
-            interact_handle_opacity,
             dormant_background_opacity,
             active_background_opacity,
             interact_background_opacity,
+            dormant_handle_opacity,
+            active_handle_opacity,
+            interact_handle_opacity,
         } = self;
 
         ui.horizontal(|ui| {

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -327,7 +327,12 @@ impl Spacing {
 
 // ----------------------------------------------------------------------------
 
-/// Controls the spacing of a [`crate::ScrollArea`].
+/// Controls the spacing and visuals of a [`crate::ScrollArea`].
+///
+/// There are three presets to chose from:
+/// * [`Self::solid`]
+/// * [`Self::thin`]
+/// * [`Self::floating`]
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -497,6 +497,12 @@ impl ScrollStyle {
             ui.selectable_value(self, Self::floating(), "Floating");
         });
 
+        ui.collapsing("Details", |ui| {
+            self.details_ui(ui);
+        });
+    }
+
+    pub fn details_ui(&mut self, ui: &mut Ui) {
         let Self {
             floating,
             bar_width,

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -415,7 +415,7 @@ pub struct ScrollStyle {
 
 impl Default for ScrollStyle {
     fn default() -> Self {
-        Self::solid()
+        Self::floating()
     }
 }
 

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -359,28 +359,54 @@ pub struct ScrollStyle {
     /// When the user hovers the scroll bars they expand to [`Self::bar_width`].
     pub floating_width: f32,
 
+    /// How much space i allocated for a floating scroll bar?
+    ///
+    /// Normally this is zero, but you could set this to something small
+    /// like 4.0 and set [`Self::dormant_handle_opacity`] and
+    /// [`Self::dormant_background_opacity`] to e.g. 0.5
+    /// so as to always show a thin scroll bar.
+    pub floating_allocated_width: f32,
+
     /// The opaqueness of the background when the user is neither scrolling
     /// nor hovering the scroll area.
+    ///
+    /// This is only for floating scroll bars.
+    /// Solid scroll bars are always opaque.
     pub dormant_background_opacity: f32,
 
     /// The opaqueness of the background when the user is hovering
     /// the scroll area, but not the scroll bar.
+    ///
+    /// This is only for floating scroll bars.
+    /// Solid scroll bars are always opaque.
     pub active_background_opacity: f32,
 
     /// The opaqueness of the background when the user is hovering
     /// over the scroll bars.
+    ///
+    /// This is only for floating scroll bars.
+    /// Solid scroll bars are always opaque.
     pub interact_background_opacity: f32,
 
     /// The opaqueness of the handle when the user is neither scrolling
     /// nor hovering the scroll area.
+    ///
+    /// This is only for floating scroll bars.
+    /// Solid scroll bars are always opaque.
     pub dormant_handle_opacity: f32,
 
     /// The opaqueness of the handle when the user is hovering
     /// the scroll area, but not the scroll bar.
+    ///
+    /// This is only for floating scroll bars.
+    /// Solid scroll bars are always opaque.
     pub active_handle_opacity: f32,
 
     /// The opaqueness of the handle when the user is hovering
     /// over the scroll bars.
+    ///
+    /// This is only for floating scroll bars.
+    /// Solid scroll bars are always opaque.
     pub interact_handle_opacity: f32,
 }
 
@@ -392,7 +418,8 @@ impl Default for ScrollStyle {
             handle_min_length: 12.0,
             bar_inner_margin: 4.0,
             bar_outer_margin: 0.0,
-            floating_width: 3.0,
+            floating_width: 2.0,
+            floating_allocated_width: 0.0,
 
             dormant_background_opacity: 0.0,
             active_background_opacity: 0.4,
@@ -407,8 +434,12 @@ impl Default for ScrollStyle {
 
 impl ScrollStyle {
     /// Width of a solid vertical scrollbar, or height of a horizontal scroll bar, when it is at its widest.
-    pub fn max_width_with_margin(&self) -> f32 {
-        self.bar_inner_margin + self.bar_width + self.bar_outer_margin
+    pub fn allocated_width(&self) -> f32 {
+        if self.floating {
+            self.floating_allocated_width
+        } else {
+            self.bar_inner_margin + self.bar_width + self.bar_outer_margin
+        }
     }
 
     pub fn ui(&mut self, ui: &mut Ui) {
@@ -419,6 +450,7 @@ impl ScrollStyle {
             bar_inner_margin,
             bar_outer_margin,
             floating_width,
+            floating_allocated_width,
 
             dormant_background_opacity,
             active_background_opacity,
@@ -442,6 +474,10 @@ impl ScrollStyle {
             ui.horizontal(|ui| {
                 ui.add(DragValue::new(floating_width).clamp_range(0.0..=32.0));
                 ui.label("Thin bar width");
+            });
+            ui.horizontal(|ui| {
+                ui.add(DragValue::new(floating_allocated_width).clamp_range(0.0..=32.0));
+                ui.label("Allocated width");
             });
         }
 

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -371,7 +371,7 @@ impl BoxPainting {
                 ui.painter().rect(
                     rect,
                     self.rounding,
-                    Color32::from_gray(64),
+                    ui.visuals().text_color().gamma_multiply(0.5),
                     Stroke::new(self.stroke_width, Color32::WHITE),
                 );
             }

--- a/crates/egui_demo_lib/src/demo/scrolling.rs
+++ b/crates/egui_demo_lib/src/demo/scrolling.rs
@@ -103,7 +103,7 @@ struct ScrollAppearance {
 impl Default for ScrollAppearance {
     fn default() -> Self {
         Self {
-            num_lorem_ipsums: 10,
+            num_lorem_ipsums: 2,
             visibility: ScrollBarVisibility::default(),
         }
     }
@@ -128,6 +128,7 @@ impl ScrollAppearance {
                 ui.selectable_value(visibility, option, format!("{option:?}"));
             }
         });
+        ui.weak("When to show scroll bars; resize the window to see the effect.");
 
         ui.add_space(8.0);
 
@@ -141,7 +142,11 @@ impl ScrollAppearance {
 
         ui.separator();
 
-        ui.add(egui::Slider::new(num_lorem_ipsums, 1..=100).text("Content length"));
+        ui.add(
+            egui::Slider::new(num_lorem_ipsums, 1..=100)
+                .text("Content length")
+                .logarithmic(true),
+        );
 
         ui.separator();
 

--- a/crates/egui_demo_lib/src/demo/scrolling.rs
+++ b/crates/egui_demo_lib/src/demo/scrolling.rs
@@ -132,11 +132,6 @@ impl ScrollAppearance {
 
         ui.add_space(8.0);
 
-        if ui.button("Reset").clicked() {
-            style.spacing.scroll = Default::default();
-            *visibility = Default::default();
-        }
-
         ui.ctx().set_style(style.clone());
         ui.set_style(style);
 

--- a/crates/egui_demo_lib/src/demo/scrolling.rs
+++ b/crates/egui_demo_lib/src/demo/scrolling.rs
@@ -36,6 +36,8 @@ impl super::Demo for Scrolling {
         egui::Window::new(self.name())
             .open(open)
             .resizable(true)
+            .hscroll(false)
+            .vscroll(false)
             .show(ctx, |ui| {
                 use super::View as _;
                 self.ui(ui);
@@ -92,14 +94,27 @@ impl super::View for Scrolling {
 
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
-#[derive(Default, PartialEq)]
+#[derive(PartialEq)]
 struct ScrollAppearance {
+    num_lorem_ipsums: usize,
     visibility: ScrollBarVisibility,
+}
+
+impl Default for ScrollAppearance {
+    fn default() -> Self {
+        Self {
+            num_lorem_ipsums: 10,
+            visibility: ScrollBarVisibility::default(),
+        }
+    }
 }
 
 impl ScrollAppearance {
     fn ui(&mut self, ui: &mut egui::Ui) {
-        let Self { visibility } = self;
+        let Self {
+            num_lorem_ipsums,
+            visibility,
+        } = self;
 
         let mut style: Style = (*ui.ctx().style()).clone();
 
@@ -126,6 +141,10 @@ impl ScrollAppearance {
 
         ui.separator();
 
+        ui.add(egui::Slider::new(num_lorem_ipsums, 1..=100).text("Content length"));
+
+        ui.separator();
+
         ScrollArea::vertical()
             .auto_shrink([false; 2])
             .scroll_bar_visibility(*visibility)
@@ -133,7 +152,7 @@ impl ScrollAppearance {
                 ui.with_layout(
                     egui::Layout::top_down(egui::Align::LEFT).with_cross_justify(true),
                     |ui| {
-                        for _ in 0..2 {
+                        for _ in 0..*num_lorem_ipsums {
                             ui.label(crate::LOREM_IPSUM_LONG);
                         }
                     },

--- a/crates/egui_demo_lib/src/demo/scrolling.rs
+++ b/crates/egui_demo_lib/src/demo/scrolling.rs
@@ -3,6 +3,7 @@ use egui::*;
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 enum ScrollDemo {
+    ScrollAppearance,
     ScrollTo,
     ManyLines,
     LargeCanvas,
@@ -12,7 +13,7 @@ enum ScrollDemo {
 
 impl Default for ScrollDemo {
     fn default() -> Self {
-        Self::ScrollTo
+        Self::ScrollAppearance
     }
 }
 
@@ -44,6 +45,7 @@ impl super::Demo for Scrolling {
 impl super::View for Scrolling {
     fn ui(&mut self, ui: &mut Ui) {
         ui.horizontal(|ui| {
+            ui.selectable_value(&mut self.demo, ScrollDemo::ScrollAppearance, "Appearance");
             ui.selectable_value(&mut self.demo, ScrollDemo::ScrollTo, "Scroll to");
             ui.selectable_value(
                 &mut self.demo,
@@ -60,6 +62,9 @@ impl super::View for Scrolling {
         });
         ui.separator();
         match self.demo {
+            ScrollDemo::ScrollAppearance => {
+                scroll_bar_appearance(ui);
+            }
             ScrollDemo::ScrollTo => {
                 self.scroll_to.ui(ui);
             }
@@ -82,6 +87,28 @@ impl super::View for Scrolling {
             }
         }
     }
+}
+
+fn scroll_bar_appearance(ui: &mut egui::Ui) {
+    ui.label("Settings:");
+
+    let mut style: Style = (*ui.ctx().style()).clone();
+    style.spacing.scroll.ui(ui);
+    if ui.button("Reset").clicked() {
+        style.spacing.scroll = Default::default();
+    }
+    ui.ctx().set_style(style.clone());
+    ui.set_style(style);
+
+    ui.separator();
+
+    ScrollArea::vertical()
+        .auto_shrink([false; 2])
+        .show(ui, |ui| {
+            for _ in 0..100 {
+                ui.label(crate::LOREM_IPSUM_LONG);
+            }
+        });
 }
 
 fn huge_content_lines(ui: &mut egui::Ui) {

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -366,9 +366,9 @@ impl<'a> TableBuilder<'a> {
     fn available_width(&self) -> f32 {
         self.ui.available_rect_before_wrap().width()
             - if self.scroll_options.vscroll {
-                self.ui.spacing().scroll_bar_inner_margin
-                    + self.ui.spacing().scroll_bar_width
-                    + self.ui.spacing().scroll_bar_outer_margin
+                self.ui.spacing().scroll.bar_inner_margin
+                    + self.ui.spacing().scroll.bar_width
+                    + self.ui.spacing().scroll.bar_outer_margin
             } else {
                 0.0
             }

--- a/crates/emath/src/rect.rs
+++ b/crates/emath/src/rect.rs
@@ -150,6 +150,34 @@ impl Rect {
         rect
     }
 
+    #[inline]
+    #[must_use]
+    pub fn with_min_x(mut self, min_x: f32) -> Self {
+        self.min.x = min_x;
+        self
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn with_min_y(mut self, min_y: f32) -> Self {
+        self.min.y = min_y;
+        self
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn with_max_x(mut self, max_x: f32) -> Self {
+        self.max.x = max_x;
+        self
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn with_max_y(mut self, max_y: f32) -> Self {
+        self.max.y = max_y;
+        self
+    }
+
     /// Expand by this much in each direction, keeping the center
     #[must_use]
     pub fn expand(self, amnt: f32) -> Self {

--- a/crates/emath/src/vec2.rs
+++ b/crates/emath/src/vec2.rs
@@ -274,6 +274,16 @@ impl Vec2 {
         self.x.max(self.y)
     }
 
+    /// Swizzle the axes.
+    #[inline]
+    #[must_use]
+    pub fn yx(self) -> Vec2 {
+        Vec2 {
+            x: self.y,
+            y: self.x,
+        }
+    }
+
     #[must_use]
     #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -535,6 +535,7 @@ pub mod path {
             add_circle_quadrant(path, pos2(min.x + r.sw, max.y - r.sw), r.sw, 1.0);
             add_circle_quadrant(path, pos2(min.x + r.nw, min.y + r.nw), r.nw, 2.0);
             add_circle_quadrant(path, pos2(max.x - r.ne, min.y + r.ne), r.ne, 3.0);
+            path.dedup(); // We get duplicates for thin rectangles, producing visual artifats
         }
     }
 


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/3316

This introduces settings to control the visuals of scroll bars, with three pre-sets to chose from:
* Solid (old default)
* Thin
* Floating (new default)

To change to the default, use:

```rust
ctx.style_mut(|style| {
    style.spacing.scroll = egui::style::ScrollStyle::solid();
});
```

![scroll-bar-styles](https://github.com/emilk/egui/assets/1148717/dd30d9ad-169c-4786-99f0-224e72f94328)
