### PR TITLE
Fix egui-wgpu performance regression

### DIFF
--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -70,7 +70,13 @@ persistence = [
 ## `eframe` will call `puffin::GlobalProfiler::lock().new_frame()` for you
 ##
 ## Only enabled on native, because of the low resolution (1ms) of clocks in browsers.
-puffin = ["dep:puffin", "egui/puffin", "egui_glow?/puffin", "egui-wgpu?/puffin"]
+puffin = [
+  "dep:puffin",
+  "egui/puffin",
+  "egui_glow?/puffin",
+  "egui-wgpu?/puffin",
+  "egui-winit/puffin",
+]
 
 ## Enables wayland support and fixes clipboard issue.
 wayland = ["egui-winit/wayland"]

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -210,7 +210,7 @@ impl EpiIntegration {
         self.close
     }
 
-    pub fn on_event(
+    pub fn on_window_event(
         &mut self,
         app: &mut dyn epi::App,
         event: &winit::event::WindowEvent<'_>,
@@ -247,7 +247,7 @@ impl EpiIntegration {
             _ => {}
         }
 
-        egui_winit.on_event(&self.egui_ctx, event, viewport_id)
+        egui_winit.on_window_event(&self.egui_ctx, event, viewport_id)
     }
 
     pub fn pre_update(&mut self) {

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -7,7 +7,7 @@ use winit::event_loop::EventLoopWindowTarget;
 use raw_window_handle::{HasRawDisplayHandle as _, HasRawWindowHandle as _};
 
 use egui::{DeferredViewportUiCallback, NumExt as _, ViewportBuilder, ViewportId};
-use egui_winit::{short_window_event_description, EventResponse, WindowSettings};
+use egui_winit::{EventResponse, WindowSettings};
 
 use crate::{epi, Theme};
 
@@ -225,7 +225,7 @@ impl EpiIntegration {
         egui_winit: &mut egui_winit::State,
         viewport_id: ViewportId,
     ) -> EventResponse {
-        crate::profile_function!(short_window_event_description(event));
+        crate::profile_function!(egui_winit::short_window_event_description(event));
 
         use winit::event::{ElementState, MouseButton, WindowEvent};
 

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -469,14 +469,14 @@ impl WinitApp for GlowWinitApp {
 impl GlowWinitRunning {
     fn run_ui_and_paint(&mut self, window_id: WindowId) -> EventResult {
         let Some(viewport_id) = self
-                .glutin
-                .borrow()
-                .viewport_from_window
-                .get(&window_id)
-                .copied()
-            else {
-                return EventResult::Wait;
-            };
+            .glutin
+            .borrow()
+            .viewport_from_window
+            .get(&window_id)
+            .copied()
+        else {
+            return EventResult::Wait;
+        };
 
         #[cfg(feature = "puffin")]
         puffin::GlobalProfiler::lock().new_frame();
@@ -1129,11 +1129,11 @@ impl Viewport {
     /// Update the stored `ViewportInfo`.
     fn update_viewport_info(&mut self) {
         let Some(window) = &self.window else {
-                return;
-            };
+            return;
+        };
         let Some(egui_winit) = &self.egui_winit else {
-                return;
-            };
+            return;
+        };
         egui_winit.update_viewport_info(&mut self.info, window);
     }
 }
@@ -1247,15 +1247,15 @@ fn render_immediate_viewport(
         let mut glutin = glutin.borrow_mut();
 
         let Some(viewport) = glutin.viewports.get_mut(&ids.this) else {
-                return;
-            };
+            return;
+        };
         viewport.update_viewport_info();
         let Some(winit_state) = &mut viewport.egui_winit else {
-                return;
-            };
+            return;
+        };
         let Some(window) = &viewport.window else {
-                return;
-            };
+            return;
+        };
 
         let mut raw_input = winit_state.take_egui_input(window, ids);
         raw_input.viewports = glutin
@@ -1292,15 +1292,15 @@ fn render_immediate_viewport(
     } = &mut *glutin;
 
     let Some(viewport) = viewports.get_mut(&ids.this) else {
-            return;
-        };
+        return;
+    };
 
     let Some(winit_state) = &mut viewport.egui_winit else {
-            return;
-        };
+        return;
+    };
     let (Some(window), Some(gl_surface)) = (&viewport.window, &viewport.gl_surface) else {
-            return;
-        };
+        return;
+    };
 
     let screen_size_in_pixels: [u32; 2] = window.inner_size().into();
 

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -20,12 +20,12 @@ use egui::{
 use egui_winit::accesskit_winit;
 use egui_winit::{
     apply_viewport_builder_to_new_window, create_winit_window_builder, process_viewport_commands,
-    EventResponse,
+    short_window_event_description, EventResponse,
 };
 
 use crate::{
-    native::epi_integration::EpiIntegration, App, AppCreator, CreationContext, NativeOptions,
-    Result, Storage,
+    native::{epi_integration::EpiIntegration, winit_integration::short_event_description},
+    App, AppCreator, CreationContext, NativeOptions, Result, Storage,
 };
 
 use super::{
@@ -393,7 +393,7 @@ impl WinitApp for GlowWinitApp {
         event_loop: &EventLoopWindowTarget<UserEvent>,
         event: &winit::event::Event<'_, UserEvent>,
     ) -> Result<EventResult> {
-        crate::profile_function!();
+        crate::profile_function!(short_event_description(event));
 
         Ok(match event {
             winit::event::Event::Resumed => {
@@ -646,6 +646,8 @@ impl GlowWinitRunning {
         window_id: WindowId,
         event: &winit::event::WindowEvent<'_>,
     ) -> EventResult {
+        crate::profile_function!(short_window_event_description(event));
+
         let viewport_id = self
             .glutin
             .borrow()

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -24,8 +24,8 @@ use egui_winit::{
 };
 
 use crate::{
-    native::{epi_integration::EpiIntegration, winit_integration::short_event_description},
-    App, AppCreator, CreationContext, NativeOptions, Result, Storage,
+    native::epi_integration::EpiIntegration, App, AppCreator, CreationContext, NativeOptions,
+    Result, Storage,
 };
 
 use super::{
@@ -393,7 +393,7 @@ impl WinitApp for GlowWinitApp {
         event_loop: &EventLoopWindowTarget<UserEvent>,
         event: &winit::event::Event<'_, UserEvent>,
     ) -> Result<EventResult> {
-        crate::profile_function!(short_event_description(event));
+        crate::profile_function!(winit_integration::short_event_description(event));
 
         Ok(match event {
             winit::event::Event::Resumed => {

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -710,7 +710,7 @@ impl GlowWinitRunning {
             if let Some(viewport_id) = viewport_id {
                 let mut glutin = self.glutin.borrow_mut();
                 if let Some(viewport) = glutin.viewports.get_mut(&viewport_id) {
-                    break 'res self.integration.on_event(
+                    break 'res self.integration.on_window_event(
                         self.app.as_mut(),
                         event,
                         viewport.egui_winit.as_mut().unwrap(),

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -20,7 +20,7 @@ use egui::{
 use egui_winit::accesskit_winit;
 use egui_winit::{
     apply_viewport_builder_to_new_window, create_winit_window_builder, process_viewport_commands,
-    short_window_event_description, EventResponse,
+    EventResponse,
 };
 
 use crate::{
@@ -654,7 +654,7 @@ impl GlowWinitRunning {
         window_id: WindowId,
         event: &winit::event::WindowEvent<'_>,
     ) -> EventResult {
-        crate::profile_function!(short_window_event_description(event));
+        crate::profile_function!(egui_winit::short_window_event_description(event));
 
         let viewport_id = self
             .glutin

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -11,7 +11,11 @@ use winit::event_loop::{EventLoop, EventLoopBuilder};
 
 use egui::epaint::ahash::HashMap;
 
-use crate::{epi, native::winit_integration::EventResult, Result};
+use crate::{
+    epi,
+    native::winit_integration::{short_event_description, EventResult},
+    Result,
+};
 
 use super::winit_integration::{UserEvent, WinitApp};
 
@@ -396,70 +400,4 @@ pub fn run_wgpu(
     let event_loop = create_event_loop(&mut native_options);
     let wgpu_eframe = WgpuWinitApp::new(&event_loop, app_name, native_options, app_creator);
     run_and_exit(event_loop, wgpu_eframe);
-}
-
-// ----------------------------------------------------------------------------
-
-// For the puffin profiler!
-#[allow(dead_code)] // Only used for profiling
-fn short_event_description(event: &winit::event::Event<'_, UserEvent>) -> &'static str {
-    use winit::event::{DeviceEvent, Event, StartCause, WindowEvent};
-
-    match event {
-        Event::Suspended => "Event::Suspended",
-        Event::Resumed => "Event::Resumed",
-        Event::MainEventsCleared => "Event::MainEventsCleared",
-        Event::RedrawRequested(_) => "Event::RedrawRequested",
-        Event::RedrawEventsCleared => "Event::RedrawEventsCleared",
-        Event::LoopDestroyed => "Event::LoopDestroyed",
-        Event::UserEvent(user_event) => match user_event {
-            UserEvent::RequestRepaint { .. } => "UserEvent::RequestRepaint",
-            #[cfg(feature = "accesskit")]
-            UserEvent::AccessKitActionRequest(_) => "UserEvent::AccessKitActionRequest",
-        },
-        Event::DeviceEvent { event, .. } => match event {
-            DeviceEvent::Added { .. } => "DeviceEvent::Added",
-            DeviceEvent::Removed { .. } => "DeviceEvent::Removed",
-            DeviceEvent::MouseMotion { .. } => "DeviceEvent::MouseMotion",
-            DeviceEvent::MouseWheel { .. } => "DeviceEvent::MouseWheel",
-            DeviceEvent::Motion { .. } => "DeviceEvent::Motion",
-            DeviceEvent::Button { .. } => "DeviceEvent::Button",
-            DeviceEvent::Key { .. } => "DeviceEvent::Key",
-            DeviceEvent::Text { .. } => "DeviceEvent::Text",
-        },
-        Event::NewEvents(start_cause) => match start_cause {
-            StartCause::ResumeTimeReached { .. } => "NewEvents::ResumeTimeReached",
-            StartCause::WaitCancelled { .. } => "NewEvents::WaitCancelled",
-            StartCause::Poll => "NewEvents::Poll",
-            StartCause::Init => "NewEvents::Init",
-        },
-        Event::WindowEvent { event, .. } => match event {
-            WindowEvent::Resized { .. } => "WindowEvent::Resized",
-            WindowEvent::Moved { .. } => "WindowEvent::Moved",
-            WindowEvent::CloseRequested { .. } => "WindowEvent::CloseRequested",
-            WindowEvent::Destroyed { .. } => "WindowEvent::Destroyed",
-            WindowEvent::DroppedFile { .. } => "WindowEvent::DroppedFile",
-            WindowEvent::HoveredFile { .. } => "WindowEvent::HoveredFile",
-            WindowEvent::HoveredFileCancelled { .. } => "WindowEvent::HoveredFileCancelled",
-            WindowEvent::ReceivedCharacter { .. } => "WindowEvent::ReceivedCharacter",
-            WindowEvent::Focused { .. } => "WindowEvent::Focused",
-            WindowEvent::KeyboardInput { .. } => "WindowEvent::KeyboardInput",
-            WindowEvent::ModifiersChanged { .. } => "WindowEvent::ModifiersChanged",
-            WindowEvent::Ime { .. } => "WindowEvent::Ime",
-            WindowEvent::CursorMoved { .. } => "WindowEvent::CursorMoved",
-            WindowEvent::CursorEntered { .. } => "WindowEvent::CursorEntered",
-            WindowEvent::CursorLeft { .. } => "WindowEvent::CursorLeft",
-            WindowEvent::MouseWheel { .. } => "WindowEvent::MouseWheel",
-            WindowEvent::MouseInput { .. } => "WindowEvent::MouseInput",
-            WindowEvent::TouchpadMagnify { .. } => "WindowEvent::TouchpadMagnify",
-            WindowEvent::SmartMagnify { .. } => "WindowEvent::SmartMagnify",
-            WindowEvent::TouchpadRotate { .. } => "WindowEvent::TouchpadRotate",
-            WindowEvent::TouchpadPressure { .. } => "WindowEvent::TouchpadPressure",
-            WindowEvent::AxisMotion { .. } => "WindowEvent::AxisMotion",
-            WindowEvent::Touch { .. } => "WindowEvent::Touch",
-            WindowEvent::ScaleFactorChanged { .. } => "WindowEvent::ScaleFactorChanged",
-            WindowEvent::ThemeChanged { .. } => "WindowEvent::ThemeChanged",
-            WindowEvent::Occluded { .. } => "WindowEvent::Occluded",
-        },
-    }
 }

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -115,8 +115,8 @@ impl WgpuWinitApp {
 
     fn build_windows(&mut self, event_loop: &EventLoopWindowTarget<UserEvent>) {
         let Some(running) = &mut self.running else {
-                return;
-            };
+            return;
+        };
         let mut shared = running.shared.borrow_mut();
         let SharedState {
             viewports,
@@ -457,14 +457,14 @@ impl WgpuWinitRunning {
     /// This is called both for the root viewport, and all deferred viewports
     fn run_ui_and_paint(&mut self, window_id: WindowId) -> EventResult {
         let Some(viewport_id) = self
-                .shared
-                .borrow()
-                .viewport_from_window
-                .get(&window_id)
-                .copied()
-            else {
-                return EventResult::Wait;
-            };
+            .shared
+            .borrow()
+            .viewport_from_window
+            .get(&window_id)
+            .copied()
+        else {
+            return EventResult::Wait;
+        };
 
         #[cfg(feature = "puffin")]
         puffin::GlobalProfiler::lock().new_frame();
@@ -485,8 +485,8 @@ impl WgpuWinitRunning {
             } = &mut *shared_lock;
 
             let Some(viewport) = viewports.get(&viewport_id) else {
-                    return EventResult::Wait;
-                };
+                return EventResult::Wait;
+            };
 
             if viewport_id != ViewportId::ROOT && viewport.viewport_ui_cb.is_none() {
                 // This will only happen if this is an immediate viewport.
@@ -500,8 +500,8 @@ impl WgpuWinitRunning {
             }
 
             let Some(viewport) = viewports.get_mut(&viewport_id) else {
-                    return EventResult::Wait;
-                };
+                return EventResult::Wait;
+            };
             viewport.update_viewport_info();
 
             let Viewport {
@@ -514,8 +514,8 @@ impl WgpuWinitRunning {
             let viewport_ui_cb = viewport_ui_cb.clone();
 
             let Some(window) = window else {
-                    return EventResult::Wait;
-                };
+                return EventResult::Wait;
+            };
 
             if let Err(err) = pollster::block_on(painter.set_window(viewport_id, Some(window))) {
                 log::warn!("Failed to set window: {err}");
@@ -555,17 +555,17 @@ impl WgpuWinitRunning {
         } = &mut *shared;
 
         let Some(viewport) = viewports.get_mut(&viewport_id) else {
-                return EventResult::Wait;
-            };
+            return EventResult::Wait;
+        };
 
         let Viewport {
-                window: Some(window),
-                egui_winit: Some(egui_winit),
-                ..
-            } = viewport
-            else {
-                return EventResult::Wait;
-            };
+            window: Some(window),
+            egui_winit: Some(egui_winit),
+            ..
+        } = viewport
+        else {
+            return EventResult::Wait;
+        };
 
         integration.post_update();
 
@@ -776,11 +776,11 @@ impl Viewport {
     /// Update the stored `ViewportInfo`.
     pub fn update_viewport_info(&mut self) {
         let Some(window) = &self.window else {
-                return;
-            };
+            return;
+        };
         let Some(egui_winit) = &self.egui_winit else {
-                return;
-            };
+            return;
+        };
         egui_winit.update_viewport_info(&mut self.info, window);
     }
 }
@@ -840,10 +840,9 @@ fn render_immediate_viewport(
         }
         viewport.update_viewport_info();
 
-        let (Some(window), Some(winit_state)) = (&viewport.window, &mut viewport.egui_winit)
-            else {
-                return;
-            };
+        let (Some(window), Some(winit_state)) = (&viewport.window, &mut viewport.egui_winit) else {
+            return;
+        };
 
         let mut input = winit_state.take_egui_input(window, ids);
         input.viewports = viewports
@@ -879,14 +878,14 @@ fn render_immediate_viewport(
     } = &mut *shared;
 
     let Some(viewport) = viewports.get_mut(&ids.this) else {
-            return;
-        };
+        return;
+    };
     let Some(winit_state) = &mut viewport.egui_winit else {
-            return;
-        };
+        return;
+    };
     let Some(window) = &viewport.window else {
-            return;
-        };
+        return;
+    };
 
     if let Err(err) = pollster::block_on(painter.set_window(ids.this, Some(window))) {
         log::error!(

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -19,10 +19,7 @@ use egui_winit::{
 };
 
 use crate::{
-    native::{
-        epi_integration::EpiIntegration,
-        winit_integration::{short_event_description, EventResult},
-    },
+    native::{epi_integration::EpiIntegration, winit_integration::EventResult},
     App, AppCreator, CreationContext, NativeOptions, Result, Storage, UserEvent,
 };
 
@@ -360,7 +357,7 @@ impl WinitApp for WgpuWinitApp {
         event_loop: &EventLoopWindowTarget<UserEvent>,
         event: &winit::event::Event<'_, UserEvent>,
     ) -> Result<EventResult> {
-        crate::profile_function!(short_event_description(event));
+        crate::profile_function!(winit_integration::short_event_description(event));
 
         self.build_windows(event_loop);
 

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -16,7 +16,6 @@ use egui::{
 use egui_winit::accesskit_winit;
 use egui_winit::{
     apply_viewport_builder_to_new_window, create_winit_window_builder, process_viewport_commands,
-    short_window_event_description,
 };
 
 use crate::{
@@ -649,7 +648,7 @@ impl WgpuWinitRunning {
         window_id: WindowId,
         event: &winit::event::WindowEvent<'_>,
     ) -> EventResult {
-        crate::profile_function!(short_window_event_description(event));
+        crate::profile_function!(egui_winit::short_window_event_description(event));
 
         let Self {
             integration,

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -705,7 +705,7 @@ impl WgpuWinitRunning {
         let event_response = viewport_id.and_then(|viewport_id| {
             shared.viewports.get_mut(&viewport_id).and_then(|viewport| {
                 viewport.egui_winit.as_mut().map(|egui_winit| {
-                    integration.on_event(app.as_mut(), event, egui_winit, viewport_id)
+                    integration.on_window_event(app.as_mut(), event, egui_winit, viewport_id)
                 })
             })
         });

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -16,10 +16,14 @@ use egui::{
 use egui_winit::accesskit_winit;
 use egui_winit::{
     apply_viewport_builder_to_new_window, create_winit_window_builder, process_viewport_commands,
+    short_window_event_description,
 };
 
 use crate::{
-    native::{epi_integration::EpiIntegration, winit_integration::EventResult},
+    native::{
+        epi_integration::EpiIntegration,
+        winit_integration::{short_event_description, EventResult},
+    },
     App, AppCreator, CreationContext, NativeOptions, Result, Storage, UserEvent,
 };
 
@@ -357,7 +361,7 @@ impl WinitApp for WgpuWinitApp {
         event_loop: &EventLoopWindowTarget<UserEvent>,
         event: &winit::event::Event<'_, UserEvent>,
     ) -> Result<EventResult> {
-        crate::profile_function!();
+        crate::profile_function!(short_event_description(event));
 
         self.build_windows(event_loop);
 
@@ -637,6 +641,8 @@ impl WgpuWinitRunning {
         window_id: WindowId,
         event: &winit::event::WindowEvent<'_>,
     ) -> EventResult {
+        crate::profile_function!(short_window_event_description(event));
+
         let Self {
             integration,
             app,

--- a/crates/eframe/src/native/winit_integration.rs
+++ b/crates/eframe/src/native/winit_integration.rs
@@ -100,3 +100,18 @@ pub fn system_theme(window: &Window, options: &crate::NativeOptions) -> Option<c
         None
     }
 }
+
+/// Short and fast description of an event.
+/// Useful for logging and profiling.
+pub fn short_event_description(event: &winit::event::Event<'_, UserEvent>) -> &'static str {
+    use winit::event::Event;
+
+    match event {
+        Event::UserEvent(user_event) => match user_event {
+            UserEvent::RequestRepaint { .. } => "UserEvent::RequestRepaint",
+            #[cfg(feature = "accesskit")]
+            UserEvent::AccessKitActionRequest(_) => "UserEvent::AccessKitActionRequest",
+        },
+        _ => egui_winit::short_generic_event_description(event),
+    }
+}

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -143,6 +143,7 @@ impl Painter {
         present_mode: wgpu::PresentMode,
     ) {
         crate::profile_function!();
+
         let usage = if surface_state.supports_screenshot {
             wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_DST
         } else {
@@ -188,12 +189,16 @@ impl Painter {
         viewport_id: ViewportId,
         window: Option<&winit::window::Window>,
     ) -> Result<(), crate::WgpuError> {
-        crate::profile_function!();
+        crate::profile_scope!("Painter::set_window"); // profle_function gives bad names for async functions
 
         if let Some(window) = window {
             let size = window.inner_size();
             if self.surfaces.get(&viewport_id).is_none() {
-                let surface = unsafe { self.instance.create_surface(&window)? };
+
+                let surface = unsafe {
+                    crate::profile_scope!("create_surface");
+                    self.instance.create_surface(&window)?
+                };
 
                 let render_state = if let Some(render_state) = &self.render_state {
                     render_state

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -194,7 +194,6 @@ impl Painter {
         if let Some(window) = window {
             let size = window.inner_size();
             if self.surfaces.get(&viewport_id).is_none() {
-
                 let surface = unsafe {
                     crate::profile_scope!("create_surface");
                     self.instance.create_surface(&window)?

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -246,19 +246,24 @@ impl Painter {
                         supports_screenshot,
                     },
                 );
-            }
 
-            let Some(width) = NonZeroU32::new(size.width) else {
-                log::debug!("The window width was zero; skipping generate textures");
-                return Ok(());
-            };
-            let Some(height) = NonZeroU32::new(size.height) else {
-                log::debug!("The window height was zero; skipping generate textures");
-                return Ok(());
-            };
-            self.resize_and_generate_depth_texture_view_and_msaa_view(viewport_id, width, height);
+                let Some(width) = NonZeroU32::new(size.width) else {
+                    log::debug!("The window width was zero; skipping generate textures");
+                    return Ok(());
+                };
+                let Some(height) = NonZeroU32::new(size.height) else {
+                    log::debug!("The window height was zero; skipping generate textures");
+                    return Ok(());
+                };
+
+                self.resize_and_generate_depth_texture_view_and_msaa_view(
+                    viewport_id,
+                    width,
+                    height,
+                );
+            }
         } else {
-            log::warn!("All surfaces was deleted!");
+            log::warn!("No window - clearing all surfaces");
             self.surfaces.clear();
         }
         Ok(())

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -822,16 +822,14 @@ fn update_viewport_info(viewport_info: &mut ViewportInfo, window: &Window, pixel
     let inner_rect = inner_rect_px.map(|r| r / pixels_per_point);
     let outer_rect = outer_rect_px.map(|r| r / pixels_per_point);
 
-    let monitor = window.current_monitor().is_some();
-    let monitor_size = if monitor {
-        let size = window
-            .current_monitor()
-            .unwrap()
-            .size()
-            .to_logical::<f32>(pixels_per_point.into());
-        Some(egui::vec2(size.width, size.height))
-    } else {
-        None
+    let monitor_size = {
+        crate::profile_scope!("monitor_size");
+        if let Some(monitor) = window.current_monitor() {
+            let size = monitor.size().to_logical::<f32>(pixels_per_point.into());
+            Some(egui::vec2(size.width, size.height))
+        } else {
+            None
+        }
     };
 
     viewport_info.title = Some(window.title());

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -239,7 +239,7 @@ impl State {
         event: &winit::event::WindowEvent<'_>,
         viewport_id: ViewportId,
     ) -> EventResponse {
-        crate::profile_function!();
+        crate::profile_function!(short_window_event_description(event));
 
         use winit::event::WindowEvent;
         match event {
@@ -1334,6 +1334,76 @@ pub fn apply_viewport_builder_to_new_window(window: &Window, builder: &ViewportB
         if let Err(err) = window.set_cursor_hittest(!mouse_passthrough) {
             log::warn!("set_cursor_hittest failed: {err}");
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+/// Short and fast description of an event.
+/// Useful for logging and profiling.
+pub fn short_generic_event_description<T>(event: &winit::event::Event<'_, T>) -> &'static str {
+    use winit::event::{DeviceEvent, Event, StartCause};
+
+    match event {
+        Event::Suspended => "Event::Suspended",
+        Event::Resumed => "Event::Resumed",
+        Event::MainEventsCleared => "Event::MainEventsCleared",
+        Event::RedrawRequested(_) => "Event::RedrawRequested",
+        Event::RedrawEventsCleared => "Event::RedrawEventsCleared",
+        Event::LoopDestroyed => "Event::LoopDestroyed",
+        Event::UserEvent(_) => "UserEvent",
+        Event::DeviceEvent { event, .. } => match event {
+            DeviceEvent::Added { .. } => "DeviceEvent::Added",
+            DeviceEvent::Removed { .. } => "DeviceEvent::Removed",
+            DeviceEvent::MouseMotion { .. } => "DeviceEvent::MouseMotion",
+            DeviceEvent::MouseWheel { .. } => "DeviceEvent::MouseWheel",
+            DeviceEvent::Motion { .. } => "DeviceEvent::Motion",
+            DeviceEvent::Button { .. } => "DeviceEvent::Button",
+            DeviceEvent::Key { .. } => "DeviceEvent::Key",
+            DeviceEvent::Text { .. } => "DeviceEvent::Text",
+        },
+        Event::NewEvents(start_cause) => match start_cause {
+            StartCause::ResumeTimeReached { .. } => "NewEvents::ResumeTimeReached",
+            StartCause::WaitCancelled { .. } => "NewEvents::WaitCancelled",
+            StartCause::Poll => "NewEvents::Poll",
+            StartCause::Init => "NewEvents::Init",
+        },
+        Event::WindowEvent { event, .. } => short_window_event_description(event),
+    }
+}
+
+/// Short and fast description of an event.
+/// Useful for logging and profiling.
+pub fn short_window_event_description(event: &winit::event::WindowEvent<'_>) -> &'static str {
+    use winit::event::WindowEvent;
+
+    match event {
+        WindowEvent::Resized { .. } => "WindowEvent::Resized",
+        WindowEvent::Moved { .. } => "WindowEvent::Moved",
+        WindowEvent::CloseRequested { .. } => "WindowEvent::CloseRequested",
+        WindowEvent::Destroyed { .. } => "WindowEvent::Destroyed",
+        WindowEvent::DroppedFile { .. } => "WindowEvent::DroppedFile",
+        WindowEvent::HoveredFile { .. } => "WindowEvent::HoveredFile",
+        WindowEvent::HoveredFileCancelled { .. } => "WindowEvent::HoveredFileCancelled",
+        WindowEvent::ReceivedCharacter { .. } => "WindowEvent::ReceivedCharacter",
+        WindowEvent::Focused { .. } => "WindowEvent::Focused",
+        WindowEvent::KeyboardInput { .. } => "WindowEvent::KeyboardInput",
+        WindowEvent::ModifiersChanged { .. } => "WindowEvent::ModifiersChanged",
+        WindowEvent::Ime { .. } => "WindowEvent::Ime",
+        WindowEvent::CursorMoved { .. } => "WindowEvent::CursorMoved",
+        WindowEvent::CursorEntered { .. } => "WindowEvent::CursorEntered",
+        WindowEvent::CursorLeft { .. } => "WindowEvent::CursorLeft",
+        WindowEvent::MouseWheel { .. } => "WindowEvent::MouseWheel",
+        WindowEvent::MouseInput { .. } => "WindowEvent::MouseInput",
+        WindowEvent::TouchpadMagnify { .. } => "WindowEvent::TouchpadMagnify",
+        WindowEvent::SmartMagnify { .. } => "WindowEvent::SmartMagnify",
+        WindowEvent::TouchpadRotate { .. } => "WindowEvent::TouchpadRotate",
+        WindowEvent::TouchpadPressure { .. } => "WindowEvent::TouchpadPressure",
+        WindowEvent::AxisMotion { .. } => "WindowEvent::AxisMotion",
+        WindowEvent::Touch { .. } => "WindowEvent::Touch",
+        WindowEvent::ScaleFactorChanged { .. } => "WindowEvent::ScaleFactorChanged",
+        WindowEvent::ThemeChanged { .. } => "WindowEvent::ThemeChanged",
+        WindowEvent::Occluded { .. } => "WindowEvent::Occluded",
     }
 }
 

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -233,7 +233,7 @@ impl State {
     /// Call this when there is a new event.
     ///
     /// The result can be found in [`Self::egui_input`] and be extracted with [`Self::take_egui_input`].
-    pub fn on_event(
+    pub fn on_window_event(
         &mut self,
         egui_ctx: &egui::Context,
         event: &winit::event::WindowEvent<'_>,

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -174,14 +174,14 @@ impl State {
     }
 
     /// The current input state.
-    /// This is changed by [`Self::on_event`] and cleared by [`Self::take_egui_input`].
+    /// This is changed by [`Self::on_window_event`] and cleared by [`Self::take_egui_input`].
     #[inline]
     pub fn egui_input(&self) -> &egui::RawInput {
         &self.egui_input
     }
 
     /// The current input state.
-    /// This is changed by [`Self::on_event`] and cleared by [`Self::take_egui_input`].
+    /// This is changed by [`Self::on_window_event`] and cleared by [`Self::take_egui_input`].
     #[inline]
     pub fn egui_input_mut(&mut self) -> &mut egui::RawInput {
         &mut self.egui_input

--- a/crates/egui-winit/src/window_settings.rs
+++ b/crates/egui-winit/src/window_settings.rs
@@ -52,6 +52,8 @@ impl WindowSettings {
         &self,
         mut viewport_builder: ViewportBuilder,
     ) -> ViewportBuilder {
+        crate::profile_function!();
+
         // `WindowBuilder::with_position` expects inner position in Macos, and outer position elsewhere
         // See [`winit::window::WindowBuilder::with_position`] for details.
         let pos_px = if cfg!(target_os = "macos") {
@@ -127,6 +129,8 @@ fn clamp_pos_to_monitors<E>(
     window_size_pts: egui::Vec2,
     position_px: &mut egui::Pos2,
 ) {
+    crate::profile_function!();
+
     let monitors = event_loop.available_monitors();
 
     // default to primary monitor, in case the correct monitor was disconnected.

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2391,7 +2391,7 @@ impl Context {
     /// [not_supported]: crate::load::LoadError::NotSupported
     /// [custom]: crate::load::LoadError::Loading
     pub fn try_load_bytes(&self, uri: &str) -> load::BytesLoadResult {
-        crate::profile_function!();
+        crate::profile_function!(uri);
 
         let loaders = self.loaders();
         let bytes_loaders = loaders.bytes.lock();
@@ -2428,7 +2428,7 @@ impl Context {
     /// [not_supported]: crate::load::LoadError::NotSupported
     /// [custom]: crate::load::LoadError::Loading
     pub fn try_load_image(&self, uri: &str, size_hint: load::SizeHint) -> load::ImageLoadResult {
-        crate::profile_function!();
+        crate::profile_function!(uri);
 
         let loaders = self.loaders();
         let image_loaders = loaders.image.lock();
@@ -2471,7 +2471,7 @@ impl Context {
         texture_options: TextureOptions,
         size_hint: load::SizeHint,
     ) -> load::TextureLoadResult {
-        crate::profile_function!();
+        crate::profile_function!(uri);
 
         let loaders = self.loaders();
         let texture_loaders = loaders.texture.lock();

--- a/crates/egui_glow/examples/pure_glow.rs
+++ b/crates/egui_glow/examples/pure_glow.rs
@@ -235,7 +235,7 @@ fn main() {
                     gl_window.resize(**new_inner_size);
                 }
 
-                let event_response = egui_glow.on_event(&event);
+                let event_response = egui_glow.on_window_event(&event);
 
                 if event_response.repaint {
                     gl_window.window().request_redraw();

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -52,9 +52,9 @@ impl EguiGlow {
         }
     }
 
-    pub fn on_event(&mut self, event: &winit::event::WindowEvent<'_>) -> EventResponse {
+    pub fn on_window_event(&mut self, event: &winit::event::WindowEvent<'_>) -> EventResponse {
         self.egui_winit
-            .on_event(&self.egui_ctx, event, ViewportId::ROOT)
+            .on_window_event(&self.egui_ctx, event, ViewportId::ROOT)
     }
 
     /// Call [`Self::paint`] later to paint.


### PR DESCRIPTION
Introduced in the recent multi-viewports work, we accidentally recreated the wgpu surfaces every frame. This is now fixed.

I found this while improving the profiling of `eframe`