### PR TITLE
CI: Add workflow to publish web-demo to `gh-pages` branch on each PR

### DIFF
--- a/.github/workflows/deploy_web_demo.yml
+++ b/.github/workflows/deploy_web_demo.yml
@@ -1,0 +1,62 @@
+name: Deploy web demo
+
+on: [push, pull_request]
+
+# TODO: run only on master
+# on:
+#   # Runs on pushes targeting the default branch
+#   push:
+#     branches: ["master"]
+
+#   # Allows you to run this workflow manually from the Actions tab
+#   workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          target: wasm32-unknown-unknown
+          toolchain: 1.70.0
+          override: true
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "web-demo-"
+
+      - uses: jetli/wasm-bindgen-action@v0.2.0
+
+      - run: |
+          scripts/build_demo_web.sh --release
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: "docs"
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/deploy_web_demo.yml
+++ b/.github/workflows/deploy_web_demo.yml
@@ -11,10 +11,11 @@ on: [push, pull_request]
 #   # Allows you to run this workflow manually from the Actions tab
 #   workflow_dispatch:
 
+# Grant GITHUB_TOKEN the permissions required to make a Pages deployment
 permissions:
   contents: read
-  pages: write
-  id-token: write
+  pages:    write # to deploy to Pages
+  id-token: write # to verify the deployment originates from an appropriate source
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -22,12 +23,23 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  # web_sys_unstable_apis is required to enable the web_sys clipboard API which eframe web uses,
+  # as well as by the wasm32-backend of the wgpu crate.
+  # https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Clipboard.html
+  # https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html
+  RUSTFLAGS: --cfg=web_sys_unstable_apis -D warnings
+  RUSTDOCFLAGS: -D warnings
+
 jobs:
   # Single deploy job since we're just deploying
   deploy:
+    name: Deploy web demo
+
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -43,6 +55,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "web-demo-"
+
+      - name: "Install wasmopt / binaryen"
+        run: |
+          sudo apt-get update && sudo apt-get install binaryen
 
       - run: |
           scripts/build_demo_web.sh --release

--- a/.github/workflows/deploy_web_demo.yml
+++ b/.github/workflows/deploy_web_demo.yml
@@ -44,8 +44,6 @@ jobs:
         with:
           prefix-key: "web-demo-"
 
-      - uses: jetli/wasm-bindgen-action@v0.2.0
-
       - run: |
           scripts/build_demo_web.sh --release
 

--- a/.github/workflows/deploy_web_demo.yml
+++ b/.github/workflows/deploy_web_demo.yml
@@ -1,15 +1,12 @@
 name: Deploy web demo
 
-on: [push, pull_request]
+on:
+  # We only run this on merges to master
+  push:
+    branches: ["master"]
 
-# TODO: run only on master
-# on:
-#   # Runs on pushes targeting the default branch
-#   push:
-#     branches: ["master"]
-
-#   # Allows you to run this workflow manually from the Actions tab
-#   workflow_dispatch:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
 permissions:


### PR DESCRIPTION
The goal is to host the egui web-demo on its own `gh-pages` branch, and have the CI build and publish a new demo on each merged CI.

Let's see if I can get this to work…