### PR TITLE
Add `emath::Vec2b`, replacing `egui_plot::AxisBools`

### DIFF
--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -272,7 +272,7 @@ impl<'open> Window<'open> {
     }
 
     /// Enable/disable horizontal/vertical scrolling. `false` by default.
-    pub fn scroll2(mut self, scroll: [bool; 2]) -> Self {
+    pub fn scroll2(mut self, scroll: impl Into<Vec2b>) -> Self {
         self.scroll = self.scroll.scroll2(scroll);
         self
     }

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -377,7 +377,7 @@ pub use epaint::emath;
 pub use ecolor::hex_color;
 pub use ecolor::{Color32, Rgba};
 pub use emath::{
-    lerp, pos2, remap, remap_clamp, vec2, Align, Align2, NumExt, Pos2, Rangef, Rect, Vec2,
+    lerp, pos2, remap, remap_clamp, vec2, Align, Align2, NumExt, Pos2, Rangef, Rect, Vec2, Vec2b,
 };
 pub use epaint::{
     mutex,

--- a/crates/egui_demo_app/src/apps/custom3d_glow.rs
+++ b/crates/egui_demo_app/src/apps/custom3d_glow.rs
@@ -24,7 +24,7 @@ impl eframe::App for Custom3d {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             egui::ScrollArea::both()
-                .auto_shrink([false; 2])
+                .auto_shrink(false)
                 .show(ui, |ui| {
                     ui.horizontal(|ui| {
                         ui.spacing_mut().item_spacing.x = 0.0;

--- a/crates/egui_demo_app/src/apps/custom3d_wgpu.rs
+++ b/crates/egui_demo_app/src/apps/custom3d_wgpu.rs
@@ -99,7 +99,7 @@ impl eframe::App for Custom3d {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             egui::ScrollArea::both()
-                .auto_shrink([false; 2])
+                .auto_shrink(false)
                 .show(ui, |ui| {
                     ui.horizontal(|ui| {
                         ui.spacing_mut().item_spacing.x = 0.0;

--- a/crates/egui_demo_app/src/apps/http_app.rs
+++ b/crates/egui_demo_app/src/apps/http_app.rs
@@ -174,7 +174,7 @@ fn ui_resource(ui: &mut egui::Ui, resource: &Resource) {
     ui.separator();
 
     egui::ScrollArea::vertical()
-        .auto_shrink([false; 2])
+        .auto_shrink(false)
         .show(ui, |ui| {
             egui::CollapsingHeader::new("Response headers")
                 .default_open(false)

--- a/crates/egui_demo_app/src/apps/image_viewer.rs
+++ b/crates/egui_demo_app/src/apps/image_viewer.rs
@@ -187,7 +187,7 @@ impl eframe::App for ImageViewer {
         });
 
         egui::CentralPanel::default().show(ctx, |ui| {
-            egui::ScrollArea::new([true, true]).show(ui, |ui| {
+            egui::ScrollArea::both().show(ui, |ui| {
                 let mut image = egui::Image::from_uri(&self.current_uri);
                 image = image.uv(self.image_options.uv);
                 image = image.bg_fill(self.image_options.bg_fill);

--- a/crates/egui_demo_app/src/wrap_app.rs
+++ b/crates/egui_demo_app/src/wrap_app.rs
@@ -68,7 +68,7 @@ impl eframe::App for ColorTestApp {
                 );
                 ui.separator();
             }
-            egui::ScrollArea::both().auto_shrink([false; 2]).show(ui, |ui| {
+            egui::ScrollArea::both().auto_shrink(false).show(ui, |ui| {
                 self.color_test.ui(ui);
             });
         });

--- a/crates/egui_demo_lib/src/demo/context_menu.rs
+++ b/crates/egui_demo_lib/src/demo/context_menu.rs
@@ -1,3 +1,5 @@
+use egui::Vec2b;
+
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 enum Plot {
@@ -19,7 +21,7 @@ fn sigmoid(x: f64) -> f64 {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ContextMenus {
     plot: Plot,
-    show_axes: [bool; 2],
+    show_axes: Vec2b,
     allow_drag: bool,
     allow_zoom: bool,
     allow_scroll: bool,
@@ -33,7 +35,7 @@ impl Default for ContextMenus {
     fn default() -> Self {
         Self {
             plot: Plot::Sin,
-            show_axes: [true, true],
+            show_axes: Vec2b::TRUE,
             allow_drag: true,
             allow_zoom: true,
             allow_scroll: true,

--- a/crates/egui_demo_lib/src/demo/plot_demo.rs
+++ b/crates/egui_demo_lib/src/demo/plot_demo.rs
@@ -4,9 +4,9 @@ use std::ops::RangeInclusive;
 use egui::*;
 
 use egui_plot::{
-    Arrows, AxisBools, AxisHints, Bar, BarChart, BoxElem, BoxPlot, BoxSpread, CoordinatesFormatter,
-    Corner, GridInput, GridMark, HLine, Legend, Line, LineStyle, MarkerShape, Plot, PlotImage,
-    PlotPoint, PlotPoints, PlotResponse, Points, Polygon, Text, VLine,
+    Arrows, AxisHints, Bar, BarChart, BoxElem, BoxPlot, BoxSpread, CoordinatesFormatter, Corner,
+    GridInput, GridMark, HLine, Legend, Line, LineStyle, MarkerShape, Plot, PlotImage, PlotPoint,
+    PlotPoints, PlotResponse, Points, Polygon, Text, VLine,
 };
 
 // ----------------------------------------------------------------------------
@@ -830,8 +830,8 @@ impl Default for Chart {
 struct ChartsDemo {
     chart: Chart,
     vertical: bool,
-    allow_zoom: AxisBools,
-    allow_drag: AxisBools,
+    allow_zoom: Vec2b,
+    allow_drag: Vec2b,
 }
 
 impl Default for ChartsDemo {

--- a/crates/egui_demo_lib/src/demo/scrolling.rs
+++ b/crates/egui_demo_lib/src/demo/scrolling.rs
@@ -146,7 +146,7 @@ impl ScrollAppearance {
         ui.separator();
 
         ScrollArea::vertical()
-            .auto_shrink([false; 2])
+            .auto_shrink(false)
             .scroll_bar_visibility(*visibility)
             .show(ui, |ui| {
                 ui.with_layout(
@@ -170,7 +170,7 @@ fn huge_content_lines(ui: &mut egui::Ui) {
     let text_style = TextStyle::Body;
     let row_height = ui.text_style_height(&text_style);
     let num_rows = 10_000;
-    ScrollArea::vertical().auto_shrink([false; 2]).show_rows(
+    ScrollArea::vertical().auto_shrink(false).show_rows(
         ui,
         row_height,
         num_rows,
@@ -193,7 +193,7 @@ fn huge_content_painter(ui: &mut egui::Ui) {
     let num_rows = 10_000;
 
     ScrollArea::vertical()
-        .auto_shrink([false; 2])
+        .auto_shrink(false)
         .show_viewport(ui, |ui, viewport| {
             ui.set_height(row_height * num_rows as f32);
 
@@ -292,9 +292,7 @@ impl super::View for ScrollTo {
             scroll_bottom |= ui.button("Scroll to bottom").clicked();
         });
 
-        let mut scroll_area = ScrollArea::vertical()
-            .max_height(200.0)
-            .auto_shrink([false; 2]);
+        let mut scroll_area = ScrollArea::vertical().max_height(200.0).auto_shrink(false);
         if go_to_scroll_offset {
             scroll_area = scroll_area.vertical_scroll_offset(self.offset);
         }

--- a/crates/egui_demo_lib/src/demo/text_layout.rs
+++ b/crates/egui_demo_lib/src/demo/text_layout.rs
@@ -124,7 +124,7 @@ impl super::View for TextLayoutDemo {
         };
 
         egui::ScrollArea::vertical()
-            .auto_shrink([false; 2])
+            .auto_shrink(false)
             .show(ui, |ui| {
                 let extra_letter_spacing = points_per_pixel * *extra_letter_spacing_pixels as f32;
                 let line_height = (*line_height_pixels != 0)

--- a/crates/egui_demo_lib/src/demo/window_options.rs
+++ b/crates/egui_demo_lib/src/demo/window_options.rs
@@ -1,3 +1,5 @@
+use egui::Vec2b;
+
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct WindowOptions {
@@ -7,7 +9,7 @@ pub struct WindowOptions {
     collapsible: bool,
     resizable: bool,
     constrain: bool,
-    scroll2: [bool; 2],
+    scroll2: Vec2b,
     disabled_time: f64,
 
     anchored: bool,
@@ -24,7 +26,7 @@ impl Default for WindowOptions {
             collapsible: true,
             resizable: true,
             constrain: true,
-            scroll2: [true; 2],
+            scroll2: Vec2b::TRUE,
             disabled_time: f64::NEG_INFINITY,
             anchored: false,
             anchor: egui::Align2::RIGHT_TOP,

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -3,7 +3,7 @@
 //! | fixed size | all available space/minimum | 30% of available width | fixed size |
 //! Takes all available height, so if you want something below the table, put it in a strip.
 
-use egui::{Align, NumExt as _, Rangef, Rect, Response, ScrollArea, Ui, Vec2};
+use egui::{Align, NumExt as _, Rangef, Rect, Response, ScrollArea, Ui, Vec2, Vec2b};
 
 use crate::{
     layout::{CellDirection, CellSize},
@@ -165,7 +165,7 @@ struct TableScrollOptions {
     scroll_offset_y: Option<f32>,
     min_scrolled_height: f32,
     max_scroll_height: f32,
-    auto_shrink: [bool; 2],
+    auto_shrink: Vec2b,
 }
 
 impl Default for TableScrollOptions {
@@ -178,7 +178,7 @@ impl Default for TableScrollOptions {
             scroll_offset_y: None,
             min_scrolled_height: 200.0,
             max_scroll_height: 800.0,
-            auto_shrink: [true; 2],
+            auto_shrink: Vec2b::TRUE,
         }
     }
 }
@@ -335,11 +335,11 @@ impl<'a> TableBuilder<'a> {
     /// * If true, add blank space outside the table, keeping the table small.
     /// * If false, add blank space inside the table, expanding the table to fit the containing ui.
     ///
-    /// Default: `[true; 2]`.
+    /// Default: `true`.
     ///
     /// See [`ScrollArea::auto_shrink`] for more.
-    pub fn auto_shrink(mut self, auto_shrink: [bool; 2]) -> Self {
-        self.scroll_options.auto_shrink = auto_shrink;
+    pub fn auto_shrink(mut self, auto_shrink: impl Into<Vec2b>) -> Self {
+        self.scroll_options.auto_shrink = auto_shrink.into();
         self
     }
 
@@ -577,7 +577,7 @@ impl<'a> Table<'a> {
         let avail_rect = ui.available_rect_before_wrap();
 
         let mut scroll_area = ScrollArea::new([false, vscroll])
-            .auto_shrink([true; 2])
+            .auto_shrink(true)
             .drag_to_scroll(drag_to_scroll)
             .stick_to_bottom(stick_to_bottom)
             .min_scrolled_height(min_scrolled_height)

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -496,6 +496,7 @@ impl Plot {
     }
 
     /// Whether or not to show the background [`Rect`].
+    ///
     /// Can be useful to disable if the plot is overlaid over existing content.
     /// Default: `true`.
     pub fn show_background(mut self, show: bool) -> Self {
@@ -505,7 +506,7 @@ impl Plot {
 
     /// Show axis labels and grid tick values on the side of the plot.
     ///
-    /// Default: `[true; 2]`.
+    /// Default: `true`.
     pub fn show_axes(mut self, show: impl Into<Vec2b>) -> Self {
         self.show_axes = show.into();
         self
@@ -513,7 +514,7 @@ impl Plot {
 
     /// Show a grid overlay on the plot.
     ///
-    /// Default: `[true; 2]`.
+    /// Default: `true`.
     pub fn show_grid(mut self, show: impl Into<Vec2b>) -> Self {
         self.show_grid = show.into();
         self

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -77,47 +77,13 @@ impl Default for CoordinatesFormatter {
 
 const MIN_LINE_SPACING_IN_POINTS: f64 = 6.0; // TODO(emilk): large enough for a wide label
 
-/// Two bools, one for each axis (X and Y).
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct AxisBools {
-    pub x: bool,
-    pub y: bool,
-}
-
-impl AxisBools {
-    #[inline]
-    pub fn new(x: bool, y: bool) -> Self {
-        Self { x, y }
-    }
-
-    #[inline]
-    pub fn any(&self) -> bool {
-        self.x || self.y
-    }
-}
-
-impl From<bool> for AxisBools {
-    #[inline]
-    fn from(val: bool) -> Self {
-        AxisBools { x: val, y: val }
-    }
-}
-
-impl From<[bool; 2]> for AxisBools {
-    #[inline]
-    fn from([x, y]: [bool; 2]) -> Self {
-        AxisBools { x, y }
-    }
-}
-
 /// Information about the plot that has to persist between frames.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Clone)]
 struct PlotMemory {
     /// Indicates if the user has modified the bounds, for example by moving or zooming,
     /// or if the bounds should be calculated based by included point or auto bounds.
-    bounds_modified: AxisBools,
+    bounds_modified: Vec2b,
 
     hovered_entry: Option<String>,
     hidden_items: ahash::HashSet<String>,
@@ -171,7 +137,7 @@ struct CursorLinkGroups(HashMap<Id, Vec<PlotFrameCursors>>);
 #[derive(Clone)]
 struct LinkedBounds {
     bounds: PlotBounds,
-    bounds_modified: AxisBools,
+    bounds_modified: Vec2b,
 }
 
 #[derive(Default, Clone)]
@@ -211,18 +177,18 @@ pub struct PlotResponse<R> {
 pub struct Plot {
     id_source: Id,
 
-    center_axis: AxisBools,
-    allow_zoom: AxisBools,
-    allow_drag: AxisBools,
+    center_axis: Vec2b,
+    allow_zoom: Vec2b,
+    allow_drag: Vec2b,
     allow_scroll: bool,
     allow_double_click_reset: bool,
     allow_boxed_zoom: bool,
-    auto_bounds: AxisBools,
+    auto_bounds: Vec2b,
     min_auto_bounds: PlotBounds,
     margin_fraction: Vec2,
     boxed_zoom_pointer_button: PointerButton,
-    linked_axes: Option<(Id, AxisBools)>,
-    linked_cursors: Option<(Id, AxisBools)>,
+    linked_axes: Option<(Id, Vec2b)>,
+    linked_cursors: Option<(Id, Vec2b)>,
 
     min_size: Vec2,
     width: Option<f32>,
@@ -240,8 +206,8 @@ pub struct Plot {
     y_axes: Vec<AxisHints>, // default y axes
     legend_config: Option<Legend>,
     show_background: bool,
-    show_axes: AxisBools,
-    show_grid: AxisBools,
+    show_axes: Vec2b,
+    show_grid: Vec2b,
     grid_spacers: [GridSpacer; 2],
     sharp_grid_lines: bool,
     clamp_grid: bool,
@@ -357,7 +323,7 @@ impl Plot {
     /// Note: Allowing zoom in one axis but not the other may lead to unexpected results if used in combination with `data_aspect`.
     pub fn allow_zoom<T>(mut self, on: T) -> Self
     where
-        T: Into<AxisBools>,
+        T: Into<Vec2b>,
     {
         self.allow_zoom = on.into();
         self
@@ -401,7 +367,7 @@ impl Plot {
     /// Whether to allow dragging in the plot to move the bounds. Default: `true`.
     pub fn allow_drag<T>(mut self, on: T) -> Self
     where
-        T: Into<AxisBools>,
+        T: Into<Vec2b>,
     {
         self.allow_drag = on.into();
         self
@@ -540,7 +506,7 @@ impl Plot {
     /// Show axis labels and grid tick values on the side of the plot.
     ///
     /// Default: `[true; 2]`.
-    pub fn show_axes(mut self, show: impl Into<AxisBools>) -> Self {
+    pub fn show_axes(mut self, show: impl Into<Vec2b>) -> Self {
         self.show_axes = show.into();
         self
     }
@@ -548,7 +514,7 @@ impl Plot {
     /// Show a grid overlay on the plot.
     ///
     /// Default: `[true; 2]`.
-    pub fn show_grid(mut self, show: impl Into<AxisBools>) -> Self {
+    pub fn show_grid(mut self, show: impl Into<Vec2b>) -> Self {
         self.show_grid = show.into();
         self
     }
@@ -558,7 +524,7 @@ impl Plot {
     pub fn link_axis(mut self, group_id: impl Into<Id>, link_x: bool, link_y: bool) -> Self {
         self.linked_axes = Some((
             group_id.into(),
-            AxisBools {
+            Vec2b {
                 x: link_x,
                 y: link_y,
             },
@@ -571,7 +537,7 @@ impl Plot {
     pub fn link_cursor(mut self, group_id: impl Into<Id>, link_x: bool, link_y: bool) -> Self {
         self.linked_cursors = Some((
             group_id.into(),
-            AxisBools {
+            Vec2b {
                 x: link_x,
                 y: link_y,
             },
@@ -1245,7 +1211,7 @@ impl Plot {
 }
 
 fn axis_widgets(
-    show_axes: AxisBools,
+    show_axes: Vec2b,
     plot_rect: Rect,
     [x_axes, y_axes]: [&[AxisHints]; 2],
 ) -> [Vec<AxisWidget>; 2] {
@@ -1616,7 +1582,7 @@ struct PreparedPlot {
     coordinates_formatter: Option<(Corner, CoordinatesFormatter)>,
     // axis_formatters: [AxisFormatter; 2],
     transform: PlotTransform,
-    show_grid: AxisBools,
+    show_grid: Vec2b,
     grid_spacers: [GridSpacer; 2],
     draw_cursor_x: bool,
     draw_cursor_y: bool,

--- a/crates/emath/src/lib.rs
+++ b/crates/emath/src/lib.rs
@@ -36,6 +36,7 @@ mod rect_transform;
 mod rot2;
 pub mod smart_aim;
 mod vec2;
+mod vec2b;
 
 pub use {
     align::{Align, Align2},
@@ -47,6 +48,7 @@ pub use {
     rect_transform::*,
     rot2::*,
     vec2::*,
+    vec2b::*,
 };
 
 // ----------------------------------------------------------------------------

--- a/crates/emath/src/vec2b.rs
+++ b/crates/emath/src/vec2b.rs
@@ -1,0 +1,33 @@
+/// Two bools, one for each axis (X and Y).
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Vec2b {
+    pub x: bool,
+    pub y: bool,
+}
+
+impl Vec2b {
+    #[inline]
+    pub fn new(x: bool, y: bool) -> Self {
+        Self { x, y }
+    }
+
+    #[inline]
+    pub fn any(&self) -> bool {
+        self.x || self.y
+    }
+}
+
+impl From<bool> for Vec2b {
+    #[inline]
+    fn from(val: bool) -> Self {
+        Vec2b { x: val, y: val }
+    }
+}
+
+impl From<[bool; 2]> for Vec2b {
+    #[inline]
+    fn from([x, y]: [bool; 2]) -> Self {
+        Vec2b { x, y }
+    }
+}

--- a/crates/emath/src/vec2b.rs
+++ b/crates/emath/src/vec2b.rs
@@ -1,12 +1,15 @@
 /// Two bools, one for each axis (X and Y).
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Vec2b {
     pub x: bool,
     pub y: bool,
 }
 
 impl Vec2b {
+    pub const FALSE: Self = Self { x: false, y: false };
+    pub const TRUE: Self = Self { x: true, y: true };
+
     #[inline]
     pub fn new(x: bool, y: bool) -> Self {
         Self { x, y }
@@ -29,5 +32,29 @@ impl From<[bool; 2]> for Vec2b {
     #[inline]
     fn from([x, y]: [bool; 2]) -> Self {
         Vec2b { x, y }
+    }
+}
+
+impl std::ops::Index<usize> for Vec2b {
+    type Output = bool;
+
+    #[inline(always)]
+    fn index(&self, index: usize) -> &bool {
+        match index {
+            0 => &self.x,
+            1 => &self.y,
+            _ => panic!("Vec2b index out of bounds: {index}"),
+        }
+    }
+}
+
+impl std::ops::IndexMut<usize> for Vec2b {
+    #[inline(always)]
+    fn index_mut(&mut self, index: usize) -> &mut bool {
+        match index {
+            0 => &mut self.x,
+            1 => &mut self.y,
+            _ => panic!("Vec2b index out of bounds: {index}"),
+        }
     }
 }

--- a/examples/images/src/main.rs
+++ b/examples/images/src/main.rs
@@ -25,7 +25,7 @@ struct MyApp {}
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
-            egui::ScrollArea::new([true, true]).show(ui, |ui| {
+            egui::ScrollArea::both().show(ui, |ui| {
                 ui.image(egui::include_image!("ferris.svg"));
 
                 ui.add(

--- a/examples/keyboard_events/src/main.rs
+++ b/examples/keyboard_events/src/main.rs
@@ -26,7 +26,7 @@ impl eframe::App for Content {
                 self.text.clear();
             }
             ScrollArea::vertical()
-                .auto_shrink([false; 2])
+                .auto_shrink(false)
                 .stick_to_bottom(true)
                 .show(ui, |ui| {
                     ui.label(&self.text);


### PR DESCRIPTION
Thanks to `impl From<bool> for Vec2b` one can now shorten some builder calls, like:

Previous:
```rust
 egui::ScrollArea::vertical()
        .auto_shrink([false; 2])
```

New:
```rust
 egui::ScrollArea::vertical()
        .auto_shrink(false)
```