### PR TITLE
Change `Arc<glow::Context>` to `Rc<glow::Context>`

### DIFF
--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -64,7 +64,7 @@ pub struct CreationContext<'s> {
     ///
     /// Only available when compiling with the `glow` feature and using [`Renderer::Glow`].
     #[cfg(feature = "glow")]
-    pub gl: Option<std::sync::Arc<glow::Context>>,
+    pub gl: Option<std::rc::Rc<glow::Context>>,
 
     /// The underlying WGPU render state.
     ///
@@ -602,7 +602,7 @@ pub struct Frame {
 
     /// A reference to the underlying [`glow`] (OpenGL) context.
     #[cfg(feature = "glow")]
-    pub(crate) gl: Option<std::sync::Arc<glow::Context>>,
+    pub(crate) gl: Option<std::rc::Rc<glow::Context>>,
 
     /// Can be used to manage GPU resources for custom rendering with WGPU using [`egui::PaintCallback`]s.
     #[cfg(feature = "wgpu")]
@@ -674,7 +674,7 @@ impl Frame {
     /// To get a [`glow`] context you need to compile with the `glow` feature flag,
     /// and run eframe using [`Renderer::Glow`].
     #[cfg(feature = "glow")]
-    pub fn gl(&self) -> Option<&std::sync::Arc<glow::Context>> {
+    pub fn gl(&self) -> Option<&std::rc::Rc<glow::Context>> {
         self.gl.as_ref()
     }
 

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -143,7 +143,7 @@ impl EpiIntegration {
         native_options: &crate::NativeOptions,
         storage: Option<Box<dyn epi::Storage>>,
         is_desktop: bool,
-        #[cfg(feature = "glow")] gl: Option<std::sync::Arc<glow::Context>>,
+        #[cfg(feature = "glow")] gl: Option<std::rc::Rc<glow::Context>>,
         #[cfg(feature = "wgpu")] wgpu_render_state: Option<egui_wgpu::RenderState>,
     ) -> Self {
         let egui_ctx = egui::Context::default();

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -163,7 +163,7 @@ impl GlowWinitApp {
 
         let gl = unsafe {
             crate::profile_scope!("glow::Context::from_loader_function");
-            Arc::new(glow::Context::from_loader_function(|s| {
+            Rc::new(glow::Context::from_loader_function(|s| {
                 let s = std::ffi::CString::new(s)
                     .expect("failed to construct C string from string for gl proc address");
 

--- a/crates/eframe/src/web/web_painter_glow.rs
+++ b/crates/eframe/src/web/web_painter_glow.rs
@@ -15,7 +15,7 @@ pub(crate) struct WebPainterGlow {
 }
 
 impl WebPainterGlow {
-    pub fn gl(&self) -> &std::sync::Arc<glow::Context> {
+    pub fn gl(&self) -> &std::rc::Rc<glow::Context> {
         self.painter.gl()
     }
 
@@ -24,7 +24,7 @@ impl WebPainterGlow {
 
         let (gl, shader_prefix) =
             init_glow_context_from_canvas(&canvas, options.webgl_context_option)?;
-        let gl = std::sync::Arc::new(gl);
+        let gl = std::rc::Rc::new(gl);
 
         let painter = egui_glow::Painter::new(gl, shader_prefix, None)
             .map_err(|err| format!("Error starting glow painter: {err}"))?;

--- a/crates/egui_glow/examples/pure_glow.rs
+++ b/crates/egui_glow/examples/pure_glow.rs
@@ -152,7 +152,7 @@ fn main() {
 
     let event_loop = winit::event_loop::EventLoopBuilder::<UserEvent>::with_user_event().build();
     let (gl_window, gl) = create_display(&event_loop);
-    let gl = std::sync::Arc::new(gl);
+    let gl = std::rc::Rc::new(gl);
 
     let mut egui_glow = egui_glow::EguiGlow::new(&event_loop, gl.clone(), None, None);
 

--- a/crates/egui_glow/src/painter.rs
+++ b/crates/egui_glow/src/painter.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::collapsible_else_if)]
 #![allow(unsafe_code)]
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, rc::Rc};
 
 use egui::{
     emath::Rect,
@@ -60,7 +60,7 @@ impl From<String> for PainterError {
 /// This struct must be destroyed with [`Painter::destroy`] before dropping, to ensure OpenGL
 /// objects have been properly deleted and are not leaked.
 pub struct Painter {
-    gl: Arc<glow::Context>,
+    gl: Rc<glow::Context>,
 
     max_texture_side: usize,
 
@@ -118,7 +118,7 @@ impl Painter {
     /// * failed to create postprocess on webgl with `sRGB` support
     /// * failed to create buffer
     pub fn new(
-        gl: Arc<glow::Context>,
+        gl: Rc<glow::Context>,
         shader_prefix: &str,
         shader_version: Option<ShaderVersion>,
     ) -> Result<Painter, PainterError> {
@@ -248,7 +248,7 @@ impl Painter {
     }
 
     /// Access the shared glow context.
-    pub fn gl(&self) -> &Arc<glow::Context> {
+    pub fn gl(&self) -> &Rc<glow::Context> {
         &self.gl
     }
 

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -24,7 +24,7 @@ impl EguiGlow {
     /// For automatic shader version detection set `shader_version` to `None`.
     pub fn new<E>(
         event_loop: &winit::event_loop::EventLoopWindowTarget<E>,
-        gl: std::sync::Arc<glow::Context>,
+        gl: std::rc::Rc<glow::Context>,
         shader_version: Option<ShaderVersion>,
         native_pixels_per_point: Option<f32>,
     ) -> Self {


### PR DESCRIPTION
This is required for Rust 1.72 (for unknown reasons; see https://github.com/emilk/egui/pull/3595), but also for updating to glow 0.13, where the `glow::Context` is not longer `Sync+Send`
