### PR TITLE
Keep unsafe code forbidden when puffin is disabled

### DIFF
--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -336,7 +336,8 @@
 
 #![allow(clippy::float_cmp)]
 #![allow(clippy::manual_range_contains)]
-#![deny(unsafe_code)]
+#![cfg_attr(feature = "puffin", deny(unsafe_code))]
+#![cfg_attr(not(feature = "puffin"), forbid(unsafe_code))]
 
 mod animation_manager;
 pub mod containers;

--- a/crates/egui_demo_lib/src/lib.rs
+++ b/crates/egui_demo_lib/src/lib.rs
@@ -10,7 +10,8 @@
 
 #![allow(clippy::float_cmp)]
 #![allow(clippy::manual_range_contains)]
-#![deny(unsafe_code)]
+#![cfg_attr(feature = "puffin", deny(unsafe_code))]
+#![cfg_attr(not(feature = "puffin"), forbid(unsafe_code))]
 
 mod color_test;
 mod demo;

--- a/crates/egui_extras/src/lib.rs
+++ b/crates/egui_extras/src/lib.rs
@@ -8,7 +8,8 @@
 
 #![allow(clippy::float_cmp)]
 #![allow(clippy::manual_range_contains)]
-#![deny(unsafe_code)]
+#![cfg_attr(feature = "puffin", deny(unsafe_code))]
+#![cfg_attr(not(feature = "puffin"), forbid(unsafe_code))]
 
 #[cfg(feature = "chrono")]
 mod datepicker;

--- a/crates/emath/src/lib.rs
+++ b/crates/emath/src/lib.rs
@@ -20,7 +20,8 @@
 //!
 
 #![allow(clippy::float_cmp)]
-#![deny(unsafe_code)]
+#![cfg_attr(feature = "puffin", deny(unsafe_code))]
+#![cfg_attr(not(feature = "puffin"), forbid(unsafe_code))]
 
 use std::ops::{Add, Div, Mul, RangeInclusive, Sub};
 

--- a/crates/epaint/src/lib.rs
+++ b/crates/epaint/src/lib.rs
@@ -22,7 +22,8 @@
 
 #![allow(clippy::float_cmp)]
 #![allow(clippy::manual_range_contains)]
-#![deny(unsafe_code)]
+#![cfg_attr(feature = "puffin", deny(unsafe_code))]
+#![cfg_attr(not(feature = "puffin"), forbid(unsafe_code))]
 
 mod bezier;
 pub mod image;


### PR DESCRIPTION
This helps document what unsafe is being used for, and prevent other uses from going unnoticed.