### PR TITLE
egui-extras: add ReqwestLoader as alternative to EhttpLoader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ dependencies = [
  "polling",
  "rustix 0.37.25",
  "slab",
- "socket2",
+ "socket2 0.4.9",
  "waker-fn",
 ]
 
@@ -1351,10 +1351,12 @@ dependencies = [
  "log",
  "mime_guess2",
  "puffin",
+ "reqwest",
  "resvg",
  "serde",
  "syntect",
  "tiny-skia",
+ "tokio",
  "usvg",
 ]
 
@@ -1414,6 +1416,15 @@ dependencies = [
  "document-features",
  "mint",
  "serde",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1680,6 +1691,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -2026,6 +2046,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap 2.0.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,10 +2169,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.4.9",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -2247,6 +2344,12 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
@@ -2368,9 +2471,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libloading"
@@ -2544,9 +2647,9 @@ checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "log",
@@ -3241,6 +3344,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216080ab382b992234dda86873c18d4c48358f5cfcb70fd693d7f6f2131b628b"
 
 [[package]]
+name = "reqwest"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+dependencies = [
+ "base64 0.21.4",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "resvg"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3513,6 +3651,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serial_windows"
 version = "0.1.0"
 dependencies = [
@@ -3628,6 +3778,16 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3752,6 +3912,27 @@ dependencies = [
  "thiserror",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3900,6 +4081,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokio"
+version = "1.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2 0.5.5",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3934,6 +4144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
 name = "tracing"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3964,6 +4180,12 @@ checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "ttf-parser"
@@ -4161,6 +4383,15 @@ checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -4759,6 +4990,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/egui_extras/Cargo.toml
+++ b/crates/egui_extras/Cargo.toml
@@ -29,6 +29,9 @@ default = ["dep:mime_guess2"]
 ## Shorthand for enabling the different types of image loaders (`file`, `http`, `image`, `svg`).
 all_loaders = ["file", "http", "image", "svg"]
 
+## Shorthand for enabling the different types of image loaders (`file`, `image`, `reqwest`, `svg`). Read `reqwest` feature description!
+all_loaders_reqwest = ["file", "image", "reqwest", "svg"]
+
 ## Enable [`DatePickerButton`] widget.
 datepicker = ["chrono"]
 
@@ -37,6 +40,16 @@ file = ["dep:mime_guess2"]
 
 ## Add support for loading images via HTTP.
 http = ["dep:ehttp"]
+
+## Add support for loading images via HTTP using reqwest.
+##
+## ⚠ It shall be treated as mutually exclusive with `http`!
+##
+## Use this feature over `http` if you use `reqwest`+`tokio` in the rest of your project.
+##
+## Images using this loader shall be only created in thread that is in `tokio` runtime context
+## (, as GUI thread is rather not async this means ie. calling `let _rt_guard = RUNTIME.enter();` before running eframe app)
+reqwest = ["dep:reqwest", "dep:tokio"]
 
 ## Add support for loading images with the [`image`](https://docs.rs/image) crate.
 ##
@@ -98,3 +111,7 @@ usvg = { version = "0.28", optional = true, default-features = false }
 
 # http feature
 ehttp = { version = "0.3.1", optional = true, default-features = false }
+
+# reqwest feature
+reqwest={ version = "0.11", optional = true, default-features = false }
+tokio={ version = "1.34", optional = true, features = ["rt"]}

--- a/crates/egui_extras/src/loaders/reqwest_loader.rs
+++ b/crates/egui_extras/src/loaders/reqwest_loader.rs
@@ -1,0 +1,152 @@
+use egui::{
+    ahash::HashMap,
+    load::{Bytes, BytesLoadResult, BytesLoader, BytesPoll, LoadError},
+    mutex::Mutex,
+};
+use image::EncodableLayout;
+use reqwest::header::CONTENT_TYPE;
+use reqwest::Client;
+use std::sync::OnceLock;
+use std::{sync::Arc, task::Poll};
+use tokio::runtime;
+
+#[derive(Clone)]
+struct File {
+    bytes: Arc<[u8]>,
+    mime: Option<String>,
+}
+
+static REQWEST: OnceLock<Client> = OnceLock::new();
+static RT_HANDLE: OnceLock<runtime::Handle> = OnceLock::new();
+
+impl File {
+    async fn from_response(uri: &str, response: reqwest::Response) -> Result<Self, String> {
+        let status = response.status();
+        let mime = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok().map(|v| v.to_owned()));
+        match response.bytes().await {
+            Ok(bytes) => Ok(File {
+                bytes: bytes.as_bytes().into(),
+                mime,
+            }),
+            Err(err) => Err(format!(
+                "failed to load {uri:?}: {} {}; Error: {}",
+                status,
+                status.canonical_reason().unwrap_or_default(),
+                err
+            )),
+        }
+    }
+}
+
+type Entry = Poll<Result<File, String>>;
+
+#[derive(Default)]
+pub struct ReqwestLoader {
+    cache: Arc<Mutex<HashMap<String, Entry>>>,
+}
+
+impl ReqwestLoader {
+    pub const ID: &str = egui::generate_loader_id!(ReqwestLoader);
+}
+
+const PROTOCOLS: &[&str] = &["http://", "https://"];
+
+fn starts_with_one_of(s: &str, prefixes: &[&str]) -> bool {
+    prefixes.iter().any(|prefix| s.starts_with(prefix))
+}
+
+impl BytesLoader for ReqwestLoader {
+    fn id(&self) -> &str {
+        Self::ID
+    }
+
+    fn load(&self, ctx: &egui::Context, uri: &str) -> BytesLoadResult {
+        if !starts_with_one_of(uri, PROTOCOLS) {
+            return Err(LoadError::NotSupported);
+        }
+
+        let mut cache = self.cache.lock();
+        if let Some(entry) = cache.get(uri).cloned() {
+            match entry {
+                Poll::Ready(Ok(file)) => Ok(BytesPoll::Ready {
+                    size: None,
+                    bytes: Bytes::Shared(file.bytes),
+                    mime: file.mime,
+                }),
+                Poll::Ready(Err(err)) => Err(LoadError::Loading(err)),
+                Poll::Pending => Ok(BytesPoll::Pending { size: None }),
+            }
+        } else {
+            log::trace!("started loading {uri:?}");
+
+            let uri = uri.to_owned();
+
+            let rt_handle = if let Some(rth) = RT_HANDLE.get() {
+                rth.clone()
+            } else {
+                match runtime::Handle::try_current() {
+                    Ok(rth) => {
+                        let r = rth.clone();
+                        _ = RT_HANDLE.set(rth);
+                        r
+                    }
+                    Err(err) => {
+                        let err = format!("Failed to attach to tokio runtime {err}");
+                        cache.insert(uri.clone(), Poll::Ready(Err(err.clone())));
+                        log::error!("{}", err);
+                        return Err(LoadError::Loading(err));
+                    }
+                }
+            };
+
+            cache.insert(uri.clone(), Poll::Pending);
+            drop(cache);
+
+            let ctx = ctx.clone();
+            let cache = self.cache.clone();
+
+            _ = rt_handle.spawn(async move {
+                let response = REQWEST.get_or_init(Client::new).get(&uri).send().await;
+                let result = match response {
+                    Ok(response) => File::from_response(&uri, response).await,
+                    Err(err) => {
+                        // Log details; return summary
+                        log::error!("Failed to load {uri:?}: {err}");
+                        Err(format!("Failed to load {uri:?}"))
+                    }
+                };
+                log::trace!("finished loading {uri:?}");
+                let prev = cache.lock().insert(uri, Poll::Ready(result));
+                assert!(matches!(prev, Some(Poll::Pending)));
+                ctx.request_repaint();
+            });
+
+            Ok(BytesPoll::Pending { size: None })
+        }
+    }
+
+    fn forget(&self, uri: &str) {
+        let _ = self.cache.lock().remove(uri);
+    }
+
+    fn forget_all(&self) {
+        self.cache.lock().clear();
+    }
+
+    fn byte_size(&self) -> usize {
+        self.cache
+            .lock()
+            .values()
+            .map(|entry| match entry {
+                Poll::Ready(Ok(file)) => {
+                    file.bytes.len() + file.mime.as_ref().map_or(0, |m| m.len())
+                }
+                Poll::Ready(Err(err)) => err.len(),
+                _ => 0,
+            })
+            .sum()
+    }
+}


### PR DESCRIPTION
This PR adds new http loader (`ReqwestLoader`) to `egui-extras`, as an alternative to `EhttpLoader`. 

If the rest of the project uses `reqwest`+`tokio`, using this new loader (that uses `reqwest` instead of `ehttp`) reduces project dependencies (in my case this was c. -35 crates & -0.3MB binary size in release).

Considering `reqwest` popularity (according to `crates.io` `reqwest` has more daily downloads than `ehttp` of all time, I don't know how this looks like for `egui` users only, but I guess it's still popular), I think this loader would better fit integrated into official `egui-extras` than as separate crate (but if You would find this fits better outside `egui`, I would probably release this as separate crate).

There is a small catch, about using `ReqwestLoader`, but I described it in feature description (even if sb misses it, it should error in a descriptive way).