### PR TITLE
CentralPanel: base id on the current viewport

### DIFF
--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -1062,7 +1062,7 @@ impl CentralPanel {
     ) -> InnerResponse<R> {
         let available_rect = ctx.available_rect();
         let layer_id = LayerId::background();
-        let id = Id::new("central_panel");
+        let id = Id::new((ctx.viewport_id(), "central_panel"));
 
         let clip_rect = ctx.screen_rect();
         let mut panel_ui = Ui::new(ctx.clone(), layer_id, id, available_rect, clip_rect);

--- a/crates/egui_demo_lib/src/demo/extra_viewport.rs
+++ b/crates/egui_demo_lib/src/demo/extra_viewport.rs
@@ -33,9 +33,7 @@ impl super::Demo for ExtraViewport {
                         });
                 } else {
                     egui::CentralPanel::default().show(ctx, |ui| {
-                        ui.push_id(id, |ui| {
-                            viewport_content(ui, ctx, open);
-                        })
+                        viewport_content(ui, ctx, open);
                     });
                 }
             },

--- a/examples/test_viewports/src/main.rs
+++ b/examples/test_viewports/src/main.rs
@@ -178,7 +178,7 @@ fn show_as_popup(
         // Not a real viewport
         egui::Window::new(title).id(id).show(ctx, content);
     } else {
-        egui::CentralPanel::default().show(ctx, |ui| ui.push_id(id, content));
+        egui::CentralPanel::default().show(ctx, content);
     }
 }
 


### PR DESCRIPTION
This means two `CentralPanel`s in different viewports get different ids, avoiding id clashes