### PR TITLE
Add override to egui_plot

### DIFF
--- a/crates/egui/src/painter.rs
+++ b/crates/egui/src/painter.rs
@@ -443,6 +443,18 @@ impl Painter {
             self.add(Shape::galley_with_color(pos, galley, text_color));
         }
     }
+
+    /// Paint text that has already been laid out in a [`Galley`].
+    ///
+    /// You can create the [`Galley`] with [`Self::layout`].
+    ///
+    /// The text color in the [`Galley`] will be gamma multiplied by the given factor.
+    #[inline(always)]
+    pub fn galley_with_gamma(&self, pos: Pos2, galley: Arc<Galley>, gamma_multiply: f32) {
+        if !galley.is_empty() && gamma_multiply != 0.0 {
+            self.add(Shape::galley_with_gamma(pos, galley, gamma_multiply));
+        }
+    }
 }
 
 fn tint_shape_towards(shape: &mut Shape, target: Color32) {

--- a/crates/egui/src/widgets/hyperlink.rs
+++ b/crates/egui/src/widgets/hyperlink.rs
@@ -55,6 +55,7 @@ impl Widget for Link {
                 pos,
                 galley: text_galley.galley,
                 override_text_color: Some(color),
+                gamma_multiply: None,
                 underline,
                 angle: 0.0,
             });

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -223,6 +223,7 @@ impl Widget for Label {
                 pos,
                 galley: text_galley.galley,
                 override_text_color,
+                gamma_multiply: None,
                 underline,
                 angle: 0.0,
             });

--- a/crates/egui_plot/src/axis.rs
+++ b/crates/egui_plot/src/axis.rs
@@ -249,6 +249,7 @@ impl AxisWidget {
                 galley: galley.galley,
                 underline: Stroke::NONE,
                 override_text_color: Some(text_color),
+                gamma_multiply: None,
                 angle,
             };
             ui.painter().add(shape);

--- a/crates/epaint/src/shape.rs
+++ b/crates/epaint/src/shape.rs
@@ -229,6 +229,16 @@ impl Shape {
         .into()
     }
 
+    #[inline]
+    /// The text color in the [`Galley`] will be gamma multiplied by the given factor.
+    pub fn galley_with_gamma(pos: Pos2, galley: Arc<Galley>, gamma_multiply: f32) -> Self {
+        TextShape {
+            gamma_multiply: Some(gamma_multiply),
+            ..TextShape::new(pos, galley)
+        }
+        .into()
+    }
+
     pub fn mesh(mesh: Mesh) -> Self {
         crate::epaint_assert!(mesh.is_valid());
         Self::Mesh(mesh)
@@ -685,6 +695,10 @@ pub struct TextShape {
     /// This will NOT replace background color nor strikethrough/underline color.
     pub override_text_color: Option<Color32>,
 
+    /// If set, the text color will be gamma multiplied by the given factor
+    /// This will NOT replace background color nor strikethrough/underline color.
+    pub gamma_multiply: Option<f32>,
+
     /// Rotate text by this many radians clockwise.
     /// The pivot is `pos` (the upper left corner of the text).
     pub angle: f32,
@@ -698,6 +712,7 @@ impl TextShape {
             galley,
             underline: Stroke::NONE,
             override_text_color: None,
+            gamma_multiply: None,
             angle: 0.0,
         }
     }

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -1473,6 +1473,7 @@ impl Tessellator {
             galley,
             underline,
             override_text_color,
+            gamma_multiply,
             angle,
         } = text_shape;
 
@@ -1541,6 +1542,12 @@ impl Tessellator {
                         if let Some(override_text_color) = override_text_color {
                             if row.visuals.glyph_vertex_range.contains(&i) {
                                 color = *override_text_color;
+                            }
+                        }
+
+                        if let Some(gamma_multiply) = gamma_multiply {
+                            if row.visuals.glyph_vertex_range.contains(&i) {
+                                color = color.gamma_multiply(*gamma_multiply);
                             }
                         }
 


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

This PR simply allows you to override the opacity of a `Galley` when you draw it on screen. For my use case ([grezi-next](https://github.com/StratusFearMe21/grezi-next), a slideshow program), I am caching the text on slides as galleys, and drawing them on screen directly using the `ui.painter()`. My previous solution to controlling text opacity was to draw a background colored box in front of the text with the desired opacity. This caused a lot of jank for me, especially with a moving image as the background. Now I can fade in and out text without the jank!

https://github.com/emilk/egui/assets/57533634/6bee622e-8c17-4454-b442-9147f1b3bab0




Closes discussion <https://github.com/emilk/egui/discussions/3416>.
