### PR TITLE
Fix closing of viewports

### DIFF
--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -194,7 +194,7 @@ impl EpiIntegration {
 
     #[cfg(feature = "accesskit")]
     pub fn init_accesskit<E: From<egui_winit::accesskit_winit::ActionRequestEvent> + Send>(
-        &mut self,
+        &self,
         egui_winit: &mut egui_winit::State,
         window: &winit::window::Window,
         event_loop_proxy: winit::event_loop::EventLoopProxy<E>,

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -231,7 +231,6 @@ impl EpiIntegration {
 
         match event {
             WindowEvent::CloseRequested => {
-                log::debug!("Received WindowEvent::CloseRequested for viewport {viewport_id:?}");
                 if viewport_id == ViewportId::ROOT {
                     self.close = app.on_close_event();
                     log::debug!("App::on_close_event returned {}", self.close);
@@ -257,7 +256,7 @@ impl EpiIntegration {
             _ => {}
         }
 
-        egui_winit.on_window_event(&self.egui_ctx, event, viewport_id)
+        egui_winit.on_window_event(&self.egui_ctx, event)
     }
 
     pub fn pre_update(&mut self) {
@@ -283,7 +282,7 @@ impl EpiIntegration {
                 viewport_ui_cb(egui_ctx);
             } else {
                 // Root viewport
-                if egui_ctx.input(|i| i.viewport().close_requested) {
+                if egui_ctx.input(|i| i.viewport().close_requested()) {
                     self.close = app.on_close_event();
                     log::debug!("App::on_close_event returned {}", self.close);
                 }

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -231,9 +231,11 @@ impl EpiIntegration {
 
         match event {
             WindowEvent::CloseRequested => {
-                log::debug!("Received WindowEvent::CloseRequested");
-                self.close = app.on_close_event() && viewport_id == ViewportId::ROOT;
-                log::debug!("App::on_close_event returned {}", self.close);
+                log::debug!("Received WindowEvent::CloseRequested for viewport {viewport_id:?}");
+                if viewport_id == ViewportId::ROOT {
+                    self.close = app.on_close_event();
+                    log::debug!("App::on_close_event returned {}", self.close);
+                }
             }
             WindowEvent::Destroyed => {
                 log::debug!("Received WindowEvent::Destroyed");

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -208,7 +208,7 @@ impl GlowWinitApp {
         let system_theme =
             winit_integration::system_theme(&glutin.window(ViewportId::ROOT), &self.native_options);
 
-        let mut integration = EpiIntegration::new(
+        let integration = EpiIntegration::new(
             &glutin.window(ViewportId::ROOT),
             system_theme,
             &self.app_name,

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -706,9 +706,20 @@ impl GlowWinitRunning {
             }
 
             winit::event::WindowEvent::CloseRequested => {
+                log::debug!("Received WindowEvent::CloseRequested for viewport {viewport_id:?}");
+
+                if let Some(viewport_id) = viewport_id {
+                    if let Some(viewport) = self.glutin.borrow_mut().viewports.get_mut(&viewport_id)
+                    {
+                        viewport.info.close_requested = true;
+                    }
+                }
+
                 let is_root = viewport_id == Some(ViewportId::ROOT);
                 if is_root && self.integration.should_close() {
-                    log::debug!("Received WindowEvent::CloseRequested");
+                    log::debug!(
+                        "Received WindowEvent::CloseRequested for main viewport - shutting down."
+                    );
                     return EventResult::Exit;
                 }
             }

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -656,12 +656,8 @@ impl GlowWinitRunning {
     ) -> EventResult {
         crate::profile_function!(egui_winit::short_window_event_description(event));
 
-        let viewport_id = self
-            .glutin
-            .borrow()
-            .viewport_from_window
-            .get(&window_id)
-            .copied();
+        let mut glutin = self.glutin.borrow_mut();
+        let viewport_id = glutin.viewport_from_window.get(&window_id).copied();
 
         // On Windows, if a window is resized by the user, it should repaint synchronously, inside the
         // event handler.
@@ -680,8 +676,7 @@ impl GlowWinitRunning {
 
         match event {
             winit::event::WindowEvent::Focused(new_focused) => {
-                self.glutin.borrow_mut().focused_viewport =
-                    new_focused.then(|| viewport_id).flatten();
+                glutin.focused_viewport = new_focused.then(|| viewport_id).flatten();
             }
 
             winit::event::WindowEvent::Resized(physical_size) => {
@@ -691,7 +686,7 @@ impl GlowWinitRunning {
                 if 0 < physical_size.width && 0 < physical_size.height {
                     if let Some(viewport_id) = viewport_id {
                         repaint_asap = true;
-                        self.glutin.borrow_mut().resize(viewport_id, *physical_size);
+                        glutin.resize(viewport_id, *physical_size);
                     }
                 }
             }
@@ -699,56 +694,59 @@ impl GlowWinitRunning {
             winit::event::WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
                 if let Some(viewport_id) = viewport_id {
                     repaint_asap = true;
-                    self.glutin
-                        .borrow_mut()
-                        .resize(viewport_id, **new_inner_size);
+                    glutin.resize(viewport_id, **new_inner_size);
                 }
             }
 
             winit::event::WindowEvent::CloseRequested => {
-                log::debug!("Received WindowEvent::CloseRequested for viewport {viewport_id:?}");
-
-                if let Some(viewport_id) = viewport_id {
-                    if let Some(viewport) = self.glutin.borrow_mut().viewports.get_mut(&viewport_id)
-                    {
-                        viewport.info.close_requested = true;
-                    }
-                }
-
-                let is_root = viewport_id == Some(ViewportId::ROOT);
-                if is_root && self.integration.should_close() {
+                if viewport_id == Some(ViewportId::ROOT) && self.integration.should_close() {
                     log::debug!(
                         "Received WindowEvent::CloseRequested for main viewport - shutting down."
                     );
                     return EventResult::Exit;
+                }
+
+                log::debug!("Received WindowEvent::CloseRequested for viewport {viewport_id:?}");
+
+                if let Some(viewport_id) = viewport_id {
+                    if let Some(viewport) = glutin.viewports.get_mut(&viewport_id) {
+                        // Tell viewport it should close:
+                        viewport.info.events.push(egui::ViewportEvent::Close);
+
+                        // We may need to repaint both us and our parent to close the window,
+                        // and perhaps twice (once to notice the close-event, once again to enforce it).
+                        // `request_repaint_of` does a double-repaint though:
+                        self.integration.egui_ctx.request_repaint_of(viewport_id);
+                        self.integration
+                            .egui_ctx
+                            .request_repaint_of(viewport.ids.parent);
+                    }
                 }
             }
 
             _ => {}
         }
 
-        let event_response = 'res: {
-            if let Some(viewport_id) = viewport_id {
-                let mut glutin = self.glutin.borrow_mut();
-                if let Some(viewport) = glutin.viewports.get_mut(&viewport_id) {
-                    break 'res self.integration.on_window_event(
-                        self.app.as_mut(),
-                        event,
-                        viewport.egui_winit.as_mut().unwrap(),
-                        viewport.ids.this,
-                    );
-                }
-            }
-
-            EventResponse {
-                consumed: false,
-                repaint: false,
-            }
-        };
-
         if self.integration.should_close() {
-            EventResult::Exit
-        } else if event_response.repaint {
+            return EventResult::Exit;
+        }
+
+        let mut event_response = EventResponse {
+            consumed: false,
+            repaint: false,
+        };
+        if let Some(viewport_id) = viewport_id {
+            if let Some(viewport) = glutin.viewports.get_mut(&viewport_id) {
+                event_response = self.integration.on_window_event(
+                    self.app.as_mut(),
+                    event,
+                    viewport.egui_winit.as_mut().unwrap(),
+                    viewport.ids.this,
+                );
+            }
+        }
+
+        if event_response.repaint {
             if repaint_asap {
                 EventResult::RepaintNow(window_id)
             } else {

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -147,7 +147,6 @@ fn run_and_return(
                 }
             }
             EventResult::RepaintNext(window_id) => {
-                log::trace!("Repaint caused by {}", short_event_description(&event));
                 windows_next_repaint_times.insert(window_id, Instant::now());
             }
             EventResult::RepaintAt(window_id, repaint_time) => {

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -697,7 +697,7 @@ impl WgpuWinitRunning {
                 if let (Some(width), Some(height), Some(viewport_id)) = (
                     NonZeroU32::new(new_inner_size.width),
                     NonZeroU32::new(new_inner_size.height),
-                    shared.viewport_from_window.get(&window_id).copied(),
+                    viewport_id,
                 ) {
                     repaint_asap = true;
                     shared.painter.on_window_resized(viewport_id, width, height);
@@ -705,45 +705,49 @@ impl WgpuWinitRunning {
             }
 
             winit::event::WindowEvent::CloseRequested => {
-                log::debug!("Received WindowEvent::CloseRequested for viewport {viewport_id:?}");
-
-                if let Some(viewport_id) = viewport_id {
-                    if let Some(viewport) = shared.viewports.get_mut(&viewport_id) {
-                        viewport.info.close_requested = true;
-                    }
-                }
-
-                let is_root = viewport_id == Some(ViewportId::ROOT);
-                if is_root && integration.should_close() {
+                if viewport_id == Some(ViewportId::ROOT) && integration.should_close() {
                     log::debug!(
                         "Received WindowEvent::CloseRequested for main viewport - shutting down."
                     );
                     return EventResult::Exit;
+                }
+
+                log::debug!("Received WindowEvent::CloseRequested for viewport {viewport_id:?}");
+
+                if let Some(viewport_id) = viewport_id {
+                    if let Some(viewport) = shared.viewports.get_mut(&viewport_id) {
+                        // Tell viewport it should close:
+                        viewport.info.events.push(egui::ViewportEvent::Close);
+
+                        // We may need to repaint both us and our parent to close the window,
+                        // and perhaps twice (once to notice the close-event, once again to enforce it).
+                        // `request_repaint_of` does a double-repaint though:
+                        integration.egui_ctx.request_repaint_of(viewport_id);
+                        integration.egui_ctx.request_repaint_of(viewport.ids.parent);
+                    }
                 }
             }
 
             _ => {}
         };
 
-        let event_response = viewport_id.and_then(|viewport_id| {
-            shared.viewports.get_mut(&viewport_id).and_then(|viewport| {
-                viewport.egui_winit.as_mut().map(|egui_winit| {
-                    integration.on_window_event(app.as_mut(), event, egui_winit, viewport_id)
+        let event_response = viewport_id
+            .and_then(|viewport_id| {
+                shared.viewports.get_mut(&viewport_id).and_then(|viewport| {
+                    viewport.egui_winit.as_mut().map(|egui_winit| {
+                        integration.on_window_event(app.as_mut(), event, egui_winit, viewport_id)
+                    })
                 })
             })
-        });
+            .unwrap_or_default();
 
         if integration.should_close() {
             EventResult::Exit
-        } else if let Some(event_response) = event_response {
-            if event_response.repaint {
-                if repaint_asap {
-                    EventResult::RepaintNow(window_id)
-                } else {
-                    EventResult::RepaintNext(window_id)
-                }
+        } else if event_response.repaint {
+            if repaint_asap {
+                EventResult::RepaintNow(window_id)
             } else {
-                EventResult::Wait
+                EventResult::RepaintNext(window_id)
             }
         } else {
             EventResult::Wait

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -704,9 +704,22 @@ impl WgpuWinitRunning {
                 }
             }
 
-            winit::event::WindowEvent::CloseRequested if integration.should_close() => {
-                log::debug!("Received WindowEvent::CloseRequested");
-                return EventResult::Exit;
+            winit::event::WindowEvent::CloseRequested => {
+                log::debug!("Received WindowEvent::CloseRequested for viewport {viewport_id:?}");
+
+                if let Some(viewport_id) = viewport_id {
+                    if let Some(viewport) = shared.viewports.get_mut(&viewport_id) {
+                        viewport.info.close_requested = true;
+                    }
+                }
+
+                let is_root = viewport_id == Some(ViewportId::ROOT);
+                if is_root && integration.should_close() {
+                    log::debug!(
+                        "Received WindowEvent::CloseRequested for main viewport - shutting down."
+                    );
+                    return EventResult::Exit;
+                }
             }
 
             _ => {}

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -162,7 +162,7 @@ impl WgpuWinitApp {
         let wgpu_render_state = painter.render_state();
 
         let system_theme = winit_integration::system_theme(&window, &self.native_options);
-        let mut integration = EpiIntegration::new(
+        let integration = EpiIntegration::new(
             &window,
             system_theme,
             &self.app_name,

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1143,7 +1143,7 @@ pub fn process_viewport_commands(
                 egui::viewport::WindowLevel::AlwaysOnTop => WindowLevel::AlwaysOnTop,
                 egui::viewport::WindowLevel::Normal => WindowLevel::Normal,
             }),
-            ViewportCommand::WindowIcon(icon) => {
+            ViewportCommand::Icon(icon) => {
                 window.set_window_icon(icon.map(|icon| {
                     winit::window::Icon::from_rgba(icon.rgba.clone(), icon.width, icon.height)
                         .expect("Invalid ICON data!")

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2563,8 +2563,13 @@ impl Context {
     ///
     /// This lets you affect another viewport, e.g. resizing its window.
     pub fn send_viewport_cmd_to(&self, id: ViewportId, command: ViewportCommand) {
-        self.write(|ctx| ctx.viewport_for(id).commands.push(command));
         self.request_repaint_of(id);
+
+        if command.requires_parent_repaint() {
+            self.request_repaint_of(self.parent_viewport_id());
+        }
+
+        self.write(|ctx| ctx.viewport_for(id).commands.push(command));
     }
 
     /// Show a deferred viewport, creating a new native window, if possible.

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -369,7 +369,7 @@ impl ViewportBuilder {
     /// The default icon is a white `e` on a black background (for "egui" or "eframe").
     /// If you prefer the OS default, set this to `None`.
     #[inline]
-    pub fn with_window_icon(mut self, icon: impl Into<Arc<IconData>>) -> Self {
+    pub fn with_icon(mut self, icon: impl Into<Arc<IconData>>) -> Self {
         self.icon = Some(icon.into());
         self
     }
@@ -641,7 +641,7 @@ impl ViewportBuilder {
             };
 
             if is_new {
-                commands.push(ViewportCommand::WindowIcon(Some(new_icon.clone())));
+                commands.push(ViewportCommand::Icon(Some(new_icon.clone())));
                 self.icon = Some(new_icon.clone());
             }
         }
@@ -842,7 +842,7 @@ pub enum ViewportCommand {
     WindowLevel(WindowLevel),
 
     /// The the window icon.
-    WindowIcon(Option<Arc<IconData>>),
+    Icon(Option<Arc<IconData>>),
 
     IMEPosition(Pos2),
     IMEAllowed(bool),

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -765,7 +765,9 @@ pub enum ResizeDirection {
     SouthWest,
 }
 
-/// You can send a [`ViewportCommand`] to the viewport with [`Context::send_viewport_cmd`].
+/// An output [viewport](crate::viewport)-command from egui to the backend, e.g. to change the window title or size.
+///
+///  You can send a [`ViewportCommand`] to the viewport with [`Context::send_viewport_cmd`].
 ///
 /// See [`crate::viewport`] for how to build new viewports (native windows).
 ///
@@ -902,6 +904,11 @@ impl ViewportCommand {
                 None
             }
         })
+    }
+
+    /// This command requires the parent viewport to repaint.
+    pub fn requires_parent_repaint(&self) -> bool {
+        self == &Self::Close
     }
 }
 

--- a/crates/egui_demo_lib/src/demo/extra_viewport.rs
+++ b/crates/egui_demo_lib/src/demo/extra_viewport.rs
@@ -66,7 +66,7 @@ fn viewport_content(ui: &mut egui::Ui, ctx: &egui::Context, open: &mut bool) {
         }
     });
 
-    if ui.input(|i| i.viewport().close_requested) {
+    if ui.input(|i| i.viewport().close_requested()) {
         *open = false;
     }
 }

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -53,8 +53,7 @@ impl EguiGlow {
     }
 
     pub fn on_window_event(&mut self, event: &winit::event::WindowEvent<'_>) -> EventResponse {
-        self.egui_winit
-            .on_window_event(&self.egui_ctx, event, ViewportId::ROOT)
+        self.egui_winit.on_window_event(&self.egui_ctx, event)
     }
 
     /// Call [`Self::paint`] later to paint.

--- a/examples/multiple_viewports/src/main.rs
+++ b/examples/multiple_viewports/src/main.rs
@@ -5,7 +5,7 @@ use std::sync::{
     Arc,
 };
 
-use eframe::egui::{self, ViewportId};
+use eframe::egui;
 
 fn main() -> Result<(), eframe::Error> {
     env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
@@ -65,10 +65,9 @@ impl eframe::App for MyApp {
                         ui.label("Hello from immediate viewport");
                     });
 
-                    if ctx.input(|i| i.viewport().close_requested) {
+                    if ctx.input(|i| i.viewport().close_requested()) {
                         // Tell parent viewport that we should not show next frame:
                         self.show_immediate_viewport = false;
-                        ctx.request_repaint_of(ctx.parent_viewport_id()); // make sure we get closed
                     }
                 },
             );
@@ -90,10 +89,9 @@ impl eframe::App for MyApp {
                     egui::CentralPanel::default().show(ctx, |ui| {
                         ui.label("Hello from deferred viewport");
                     });
-                    if ctx.input(|i| i.viewport().close_requested) {
+                    if ctx.input(|i| i.viewport().close_requested()) {
                         // Tell parent to close us.
                         show_deferred_viewport.store(false, Ordering::Relaxed);
-                        ctx.request_repaint_of(ctx.parent_viewport_id()); // make sure we get closed
                     }
                 },
             );


### PR DESCRIPTION
This ensures the closed viewport gets a close-event, and that it and the parent viewport gets repainting, allowing the event to be registered.