### PR TITLE
Replace `eframe::Frame` commands and `WindowInfo` with egui

### DIFF
--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -892,15 +892,6 @@ impl Frame {
         self.wgpu_render_state.as_ref()
     }
 
-    /// Bring the window into focus (native only). Has no effect on Wayland, or if the window is minimized or invisible.
-    ///
-    /// This method puts the window on top of other applications and takes input focus away from them,
-    /// which, if unexpected, will disturb the user.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn focus(&mut self) {
-        self.output.focus = Some(true);
-    }
-
     /// for integrations only: call once per frame
     #[cfg(any(feature = "glow", feature = "wgpu"))]
     pub(crate) fn take_app_output(&mut self) -> backend::AppOutput {
@@ -1063,10 +1054,6 @@ pub(crate) mod backend {
     #[derive(Clone, Debug, Default)]
     #[must_use]
     pub struct AppOutput {
-        /// Set to some bool to focus window.
-        #[cfg(not(target_arch = "wasm32"))]
-        pub focus: Option<bool>,
-
         #[cfg(not(target_arch = "wasm32"))]
         pub screenshot_requested: bool,
     }

--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -892,26 +892,6 @@ impl Frame {
         self.wgpu_render_state.as_ref()
     }
 
-    /// Tell `eframe` to close the desktop window.
-    ///
-    /// The window will not close immediately, but at the end of the this frame.
-    ///
-    /// Calling this will likely result in the app quitting, unless
-    /// you have more code after the call to [`crate::run_native`].
-    #[cfg(not(target_arch = "wasm32"))]
-    #[doc(alias = "exit")]
-    #[doc(alias = "quit")]
-    pub fn close(&mut self) {
-        log::debug!("eframe::Frame::close called");
-        self.output.close = true;
-    }
-
-    /// Minimize or unminimize window. (native only)
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn set_minimized(&mut self, minimized: bool) {
-        self.output.minimized = Some(minimized);
-    }
-
     /// Bring the window into focus (native only). Has no effect on Wayland, or if the window is minimized or invisible.
     ///
     /// This method puts the window on top of other applications and takes input focus away from them,
@@ -919,106 +899,6 @@ impl Frame {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn focus(&mut self) {
         self.output.focus = Some(true);
-    }
-
-    /// If the window is unfocused, attract the user's attention (native only).
-    ///
-    /// Typically, this means that the window will flash on the taskbar, or bounce, until it is interacted with.
-    ///
-    /// When the window comes into focus, or if `None` is passed, the attention request will be automatically reset.
-    ///
-    /// See [winit's documentation][user_attention_details] for platform-specific effect details.
-    ///
-    /// [user_attention_details]: https://docs.rs/winit/latest/winit/window/enum.UserAttentionType.html
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn request_user_attention(&mut self, kind: egui::UserAttentionType) {
-        self.output.attention = Some(kind);
-    }
-
-    /// Maximize or unmaximize window. (native only)
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn set_maximized(&mut self, maximized: bool) {
-        self.output.maximized = Some(maximized);
-    }
-
-    /// Tell `eframe` to close the desktop window.
-    #[cfg(not(target_arch = "wasm32"))]
-    #[deprecated = "Renamed `close`"]
-    pub fn quit(&mut self) {
-        self.close();
-    }
-
-    /// Set the desired inner size of the window (in egui points).
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn set_window_size(&mut self, size: egui::Vec2) {
-        self.output.window_size = Some(size);
-        self.info.window_info.size = size; // so that subsequent calls see the updated value
-    }
-
-    /// Set the desired title of the window.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn set_window_title(&mut self, title: &str) {
-        self.output.window_title = Some(title.to_owned());
-    }
-
-    /// Set whether to show window decorations (i.e. a frame around you app).
-    ///
-    /// If false it will be difficult to move and resize the app.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn set_decorations(&mut self, decorated: bool) {
-        self.output.decorated = Some(decorated);
-    }
-
-    /// Turn borderless fullscreen on/off (native only).
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn set_fullscreen(&mut self, fullscreen: bool) {
-        self.output.fullscreen = Some(fullscreen);
-        self.info.window_info.fullscreen = fullscreen; // so that subsequent calls see the updated value
-    }
-
-    /// set the position of the outer window.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn set_window_pos(&mut self, pos: egui::Pos2) {
-        self.output.window_pos = Some(pos);
-        self.info.window_info.position = Some(pos); // so that subsequent calls see the updated value
-    }
-
-    /// When called, the native window will follow the
-    /// movement of the cursor while the primary mouse button is down.
-    ///
-    /// Does not work on the web.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn drag_window(&mut self) {
-        self.output.drag_window = true;
-    }
-
-    /// Set the visibility of the window.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn set_visible(&mut self, visible: bool) {
-        self.output.visible = Some(visible);
-    }
-
-    /// On desktop: Set the window always on top.
-    ///
-    /// (Wayland desktop currently not supported)
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn set_always_on_top(&mut self, always_on_top: bool) {
-        self.output.always_on_top = Some(always_on_top);
-    }
-
-    /// On desktop: Set the window to be centered.
-    ///
-    /// (Wayland desktop currently not supported)
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn set_centered(&mut self) {
-        if let Some(monitor_size) = self.info.window_info.monitor_size {
-            let inner_size = self.info.window_info.size;
-            if monitor_size.x > 1.0 && monitor_size.y > 1.0 {
-                let x = (monitor_size.x - inner_size.x) / 2.0;
-                let y = (monitor_size.y - inner_size.y) / 2.0;
-                self.set_window_pos(egui::Pos2 { x, y });
-            }
-        }
     }
 
     /// for integrations only: call once per frame
@@ -1038,39 +918,6 @@ pub struct WebInfo {
     /// Information about the URL.
     pub location: Location,
 }
-
-/// Information about the application's main window, if available.
-#[cfg(not(target_arch = "wasm32"))]
-#[derive(Clone, Debug)]
-pub struct WindowInfo {
-    /// Coordinates of the window's outer top left corner, relative to the top left corner of the first display.
-    ///
-    /// Unit: egui points (logical pixels).
-    ///
-    /// `None` = unknown.
-    pub position: Option<egui::Pos2>,
-
-    /// Are we in fullscreen mode?
-    pub fullscreen: bool,
-
-    /// Are we minimized?
-    pub minimized: bool,
-
-    /// Are we maximized?
-    pub maximized: bool,
-
-    /// Is the window focused and able to receive input?
-    ///
-    /// This should be the same as [`egui::InputState::focused`].
-    pub focused: bool,
-
-    /// Window inner size in egui points (logical pixels).
-    pub size: egui::Vec2,
-
-    /// Current monitor size in egui points (logical pixels)
-    pub monitor_size: Option<egui::Vec2>,
-}
-
 /// Information about the URL.
 ///
 /// Everything has been percent decoded (`%20` -> ` ` etc).
@@ -1144,10 +991,6 @@ pub struct IntegrationInfo {
 
     /// The OS native pixels-per-point
     pub native_pixels_per_point: Option<f32>,
-
-    /// The position and size of the native window.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub window_info: WindowInfo,
 }
 
 // ----------------------------------------------------------------------------
@@ -1220,57 +1063,9 @@ pub(crate) mod backend {
     #[derive(Clone, Debug, Default)]
     #[must_use]
     pub struct AppOutput {
-        /// Set to `true` to close the native window (which often quits the app).
-        #[cfg(not(target_arch = "wasm32"))]
-        pub close: bool,
-
-        /// Set to some size to resize the outer window (e.g. glium window) to this size.
-        #[cfg(not(target_arch = "wasm32"))]
-        pub window_size: Option<egui::Vec2>,
-
-        /// Set to some string to rename the outer window (e.g. glium window) to this title.
-        #[cfg(not(target_arch = "wasm32"))]
-        pub window_title: Option<String>,
-
-        /// Set to some bool to change window decorations.
-        #[cfg(not(target_arch = "wasm32"))]
-        pub decorated: Option<bool>,
-
-        /// Set to some bool to change window fullscreen.
-        #[cfg(not(target_arch = "wasm32"))] // TODO: implement fullscreen on web
-        pub fullscreen: Option<bool>,
-
-        /// Set to true to drag window while primary mouse button is down.
-        #[cfg(not(target_arch = "wasm32"))]
-        pub drag_window: bool,
-
-        /// Set to some position to move the outer window (e.g. glium window) to this position
-        #[cfg(not(target_arch = "wasm32"))]
-        pub window_pos: Option<egui::Pos2>,
-
-        /// Set to some bool to change window visibility.
-        #[cfg(not(target_arch = "wasm32"))]
-        pub visible: Option<bool>,
-
-        /// Set to some bool to tell the window always on top.
-        #[cfg(not(target_arch = "wasm32"))]
-        pub always_on_top: Option<bool>,
-
-        /// Set to some bool to minimize or unminimize window.
-        #[cfg(not(target_arch = "wasm32"))]
-        pub minimized: Option<bool>,
-
-        /// Set to some bool to maximize or unmaximize window.
-        #[cfg(not(target_arch = "wasm32"))]
-        pub maximized: Option<bool>,
-
         /// Set to some bool to focus window.
         #[cfg(not(target_arch = "wasm32"))]
         pub focus: Option<bool>,
-
-        /// Set to request a user's attention to the native window.
-        #[cfg(not(target_arch = "wasm32"))]
-        pub attention: Option<egui::UserAttentionType>,
 
         #[cfg(not(target_arch = "wasm32"))]
         pub screenshot_requested: bool,

--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -900,9 +900,6 @@ pub struct IntegrationInfo {
     /// Seconds of cpu usage (in seconds) of UI code on the previous frame.
     /// `None` if this is the first frame.
     pub cpu_usage: Option<f32>,
-
-    /// The OS native pixels-per-point
-    pub native_pixels_per_point: Option<f32>,
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -829,6 +829,7 @@ pub struct WebInfo {
     /// Information about the URL.
     pub location: Location,
 }
+
 /// Information about the URL.
 ///
 /// Everything has been percent decoded (`%20` -> ` ` etc).

--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -743,11 +743,6 @@ pub struct Frame {
     #[cfg(feature = "wgpu")]
     pub(crate) wgpu_render_state: Option<egui_wgpu::RenderState>,
 
-    /// If [`Frame::request_screenshot`] was called during a frame, this field will store the screenshot
-    /// such that it can be retrieved during [`App::post_rendering`] with [`Frame::screenshot`]
-    #[cfg(not(target_arch = "wasm32"))]
-    pub(crate) screenshot: std::cell::Cell<Option<egui::ColorImage>>,
-
     /// Raw platform window handle
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) raw_window_handle: RawWindowHandle,
@@ -794,54 +789,6 @@ impl Frame {
     /// A place where you can store custom data in a way that persists when you restart the app.
     pub fn storage(&self) -> Option<&dyn Storage> {
         self.storage.as_deref()
-    }
-
-    /// During [`App::post_rendering`], use this to retrieve the pixel data that was requested during
-    /// [`App::update`] via [`Frame::request_screenshot`].
-    ///
-    /// Returns None if:
-    /// * Called in [`App::update`]
-    /// * [`Frame::request_screenshot`] wasn't called on this frame during [`App::update`]
-    /// * The rendering backend doesn't support this feature (yet). Currently implemented for wgpu and glow, but not with wasm as target.
-    /// * Wgpu's GL target is active (not yet supported)
-    /// * Retrieving the data was unsuccessful in some way.
-    ///
-    /// See also [`egui::ColorImage::region`]
-    ///
-    /// ## Example generating a capture of everything within a square of 100 pixels located at the top left of the app and saving it with the [`image`](crates.io/crates/image) crate:
-    /// ```
-    /// struct MyApp;
-    ///
-    /// impl eframe::App for MyApp {
-    ///     fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
-    ///         // In real code the app would render something here
-    ///         ctx.send_viewport_command(egui::ViewportCommand::Screenshot);
-    ///         // Things that are added to the frame after the call to
-    ///         // request_screenshot() will still be included.
-    ///     }
-    ///
-    ///     fn post_rendering(&mut self, _window_size: [u32; 2], frame: &eframe::Frame) {
-    ///         if let Some(screenshot) = frame.screenshot() {
-    ///             let pixels_per_point = frame.info().native_pixels_per_point;
-    ///             let region = egui::Rect::from_two_pos(
-    ///                 egui::Pos2::ZERO,
-    ///                 egui::Pos2{ x: 100., y: 100. },
-    ///             );
-    ///             let top_left_corner = screenshot.region(&region, pixels_per_point);
-    ///             image::save_buffer(
-    ///                 "top_left.png",
-    ///                 top_left_corner.as_raw(),
-    ///                 top_left_corner.width() as u32,
-    ///                 top_left_corner.height() as u32,
-    ///                 image::ColorType::Rgba8,
-    ///             ).unwrap();
-    ///         }
-    ///     }
-    /// }
-    /// ```
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn screenshot(&self) -> Option<egui::ColorImage> {
-        self.screenshot.take()
     }
 
     /// A place where you can store custom data in a way that persists when you restart the app.

--- a/crates/eframe/src/epi/mod.rs
+++ b/crates/eframe/src/epi/mod.rs
@@ -230,11 +230,6 @@ pub trait App {
     fn warm_up_enabled(&self) -> bool {
         false
     }
-
-    /// Called each time after the rendering the UI.
-    ///
-    /// Can be used to access pixel data with [`Frame::screenshot`]
-    fn post_rendering(&mut self, _window_size_px: [u32; 2], _frame: &Frame) {}
 }
 
 /// Selects the level of hardware graphics acceleration.

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -520,6 +520,11 @@ impl EpiIntegration {
                 viewport_ui_cb(egui_ctx);
             } else {
                 // Root viewport
+                if egui_ctx.input(|i| i.viewport().close_requested) {
+                    self.close = app.on_close_event();
+                    log::debug!("App::on_close_event returned {}", self.close);
+                }
+
                 crate::profile_scope!("App::update");
                 app.update(egui_ctx, &mut self.frame);
             }

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -180,6 +180,7 @@ pub struct EpiIntegration {
     pub frame: epi::Frame,
     last_auto_save: Instant,
     pub beginning: Instant,
+    is_first_frame: bool,
     pub frame_start: Instant,
     pub egui_ctx: egui::Context,
     pending_full_output: egui::FullOutput,
@@ -248,6 +249,7 @@ impl EpiIntegration {
             persist_window: native_options.persist_window,
             app_icon_setter,
             beginning: Instant::now(),
+            is_first_frame: true,
             frame_start: Instant::now(),
         }
     }
@@ -392,6 +394,11 @@ impl EpiIntegration {
         let inner_size = window.inner_size();
         let window_size_px = [inner_size.width, inner_size.height];
         app.post_rendering(window_size_px, &self.frame);
+
+        if std::mem::take(&mut self.is_first_frame) {
+            // We keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
+            window.set_visible(true);
+        }
     }
 
     pub fn handle_platform_output(

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -226,7 +226,6 @@ impl EpiIntegration {
             gl,
             #[cfg(feature = "wgpu")]
             wgpu_render_state,
-            screenshot: std::cell::Cell::new(None),
             raw_display_handle: window.raw_display_handle(),
             raw_window_handle: window.raw_window_handle(),
         };

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -213,13 +213,10 @@ impl EpiIntegration {
         let memory = load_egui_memory(storage.as_deref()).unwrap_or_default();
         egui_ctx.memory_mut(|mem| *mem = memory);
 
-        let native_pixels_per_point = window.scale_factor() as f32;
-
         let frame = epi::Frame {
             info: epi::IntegrationInfo {
                 system_theme,
                 cpu_usage: None,
-                native_pixels_per_point: Some(native_pixels_per_point),
             },
             storage,
             #[cfg(feature = "glow")]
@@ -327,7 +324,7 @@ impl EpiIntegration {
                 ..
             } => self.can_drag_window = true,
             WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
-                self.frame.info.native_pixels_per_point = Some(*scale_factor as _);
+                egui_winit.egui_input_mut().native_pixels_per_point = Some(*scale_factor as _);
             }
             WindowEvent::ThemeChanged(winit_theme) if self.follow_system_theme => {
                 let theme = theme_from_winit_theme(*winit_theme);

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -4,7 +4,10 @@ use winit::event_loop::EventLoopWindowTarget;
 
 use raw_window_handle::{HasRawDisplayHandle as _, HasRawWindowHandle as _};
 
-use egui::{DeferredViewportUiCallback, NumExt as _, ViewportBuilder, ViewportId, ViewportIdPair};
+use egui::{
+    DeferredViewportUiCallback, NumExt as _, ViewportBuilder, ViewportId, ViewportIdPair,
+    ViewportInfo,
+};
 use egui_winit::{native_pixels_per_point, EventResponse, WindowSettings};
 
 use crate::{epi, Theme, WindowInfo};
@@ -434,8 +437,8 @@ impl EpiIntegration {
         self.egui_ctx
             .memory_mut(|mem| mem.set_everything_is_visible(true));
 
-        let all_viewports = std::iter::once(ViewportId::ROOT).collect();
-        let raw_input = egui_winit.take_egui_input(window, ViewportIdPair::ROOT, &all_viewports);
+        let viewports = std::iter::once((ViewportId::ROOT, ViewportInfo::default())).collect();
+        let raw_input = egui_winit.take_egui_input(window, ViewportIdPair::ROOT, viewports);
         self.pre_update(window);
         let full_output = self.update(app, None, raw_input);
         self.post_update(app, window);

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -382,12 +382,8 @@ impl EpiIntegration {
         self.frame.info.cpu_usage = Some(frame_time);
     }
 
-    pub fn post_rendering(&mut self, app: &mut dyn epi::App, window: &winit::window::Window) {
+    pub fn post_rendering(&mut self, window: &winit::window::Window) {
         crate::profile_function!();
-        let inner_size = window.inner_size();
-        let window_size_px = [inner_size.width, inner_size.height];
-        app.post_rendering(window_size_px, &self.frame);
-
         if std::mem::take(&mut self.is_first_frame) {
             // We keep hidden until we've painted something. See https://github.com/emilk/egui/pull/2279
             window.set_visible(true);

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -10,7 +10,7 @@ use egui::{
 };
 use egui_winit::{EventResponse, WindowSettings};
 
-use crate::{backend::AppOutput, epi, Theme};
+use crate::{epi, Theme};
 
 pub fn window_builder<E>(
     event_loop: &EventLoopWindowTarget<E>,
@@ -221,7 +221,6 @@ impl EpiIntegration {
                 cpu_usage: None,
                 native_pixels_per_point: Some(native_pixels_per_point),
             },
-            output: epi::backend::AppOutput::default(),
             storage,
             #[cfg(feature = "glow")]
             gl,
@@ -380,11 +379,6 @@ impl EpiIntegration {
     }
 
     pub fn post_update(&mut self) {
-        let AppOutput {
-            screenshot_requested,
-        } = self.frame.take_app_output();
-        self.frame.output.screenshot_requested = screenshot_requested;
-
         let frame_time = self.frame_start.elapsed().as_secs_f64() as f32;
         self.frame.info.cpu_usage = Some(frame_time);
     }

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -437,8 +437,9 @@ impl EpiIntegration {
         self.egui_ctx
             .memory_mut(|mem| mem.set_everything_is_visible(true));
 
-        let viewports = std::iter::once((ViewportId::ROOT, ViewportInfo::default())).collect();
-        let raw_input = egui_winit.take_egui_input(window, ViewportIdPair::ROOT, viewports);
+        let mut raw_input = egui_winit.take_egui_input(window, ViewportIdPair::ROOT);
+        raw_input.viewports =
+            std::iter::once((ViewportId::ROOT, ViewportInfo::default())).collect();
         self.pre_update(window);
         let full_output = self.update(app, None, raw_input);
         self.post_update(app, window);

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -434,7 +434,8 @@ impl EpiIntegration {
         self.egui_ctx
             .memory_mut(|mem| mem.set_everything_is_visible(true));
 
-        let raw_input = egui_winit.take_egui_input(window, ViewportIdPair::ROOT);
+        let all_viewports = std::iter::once(ViewportId::ROOT).collect();
+        let raw_input = egui_winit.take_egui_input(window, ViewportIdPair::ROOT, &all_viewports);
         self.pre_update(window);
         let full_output = self.update(app, None, raw_input);
         self.post_update(app, window);
@@ -485,7 +486,7 @@ impl EpiIntegration {
             _ => {}
         }
 
-        egui_winit.on_event(&self.egui_ctx, event)
+        egui_winit.on_event(&self.egui_ctx, event, viewport_id)
     }
 
     pub fn pre_update(&mut self, window: &winit::window::Window) {

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -313,6 +313,8 @@ pub fn create_storage(_app_name: &str) -> Option<Box<dyn epi::Storage>> {
 // ----------------------------------------------------------------------------
 
 /// Everything needed to make a winit-based integration for [`epi`].
+///
+/// Only one instance per app (not one per viewport).
 pub struct EpiIntegration {
     pub frame: epi::Frame,
     last_auto_save: Instant,

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -588,7 +588,7 @@ mod glow_integration {
             let gl_surface = viewport.gl_surface.as_ref().unwrap();
             let egui_winit = viewport.egui_winit.as_mut().unwrap();
 
-            integration.post_update(window);
+            integration.post_update();
             integration.handle_platform_output(window, viewport_id, platform_output, egui_winit);
 
             let clipped_primitives = integration.egui_ctx.tessellate(shapes, pixels_per_point);
@@ -2579,7 +2579,7 @@ mod wgpu_integration {
                 return EventResult::Wait;
             };
 
-            integration.post_update(window);
+            integration.post_update();
 
             let FullOutput {
                 platform_output,

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -621,7 +621,13 @@ mod glow_integration {
                 let screenshot_requested = std::mem::take(&mut viewport.screenshot_requested);
                 if screenshot_requested {
                     let screenshot = painter.read_screen_rgba(screen_size_in_pixels);
-                    integration.frame.screenshot.set(Some(screenshot));
+                    egui_winit
+                        .egui_input_mut()
+                        .events
+                        .push(egui::Event::Screenshot {
+                            viewport_id,
+                            image: screenshot.into(),
+                        });
                 }
                 integration.post_rendering(app.as_mut(), window);
             }
@@ -2609,7 +2615,15 @@ mod wgpu_integration {
                     &textures_delta,
                     screenshot_requested,
                 );
-                integration.frame.screenshot.set(screenshot);
+                if let Some(screenshot) = screenshot {
+                    egui_winit
+                        .egui_input_mut()
+                        .events
+                        .push(egui::Event::Screenshot {
+                            viewport_id,
+                            image: screenshot.into(),
+                        });
+                }
             }
 
             integration.post_rendering(app.as_mut(), window);

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -2358,20 +2358,6 @@ mod wgpu_integration {
             Ok(match event {
                 winit::event::Event::Resumed => {
                     let running = if let Some(running) = &self.running {
-                        if !running
-                            .shared
-                            .borrow()
-                            .viewports
-                            .contains_key(&ViewportId::ROOT)
-                        {
-                            create_window(
-                                event_loop,
-                                running.integration.frame.storage(),
-                                &self.app_name,
-                                &mut self.native_options,
-                            )?;
-                            running.set_window(ViewportId::ROOT)?;
-                        }
                         running
                     } else {
                         let storage = epi_integration::create_storage(
@@ -2444,18 +2430,6 @@ mod wgpu_integration {
     }
 
     impl WgpuWinitRunning {
-        fn set_window(&self, id: ViewportId) -> Result<(), egui_wgpu::WgpuError> {
-            crate::profile_function!();
-            let mut shared = self.shared.borrow_mut();
-            let SharedState {
-                viewports, painter, ..
-            } = &mut *shared;
-            if let Some(Viewport { window, .. }) = viewports.get(&id) {
-                return pollster::block_on(painter.set_window(id, window.as_deref()));
-            }
-            Ok(())
-        }
-
         fn save_and_destroy(&mut self) {
             crate::profile_function!();
 

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -618,9 +618,8 @@ mod glow_integration {
             );
 
             {
-                let screenshot_requested = &mut integration.frame.output.screenshot_requested;
-                if *screenshot_requested {
-                    *screenshot_requested = false;
+                let screenshot_requested = std::mem::take(&mut viewport.screenshot_requested);
+                if screenshot_requested {
                     let screenshot = painter.read_screen_rgba(screen_size_in_pixels);
                     integration.frame.screenshot.set(Some(screenshot));
                 }
@@ -794,6 +793,7 @@ mod glow_integration {
         class: ViewportClass,
         builder: ViewportBuilder,
         info: ViewportInfo,
+        screenshot_requested: bool,
 
         /// The user-callback that shows the ui.
         /// None for immediate viewports.
@@ -975,6 +975,7 @@ mod glow_integration {
                     class: ViewportClass::Root,
                     builder: viewport_builder,
                     info,
+                    screenshot_requested: false,
                     viewport_ui_cb: None,
                     gl_surface: None,
                     window: window.map(Rc::new),
@@ -1223,6 +1224,7 @@ mod glow_integration {
                         commands,
                         window,
                         is_viewport_focused,
+                        &mut viewport.screenshot_requested,
                     );
                 }
             }
@@ -1263,6 +1265,7 @@ mod glow_integration {
                     class,
                     builder,
                     info: Default::default(),
+                    screenshot_requested: false,
                     viewport_ui_cb,
                     window: None,
                     egui_winit: None,
@@ -1295,6 +1298,7 @@ mod glow_integration {
                         delta_commands,
                         window,
                         is_viewport_focused,
+                        &mut viewport.screenshot_requested,
                     );
                 }
 
@@ -1865,6 +1869,7 @@ mod wgpu_integration {
         class: ViewportClass,
         builder: ViewportBuilder,
         info: ViewportInfo,
+        screenshot_requested: bool,
 
         /// `None` for sync viewports.
         viewport_ui_cb: Option<Arc<DeferredViewportUiCallback>>,
@@ -2125,6 +2130,7 @@ mod wgpu_integration {
                         maximized: Some(window.is_maximized()),
                         ..Default::default()
                     },
+                    screenshot_requested: false,
                     viewport_ui_cb: None,
                     window: Some(Rc::new(window)),
                     egui_winit: Some(egui_winit),
@@ -2594,16 +2600,15 @@ mod wgpu_integration {
             {
                 let clipped_primitives = integration.egui_ctx.tessellate(shapes, pixels_per_point);
 
-                let screenshot_requested = &mut integration.frame.output.screenshot_requested;
+                let screenshot_requested = std::mem::take(&mut viewport.screenshot_requested);
                 let screenshot = painter.paint_and_update_textures(
                     viewport_id,
                     pixels_per_point,
                     app.clear_color(&integration.egui_ctx.style().visuals),
                     &clipped_primitives,
                     &textures_delta,
-                    *screenshot_requested,
+                    screenshot_requested,
                 );
-                *screenshot_requested = false;
                 integration.frame.screenshot.set(screenshot);
             }
 
@@ -2774,6 +2779,7 @@ mod wgpu_integration {
                     commands,
                     window,
                     is_viewport_focused,
+                    &mut viewport.screenshot_requested,
                 );
             }
         }
@@ -2803,6 +2809,7 @@ mod wgpu_integration {
                     class,
                     builder,
                     info: Default::default(),
+                    screenshot_requested: false,
                     viewport_ui_cb,
                     window: None,
                     egui_winit: None,
@@ -2834,6 +2841,7 @@ mod wgpu_integration {
                         delta_commands,
                         window,
                         is_viewport_focused,
+                        &mut viewport.screenshot_requested,
                     );
                 }
 

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -629,7 +629,7 @@ mod glow_integration {
                             image: screenshot.into(),
                         });
                 }
-                integration.post_rendering(app.as_mut(), window);
+                integration.post_rendering(window);
             }
 
             {
@@ -2626,7 +2626,7 @@ mod wgpu_integration {
                 }
             }
 
-            integration.post_rendering(app.as_mut(), window);
+            integration.post_rendering(window);
 
             let active_viewports_ids: ViewportIdSet = viewport_output.keys().copied().collect();
 

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -536,7 +536,7 @@ mod glow_integration {
                 let mut raw_input = egui_winit.take_egui_input(window, viewport.ids);
                 let viewport_ui_cb = viewport.viewport_ui_cb.clone();
 
-                self.integration.pre_update(window);
+                self.integration.pre_update();
 
                 raw_input.time = Some(self.integration.beginning.elapsed().as_secs_f64());
                 raw_input.viewports = glutin
@@ -588,7 +588,7 @@ mod glow_integration {
             let gl_surface = viewport.gl_surface.as_ref().unwrap();
             let egui_winit = viewport.egui_winit.as_mut().unwrap();
 
-            integration.post_update(app.as_mut(), window);
+            integration.post_update(window);
             integration.handle_platform_output(window, viewport_id, platform_output, egui_winit);
 
             let clipped_primitives = integration.egui_ctx.tessellate(shapes, pixels_per_point);
@@ -637,8 +637,6 @@ mod glow_integration {
                     log::error!("swap_buffers failed: {err}");
                 }
             }
-
-            integration.post_present(window);
 
             // give it time to settle:
             #[cfg(feature = "__screenshot")]
@@ -727,6 +725,7 @@ mod glow_integration {
                         return EventResult::Exit;
                     }
                 }
+
                 _ => {}
             }
 
@@ -2539,7 +2538,7 @@ mod wgpu_integration {
                     ViewportIdPair::from_self_and_parent(viewport_id, ids.parent),
                 );
 
-                integration.pre_update(window);
+                integration.pre_update();
 
                 raw_input.time = Some(integration.beginning.elapsed().as_secs_f64());
                 raw_input.viewports = viewports
@@ -2580,7 +2579,7 @@ mod wgpu_integration {
                 return EventResult::Wait;
             };
 
-            integration.post_update(app.as_mut(), window);
+            integration.post_update(window);
 
             let FullOutput {
                 platform_output,
@@ -2609,7 +2608,6 @@ mod wgpu_integration {
             }
 
             integration.post_rendering(app.as_mut(), window);
-            integration.post_present(window);
 
             let active_viewports_ids: ViewportIdSet = viewport_output.keys().copied().collect();
 
@@ -2677,6 +2675,7 @@ mod wgpu_integration {
                 winit::event::WindowEvent::Focused(new_focused) => {
                     *focused_viewport = new_focused.then(|| viewport_id).flatten();
                 }
+
                 winit::event::WindowEvent::Resized(physical_size) => {
                     // Resize with 0 width and height is used by winit to signal a minimize event on Windows.
                     // See: https://github.com/rust-windowing/winit/issues/208
@@ -2692,6 +2691,7 @@ mod wgpu_integration {
                         }
                     }
                 }
+
                 winit::event::WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
                     use std::num::NonZeroU32;
                     if let (Some(width), Some(height), Some(viewport_id)) = (
@@ -2703,10 +2703,12 @@ mod wgpu_integration {
                         shared.painter.on_window_resized(viewport_id, width, height);
                     }
                 }
+
                 winit::event::WindowEvent::CloseRequested if integration.should_close() => {
                     log::debug!("Received WindowEvent::CloseRequested");
                     return EventResult::Exit;
                 }
+
                 _ => {}
             };
 

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -1208,7 +1208,7 @@ mod glow_integration {
             {
                 let ids = ViewportIdPair::from_self_and_parent(viewport_id, parent);
 
-                initialize_or_update_viewport(
+                let viewport = initialize_or_update_viewport(
                     &mut self.viewports,
                     ids,
                     class,
@@ -1217,16 +1217,14 @@ mod glow_integration {
                     focused_viewport,
                 );
 
-                if let Some(viewport) = self.viewports.get_mut(&viewport_id) {
-                    if let Some(window) = &viewport.window {
-                        let is_viewport_focused = focused_viewport == Some(viewport_id);
-                        egui_winit::process_viewport_commands(
-                            &mut viewport.info,
-                            commands,
-                            window,
-                            is_viewport_focused,
-                        );
-                    }
+                if let Some(window) = &viewport.window {
+                    let is_viewport_focused = focused_viewport == Some(viewport_id);
+                    egui_winit::process_viewport_commands(
+                        &mut viewport.info,
+                        commands,
+                        window,
+                        is_viewport_focused,
+                    );
                 }
             }
 
@@ -2758,7 +2756,7 @@ mod wgpu_integration {
         {
             let ids = ViewportIdPair::from_self_and_parent(viewport_id, parent);
 
-            initialize_or_update_viewport(
+            let viewport = initialize_or_update_viewport(
                 viewports,
                 ids,
                 class,
@@ -2767,16 +2765,14 @@ mod wgpu_integration {
                 focused_viewport,
             );
 
-            if let Some(viewport) = viewports.get_mut(&viewport_id) {
-                if let Some(window) = viewport.window.as_ref() {
-                    let is_viewport_focused = focused_viewport == Some(viewport_id);
-                    egui_winit::process_viewport_commands(
-                        &mut viewport.info,
-                        commands,
-                        window,
-                        is_viewport_focused,
-                    );
-                }
+            if let Some(window) = viewport.window.as_ref() {
+                let is_viewport_focused = focused_viewport == Some(viewport_id);
+                egui_winit::process_viewport_commands(
+                    &mut viewport.info,
+                    commands,
+                    window,
+                    is_viewport_focused,
+                );
             }
         }
     }

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -113,6 +113,7 @@ impl AppRunner {
         };
 
         runner.input.raw.max_texture_side = Some(runner.painter.max_texture_side());
+        runner.input.native_pixels_per_point = Some(super::native_pixels_per_point());
 
         Ok(runner)
     }

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -191,7 +191,14 @@ impl AppRunner {
         if viewport_output.len() > 1 {
             log::warn!("Multiple viewports not yet supported on the web");
         }
-        // TODO(emilk): handle some of the command in `viewport_output`, like setting the title and icon?
+        for viewport_output in viewport_output.values() {
+            for command in &viewport_output.commands {
+                // TODO(emilk): handle some of the commands
+                log::warn!(
+                    "Unhandled egui viewport command: {command:?} - not implemented in web backend"
+                );
+            }
+        }
 
         self.handle_platform_output(platform_output);
         self.textures_delta.append(textures_delta);

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -78,7 +78,6 @@ impl AppRunner {
 
         let frame = epi::Frame {
             info,
-            output: Default::default(),
             storage: Some(Box::new(storage)),
 
             #[cfg(feature = "glow")]
@@ -197,11 +196,6 @@ impl AppRunner {
         self.handle_platform_output(platform_output);
         self.textures_delta.append(textures_delta);
         let clipped_primitives = self.egui_ctx.tessellate(shapes, pixels_per_point);
-
-        {
-            let app_output = self.frame.take_app_output();
-            let epi::backend::AppOutput {} = app_output;
-        }
 
         self.frame.info.cpu_usage = Some((now_sec() - frame_start) as f32);
 

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -49,7 +49,6 @@ impl AppRunner {
             },
             system_theme,
             cpu_usage: None,
-            native_pixels_per_point: Some(super::native_pixels_per_point()),
         };
         let storage = LocalStorage::default();
 
@@ -113,7 +112,7 @@ impl AppRunner {
         };
 
         runner.input.raw.max_texture_side = Some(runner.painter.max_texture_side());
-        runner.input.native_pixels_per_point = Some(super::native_pixels_per_point());
+        runner.input.raw.native_pixels_per_point = Some(super::native_pixels_per_point());
 
         Ok(runner)
     }

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1038,6 +1038,7 @@ pub fn process_viewport_commands(
     commands: impl IntoIterator<Item = ViewportCommand>,
     window: &Window,
     is_viewport_focused: bool,
+    screenshot_requested: &mut bool,
 ) {
     crate::profile_function!();
 
@@ -1196,6 +1197,9 @@ pub fn process_viewport_commands(
                 if let Err(err) = window.set_cursor_hittest(v) {
                     log::warn!("{command:?}: {err}");
                 }
+            }
+            ViewportCommand::Screenshot => {
+                *screenshot_requested = true;
             }
         }
     }

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -15,8 +15,7 @@ pub use egui;
 #[cfg(feature = "accesskit")]
 use egui::accesskit;
 use egui::{
-    Pos2, Rect, Vec2, ViewportBuilder, ViewportCommand, ViewportId, ViewportIdMap, ViewportIdPair,
-    ViewportInfo,
+    Pos2, Rect, Vec2, ViewportBuilder, ViewportCommand, ViewportId, ViewportIdPair, ViewportInfo,
 };
 pub use winit;
 
@@ -195,12 +194,7 @@ impl State {
     /// You need to set [`egui::RawInput::viewports`] yourself though.
     /// Use [`Self::update_viewport_info`] to update the info for each
     /// viewport.
-    pub fn take_egui_input(
-        &mut self,
-        window: &Window,
-        ids: ViewportIdPair,
-        viewport_infos: ViewportIdMap<ViewportInfo>,
-    ) -> egui::RawInput {
+    pub fn take_egui_input(&mut self, window: &Window, ids: ViewportIdPair) -> egui::RawInput {
         crate::profile_function!();
 
         let pixels_per_point = self.pixels_per_point();
@@ -225,7 +219,6 @@ impl State {
 
         // Tell egui which viewport is now active:
         self.egui_input.viewport_ids = ids;
-        self.egui_input.viewports = viewport_infos;
         self.egui_input.take()
     }
 

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1156,14 +1156,15 @@ pub fn process_viewport_commands(
                 egui::viewport::IMEPurpose::Normal => winit::window::ImePurpose::Normal,
             }),
             ViewportCommand::RequestUserAttention(a) => {
-                window.request_user_attention(a.map(|a| match a {
-                    egui::viewport::UserAttentionType::Critical => {
-                        winit::window::UserAttentionType::Critical
+                window.request_user_attention(match a {
+                    egui::UserAttentionType::Reset => None,
+                    egui::UserAttentionType::Critical => {
+                        Some(winit::window::UserAttentionType::Critical)
                     }
-                    egui::viewport::UserAttentionType::Informational => {
-                        winit::window::UserAttentionType::Informational
+                    egui::UserAttentionType::Informational => {
+                        Some(winit::window::UserAttentionType::Informational)
                     }
-                }));
+                });
             }
             ViewportCommand::SetTheme(t) => window.set_theme(match t {
                 egui::SystemTheme::Light => Some(winit::window::Theme::Light),

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -180,6 +180,13 @@ impl State {
         &self.egui_input
     }
 
+    /// The current input state.
+    /// This is changed by [`Self::on_event`] and cleared by [`Self::take_egui_input`].
+    #[inline]
+    pub fn egui_input_mut(&mut self) -> &mut egui::RawInput {
+        &mut self.egui_input
+    }
+
     /// Update the given viewport info with the current state of the window.
     ///
     /// Call before [`Self::update_viewport_info`]

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1034,6 +1034,7 @@ fn translate_cursor(cursor_icon: egui::CursorIcon) -> Option<winit::window::Curs
 // ---------------------------------------------------------------------------
 
 pub fn process_viewport_commands(
+    info: &mut ViewportInfo,
     commands: impl IntoIterator<Item = ViewportCommand>,
     window: &Window,
     is_viewport_focused: bool,
@@ -1111,8 +1112,14 @@ pub fn process_viewport_commands(
                     WindowButtons::empty()
                 },
             ),
-            ViewportCommand::Minimized(v) => window.set_minimized(v),
-            ViewportCommand::Maximized(v) => window.set_maximized(v),
+            ViewportCommand::Minimized(v) => {
+                window.set_minimized(v);
+                info.minimized = Some(v);
+            }
+            ViewportCommand::Maximized(v) => {
+                window.set_maximized(v);
+                info.maximized = Some(v);
+            }
             ViewportCommand::Fullscreen(v) => {
                 window.set_fullscreen(v.then_some(winit::window::Fullscreen::Borderless(None)));
             }

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1049,7 +1049,11 @@ pub fn process_viewport_commands(
                 info.close_requested = true;
             }
             ViewportCommand::StartDrag => {
-                // if this is not checked on x11 the input will be permanently taken until the app is killed!
+                // If `is_viewport_focused` is not checked on x11 the input will be permanently taken until the app is killed!
+
+                // TODO: check that the left mouse-button was pressed down recently,
+                // or we will have bugs on Windows.
+                // See https://github.com/emilk/egui/pull/1108
                 if is_viewport_focused {
                     if let Err(err) = window.drag_window() {
                         log::warn!("{command:?}: {err}");

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -226,6 +226,7 @@ impl State {
 
         // Tell egui which viewport is now active:
         self.egui_input.viewport_ids = ids;
+        self.egui_input.native_pixels_per_point = Some(native_pixels_per_point(window));
         self.egui_input.take()
     }
 

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1155,6 +1155,11 @@ pub fn process_viewport_commands(
                 egui::viewport::IMEPurpose::Terminal => winit::window::ImePurpose::Terminal,
                 egui::viewport::IMEPurpose::Normal => winit::window::ImePurpose::Normal,
             }),
+            ViewportCommand::Focus => {
+                if !window.has_focus() {
+                    window.focus_window();
+                }
+            }
             ViewportCommand::RequestUserAttention(a) => {
                 window.request_user_attention(match a {
                     egui::UserAttentionType::Reset => None,

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1045,7 +1045,10 @@ pub fn process_viewport_commands(
 
     for command in commands {
         match command {
-            egui::ViewportCommand::StartDrag => {
+            ViewportCommand::Close => {
+                info.close_requested = true;
+            }
+            ViewportCommand::StartDrag => {
                 // if this is not checked on x11 the input will be permanently taken until the app is killed!
                 if is_viewport_focused {
                     if let Err(err) = window.drag_window() {
@@ -1053,12 +1056,12 @@ pub fn process_viewport_commands(
                     }
                 }
             }
-            egui::ViewportCommand::InnerSize(size) => {
+            ViewportCommand::InnerSize(size) => {
                 let width = size.x.max(1.0);
                 let height = size.y.max(1.0);
                 window.set_inner_size(LogicalSize::new(width, height));
             }
-            egui::ViewportCommand::BeginResize(direction) => {
+            ViewportCommand::BeginResize(direction) => {
                 if let Err(err) = window.drag_resize_window(match direction {
                     egui::viewport::ResizeDirection::North => ResizeDirection::North,
                     egui::viewport::ResizeDirection::South => ResizeDirection::South,

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2574,7 +2574,7 @@ impl Context {
     /// You need to call this each frame when the child viewport should exist.
     ///
     /// You can check if the user wants to close the viewport by checking the
-    /// [`crate::ViewportInfo::close_requested`] flags found in [`crate::InputState::viewports`].
+    /// [`crate::ViewportInfo::close_requested`] flags found in [`crate::InputState::viewport`].
     ///
     /// The given callback will be called whenever the child viewport needs repainting,
     /// e.g. on an event or when [`Self::request_repaint`] is called.
@@ -2634,7 +2634,7 @@ impl Context {
     /// You need to call this each frame when the child viewport should exist.
     ///
     /// You can check if the user wants to close the viewport by checking the
-    /// [`crate::ViewportInfo::close_requested`] flags found in [`crate::InputState::viewports`].
+    /// [`crate::ViewportInfo::close_requested`] flags found in [`crate::InputState::viewport`].
     ///
     /// The given ui function will be called immediately.
     /// This may only be called on the main thread.

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2555,14 +2555,14 @@ impl Context {
     /// Send a command to the current viewport.
     ///
     /// This lets you affect the current viewport, e.g. resizing the window.
-    pub fn send_viewport_command(&self, command: ViewportCommand) {
-        self.send_viewport_command_to(self.viewport_id(), command);
+    pub fn send_viewport_cmd(&self, command: ViewportCommand) {
+        self.send_viewport_cmd_to(self.viewport_id(), command);
     }
 
     /// Send a command to a speicfic viewport.
     ///
     /// This lets you affect another viewport, e.g. resizing its window.
-    pub fn send_viewport_command_to(&self, id: ViewportId, command: ViewportCommand) {
+    pub fn send_viewport_cmd_to(&self, id: ViewportId, command: ViewportCommand) {
         self.write(|ctx| ctx.viewport_for(id).commands.push(command));
         self.request_repaint_of(id);
     }

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2564,6 +2564,7 @@ impl Context {
     /// This lets you affect another viewport, e.g. resizing its window.
     pub fn send_viewport_command_to(&self, id: ViewportId, command: ViewportCommand) {
         self.write(|ctx| ctx.viewport_for(id).commands.push(command));
+        self.request_repaint_of(id);
     }
 
     /// This creates a new native window, if possible.

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -227,7 +227,7 @@ struct ContextImpl {
 
 impl ContextImpl {
     fn begin_frame_mut(&mut self, mut new_raw_input: RawInput) {
-        let ids = new_raw_input.viewport.ids;
+        let ids = new_raw_input.viewport_ids;
         let viewport_id = ids.this;
         self.viewport_stack.push(ids);
         let viewport = self.viewports.entry(viewport_id).or_default();
@@ -2572,6 +2572,9 @@ impl Context {
     ///
     /// You need to call this each frame when the child viewport should exist.
     ///
+    /// You can check if the user wants to close the viewport by checking the
+    /// [`crate::ViewportInfo::close_requested`] flags found in [`crate::InputState::viewports`].
+    ///
     /// The given callback will be called whenever the child viewport needs repainting,
     /// e.g. on an event or when [`Self::request_repaint`] is called.
     /// This means it may be called multiple times, for instance while the
@@ -2628,6 +2631,9 @@ impl Context {
     /// The given id must be unique for each viewport.
     ///
     /// You need to call this each frame when the child viewport should exist.
+    ///
+    /// You can check if the user wants to close the viewport by checking the
+    /// [`crate::ViewportInfo::close_requested`] flags found in [`crate::InputState::viewports`].
     ///
     /// The given ui function will be called immediately.
     /// This may only be called on the main thread.

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -32,9 +32,18 @@ pub struct RawInput {
     pub screen_rect: Option<Rect>,
 
     /// Also known as device pixel ratio, > 1 for high resolution screens.
+    ///
     /// If text looks blurry you probably forgot to set this.
     /// Set this the first frame, whenever it changes, or just on every frame.
     pub pixels_per_point: Option<f32>,
+
+    /// The OS native pixels-per-point.
+    ///
+    /// This should always be set, if known.
+    ///
+    /// On web this takes browser scaling into account,
+    /// and orresponds to [`window.devicePixelRatio`](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio) in JavaScript.
+    pub native_pixels_per_point: Option<f32>,
 
     /// Maximum size of one side of the font texture.
     ///
@@ -84,6 +93,7 @@ impl Default for RawInput {
             viewports: Default::default(),
             screen_rect: None,
             pixels_per_point: None,
+            native_pixels_per_point: None,
             max_texture_side: None,
             time: None,
             predicted_dt: 1.0 / 60.0,
@@ -106,7 +116,8 @@ impl RawInput {
             viewport_ids: self.viewport_ids,
             viewports: self.viewports.clone(),
             screen_rect: self.screen_rect.take(),
-            pixels_per_point: self.pixels_per_point.take(),
+            pixels_per_point: self.pixels_per_point.take(), // take the diff
+            native_pixels_per_point: self.native_pixels_per_point, // copy
             max_texture_side: self.max_texture_side.take(),
             time: self.time.take(),
             predicted_dt: self.predicted_dt,
@@ -125,6 +136,7 @@ impl RawInput {
             viewports,
             screen_rect,
             pixels_per_point,
+            native_pixels_per_point,
             max_texture_side,
             time,
             predicted_dt,
@@ -139,6 +151,7 @@ impl RawInput {
         self.viewports = viewports;
         self.screen_rect = screen_rect.or(self.screen_rect);
         self.pixels_per_point = pixels_per_point.or(self.pixels_per_point);
+        self.native_pixels_per_point = native_pixels_per_point.or(self.native_pixels_per_point);
         self.max_texture_side = max_texture_side.or(self.max_texture_side);
         self.time = time; // use latest time
         self.predicted_dt = predicted_dt; // use latest dt
@@ -1085,6 +1098,7 @@ impl RawInput {
             viewports,
             screen_rect,
             pixels_per_point,
+            native_pixels_per_point,
             max_texture_side,
             time,
             predicted_dt,
@@ -1112,6 +1126,12 @@ impl RawInput {
             .on_hover_text(
                 "Also called HDPI factor.\nNumber of physical pixels per each logical pixel.",
             );
+        ui.label(format!(
+            "native_pixels_per_point: {native_pixels_per_point:?}"
+        ))
+        .on_hover_text(
+            "Also called HDPI factor.\nNumber of physical pixels per each logical pixel.",
+        );
         ui.label(format!("max_texture_side: {max_texture_side:?}"));
         if let Some(time) = time {
             ui.label(format!("time: {time:.3} s"));

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -194,7 +194,7 @@ pub struct ViewportInfo {
 
     /// Is the window focused and able to receive input?
     ///
-    /// This should be the same as [`InputState::focused`].
+    /// This should be the same as [`RawInput::focused`].
     pub focused: Option<bool>,
 }
 

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -181,6 +181,12 @@ pub struct ViewportInfo {
     /// This is the content rectangle plus decoration chrome.
     pub outer_rect: Option<Rect>,
 
+    /// Are we minimized?
+    pub minimized: Option<bool>,
+
+    /// Are we maximized?
+    pub maximized: Option<bool>,
+
     /// Are we in fullscreen mode?
     pub fullscreen: Option<bool>,
 
@@ -204,6 +210,8 @@ impl ViewportInfo {
             monitor_size,
             inner_rect,
             outer_rect,
+            minimized,
+            maximized,
             fullscreen,
             focused,
         } = self;
@@ -235,6 +243,14 @@ impl ViewportInfo {
 
             ui.label("Outer rect:");
             ui.label(opt_rect_as_string(outer_rect));
+            ui.end_row();
+
+            ui.label("Minimized:");
+            ui.label(opt_as_str(minimized));
+            ui.end_row();
+
+            ui.label("Maximized:");
+            ui.label(opt_as_str(maximized));
             ui.end_row();
 
             ui.label("Fullscreen:");

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -196,7 +196,65 @@ impl ViewportInfo {
     }
 
     pub fn ui(&self, ui: &mut crate::Ui) {
-        ui.label(format!("{self:#?}"));
+        let Self {
+            parent,
+            title,
+            close_requested,
+            pixels_per_point,
+            monitor_size,
+            inner_rect,
+            outer_rect,
+            fullscreen,
+            focused,
+        } = self;
+
+        crate::Grid::new("viewport_info").show(ui, |ui| {
+            ui.label("Parent:");
+            ui.label(opt_as_str(parent));
+            ui.end_row();
+
+            ui.label("Title:");
+            ui.label(opt_as_str(title));
+            ui.end_row();
+
+            ui.label("Close requested:");
+            ui.label(close_requested.to_string());
+            ui.end_row();
+
+            ui.label("Pixels per point:");
+            ui.label(pixels_per_point.to_string());
+            ui.end_row();
+
+            ui.label("Monitor size:");
+            ui.label(opt_as_str(monitor_size));
+            ui.end_row();
+
+            ui.label("Inner rect:");
+            ui.label(opt_rect_as_string(inner_rect));
+            ui.end_row();
+
+            ui.label("Outer rect:");
+            ui.label(opt_rect_as_string(outer_rect));
+            ui.end_row();
+
+            ui.label("Fullscreen:");
+            ui.label(opt_as_str(fullscreen));
+            ui.end_row();
+
+            ui.label("Focused:");
+            ui.label(opt_as_str(focused));
+            ui.end_row();
+
+            fn opt_rect_as_string(v: &Option<Rect>) -> String {
+                v.as_ref().map_or(String::new(), |r| {
+                    format!("Pos: {:?}, size: {:?}", r.min, r.size())
+                })
+            }
+
+            fn opt_as_str<T: std::fmt::Debug>(v: &Option<T>) -> String {
+                v.as_ref().map_or(String::new(), |v| format!("{v:?}"))
+            }
+        });
     }
 }
 

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -1078,7 +1078,9 @@ impl RawInput {
         for (id, viewport) in viewports {
             ui.group(|ui| {
                 ui.label(format!("Viewport {id:?}"));
-                viewport.ui(ui);
+                ui.push_id(id, |ui| {
+                    viewport.ui(ui);
+                });
             });
         }
         ui.label(format!("screen_rect: {screen_rect:?} points"));

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -1,5 +1,7 @@
 //! The input needed by egui.
 
+use epaint::ColorImage;
+
 use crate::{emath::*, ViewportIdMap, ViewportIdPair};
 
 /// What the integrations provides to egui at the start of each frame.
@@ -445,6 +447,12 @@ pub enum Event {
     /// An assistive technology (e.g. screen reader) requested an action.
     #[cfg(feature = "accesskit")]
     AccessKitActionRequest(accesskit::ActionRequest),
+
+    /// The reply of a screenshot requested with [`crate::ViewportCommand::Screenshot`].
+    Screenshot {
+        viewport_id: crate::ViewportId,
+        image: std::sync::Arc<ColorImage>,
+    },
 }
 
 /// Mouse button (or similar for touch input)

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -1,6 +1,6 @@
 //! The input needed by egui.
 
-use crate::{emath::*, ViewportIdPair};
+use crate::{emath::*, ViewportBuilder, ViewportIdPair};
 
 /// What the integrations provides to egui at the start of each frame.
 ///
@@ -143,14 +143,26 @@ impl RawInput {
 
 /// Information about the current viewport,
 /// given as input each frame.
+///
+/// `None` means "unknown".
 #[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ViewportInfo {
     /// Id of us and our parent.
     pub ids: ViewportIdPair,
 
+    /// Name of the viewport, if known.
+    pub title: Option<String>,
+
+    /// The user requested the viewport should close,
+    /// e.g. by pressing the close button in the window decoration.
+    pub close_requested: bool,
+
     /// Number of physical pixels per ui point.
     pub pixels_per_point: f32,
+
+    /// Current monitor size in egui points.
+    pub monitor_size: Option<Vec2>,
 
     /// The inner rectangle of the native window, in monitor space and ui points scale.
     ///
@@ -162,29 +174,31 @@ pub struct ViewportInfo {
     /// This is the content rectangle plus decoration chrome.
     pub outer_rect: Option<Rect>,
 
-    /// The user requested the viewport should close,
-    /// e.g. by pressing the close button in the window decoration.
-    pub close_requested: bool,
+    /// Are we in fullscreen mode?
+    pub fullscreen: Option<bool>,
+
+    /// Is the window focused and able to receive input?
+    ///
+    /// This should be the same as [`InputState::focused`].
+    pub focused: Option<bool>,
 }
 
 impl ViewportInfo {
+    pub fn from_builder(ids: ViewportIdPair, builder: &ViewportBuilder) -> Self {
+        Self {
+            ids,
+            title: builder.title.clone(),
+            fullscreen: builder.fullscreen,
+            ..Default::default()
+        }
+    }
+
     pub fn take(&mut self) -> Self {
         core::mem::take(self)
     }
 
     pub fn ui(&self, ui: &mut crate::Ui) {
-        let Self {
-            ids,
-            pixels_per_point,
-            inner_rect,
-            outer_rect,
-            close_requested,
-        } = self;
-        ui.label(format!("ids: {ids:?}"));
-        ui.label(format!("pixels_per_point: {pixels_per_point:?}"));
-        ui.label(format!("inner_rect: {inner_rect:?}"));
-        ui.label(format!("outer_rect: {outer_rect:?}"));
-        ui.label(format!("close_requested: {close_requested:?}"));
+        ui.label(format!("{self:#?}"));
     }
 }
 

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -143,19 +143,24 @@ impl RawInput {
 
 /// Information about the current viewport,
 /// given as input each frame.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ViewportInfo {
     /// Id of us and our parent.
     pub ids: ViewportIdPair,
 
-    /// Viewport inner position and size, only the drowable area
-    /// unit = physical pixels
-    pub inner_rect_px: Option<Rect>,
+    /// Number of physical pixels per ui point.
+    pub pixels_per_point: f32,
 
-    /// Viewport outer position and size, drowable area + decorations
-    /// unit = physical pixels
-    pub outer_rect_px: Option<Rect>,
+    /// The inner rectangle of the native window, in monitor space and ui points scale.
+    ///
+    /// This is the content rectangle of the viewport.
+    pub inner_rect: Option<Rect>,
+
+    /// The outer rectangle of the native window, in monitor space and ui points scale.
+    ///
+    /// This is the content rectangle plus decoration chrome.
+    pub outer_rect: Option<Rect>,
 
     /// The user requested the viewport should close,
     /// e.g. by pressing the close button in the window decoration.
@@ -170,13 +175,15 @@ impl ViewportInfo {
     pub fn ui(&self, ui: &mut crate::Ui) {
         let Self {
             ids,
-            inner_rect_px,
-            outer_rect_px,
+            pixels_per_point,
+            inner_rect,
+            outer_rect,
             close_requested,
         } = self;
         ui.label(format!("ids: {ids:?}"));
-        ui.label(format!("inner_rect_px: {inner_rect_px:?}"));
-        ui.label(format!("outer_rect_px: {outer_rect_px:?}"));
+        ui.label(format!("pixels_per_point: {pixels_per_point:?}"));
+        ui.label(format!("inner_rect: {inner_rect:?}"));
+        ui.label(format!("outer_rect: {outer_rect:?}"));
         ui.label(format!("close_requested: {close_requested:?}"));
     }
 }

--- a/crates/egui/src/data/output.rs
+++ b/crates/egui/src/data/output.rs
@@ -210,6 +210,7 @@ impl OpenUrl {
 ///
 /// [user_attention_type]: https://docs.rs/winit/latest/winit/window/enum.UserAttentionType.html
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum UserAttentionType {
     /// Request an elevated amount of animations and flair for the window and the task bar or dock icon.
     Critical,

--- a/crates/egui/src/gui_zoom.rs
+++ b/crates/egui/src/gui_zoom.rs
@@ -15,19 +15,14 @@ pub mod kb_shortcuts {
 /// Let the user scale the GUI (change `Context::pixels_per_point`) by pressing
 /// Cmd+Plus, Cmd+Minus or Cmd+0, just like in a browser.
 ///
-/// When using [`eframe`](https://github.com/emilk/egui/tree/master/crates/eframe), you want to call this as:
-/// ```ignore
-/// // On web, the browser controls the gui zoom.
-/// if !frame.is_web() {
-///     egui::gui_zoom::zoom_with_keyboard_shortcuts(
-///         ctx,
-///         frame.info().native_pixels_per_point,
-///     );
-/// }
 /// ```
-pub fn zoom_with_keyboard_shortcuts(ctx: &Context, native_pixels_per_point: Option<f32>) {
+/// // On web, the browser controls the gui zoom.
+/// #[cfg(not(target_arch = "wasm32"))]
+/// egui::gui_zoom::zoom_with_keyboard_shortcuts(ct);
+/// ```
+pub fn zoom_with_keyboard_shortcuts(ctx: &Context) {
     if ctx.input_mut(|i| i.consume_shortcut(&kb_shortcuts::ZOOM_RESET)) {
-        if let Some(native_pixels_per_point) = native_pixels_per_point {
+        if let Some(native_pixels_per_point) = ctx.input(|i| i.raw.native_pixels_per_point) {
             ctx.set_pixels_per_point(native_pixels_per_point);
         }
     } else {

--- a/crates/egui/src/gui_zoom.rs
+++ b/crates/egui/src/gui_zoom.rs
@@ -16,9 +16,10 @@ pub mod kb_shortcuts {
 /// Cmd+Plus, Cmd+Minus or Cmd+0, just like in a browser.
 ///
 /// ```
+/// # let ctx = &egui::Context::default();
 /// // On web, the browser controls the gui zoom.
 /// #[cfg(not(target_arch = "wasm32"))]
-/// egui::gui_zoom::zoom_with_keyboard_shortcuts(ct);
+/// egui::gui_zoom::zoom_with_keyboard_shortcuts(ctx);
 /// ```
 pub fn zoom_with_keyboard_shortcuts(ctx: &Context) {
     if ctx.input_mut(|i| i.consume_shortcut(&kb_shortcuts::ZOOM_RESET)) {

--- a/crates/egui/src/input_state.rs
+++ b/crates/egui/src/input_state.rs
@@ -231,7 +231,7 @@ impl InputState {
         }
     }
 
-    /// Infor about the acitve viewport
+    /// Info about the active viewport
     pub fn viewport(&self) -> &ViewportInfo {
         self.raw.viewports.get(&self.raw.viewport_ids.this).expect("Failed to find current viewport in egui RawInput. This is the fault of the egui backend")
     }

--- a/crates/egui/src/input_state.rs
+++ b/crates/egui/src/input_state.rs
@@ -231,6 +231,11 @@ impl InputState {
         }
     }
 
+    /// Infor about the acitve viewport
+    pub fn viewport(&self) -> &ViewportInfo {
+        self.raw.viewports.get(&self.raw.viewport_ids.this).expect("Failed to find current viewport in egui RawInput. This is the fault of the egui backend")
+    }
+
     #[inline(always)]
     pub fn screen_rect(&self) -> Rect {
         self.screen_rect

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -559,7 +559,7 @@ impl Memory {
         self.window_interactions
             .retain(|id, _| viewports.contains(id));
 
-        self.viewport_id = new_input.viewport.ids.this;
+        self.viewport_id = new_input.viewport_ids.this;
         self.interactions
             .entry(self.viewport_id)
             .or_default()

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -638,13 +638,6 @@ pub enum CursorGrab {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub enum UserAttentionType {
-    Informational,
-    Critical,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum ResizeDirection {
     North,
     South,
@@ -729,7 +722,8 @@ pub enum ViewportCommand {
     IMEAllowed(bool),
     IMEPurpose(IMEPurpose),
 
-    RequestUserAttention(Option<UserAttentionType>),
+    /// Bring attention to the window.
+    RequestUserAttention(crate::UserAttentionType),
 
     SetTheme(SystemTheme),
 

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -43,7 +43,8 @@
 //! There is an example in <https://github.com/emilk/egui/tree/master/examples/multiple_viewports/src/main.rs>.
 //!
 //! ## For integrations
-//! * There is a [`crate::RawInput::viewport`] with information about the current viewport.
+//! * There is a [`crate::InputState::viewport`] with information about the current viewport.
+//! * There is a [`crate::RawInput::viewports`] with information about all viewports.
 //! * The repaint callback set by [`Context::set_request_repaint_callback`] points to which viewport should be repainted.
 //! * [`crate::FullOutput::viewport_output`] is a list of viewports which should result in their own independent windows.
 //! * To support immediate viewports you need to call [`Context::set_immediate_viewport_renderer`].
@@ -659,7 +660,7 @@ pub enum ViewportCommand {
     /// Request this viewport to be closed.
     ///
     /// For the root viewport, this usually results in the application shutting down.
-    /// For other viewports, the [`ViewportInfo::close_requested`] flag will be set.
+    /// For other viewports, the [`crate::ViewportInfo::close_requested`] flag will be set.
     Close,
 
     /// Set the window title.

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -38,9 +38,22 @@
 //!
 //! ## Using the viewports
 //! Only one viewport is active at any one time, identified with [`Context::viewport_id`].
-//! You can send commands to other viewports using [`Context::send_viewport_cmd_to`].
+//! You can modify the current (change the title, resize the window, etc) by sending
+//! a [`ViewportCommand`] to it using [`Context::send_viewport_cmd`].
+//! You can interact with other viewports using [`Context::send_viewport_cmd_to`].
 //!
 //! There is an example in <https://github.com/emilk/egui/tree/master/examples/multiple_viewports/src/main.rs>.
+//!
+//! You can find all available viewports in [`crate::RawInput::viewports`] and the active viewport in
+//! [`crate::InputState::viewport`]:
+//!
+//! ```no_run
+//! # let ctx = &egui::Context::default();
+//! ctx.input(|i| {
+//!     dbg!(&i.viewport()); // Current viewport
+//!     dbg!(&i.raw.viewports); // All viewports
+//! });
+//! ```
 //!
 //! ## For integrations
 //! * There is a [`crate::InputState::viewport`] with information about the current viewport.

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -38,7 +38,7 @@
 //!
 //! ## Using the viewports
 //! Only one viewport is active at any one time, identified with [`Context::viewport_id`].
-//! You can send commands to other viewports using [`Context::send_viewport_command_to`].
+//! You can send commands to other viewports using [`Context::send_viewport_cmd_to`].
 //!
 //! There is an example in <https://github.com/emilk/egui/tree/master/examples/multiple_viewports/src/main.rs>.
 //!
@@ -648,7 +648,7 @@ pub enum ResizeDirection {
     SouthWest,
 }
 
-/// You can send a [`ViewportCommand`] to the viewport with [`Context::send_viewport_command`].
+/// You can send a [`ViewportCommand`] to the viewport with [`Context::send_viewport_cmd`].
 ///
 /// All coordinates are in logical points.
 ///

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -760,6 +760,11 @@ pub enum ViewportCommand {
     CursorVisible(bool),
 
     CursorHitTest(bool),
+
+    /// Take a screenshot.
+    ///
+    /// In `eframe`, the results are returned in `eframe::Frame::screenshot`.
+    Screenshot,
 }
 
 impl ViewportCommand {

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -663,6 +663,12 @@ pub enum ResizeDirection {
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum ViewportCommand {
+    /// Request this viewport to be closed.
+    ///
+    /// For the root viewport, this usually results in the application shutting down.
+    /// For other viewports, the [`ViewportInfo::close_requested`] flag will be set.
+    Close,
+
     /// Set the title
     Title(String),
 

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -662,7 +662,7 @@ pub enum ViewportCommand {
     /// For other viewports, the [`ViewportInfo::close_requested`] flag will be set.
     Close,
 
-    /// Set the title
+    /// Set the window title.
     Title(String),
 
     /// Turn the window transparent or not.
@@ -708,21 +708,36 @@ pub enum ViewportCommand {
         maximize: bool,
     },
     Minimized(bool),
+
+    /// Maximize or unmaximize window.
     Maximized(bool),
+
+    /// Turn borderless fullscreen on/off.
     Fullscreen(bool),
 
     /// Show window decorations, i.e. the chrome around the content
     /// with the title bar, close buttons, resize handles, etc.
     Decorations(bool),
 
+    /// Set window to be always-on-top, always-on-bottom, or neither.
     WindowLevel(WindowLevel),
+
+    /// The the window icon.
     WindowIcon(Option<Arc<ColorImage>>),
 
     IMEPosition(Pos2),
     IMEAllowed(bool),
     IMEPurpose(IMEPurpose),
 
-    /// Bring attention to the window.
+    /// If the window is unfocused, attract the user's attention (native only).
+    ///
+    /// Typically, this means that the window will flash on the taskbar, or bounce, until it is interacted with.
+    ///
+    /// When the window comes into focus, or if `None` is passed, the attention request will be automatically reset.
+    ///
+    /// See [winit's documentation][user_attention_details] for platform-specific effect details.
+    ///
+    /// [user_attention_details]: https://docs.rs/winit/latest/winit/window/enum.UserAttentionType.html
     RequestUserAttention(crate::UserAttentionType),
 
     SetTheme(SystemTheme),
@@ -737,6 +752,24 @@ pub enum ViewportCommand {
     CursorVisible(bool),
 
     CursorHitTest(bool),
+}
+
+impl ViewportCommand {
+    /// Construct a command to center the viewport on the monitor, if possible.
+    pub fn center_on_screen(ctx: &crate::Context) -> Option<Self> {
+        ctx.input(|i| {
+            let outer_rect = i.viewport().outer_rect?;
+            let size = outer_rect.size();
+            let monitor_size = i.viewport().monitor_size?;
+            if 1.0 < monitor_size.x && 1.0 < monitor_size.y {
+                let x = (monitor_size.x - size.x) / 2.0;
+                let y = (monitor_size.y - size.y) / 2.0;
+                Some(Self::OuterPosition([x, y].into()))
+            } else {
+                None
+            }
+        })
+    }
 }
 
 /// Describes a viewport, i.e. a native window.

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -763,7 +763,7 @@ pub enum ViewportCommand {
 
     /// Take a screenshot.
     ///
-    /// In `eframe`, the results are returned in `eframe::Frame::screenshot`.
+    /// The results are returned in `crate::Event::Screenshot`.
     Screenshot,
 }
 

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -729,6 +729,14 @@ pub enum ViewportCommand {
     IMEAllowed(bool),
     IMEPurpose(IMEPurpose),
 
+    /// Bring the window into focus (native only).
+    ///
+    /// This command puts the window on top of other applications and takes input focus away from them,
+    /// which, if unexpected, will disturb the user.
+    ///
+    /// Has no effect on Wayland, or if the window is minimized or invisible.
+    Focus,
+
     /// If the window is unfocused, attract the user's attention (native only).
     ///
     /// Typically, this means that the window will flash on the taskbar, or bounce, until it is interacted with.

--- a/crates/egui_demo_app/src/backend_panel.rs
+++ b/crates/egui_demo_app/src/backend_panel.rs
@@ -151,7 +151,7 @@ impl BackendPanel {
         // On web, the browser controls `pixels_per_point`.
         let integration_controls_pixels_per_point = frame.is_web();
         if !integration_controls_pixels_per_point {
-            self.pixels_per_point_ui(ui, frame.info());
+            self.pixels_per_point_ui(ui);
         }
 
         #[cfg(not(target_arch = "wasm32"))]
@@ -196,7 +196,7 @@ impl BackendPanel {
         }
     }
 
-    fn pixels_per_point_ui(&mut self, ui: &mut egui::Ui, info: &eframe::IntegrationInfo) {
+    fn pixels_per_point_ui(&mut self, ui: &mut egui::Ui) {
         let pixels_per_point = self
             .pixels_per_point
             .get_or_insert_with(|| ui.ctx().pixels_per_point());
@@ -224,7 +224,7 @@ impl BackendPanel {
                 reset = true;
             }
 
-            if let Some(native_pixels_per_point) = info.native_pixels_per_point {
+            if let Some(native_pixels_per_point) = ui.input(|i| i.raw.native_pixels_per_point) {
                 let enabled = ui.ctx().pixels_per_point() != native_pixels_per_point;
                 if ui
                     .add_enabled(enabled, egui::Button::new("Reset"))

--- a/crates/egui_demo_app/src/backend_panel.rs
+++ b/crates/egui_demo_app/src/backend_panel.rs
@@ -117,7 +117,7 @@ impl BackendPanel {
         {
             ui.separator();
             if ui.button("Quit").clicked() {
-                frame.close();
+                ui.ctx().send_viewport_command(egui::ViewportCommand::Close);
             }
         }
 

--- a/crates/egui_demo_app/src/backend_panel.rs
+++ b/crates/egui_demo_app/src/backend_panel.rs
@@ -117,7 +117,7 @@ impl BackendPanel {
         {
             ui.separator();
             if ui.button("Quit").clicked() {
-                ui.ctx().send_viewport_command(egui::ViewportCommand::Close);
+                ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
             }
         }
 
@@ -165,7 +165,7 @@ impl BackendPanel {
                         .changed()
                     {
                         ui.ctx()
-                            .send_viewport_command(egui::ViewportCommand::Fullscreen(fullscreen));
+                            .send_viewport_cmd(egui::ViewportCommand::Fullscreen(fullscreen));
                     }
                 }
 
@@ -178,9 +178,9 @@ impl BackendPanel {
                     let size = egui::vec2(375.0, 667.0); //  iPhone SE 2nd gen
 
                     ui.ctx()
-                        .send_viewport_command(egui::ViewportCommand::InnerSize(size));
+                        .send_viewport_cmd(egui::ViewportCommand::InnerSize(size));
                     ui.ctx()
-                        .send_viewport_command(egui::ViewportCommand::Fullscreen(false));
+                        .send_viewport_cmd(egui::ViewportCommand::Fullscreen(false));
                     ui.close_menu();
                 }
             });
@@ -191,8 +191,7 @@ impl BackendPanel {
                     .button("Drag me to drag window")
                     .is_pointer_button_down_on()
             {
-                ui.ctx()
-                    .send_viewport_command(egui::ViewportCommand::StartDrag);
+                ui.ctx().send_viewport_cmd(egui::ViewportCommand::StartDrag);
             }
         }
     }

--- a/crates/egui_demo_app/src/wrap_app.rs
+++ b/crates/egui_demo_app/src/wrap_app.rs
@@ -285,7 +285,7 @@ impl eframe::App for WrapApp {
 
         // On web, the browser controls `pixels_per_point`.
         if !frame.is_web() {
-            egui::gui_zoom::zoom_with_keyboard_shortcuts(ctx, frame.info().native_pixels_per_point);
+            egui::gui_zoom::zoom_with_keyboard_shortcuts(ctx);
         }
 
         self.run_cmd(ctx, cmd);

--- a/crates/egui_demo_app/src/wrap_app.rs
+++ b/crates/egui_demo_app/src/wrap_app.rs
@@ -259,7 +259,8 @@ impl eframe::App for WrapApp {
 
         #[cfg(not(target_arch = "wasm32"))]
         if ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::F11)) {
-            frame.set_fullscreen(!frame.info().window_info.fullscreen);
+            let fullscreen = ctx.input(|i| i.viewport().fullscreen.unwrap_or(false));
+            ctx.send_viewport_command(egui::ViewportCommand::Fullscreen(!fullscreen));
         }
 
         let mut cmd = Command::Nothing;

--- a/crates/egui_demo_app/src/wrap_app.rs
+++ b/crates/egui_demo_app/src/wrap_app.rs
@@ -260,7 +260,7 @@ impl eframe::App for WrapApp {
         #[cfg(not(target_arch = "wasm32"))]
         if ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::F11)) {
             let fullscreen = ctx.input(|i| i.viewport().fullscreen.unwrap_or(false));
-            ctx.send_viewport_command(egui::ViewportCommand::Fullscreen(!fullscreen));
+            ctx.send_viewport_cmd(egui::ViewportCommand::Fullscreen(!fullscreen));
         }
 
         let mut cmd = Command::Nothing;

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -27,6 +27,7 @@ impl Default for Demos {
             Box::<super::context_menu::ContextMenus>::default(),
             Box::<super::dancing_strings::DancingStrings>::default(),
             Box::<super::drag_and_drop::DragAndDropDemo>::default(),
+            Box::<super::extra_viewport::ExtraViewport>::default(),
             Box::<super::font_book::FontBook>::default(),
             Box::<super::MiscDemoWindow>::default(),
             Box::<super::multi_touch::MultiTouch>::default(),
@@ -61,9 +62,11 @@ impl Demos {
     pub fn checkboxes(&mut self, ui: &mut Ui) {
         let Self { demos, open } = self;
         for demo in demos {
-            let mut is_open = open.contains(demo.name());
-            ui.toggle_value(&mut is_open, demo.name());
-            set_open(open, demo.name(), is_open);
+            if demo.is_enabled(ui.ctx()) {
+                let mut is_open = open.contains(demo.name());
+                ui.toggle_value(&mut is_open, demo.name());
+                set_open(open, demo.name(), is_open);
+            }
         }
     }
 

--- a/crates/egui_demo_lib/src/demo/extra_viewport.rs
+++ b/crates/egui_demo_lib/src/demo/extra_viewport.rs
@@ -1,0 +1,70 @@
+#[derive(Default)]
+pub struct ExtraViewport {}
+
+impl super::Demo for ExtraViewport {
+    fn is_enabled(&self, ctx: &egui::Context) -> bool {
+        !ctx.embed_viewports()
+    }
+
+    fn name(&self) -> &'static str {
+        "🗖 Extra Viewport"
+    }
+
+    fn show(&mut self, ctx: &egui::Context, open: &mut bool) {
+        if !*open {
+            return;
+        }
+
+        let id = egui::Id::new(self.name());
+
+        ctx.show_viewport_immediate(
+            egui::ViewportId(id),
+            egui::ViewportBuilder::default()
+                .with_title(self.name())
+                .with_inner_size([400.0, 512.0]),
+            |ctx, class| {
+                if class == egui::ViewportClass::Embedded {
+                    // Not a real viewport
+                    egui::Window::new(self.name())
+                        .id(id)
+                        .open(open)
+                        .show(ctx, |ui| {
+                            ui.label("This egui integration does not support multiple viewports");
+                        });
+                } else {
+                    egui::CentralPanel::default().show(ctx, |ui| {
+                        ui.push_id(id, |ui| {
+                            viewport_contet(ui, ctx, open);
+                        })
+                    });
+                }
+            },
+        );
+    }
+}
+
+fn viewport_contet(ui: &mut egui::Ui, ctx: &egui::Context, open: &mut bool) {
+    ui.label("egui and eframe supports having multiple native windows like this, which egui calls 'viewports'.");
+
+    ui.label(format!(
+        "This viewport has id: {:?}, child of viewport {:?}",
+        ctx.viewport_id(),
+        ctx.parent_viewport_id()
+    ));
+
+    ui.label("Here you can see all the open viewports:");
+
+    egui::ScrollArea::vertical().show(ui, |ui| {
+        let viewports = ui.input(|i| i.raw.viewports.clone());
+        for (id, viewport) in viewports {
+            ui.group(|ui| {
+                ui.label(format!("viewport {id:?}"));
+                viewport.ui(ui);
+            });
+        }
+    });
+
+    if ui.input(|i| i.viewport().close_requested) {
+        *open = false;
+    }
+}

--- a/crates/egui_demo_lib/src/demo/extra_viewport.rs
+++ b/crates/egui_demo_lib/src/demo/extra_viewport.rs
@@ -59,7 +59,9 @@ fn viewport_contet(ui: &mut egui::Ui, ctx: &egui::Context, open: &mut bool) {
         for (id, viewport) in viewports {
             ui.group(|ui| {
                 ui.label(format!("viewport {id:?}"));
-                viewport.ui(ui);
+                ui.push_id(id, |ui| {
+                    viewport.ui(ui);
+                });
             });
         }
     });

--- a/crates/egui_demo_lib/src/demo/extra_viewport.rs
+++ b/crates/egui_demo_lib/src/demo/extra_viewport.rs
@@ -34,7 +34,7 @@ impl super::Demo for ExtraViewport {
                 } else {
                     egui::CentralPanel::default().show(ctx, |ui| {
                         ui.push_id(id, |ui| {
-                            viewport_contet(ui, ctx, open);
+                            viewport_content(ui, ctx, open);
                         })
                     });
                 }
@@ -43,7 +43,7 @@ impl super::Demo for ExtraViewport {
     }
 }
 
-fn viewport_contet(ui: &mut egui::Ui, ctx: &egui::Context, open: &mut bool) {
+fn viewport_content(ui: &mut egui::Ui, ctx: &egui::Context, open: &mut bool) {
     ui.label("egui and eframe supports having multiple native windows like this, which egui calls 'viewports'.");
 
     ui.label(format!(

--- a/crates/egui_demo_lib/src/demo/mod.rs
+++ b/crates/egui_demo_lib/src/demo/mod.rs
@@ -11,6 +11,7 @@ pub mod context_menu;
 pub mod dancing_strings;
 pub mod demo_app_windows;
 pub mod drag_and_drop;
+pub mod extra_viewport;
 pub mod font_book;
 pub mod highlighting;
 pub mod layout_test;
@@ -46,6 +47,11 @@ pub trait View {
 
 /// Something to view
 pub trait Demo {
+    /// Is the demo enabled for this integraton?
+    fn is_enabled(&self, _ctx: &egui::Context) -> bool {
+        true
+    }
+
     /// `&'static` so we can also use it as a key to store open/close state.
     fn name(&self) -> &'static str;
 

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -12,6 +12,8 @@ pub struct EguiGlow {
     pub egui_winit: egui_winit::State,
     pub painter: crate::Painter,
 
+    viewport_info: egui::ViewportInfo,
+
     // output from the last update:
     shapes: Vec<egui::epaint::ClippedShape>,
     pixels_per_point: f32,
@@ -43,6 +45,7 @@ impl EguiGlow {
             egui_ctx: Default::default(),
             egui_winit,
             painter,
+            viewport_info: Default::default(),
             shapes: Default::default(),
             pixels_per_point,
             textures_delta: Default::default(),
@@ -50,7 +53,8 @@ impl EguiGlow {
     }
 
     pub fn on_event(&mut self, event: &winit::event::WindowEvent<'_>) -> EventResponse {
-        self.egui_winit.on_event(&self.egui_ctx, event)
+        self.egui_winit
+            .on_event(&self.egui_ctx, event, ViewportId::ROOT)
     }
 
     /// Call [`Self::paint`] later to paint.
@@ -71,7 +75,7 @@ impl EguiGlow {
             log::warn!("Multiple viewports not yet supported by EguiGlow");
         }
         for (_, ViewportOutput { commands, .. }) in viewport_output {
-            egui_winit::process_viewport_commands(commands, window, true);
+            egui_winit::process_viewport_commands(&mut self.viewport_info, commands, window, true);
         }
 
         self.egui_winit.handle_platform_output(

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -75,7 +75,17 @@ impl EguiGlow {
             log::warn!("Multiple viewports not yet supported by EguiGlow");
         }
         for (_, ViewportOutput { commands, .. }) in viewport_output {
-            egui_winit::process_viewport_commands(&mut self.viewport_info, commands, window, true);
+            let mut screenshot_requested = false;
+            egui_winit::process_viewport_commands(
+                &mut self.viewport_info,
+                commands,
+                window,
+                true,
+                &mut screenshot_requested,
+            );
+            if screenshot_requested {
+                log::warn!("Screenshot not yet supported by EguiGlow");
+            }
         }
 
         self.egui_winit.handle_platform_output(

--- a/crates/emath/src/pos2.rs
+++ b/crates/emath/src/pos2.rs
@@ -280,6 +280,42 @@ impl Sub<Vec2> for Pos2 {
     }
 }
 
+impl Mul<f32> for Pos2 {
+    type Output = Pos2;
+
+    #[inline(always)]
+    fn mul(self, factor: f32) -> Pos2 {
+        Pos2 {
+            x: self.x * factor,
+            y: self.y * factor,
+        }
+    }
+}
+
+impl Mul<Pos2> for f32 {
+    type Output = Pos2;
+
+    #[inline(always)]
+    fn mul(self, vec: Pos2) -> Pos2 {
+        Pos2 {
+            x: self * vec.x,
+            y: self * vec.y,
+        }
+    }
+}
+
+impl Div<f32> for Pos2 {
+    type Output = Pos2;
+
+    #[inline(always)]
+    fn div(self, factor: f32) -> Pos2 {
+        Pos2 {
+            x: self.x / factor,
+            y: self.y / factor,
+        }
+    }
+}
+
 impl std::fmt::Debug for Pos2 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "[{:.1} {:.1}]", self.x, self.y)

--- a/crates/emath/src/rect.rs
+++ b/crates/emath/src/rect.rs
@@ -622,3 +622,39 @@ impl From<[Pos2; 2]> for Rect {
         Self { min, max }
     }
 }
+
+impl Mul<f32> for Rect {
+    type Output = Rect;
+
+    #[inline]
+    fn mul(self, factor: f32) -> Rect {
+        Rect {
+            min: self.min * factor,
+            max: self.max * factor,
+        }
+    }
+}
+
+impl Mul<Rect> for f32 {
+    type Output = Rect;
+
+    #[inline]
+    fn mul(self, vec: Rect) -> Rect {
+        Rect {
+            min: self * vec.min,
+            max: self * vec.max,
+        }
+    }
+}
+
+impl Div<f32> for Rect {
+    type Output = Rect;
+
+    #[inline]
+    fn div(self, factor: f32) -> Rect {
+        Rect {
+            min: self.min / factor,
+            max: self.max / factor,
+        }
+    }
+}

--- a/examples/confirm_exit/src/main.rs
+++ b/examples/confirm_exit/src/main.rs
@@ -27,7 +27,7 @@ impl eframe::App for MyApp {
         self.allowed_to_close
     }
 
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("Try to close the window");
         });
@@ -45,7 +45,7 @@ impl eframe::App for MyApp {
 
                         if ui.button("Yes!").clicked() {
                             self.allowed_to_close = true;
-                            frame.close();
+                            ui.ctx().send_viewport_command(egui::ViewportCommand::Close);
                         }
                     });
                 });

--- a/examples/confirm_exit/src/main.rs
+++ b/examples/confirm_exit/src/main.rs
@@ -45,7 +45,7 @@ impl eframe::App for MyApp {
 
                         if ui.button("Yes!").clicked() {
                             self.allowed_to_close = true;
-                            ui.ctx().send_viewport_command(egui::ViewportCommand::Close);
+                            ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
                         }
                     });
                 });

--- a/examples/custom_window_frame/src/main.rs
+++ b/examples/custom_window_frame/src/main.rs
@@ -30,8 +30,8 @@ impl eframe::App for MyApp {
         egui::Rgba::TRANSPARENT.to_array() // Make sure we don't paint anything behind the rounded corners
     }
 
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
-        custom_window_frame(ctx, frame, "egui with custom frame", |ui| {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        custom_window_frame(ctx, "egui with custom frame", |ui| {
             ui.label("This is just the contents of the window.");
             ui.horizontal(|ui| {
                 ui.label("egui theme:");
@@ -41,12 +41,7 @@ impl eframe::App for MyApp {
     }
 }
 
-fn custom_window_frame(
-    ctx: &egui::Context,
-    frame: &mut eframe::Frame,
-    title: &str,
-    add_contents: impl FnOnce(&mut egui::Ui),
-) {
+fn custom_window_frame(ctx: &egui::Context, title: &str, add_contents: impl FnOnce(&mut egui::Ui)) {
     use egui::*;
 
     let panel_frame = egui::Frame {
@@ -66,7 +61,7 @@ fn custom_window_frame(
             rect.max.y = rect.min.y + title_bar_height;
             rect
         };
-        title_bar_ui(ui, frame, title_bar_rect, title);
+        title_bar_ui(ui, title_bar_rect, title);
 
         // Add the contents:
         let content_rect = {
@@ -80,12 +75,7 @@ fn custom_window_frame(
     });
 }
 
-fn title_bar_ui(
-    ui: &mut egui::Ui,
-    frame: &mut eframe::Frame,
-    title_bar_rect: eframe::epaint::Rect,
-    title: &str,
-) {
+fn title_bar_ui(ui: &mut egui::Ui, title_bar_rect: eframe::epaint::Rect, title: &str) {
     use egui::*;
 
     let painter = ui.painter();
@@ -124,13 +114,13 @@ fn title_bar_ui(
             ui.spacing_mut().item_spacing.x = 0.0;
             ui.visuals_mut().button_frame = false;
             ui.add_space(8.0);
-            close_maximize_minimize(ui, frame);
+            close_maximize_minimize(ui);
         });
     });
 }
 
 /// Show some close/maximize/minimize buttons for the native window.
-fn close_maximize_minimize(ui: &mut egui::Ui, frame: &mut eframe::Frame) {
+fn close_maximize_minimize(ui: &mut egui::Ui) {
     use egui::{Button, RichText};
 
     let button_height = 12.0;
@@ -139,7 +129,7 @@ fn close_maximize_minimize(ui: &mut egui::Ui, frame: &mut eframe::Frame) {
         .add(Button::new(RichText::new("❌").size(button_height)))
         .on_hover_text("Close the window");
     if close_response.clicked() {
-        frame.close();
+        ui.ctx().send_viewport_command(egui::ViewportCommand::Close);
     }
 
     let is_maximized = ui.input(|i| i.viewport().maximized.unwrap_or(false));

--- a/examples/custom_window_frame/src/main.rs
+++ b/examples/custom_window_frame/src/main.rs
@@ -104,9 +104,9 @@ fn title_bar_ui(ui: &mut egui::Ui, title_bar_rect: eframe::epaint::Rect, title: 
     if title_bar_response.double_clicked() {
         let is_maximized = ui.input(|i| i.viewport().maximized.unwrap_or(false));
         ui.ctx()
-            .send_viewport_command(ViewportCommand::Maximized(!is_maximized));
+            .send_viewport_cmd(ViewportCommand::Maximized(!is_maximized));
     } else if title_bar_response.is_pointer_button_down_on() {
-        ui.ctx().send_viewport_command(ViewportCommand::StartDrag);
+        ui.ctx().send_viewport_cmd(ViewportCommand::StartDrag);
     }
 
     ui.allocate_ui_at_rect(title_bar_rect, |ui| {
@@ -129,7 +129,7 @@ fn close_maximize_minimize(ui: &mut egui::Ui) {
         .add(Button::new(RichText::new("❌").size(button_height)))
         .on_hover_text("Close the window");
     if close_response.clicked() {
-        ui.ctx().send_viewport_command(egui::ViewportCommand::Close);
+        ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
     }
 
     let is_maximized = ui.input(|i| i.viewport().maximized.unwrap_or(false));
@@ -139,15 +139,14 @@ fn close_maximize_minimize(ui: &mut egui::Ui) {
             .on_hover_text("Restore window");
         if maximized_response.clicked() {
             ui.ctx()
-                .send_viewport_command(ViewportCommand::Maximized(false));
+                .send_viewport_cmd(ViewportCommand::Maximized(false));
         }
     } else {
         let maximized_response = ui
             .add(Button::new(RichText::new("🗗").size(button_height)))
             .on_hover_text("Maximize window");
         if maximized_response.clicked() {
-            ui.ctx()
-                .send_viewport_command(ViewportCommand::Maximized(true));
+            ui.ctx().send_viewport_cmd(ViewportCommand::Maximized(true));
         }
     }
 
@@ -155,7 +154,6 @@ fn close_maximize_minimize(ui: &mut egui::Ui) {
         .add(Button::new(RichText::new("🗕").size(button_height)))
         .on_hover_text("Minimize the window");
     if minimized_response.clicked() {
-        ui.ctx()
-            .send_viewport_command(ViewportCommand::Minimized(true));
+        ui.ctx().send_viewport_cmd(ViewportCommand::Minimized(true));
     }
 }

--- a/examples/multiple_viewports/src/main.rs
+++ b/examples/multiple_viewports/src/main.rs
@@ -65,7 +65,7 @@ impl eframe::App for MyApp {
                         ui.label("Hello from immediate viewport");
                     });
 
-                    if ctx.input(|i| i.raw.viewport.close_requested) {
+                    if ctx.input(|i| i.viewport().close_requested) {
                         // Tell parent viewport that we should not show next frame:
                         self.show_immediate_viewport = false;
                         ctx.request_repaint(); // make sure there is a next frame
@@ -90,7 +90,7 @@ impl eframe::App for MyApp {
                     egui::CentralPanel::default().show(ctx, |ui| {
                         ui.label("Hello from deferred viewport");
                     });
-                    if ctx.input(|i| i.raw.viewport.close_requested) {
+                    if ctx.input(|i| i.viewport().close_requested) {
                         // Tell parent to close us.
                         show_deferred_viewport.store(false, Ordering::Relaxed);
                         ctx.request_repaint(); // make sure there is a next frame

--- a/examples/save_plot/src/main.rs
+++ b/examples/save_plot/src/main.rs
@@ -28,7 +28,7 @@ impl eframe::App for MyApp {
         let mut plot_rect = None;
         egui::CentralPanel::default().show(ctx, |ui| {
             if ui.button("Save Plot").clicked() {
-                frame.request_screenshot();
+                ctx.send_viewport_command(egui::ViewportCommand::Screenshot);
             }
 
             let my_plot = Plot::new("My Plot").legend(Legend::default());

--- a/examples/save_plot/src/main.rs
+++ b/examples/save_plot/src/main.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), eframe::Error> {
 struct MyApp {}
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         let mut plot_rect = None;
         egui::CentralPanel::default().show(ctx, |ui| {
             if ui.button("Save Plot").clicked() {
@@ -56,8 +56,8 @@ impl eframe::App for MyApp {
                 // for a full size application, we should put this in a different thread,
                 // so that the GUI doesn't lag during saving
 
-                let pixels_per_point = frame.info().native_pixels_per_point;
-                let plot = screenshot.region(&plot_location, pixels_per_point);
+                let pixels_per_point = ctx.pixels_per_point();
+                let plot = screenshot.region(&plot_location, Some(pixels_per_point));
                 // save the plot to png
                 image::save_buffer(
                     &path,

--- a/examples/save_plot/src/main.rs
+++ b/examples/save_plot/src/main.rs
@@ -28,7 +28,7 @@ impl eframe::App for MyApp {
         let mut plot_rect = None;
         egui::CentralPanel::default().show(ctx, |ui| {
             if ui.button("Save Plot").clicked() {
-                ctx.send_viewport_command(egui::ViewportCommand::Screenshot);
+                ctx.send_viewport_cmd(egui::ViewportCommand::Screenshot);
             }
 
             let my_plot = Plot::new("My Plot").legend(Legend::default());

--- a/examples/save_plot/src/main.rs
+++ b/examples/save_plot/src/main.rs
@@ -1,9 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use std::sync::Arc;
-
 use eframe::egui;
-use egui::ColorImage;
 use egui_plot::{Legend, Line, Plot, PlotPoints};
 
 fn main() -> Result<(), eframe::Error> {

--- a/examples/screenshot/src/main.rs
+++ b/examples/screenshot/src/main.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
+use std::sync::Arc;
+
 use eframe::egui::{self, ColorImage};
 
 fn main() -> Result<(), eframe::Error> {
@@ -19,7 +21,7 @@ fn main() -> Result<(), eframe::Error> {
 struct MyApp {
     continuously_take_screenshots: bool,
     texture: Option<egui::TextureHandle>,
-    screenshot: Option<ColorImage>,
+    screenshot: Option<Arc<ColorImage>>,
     save_to_file: bool,
 }
 
@@ -68,28 +70,33 @@ impl eframe::App for MyApp {
                 ui.spinner();
             }
 
+            // Check for returned screenshot:
+            ui.input(|i| {
+                for event in &i.raw.events {
+                    if let egui::Event::Screenshot { image, .. } = event {
+                        if self.save_to_file {
+                            let pixels_per_point = i.pixels_per_point();
+                            let region = egui::Rect::from_two_pos(
+                                egui::Pos2::ZERO,
+                                egui::Pos2 { x: 100., y: 100. },
+                            );
+                            let top_left_corner = image.region(&region, Some(pixels_per_point));
+                            image::save_buffer(
+                                "top_left.png",
+                                top_left_corner.as_raw(),
+                                top_left_corner.width() as u32,
+                                top_left_corner.height() as u32,
+                                image::ColorType::Rgba8,
+                            )
+                            .unwrap();
+                            self.save_to_file = false;
+                        }
+                        self.screenshot = Some(image.clone());
+                    }
+                }
+            });
+
             ctx.request_repaint();
         });
-    }
-
-    fn post_rendering(&mut self, _window_size: [u32; 2], frame: &eframe::Frame) {
-        if let Some(screenshot) = frame.screenshot() {
-            if self.save_to_file {
-                let pixels_per_point = frame.info().native_pixels_per_point;
-                let region =
-                    egui::Rect::from_two_pos(egui::Pos2::ZERO, egui::Pos2 { x: 100., y: 100. });
-                let top_left_corner = screenshot.region(&region, pixels_per_point);
-                image::save_buffer(
-                    "top_left.png",
-                    top_left_corner.as_raw(),
-                    top_left_corner.width() as u32,
-                    top_left_corner.height() as u32,
-                    image::ColorType::Rgba8,
-                )
-                .unwrap();
-                self.save_to_file = false;
-            }
-            self.screenshot = Some(screenshot);
-        }
     }
 }

--- a/examples/screenshot/src/main.rs
+++ b/examples/screenshot/src/main.rs
@@ -24,7 +24,7 @@ struct MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             if let Some(screenshot) = self.screenshot.take() {
                 self.texture = Some(ui.ctx().load_texture(
@@ -42,7 +42,7 @@ impl eframe::App for MyApp {
 
                 if ui.button("save to 'top_left.png'").clicked() {
                     self.save_to_file = true;
-                    frame.request_screenshot();
+                    ctx.send_viewport_command(egui::ViewportCommand::Screenshot);
                 }
 
                 ui.with_layout(egui::Layout::top_down(egui::Align::RIGHT), |ui| {
@@ -55,9 +55,9 @@ impl eframe::App for MyApp {
                         } else {
                             ctx.set_visuals(egui::Visuals::light());
                         };
-                        frame.request_screenshot();
+                        ctx.send_viewport_command(egui::ViewportCommand::Screenshot);
                     } else if ui.button("take screenshot!").clicked() {
-                        frame.request_screenshot();
+                        ctx.send_viewport_command(egui::ViewportCommand::Screenshot);
                     }
                 });
             });

--- a/examples/screenshot/src/main.rs
+++ b/examples/screenshot/src/main.rs
@@ -44,7 +44,7 @@ impl eframe::App for MyApp {
 
                 if ui.button("save to 'top_left.png'").clicked() {
                     self.save_to_file = true;
-                    ctx.send_viewport_command(egui::ViewportCommand::Screenshot);
+                    ctx.send_viewport_cmd(egui::ViewportCommand::Screenshot);
                 }
 
                 ui.with_layout(egui::Layout::top_down(egui::Align::RIGHT), |ui| {
@@ -57,9 +57,9 @@ impl eframe::App for MyApp {
                         } else {
                             ctx.set_visuals(egui::Visuals::light());
                         };
-                        ctx.send_viewport_command(egui::ViewportCommand::Screenshot);
+                        ctx.send_viewport_cmd(egui::ViewportCommand::Screenshot);
                     } else if ui.button("take screenshot!").clicked() {
-                        ctx.send_viewport_command(egui::ViewportCommand::Screenshot);
+                        ctx.send_viewport_cmd(egui::ViewportCommand::Screenshot);
                     }
                 });
             });

--- a/examples/serial_windows/src/main.rs
+++ b/examples/serial_windows/src/main.rs
@@ -46,7 +46,7 @@ struct MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             let label_text = if self.has_next {
                 "When this window is closed the next will be opened after a short delay"
@@ -56,7 +56,7 @@ impl eframe::App for MyApp {
             ui.label(label_text);
             if ui.button("Close").clicked() {
                 eprintln!("Pressed Close button");
-                frame.close();
+                ui.ctx().send_viewport_command(egui::ViewportCommand::Close);
             }
         });
     }

--- a/examples/serial_windows/src/main.rs
+++ b/examples/serial_windows/src/main.rs
@@ -56,7 +56,7 @@ impl eframe::App for MyApp {
             ui.label(label_text);
             if ui.button("Close").clicked() {
                 eprintln!("Pressed Close button");
-                ui.ctx().send_viewport_command(egui::ViewportCommand::Close);
+                ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
             }
         });
     }

--- a/examples/test_viewports/src/main.rs
+++ b/examples/test_viewports/src/main.rs
@@ -258,7 +258,7 @@ fn generic_ui(ui: &mut egui::Ui, children: &[Arc<RwLock<ViewportState>>]) {
             data.insert_temp(container_id.with("pixels_per_point"), tmp_pixels_per_point);
         });
     }
-    egui::gui_zoom::zoom_with_keyboard_shortcuts(&ctx, None);
+    egui::gui_zoom::zoom_with_keyboard_shortcuts(&ctx);
 
     if ctx.viewport_id() != ctx.parent_viewport_id() {
         let parent = ctx.parent_viewport_id();

--- a/examples/test_viewports/src/main.rs
+++ b/examples/test_viewports/src/main.rs
@@ -221,14 +221,14 @@ fn generic_ui(ui: &mut egui::Ui, children: &[Arc<RwLock<ViewportState>>]) {
 
     ui.add_space(8.0);
 
-    if let Some(inner_rect) = ctx.input(|i| i.raw.viewport.inner_rect_px) {
+    if let Some(inner_rect) = ctx.input(|i| i.raw.viewport.inner_rect) {
         ui.label(format!(
             "Inner Rect: Pos: {:?}, Size: {:?}",
             inner_rect.min,
             inner_rect.size()
         ));
     }
-    if let Some(outer_rect) = ctx.input(|i| i.raw.viewport.outer_rect_px) {
+    if let Some(outer_rect) = ctx.input(|i| i.raw.viewport.outer_rect) {
         ui.label(format!(
             "Outer Rect: Pos: {:?}, Size: {:?}",
             outer_rect.min,

--- a/examples/test_viewports/src/main.rs
+++ b/examples/test_viewports/src/main.rs
@@ -263,7 +263,7 @@ fn generic_ui(ui: &mut egui::Ui, children: &[Arc<RwLock<ViewportState>>]) {
     if ctx.viewport_id() != ctx.parent_viewport_id() {
         let parent = ctx.parent_viewport_id();
         if ui.button("Set parent pos 0,0").clicked() {
-            ctx.send_viewport_command_to(
+            ctx.send_viewport_cmd_to(
                 parent,
                 egui::ViewportCommand::OuterPosition(egui::pos2(0.0, 0.0)),
             );

--- a/examples/test_viewports/src/main.rs
+++ b/examples/test_viewports/src/main.rs
@@ -221,14 +221,14 @@ fn generic_ui(ui: &mut egui::Ui, children: &[Arc<RwLock<ViewportState>>]) {
 
     ui.add_space(8.0);
 
-    if let Some(inner_rect) = ctx.input(|i| i.raw.viewport.inner_rect) {
+    if let Some(inner_rect) = ctx.input(|i| i.viewport().inner_rect) {
         ui.label(format!(
             "Inner Rect: Pos: {:?}, Size: {:?}",
             inner_rect.min,
             inner_rect.size()
         ));
     }
-    if let Some(outer_rect) = ctx.input(|i| i.raw.viewport.outer_rect) {
+    if let Some(outer_rect) = ctx.input(|i| i.viewport().outer_rect) {
         ui.label(format!(
             "Outer Rect: Pos: {:?}, Size: {:?}",
             outer_rect.min,

--- a/examples/user_attention/src/main.rs
+++ b/examples/user_attention/src/main.rs
@@ -56,9 +56,7 @@ impl eframe::App for Application {
         if let Some(request_at) = self.request_at {
             if request_at < SystemTime::now() {
                 self.request_at = None;
-                ctx.send_viewport_command(egui::ViewportCommand::RequestUserAttention(
-                    self.attention,
-                ));
+                ctx.send_viewport_cmd(egui::ViewportCommand::RequestUserAttention(self.attention));
                 if self.auto_reset {
                     self.auto_reset = false;
                     self.reset_at = Some(SystemTime::now() + Self::attention_reset_timeout());
@@ -69,7 +67,7 @@ impl eframe::App for Application {
         if let Some(reset_at) = self.reset_at {
             if reset_at < SystemTime::now() {
                 self.reset_at = None;
-                ctx.send_viewport_command(egui::ViewportCommand::RequestUserAttention(
+                ctx.send_viewport_cmd(egui::ViewportCommand::RequestUserAttention(
                     UserAttentionType::Reset,
                 ));
             }

--- a/examples/user_attention/src/main.rs
+++ b/examples/user_attention/src/main.rs
@@ -1,14 +1,12 @@
-use eframe::{
-    egui::{Button, CentralPanel, Context, UserAttentionType},
-    CreationContext, NativeOptions,
-};
+use eframe::{egui, CreationContext, NativeOptions};
+use egui::{Button, CentralPanel, Context, UserAttentionType};
 
 use std::time::{Duration, SystemTime};
 
 fn main() -> eframe::Result<()> {
     env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
     let native_options = NativeOptions {
-        initial_window_size: Some(eframe::egui::vec2(400., 200.)),
+        initial_window_size: Some(egui::vec2(400., 200.)),
         ..Default::default()
     };
     eframe::run_native(
@@ -54,11 +52,13 @@ impl Application {
 }
 
 impl eframe::App for Application {
-    fn update(&mut self, ctx: &Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &Context, _frame: &mut eframe::Frame) {
         if let Some(request_at) = self.request_at {
             if request_at < SystemTime::now() {
                 self.request_at = None;
-                frame.request_user_attention(self.attention);
+                ctx.send_viewport_command(egui::ViewportCommand::RequestUserAttention(
+                    self.attention,
+                ));
                 if self.auto_reset {
                     self.auto_reset = false;
                     self.reset_at = Some(SystemTime::now() + Self::attention_reset_timeout());
@@ -69,7 +69,9 @@ impl eframe::App for Application {
         if let Some(reset_at) = self.reset_at {
             if reset_at < SystemTime::now() {
                 self.reset_at = None;
-                frame.request_user_attention(UserAttentionType::Reset);
+                ctx.send_viewport_command(egui::ViewportCommand::RequestUserAttention(
+                    UserAttentionType::Reset,
+                ));
             }
         }
 
@@ -77,7 +79,7 @@ impl eframe::App for Application {
             ui.vertical(|ui| {
                 ui.horizontal(|ui| {
                     ui.label("Attention type:");
-                    eframe::egui::ComboBox::new("attention", "")
+                    egui::ComboBox::new("attention", "")
                         .selected_text(repr(self.attention))
                         .show_ui(ui, |ui| {
                             for kind in [

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -16,6 +16,12 @@ cargo install cargo-cranky # Uses lints defined in Cranky.toml. See https://gith
 export RUSTFLAGS="--cfg=web_sys_unstable_apis -D warnings"
 export RUSTDOCFLAGS="-D warnings" # https://github.com/emilk/egui/pull/1454
 
+# Fast checks first:
+typos
+cargo fmt --all -- --check
+cargo doc --lib --no-deps --all-features
+cargo doc --document-private-items --no-deps --all-features
+
 cargo check --all-targets
 cargo check --all-targets --all-features
 cargo check -p egui_demo_app --lib --target wasm32-unknown-unknown
@@ -23,10 +29,6 @@ cargo check -p egui_demo_app --lib --target wasm32-unknown-unknown --all-feature
 cargo cranky --all-targets --all-features -- -D warnings
 cargo test --all-targets --all-features
 cargo test --doc # slow - checks all doc-tests
-cargo fmt --all -- --check
-
-cargo doc --lib --no-deps --all-features
-cargo doc --document-private-items --no-deps --all-features
 
 (cd crates/eframe && cargo check --no-default-features --features "glow")
 (cd crates/eframe && cargo check --no-default-features --features "wgpu")

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -58,8 +58,6 @@ cargo test --doc # slow - checks all doc-tests
 
 ./scripts/wasm_bindgen_check.sh
 
-cargo cranky --target wasm32-unknown-unknown --all-features -p egui_demo_app --lib -- -D warnings
-
 ./scripts/cargo_deny.sh
 
 # TODO(emilk): consider using https://github.com/taiki-e/cargo-hack or https://github.com/frewsxcv/cargo-all-features

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -23,11 +23,13 @@ cargo fmt --all -- --check
 cargo doc --lib --no-deps --all-features
 cargo doc --document-private-items --no-deps --all-features
 
+cargo cranky --all-targets --all-features -- -D warnings
+./scripts/clippy_wasm.sh
+
 cargo check --all-targets
 cargo check --all-targets --all-features
 cargo check -p egui_demo_app --lib --target wasm32-unknown-unknown
 cargo check -p egui_demo_app --lib --target wasm32-unknown-unknown --all-features
-cargo cranky --all-targets --all-features -- -D warnings
 cargo test --all-targets --all-features
 cargo test --doc # slow - checks all doc-tests
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -18,6 +18,7 @@ export RUSTDOCFLAGS="-D warnings" # https://github.com/emilk/egui/pull/1454
 
 # Fast checks first:
 typos
+./scripts/lint.py
 cargo fmt --all -- --check
 cargo doc --lib --no-deps --all-features
 cargo doc --document-private-items --no-deps --all-features


### PR DESCRIPTION
* Part of https://github.com/emilk/egui/issues/3556

## In short
You now almost never need to use `eframe::Frame` - instead use `ui.input(|i| i.viewport())` for information about the current viewport (native window), and use `ctx.send_viewport_cmd` to modify it.

## In detail

This PR removes most commands from `eframe::Frame`, and replaces them with `ViewportCommand`.
So `frame.close()` becomes `ctx.send_viewport_cmd(ViewportCommand::Close)`, etc.

`frame.info().window_info` is now also gone, replaced with `ui.input(|i| i.viewport())`.

`frame.info().native_pixels_per_point` is replaced with `ui.input(|i| i.raw.native_pixels_per_point)`.

`RawInput` now contains one `ViewportInfo` for each viewport.

Screenshots are taken with `ctx.send_viewport_cmd(ViewportCommand::Screenshots)` and are returned in `egui::Event` which you can check with:

``` ust
ui.input(|i| {
    for event in &i.raw.events {
        if let egui::Event::Screenshot { viewport_id, image } = event {
            // handle it here
        }
    }
});
```

### Motivation
You no longer need to pass around the `&eframe::Frame` everywhere.
This also opens the door for other integrations to use the same API of `ViewportCommand`s.