### PR TITLE
Update puffin to 0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,7 +1054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16e44ab292b1dddfdaf7be62cfd8877df52f2f3fde5858d95bab606be259f20"
 dependencies = [
  "bitflags 2.4.0",
- "libloading 0.7.4",
+ "libloading 0.8.0",
  "winapi",
 ]
 
@@ -1159,7 +1159,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.0",
 ]
 
 [[package]]
@@ -3082,9 +3082,9 @@ checksum = "f89dff0959d98c9758c88826cc002e2c3d0b9dfac4139711d1f30de442f1139b"
 
 [[package]]
 name = "puffin"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39009d69b9d547c3ffa974a20648fa02f447c05bd0a664012b1ba5a5b06fb14e"
+checksum = "0e0b84517b2fb755da3a634bc030fcbc7b6337a786aa25a7fb350cdd51ab5e15"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3098,9 +3098,9 @@ dependencies = [
 
 [[package]]
 name = "puffin_http"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540d042ff82a4f4543fb2e44cf0221ba8b7d6fb7b16979840449a5ddc087486f"
+checksum = "fcf8e52cf00569807b02e8089a85e859c00476182730cda9718c94b12cdc31b8"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -4451,7 +4451,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.0",
  "log",
  "metal",
  "naga",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ opt-level = 2 # fast and small wasm, basically same as `opt-level = 's'`
 opt-level = 2
 
 [workspace.dependencies]
-puffin = "0.17"
+puffin = "0.18"
 raw-window-handle = "0.5.0"
 thiserror = "1.0.37"
 

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -158,7 +158,7 @@ winapi = "0.3.9"
 bytemuck = "1.7"
 js-sys = "0.3"
 percent-encoding = "2.1"
-wasm-bindgen = "0.2.88"
+wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3.58", features = [
   "BinaryType",

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -336,7 +336,7 @@
 
 #![allow(clippy::float_cmp)]
 #![allow(clippy::manual_range_contains)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 mod animation_manager;
 pub mod containers;

--- a/crates/egui_demo_lib/src/lib.rs
+++ b/crates/egui_demo_lib/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![allow(clippy::float_cmp)]
 #![allow(clippy::manual_range_contains)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 mod color_test;
 mod demo;

--- a/crates/egui_extras/src/lib.rs
+++ b/crates/egui_extras/src/lib.rs
@@ -8,7 +8,7 @@
 
 #![allow(clippy::float_cmp)]
 #![allow(clippy::manual_range_contains)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 #[cfg(feature = "chrono")]
 mod datepicker;

--- a/crates/egui_glow/Cargo.toml
+++ b/crates/egui_glow/Cargo.toml
@@ -65,7 +65,7 @@ puffin = { workspace = true, optional = true }
 # Web:
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ["console"] }
-wasm-bindgen = { version = "0.2" }
+wasm-bindgen = "0.2"
 
 
 [dev-dependencies]

--- a/crates/emath/src/lib.rs
+++ b/crates/emath/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 
 #![allow(clippy::float_cmp)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 use std::ops::{Add, Div, Mul, RangeInclusive, Sub};
 

--- a/crates/epaint/src/lib.rs
+++ b/crates/epaint/src/lib.rs
@@ -22,7 +22,7 @@
 
 #![allow(clippy::float_cmp)]
 #![allow(clippy::manual_range_contains)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 mod bezier;
 pub mod image;

--- a/examples/puffin_profiler/Cargo.toml
+++ b/examples/puffin_profiler/Cargo.toml
@@ -14,5 +14,5 @@ eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 env_logger = "0.10"
-puffin = "0.17"
-puffin_http = "0.14"
+puffin = "0.18"
+puffin_http = "0.15"


### PR DESCRIPTION
THe profiling macros now contain unsafe code (but in a safe way), so `#[foribd(unsafe)]` had to become `#[deny(unsafe)]`