### PR TITLE
Introduce global `zoom_factor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,6 +1317,8 @@ dependencies = [
  "image",
  "log",
  "poll-promise",
+ "puffin",
+ "puffin_http",
  "rfd",
  "serde",
  "wasm-bindgen",

--- a/clippy.toml
+++ b/clippy.toml
@@ -60,6 +60,9 @@ disallowed-types = [
     # "std::sync::Once",  # enabled for now as the `log_once` macro uses it internally
 
     "ring::digest::SHA1_FOR_LEGACY_USE_ONLY", # SHA1 is cryptographically broken
+
+    "winit::dpi::LogicalSize",     # We do our own pixels<->point conversion, taking `egui_ctx.zoom_factor` into account
+    "winit::dpi::LogicalPosition", # We do our own pixels<->point conversion, taking `egui_ctx.zoom_factor` into account
 ]
 
 # -----------------------------------------------------------------------------

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -12,6 +12,7 @@ use egui_winit::{EventResponse, WindowSettings};
 use crate::{epi, Theme};
 
 pub fn viewport_builder<E>(
+    egui_zoom_factor: f32,
     event_loop: &EventLoopWindowTarget<E>,
     native_options: &mut epi::NativeOptions,
     window_settings: Option<WindowSettings>,
@@ -26,8 +27,9 @@ pub fn viewport_builder<E>(
     let inner_size_points = if let Some(mut window_settings) = window_settings {
         // Restore pos/size from previous session
 
-        window_settings.clamp_size_to_sane_values(largest_monitor_point_size(event_loop));
-        window_settings.clamp_position_to_monitors(event_loop);
+        window_settings
+            .clamp_size_to_sane_values(largest_monitor_point_size(egui_zoom_factor, event_loop));
+        window_settings.clamp_position_to_monitors(egui_zoom_factor, event_loop);
 
         viewport_builder = window_settings.initialize_viewport_builder(viewport_builder);
         window_settings.inner_size_points()
@@ -37,8 +39,8 @@ pub fn viewport_builder<E>(
         }
 
         if let Some(initial_window_size) = viewport_builder.inner_size {
-            let initial_window_size =
-                initial_window_size.at_most(largest_monitor_point_size(event_loop));
+            let initial_window_size = initial_window_size
+                .at_most(largest_monitor_point_size(egui_zoom_factor, event_loop));
             viewport_builder = viewport_builder.with_inner_size(initial_window_size);
         }
 
@@ -49,9 +51,11 @@ pub fn viewport_builder<E>(
     if native_options.centered {
         crate::profile_scope!("center");
         if let Some(monitor) = event_loop.available_monitors().next() {
-            let monitor_size = monitor.size().to_logical::<f32>(monitor.scale_factor());
+            let monitor_size = monitor
+                .size()
+                .to_logical::<f32>(egui_zoom_factor as f64 * monitor.scale_factor());
             let inner_size = inner_size_points.unwrap_or(egui::Vec2 { x: 800.0, y: 600.0 });
-            if monitor_size.width > 0.0 && monitor_size.height > 0.0 {
+            if 0.0 < monitor_size.width && 0.0 < monitor_size.height {
                 let x = (monitor_size.width - inner_size.x) / 2.0;
                 let y = (monitor_size.height - inner_size.y) / 2.0;
                 viewport_builder = viewport_builder.with_position([x, y]);
@@ -76,7 +80,10 @@ pub fn apply_window_settings(
     }
 }
 
-fn largest_monitor_point_size<E>(event_loop: &EventLoopWindowTarget<E>) -> egui::Vec2 {
+fn largest_monitor_point_size<E>(
+    egui_zoom_factor: f32,
+    event_loop: &EventLoopWindowTarget<E>,
+) -> egui::Vec2 {
     crate::profile_function!();
 
     let mut max_size = egui::Vec2::ZERO;
@@ -87,7 +94,9 @@ fn largest_monitor_point_size<E>(event_loop: &EventLoopWindowTarget<E>) -> egui:
     };
 
     for monitor in available_monitors {
-        let size = monitor.size().to_logical::<f32>(monitor.scale_factor());
+        let size = monitor
+            .size()
+            .to_logical::<f32>(egui_zoom_factor as f64 * monitor.scale_factor());
         let size = egui::vec2(size.width, size.height);
         max_size = max_size.max(size);
     }
@@ -327,7 +336,7 @@ impl EpiIntegration {
                     epi::set_value(
                         storage,
                         STORAGE_WINDOW_KEY,
-                        &WindowSettings::from_display(window),
+                        &WindowSettings::from_window(self.egui_ctx.zoom_factor(), window),
                     );
                 }
             }

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -137,21 +137,15 @@ pub struct EpiIntegration {
 impl EpiIntegration {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        egui_ctx: egui::Context,
         window: &winit::window::Window,
         system_theme: Option<Theme>,
         app_name: &str,
         native_options: &crate::NativeOptions,
         storage: Option<Box<dyn epi::Storage>>,
-        is_desktop: bool,
         #[cfg(feature = "glow")] gl: Option<std::rc::Rc<glow::Context>>,
         #[cfg(feature = "wgpu")] wgpu_render_state: Option<egui_wgpu::RenderState>,
     ) -> Self {
-        let egui_ctx = egui::Context::default();
-        egui_ctx.set_embed_viewports(!is_desktop);
-
-        let memory = load_egui_memory(storage.as_deref()).unwrap_or_default();
-        egui_ctx.memory_mut(|mem| *mem = memory);
-
         let frame = epi::Frame {
             info: epi::IntegrationInfo {
                 system_theme,

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -245,9 +245,6 @@ impl EpiIntegration {
                 state: ElementState::Pressed,
                 ..
             } => self.can_drag_window = true,
-            WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
-                egui_winit.egui_input_mut().native_pixels_per_point = Some(*scale_factor as _);
-            }
             WindowEvent::ThemeChanged(winit_theme) if self.follow_system_theme => {
                 let theme = theme_from_winit_theme(*winit_theme);
                 self.frame.info.system_theme = Some(theme);

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -86,6 +86,8 @@ struct GlowWinitRunning {
 /// The setup is divided between the `new` fn and `on_resume` fn. we can just assume that `on_resume` is a continuation of
 /// `new` fn on all platforms. only on android, do we get multiple resumed events because app can be suspended.
 struct GlutinWindowContext {
+    egui_ctx: egui::Context,
+
     swap_interval: glutin::surface::SwapInterval,
     gl_config: glutin::config::Config,
 
@@ -138,7 +140,7 @@ impl GlowWinitApp {
 
     #[allow(unsafe_code)]
     fn create_glutin_windowed_context(
-        egui_zoom_factor: f32,
+        egui_ctx: &egui::Context,
         event_loop: &EventLoopWindowTarget<UserEvent>,
         storage: Option<&dyn Storage>,
         native_options: &mut NativeOptions,
@@ -148,14 +150,15 @@ impl GlowWinitApp {
         let window_settings = epi_integration::load_window_settings(storage);
 
         let winit_window_builder = epi_integration::viewport_builder(
-            egui_zoom_factor,
+            egui_ctx.zoom_factor(),
             event_loop,
             native_options,
             window_settings,
         );
 
-        let mut glutin_window_context =
-            unsafe { GlutinWindowContext::new(winit_window_builder, native_options, event_loop)? };
+        let mut glutin_window_context = unsafe {
+            GlutinWindowContext::new(egui_ctx, winit_window_builder, native_options, event_loop)?
+        };
 
         // Creates the window - must come before we create our glow context
         glutin_window_context.on_resume(event_loop)?;
@@ -198,7 +201,7 @@ impl GlowWinitApp {
         let egui_ctx = create_egui_context(storage.as_deref());
 
         let (mut glutin, painter) = Self::create_glutin_windowed_context(
-            egui_ctx.zoom_factor(),
+            &egui_ctx,
             event_loop,
             storage.as_deref(),
             &mut self.native_options,
@@ -648,7 +651,7 @@ impl GlowWinitRunning {
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
 
-        glutin.handle_viewport_output(viewport_output);
+        glutin.handle_viewport_output(&integration.egui_ctx, viewport_output);
 
         if integration.should_close() {
             EventResult::Exit
@@ -769,6 +772,7 @@ impl GlowWinitRunning {
 impl GlutinWindowContext {
     #[allow(unsafe_code)]
     unsafe fn new(
+        egui_ctx: &egui::Context,
         viewport_builder: ViewportBuilder,
         native_options: &NativeOptions,
         event_loop: &EventLoopWindowTarget<UserEvent>,
@@ -820,7 +824,11 @@ impl GlutinWindowContext {
         let display_builder = glutin_winit::DisplayBuilder::new()
             // we might want to expose this option to users in the future. maybe using an env var or using native_options.
             .with_preference(glutin_winit::ApiPrefence::FallbackEgl) // https://github.com/emilk/egui/issues/2520#issuecomment-1367841150
-            .with_window_builder(Some(create_winit_window_builder(viewport_builder.clone())));
+            .with_window_builder(Some(create_winit_window_builder(
+                egui_ctx,
+                event_loop,
+                viewport_builder.clone(),
+            )));
 
         let (window, gl_config) = {
             crate::profile_scope!("DisplayBuilder::build");
@@ -916,6 +924,7 @@ impl GlutinWindowContext {
         // https://github.com/emilk/egui/pull/2541#issuecomment-1370767582
 
         let mut slf = GlutinWindowContext {
+            egui_ctx: egui_ctx.clone(),
             swap_interval,
             gl_config,
             current_gl_context: None,
@@ -975,7 +984,7 @@ impl GlutinWindowContext {
             log::trace!("Window doesn't exist yet. Creating one now with finalize_window");
             let window = glutin_winit::finalize_window(
                 event_loop,
-                create_winit_window_builder(viewport.builder.clone()),
+                create_winit_window_builder(&self.egui_ctx, event_loop, viewport.builder.clone()),
                 &self.gl_config,
             )?;
             apply_viewport_builder_to_new_window(&window, &viewport.builder);
@@ -1103,7 +1112,11 @@ impl GlutinWindowContext {
         self.gl_config.display().get_proc_address(addr)
     }
 
-    fn handle_viewport_output(&mut self, viewport_output: ViewportIdMap<ViewportOutput>) {
+    fn handle_viewport_output(
+        &mut self,
+        egui_ctx: &egui::Context,
+        viewport_output: ViewportIdMap<ViewportOutput>,
+    ) {
         crate::profile_function!();
 
         let active_viewports_ids: ViewportIdSet = viewport_output.keys().copied().collect();
@@ -1123,6 +1136,7 @@ impl GlutinWindowContext {
             let ids = ViewportIdPair::from_self_and_parent(viewport_id, parent);
 
             let viewport = initialize_or_update_viewport(
+                egui_ctx,
                 &mut self.viewports,
                 ids,
                 class,
@@ -1134,6 +1148,7 @@ impl GlutinWindowContext {
             if let Some(window) = &viewport.window {
                 let is_viewport_focused = self.focused_viewport == Some(viewport_id);
                 egui_winit::process_viewport_commands(
+                    egui_ctx,
                     &mut viewport.info,
                     commands,
                     window,
@@ -1166,14 +1181,15 @@ impl Viewport {
     }
 }
 
-fn initialize_or_update_viewport(
-    viewports: &mut ViewportIdMap<Viewport>,
+fn initialize_or_update_viewport<'vp>(
+    egu_ctx: &'_ egui::Context,
+    viewports: &'vp mut ViewportIdMap<Viewport>,
     ids: ViewportIdPair,
     class: ViewportClass,
     mut builder: ViewportBuilder,
     viewport_ui_cb: Option<Arc<dyn Fn(&egui::Context) + Send + Sync>>,
     focused_viewport: Option<ViewportId>,
-) -> &mut Viewport {
+) -> &'vp mut Viewport {
     crate::profile_function!();
 
     if builder.icon.is_none() {
@@ -1221,6 +1237,7 @@ fn initialize_or_update_viewport(
             } else if let Some(window) = &viewport.window {
                 let is_viewport_focused = focused_viewport == Some(ids.this);
                 process_viewport_commands(
+                    egu_ctx,
                     &mut viewport.info,
                     delta_commands,
                     window,
@@ -1256,6 +1273,7 @@ fn render_immediate_viewport(
         let mut glutin = glutin.borrow_mut();
 
         let viewport = initialize_or_update_viewport(
+            egui_ctx,
             &mut glutin.viewports,
             ids,
             ViewportClass::Immediate,
@@ -1371,7 +1389,7 @@ fn render_immediate_viewport(
 
     winit_state.handle_platform_output(window, egui_ctx, platform_output);
 
-    glutin.handle_viewport_output(viewport_output);
+    glutin.handle_viewport_output(egui_ctx, viewport_output);
 }
 
 #[cfg(feature = "__screenshot")]

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -138,6 +138,7 @@ impl GlowWinitApp {
 
     #[allow(unsafe_code)]
     fn create_glutin_windowed_context(
+        egui_zoom_factor: f32,
         event_loop: &EventLoopWindowTarget<UserEvent>,
         storage: Option<&dyn Storage>,
         native_options: &mut NativeOptions,
@@ -146,8 +147,12 @@ impl GlowWinitApp {
 
         let window_settings = epi_integration::load_window_settings(storage);
 
-        let winit_window_builder =
-            epi_integration::viewport_builder(event_loop, native_options, window_settings);
+        let winit_window_builder = epi_integration::viewport_builder(
+            egui_zoom_factor,
+            event_loop,
+            native_options,
+            window_settings,
+        );
 
         let mut glutin_window_context =
             unsafe { GlutinWindowContext::new(winit_window_builder, native_options, event_loop)? };
@@ -193,6 +198,7 @@ impl GlowWinitApp {
         let egui_ctx = create_egui_context(storage.as_deref());
 
         let (mut glutin, painter) = Self::create_glutin_windowed_context(
+            egui_ctx.zoom_factor(),
             event_loop,
             storage.as_deref(),
             &mut self.native_options,

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -24,8 +24,8 @@ use egui_winit::{
 };
 
 use crate::{
-    native::epi_integration::EpiIntegration, App, AppCreator, CreationContext, NativeOptions,
-    Result, Storage,
+    native::{epi_integration::EpiIntegration, winit_integration::create_egui_context},
+    App, AppCreator, CreationContext, NativeOptions, Result, Storage,
 };
 
 use super::{
@@ -190,6 +190,8 @@ impl GlowWinitApp {
                 .unwrap_or(&self.app_name),
         );
 
+        let egui_ctx = create_egui_context(storage.as_deref());
+
         let (mut glutin, painter) = Self::create_glutin_windowed_context(
             event_loop,
             storage.as_deref(),
@@ -209,12 +211,12 @@ impl GlowWinitApp {
             winit_integration::system_theme(&glutin.window(ViewportId::ROOT), &self.native_options);
 
         let integration = EpiIntegration::new(
+            egui_ctx,
             &glutin.window(ViewportId::ROOT),
             system_theme,
             &self.app_name,
             &self.native_options,
             storage,
-            winit_integration::IS_DESKTOP,
             Some(gl.clone()),
             #[cfg(feature = "wgpu")]
             None,

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -376,8 +376,12 @@ impl WinitApp for WgpuWinitApp {
                             .unwrap_or(&self.app_name),
                     );
                     let egui_ctx = winit_integration::create_egui_context(storage.as_deref());
-                    let (window, builder) =
-                        create_window(event_loop, storage.as_deref(), &mut self.native_options)?;
+                    let (window, builder) = create_window(
+                        egui_ctx.zoom_factor(),
+                        event_loop,
+                        storage.as_deref(),
+                        &mut self.native_options,
+                    )?;
                     self.init_run_state(egui_ctx, event_loop, storage, window, builder)?
                 };
 
@@ -808,6 +812,7 @@ impl Viewport {
 }
 
 fn create_window(
+    egui_zoom_factor: f32,
     event_loop: &EventLoopWindowTarget<UserEvent>,
     storage: Option<&dyn Storage>,
     native_options: &mut NativeOptions,
@@ -815,8 +820,12 @@ fn create_window(
     crate::profile_function!();
 
     let window_settings = epi_integration::load_window_settings(storage);
-    let viewport_builder =
-        epi_integration::viewport_builder(event_loop, native_options, window_settings);
+    let viewport_builder = epi_integration::viewport_builder(
+        egui_zoom_factor,
+        event_loop,
+        native_options,
+        window_settings,
+    );
     let window = {
         crate::profile_scope!("WindowBuilder::build");
         create_winit_window_builder(viewport_builder.clone()).build(event_loop)?

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -140,6 +140,7 @@ impl WgpuWinitApp {
 
     fn init_run_state(
         &mut self,
+        egui_ctx: egui::Context,
         event_loop: &EventLoopWindowTarget<UserEvent>,
         storage: Option<Box<dyn Storage>>,
         window: Window,
@@ -163,12 +164,12 @@ impl WgpuWinitApp {
 
         let system_theme = winit_integration::system_theme(&window, &self.native_options);
         let integration = EpiIntegration::new(
+            egui_ctx,
             &window,
             system_theme,
             &self.app_name,
             &self.native_options,
             storage,
-            winit_integration::IS_DESKTOP,
             #[cfg(feature = "glow")]
             None,
             wgpu_render_state.clone(),
@@ -374,9 +375,10 @@ impl WinitApp for WgpuWinitApp {
                             .as_ref()
                             .unwrap_or(&self.app_name),
                     );
+                    let egui_ctx = winit_integration::create_egui_context(storage.as_deref());
                     let (window, builder) =
                         create_window(event_loop, storage.as_deref(), &mut self.native_options)?;
-                    self.init_run_state(event_loop, storage, window, builder)?
+                    self.init_run_state(egui_ctx, event_loop, storage, window, builder)?
                 };
 
                 EventResult::RepaintNow(

--- a/crates/eframe/src/native/winit_integration.rs
+++ b/crates/eframe/src/native/winit_integration.rs
@@ -11,13 +11,27 @@ use egui_winit::accesskit_winit;
 
 use super::epi_integration::EpiIntegration;
 
-pub const IS_DESKTOP: bool = cfg!(any(
-    target_os = "freebsd",
-    target_os = "linux",
-    target_os = "macos",
-    target_os = "openbsd",
-    target_os = "windows",
-));
+/// Create an egui context, restoring it from storage if possible.
+pub fn create_egui_context(storage: Option<&dyn crate::Storage>) -> egui::Context {
+    crate::profile_function!();
+
+    pub const IS_DESKTOP: bool = cfg!(any(
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "openbsd",
+        target_os = "windows",
+    ));
+
+    let egui_ctx = egui::Context::default();
+
+    egui_ctx.set_embed_viewports(!IS_DESKTOP);
+
+    let memory = crate::native::epi_integration::load_egui_memory(storage).unwrap_or_default();
+    egui_ctx.memory_mut(|mem| *mem = memory);
+
+    egui_ctx
+}
 
 /// The custom even `eframe` uses with the [`winit`] event loop.
 #[derive(Debug)]

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -112,7 +112,13 @@ impl AppRunner {
         };
 
         runner.input.raw.max_texture_side = Some(runner.painter.max_texture_side());
-        runner.input.raw.native_pixels_per_point = Some(super::native_pixels_per_point());
+        runner
+            .input
+            .raw
+            .viewports
+            .entry(egui::ViewportId::ROOT)
+            .or_default()
+            .native_pixels_per_point = Some(super::native_pixels_per_point());
 
         Ok(runner)
     }

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -60,7 +60,7 @@ impl AppRunner {
 
         egui_ctx.options_mut(|o| {
             // On web, the browser controls the zoom factor:
-            o.listen_for_zoomn_shortcuts = false;
+            o.zoom_with_keyboard = false;
             o.zoom_factor = 1.0;
         });
 

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -58,6 +58,12 @@ impl AppRunner {
         ));
         super::storage::load_memory(&egui_ctx);
 
+        egui_ctx.options_mut(|o| {
+            // On web, the browser controls the zoom factor:
+            o.listen_for_zoomn_shortcuts = false;
+            o.zoom_factor = 1.0;
+        });
+
         let theme = system_theme.unwrap_or(web_options.default_theme);
         egui_ctx.set_visuals(theme.egui_visuals());
 

--- a/crates/eframe/src/web/backend.rs
+++ b/crates/eframe/src/web/backend.rs
@@ -23,12 +23,17 @@ pub(crate) struct WebInput {
 
 impl WebInput {
     pub fn new_frame(&mut self, canvas_size: egui::Vec2) -> egui::RawInput {
-        egui::RawInput {
+        let mut raw_input = egui::RawInput {
             screen_rect: Some(egui::Rect::from_min_size(Default::default(), canvas_size)),
-            pixels_per_point: Some(super::native_pixels_per_point()), // We ALWAYS use the native pixels-per-point
             time: Some(super::now_sec()),
             ..self.raw.take()
-        }
+        };
+        raw_input
+            .viewports
+            .entry(egui::ViewportId::ROOT)
+            .or_default()
+            .native_pixels_per_point = Some(super::native_pixels_per_point());
+        raw_input
     }
 
     pub fn on_web_page_focus_change(&mut self, focused: bool) {

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -24,10 +24,6 @@ pub use window_settings::WindowSettings;
 
 use raw_window_handle::HasRawDisplayHandle;
 
-pub fn native_pixels_per_point(window: &Window) -> f32 {
-    window.scale_factor() as f32
-}
-
 pub fn screen_size_in_pixels(window: &Window) -> egui::Vec2 {
     let size = window.inner_size();
     egui::vec2(size.width as f32, size.height as f32)
@@ -222,7 +218,7 @@ impl State {
             .viewports
             .entry(self.viewport_id)
             .or_default()
-            .native_pixels_per_point = Some(native_pixels_per_point(window));
+            .native_pixels_per_point = Some(window.scale_factor() as f32);
 
         self.egui_input.take()
     }

--- a/crates/egui-winit/src/window_settings.rs
+++ b/crates/egui-winit/src/window_settings.rs
@@ -18,8 +18,10 @@ pub struct WindowSettings {
 }
 
 impl WindowSettings {
-    pub fn from_display(window: &winit::window::Window) -> Self {
-        let inner_size_points = window.inner_size().to_logical::<f32>(window.scale_factor());
+    pub fn from_window(egui_zoom_factor: f32, window: &winit::window::Window) -> Self {
+        let inner_size_points = window
+            .inner_size()
+            .to_logical::<f32>(egui_zoom_factor as f64 * window.scale_factor());
 
         let inner_position_pixels = window
             .inner_position()
@@ -100,6 +102,7 @@ impl WindowSettings {
 
     pub fn clamp_position_to_monitors<E>(
         &mut self,
+        egui_zoom_factor: f32,
         event_loop: &winit::event_loop::EventLoopWindowTarget<E>,
     ) {
         // If the app last ran on two monitors and only one is now connected, then
@@ -116,15 +119,16 @@ impl WindowSettings {
         };
 
         if let Some(pos_px) = &mut self.inner_position_pixels {
-            clamp_pos_to_monitors(event_loop, inner_size_points, pos_px);
+            clamp_pos_to_monitors(egui_zoom_factor, event_loop, inner_size_points, pos_px);
         }
         if let Some(pos_px) = &mut self.outer_position_pixels {
-            clamp_pos_to_monitors(event_loop, inner_size_points, pos_px);
+            clamp_pos_to_monitors(egui_zoom_factor, event_loop, inner_size_points, pos_px);
         }
     }
 }
 
 fn clamp_pos_to_monitors<E>(
+    egui_zoom_factor: f32,
     event_loop: &winit::event_loop::EventLoopWindowTarget<E>,
     window_size_pts: egui::Vec2,
     position_px: &mut egui::Pos2,
@@ -142,7 +146,7 @@ fn clamp_pos_to_monitors<E>(
     };
 
     for monitor in monitors {
-        let window_size_px = window_size_pts * (monitor.scale_factor() as f32);
+        let window_size_px = window_size_pts * (egui_zoom_factor * monitor.scale_factor() as f32);
         let monitor_x_range = (monitor.position().x - window_size_px.x as i32)
             ..(monitor.position().x + monitor.size().width as i32);
         let monitor_y_range = (monitor.position().y - window_size_px.y as i32)
@@ -155,10 +159,14 @@ fn clamp_pos_to_monitors<E>(
         }
     }
 
-    let mut window_size_px = window_size_pts * (active_monitor.scale_factor() as f32);
+    let mut window_size_px =
+        window_size_pts * (egui_zoom_factor * active_monitor.scale_factor() as f32);
     // Add size of title bar. This is 32 px by default in Win 10/11.
     if cfg!(target_os = "windows") {
-        window_size_px += egui::Vec2::new(0.0, 32.0 * active_monitor.scale_factor() as f32);
+        window_size_px += egui::Vec2::new(
+            0.0,
+            32.0 * egui_zoom_factor * active_monitor.scale_factor() as f32,
+        );
     }
     let monitor_position = egui::Pos2::new(
         active_monitor.position().x as f32,

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1551,8 +1551,8 @@ impl Context {
     pub fn end_frame(&self) -> FullOutput {
         crate::profile_function!();
 
-        if self.options(|o| o.listen_for_zoomn_shortcuts) {
-            crate::gui_zoom::zoom_with_keyboard_shortcuts(self);
+        if self.options(|o| o.zoom_with_keyboard) {
+            crate::gui_zoom::zoom_with_keyboard(self);
         }
 
         self.write(|ctx| ctx.end_frame())

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1550,6 +1550,11 @@ impl Context {
     #[must_use]
     pub fn end_frame(&self) -> FullOutput {
         crate::profile_function!();
+
+        if self.options(|o| o.listen_for_zoomn_shortcuts) {
+            crate::gui_zoom::zoom_with_keyboard_shortcuts(self);
+        }
+
         self.write(|ctx| ctx.end_frame())
     }
 }

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -78,8 +78,8 @@ pub struct RawInput {
 impl Default for RawInput {
     fn default() -> Self {
         Self {
-            viewport_id: Default::default(),
-            viewports: Default::default(),
+            viewport_id: ViewportId::ROOT,
+            viewports: std::iter::once((ViewportId::ROOT, Default::default())).collect(),
             screen_rect: None,
             max_texture_side: None,
             time: None,

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -14,7 +14,7 @@ use crate::{emath::*, ViewportId, ViewportIdMap};
 /// All coordinates are in points (logical pixels) with origin (0, 0) in the top left .corner.
 ///
 /// Ii "points" can be calculated from native physical pixels
-/// using `pixels_per_point` = [`Context::zoom_factor`] * `native_pixels_per_point`;
+/// using `pixels_per_point` = [`crate::Context::zoom_factor`] * `native_pixels_per_point`;
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct RawInput {
@@ -167,7 +167,7 @@ pub enum ViewportEvent {
 /// `None` means "unknown".
 ///
 /// All units are in ui "points", which can be calculated from native physical pixels
-/// using `pixels_per_point` = [`Context::zoom_factor`] * `[Self::native_pixels_per_point`];
+/// using `pixels_per_point` = [`crate::Context::zoom_factor`] * `[Self::native_pixels_per_point`];
 #[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ViewportInfo {

--- a/crates/egui/src/gui_zoom.rs
+++ b/crates/egui/src/gui_zoom.rs
@@ -16,8 +16,8 @@ pub mod kb_shortcuts {
 /// Cmd+Plus, Cmd+Minus or Cmd+0, just like in a browser.
 ///
 /// By default, `egui::Context` calls this function at the end of each frame,
-/// controllable by [`egui::Options::listen_for_zoomn_shortcuts`].
-pub(crate) fn zoom_with_keyboard_shortcuts(ctx: &Context) {
+/// controllable by [`egui::Options::zoom_with_keyboard`].
+pub(crate) fn zoom_with_keyboard(ctx: &Context) {
     if ctx.input_mut(|i| i.consume_shortcut(&kb_shortcuts::ZOOM_RESET)) {
         ctx.set_zoom_factor(1.0);
     } else {

--- a/crates/egui/src/gui_zoom.rs
+++ b/crates/egui/src/gui_zoom.rs
@@ -15,8 +15,8 @@ pub mod kb_shortcuts {
 /// Let the user scale the GUI (change [`Context::zoom_factor`]) by pressing
 /// Cmd+Plus, Cmd+Minus or Cmd+0, just like in a browser.
 ///
-/// By default, `egui::Context` calls this function at the end of each frame,
-/// controllable by [`egui::Options::zoom_with_keyboard`].
+/// By default, [`crate::Context`] calls this function at the end of each frame,
+/// controllable by [`crate::Options::zoom_with_keyboard`].
 pub(crate) fn zoom_with_keyboard(ctx: &Context) {
     if ctx.input_mut(|i| i.consume_shortcut(&kb_shortcuts::ZOOM_RESET)) {
         ctx.set_zoom_factor(1.0);

--- a/crates/egui/src/gui_zoom.rs
+++ b/crates/egui/src/gui_zoom.rs
@@ -12,16 +12,12 @@ pub mod kb_shortcuts {
     pub const ZOOM_RESET: KeyboardShortcut = KeyboardShortcut::new(Modifiers::COMMAND, Key::Num0);
 }
 
-/// Let the user scale the GUI (change `Context::zoom_factor`) by pressing
+/// Let the user scale the GUI (change [`Context::zoom_factor`]) by pressing
 /// Cmd+Plus, Cmd+Minus or Cmd+0, just like in a browser.
 ///
-/// ```
-/// # let ctx = &egui::Context::default();
-/// // On web, the browser controls the gui zoom.
-/// #[cfg(not(target_arch = "wasm32"))]
-/// egui::gui_zoom::zoom_with_keyboard_shortcuts(ctx);
-/// ```
-pub fn zoom_with_keyboard_shortcuts(ctx: &Context) {
+/// By default, `egui::Context` calls this function at the end of each frame,
+/// controllable by [`egui::Options::listen_for_zoomn_shortcuts`].
+pub(crate) fn zoom_with_keyboard_shortcuts(ctx: &Context) {
     if ctx.input_mut(|i| i.consume_shortcut(&kb_shortcuts::ZOOM_RESET)) {
         ctx.set_zoom_factor(1.0);
     } else {

--- a/crates/egui/src/gui_zoom.rs
+++ b/crates/egui/src/gui_zoom.rs
@@ -12,7 +12,7 @@ pub mod kb_shortcuts {
     pub const ZOOM_RESET: KeyboardShortcut = KeyboardShortcut::new(Modifiers::COMMAND, Key::Num0);
 }
 
-/// Let the user scale the GUI (change `Context::pixels_per_point`) by pressing
+/// Let the user scale the GUI (change `Context::zoom_factor`) by pressing
 /// Cmd+Plus, Cmd+Minus or Cmd+0, just like in a browser.
 ///
 /// ```
@@ -23,9 +23,7 @@ pub mod kb_shortcuts {
 /// ```
 pub fn zoom_with_keyboard_shortcuts(ctx: &Context) {
     if ctx.input_mut(|i| i.consume_shortcut(&kb_shortcuts::ZOOM_RESET)) {
-        if let Some(native_pixels_per_point) = ctx.input(|i| i.raw.native_pixels_per_point) {
-            ctx.set_pixels_per_point(native_pixels_per_point);
-        }
+        ctx.set_zoom_factor(1.0);
     } else {
         if ctx.input_mut(|i| i.consume_shortcut(&kb_shortcuts::ZOOM_IN)) {
             zoom_in(ctx);
@@ -36,47 +34,34 @@ pub fn zoom_with_keyboard_shortcuts(ctx: &Context) {
     }
 }
 
-const MIN_PIXELS_PER_POINT: f32 = 0.2;
-const MAX_PIXELS_PER_POINT: f32 = 4.0;
+const MIN_ZOOM_FACTOR: f32 = 0.2;
+const MAX_ZOOM_FACTOR: f32 = 5.0;
 
-/// Make everything larger.
+/// Make everything larger by increasing [`Context::zoom_factor`].
 pub fn zoom_in(ctx: &Context) {
-    let mut pixels_per_point = ctx.pixels_per_point();
-    pixels_per_point += 0.1;
-    pixels_per_point = pixels_per_point.clamp(MIN_PIXELS_PER_POINT, MAX_PIXELS_PER_POINT);
-    pixels_per_point = (pixels_per_point * 10.).round() / 10.;
-    ctx.set_pixels_per_point(pixels_per_point);
+    let mut zoom_factor = ctx.zoom_factor();
+    zoom_factor += 0.1;
+    zoom_factor = zoom_factor.clamp(MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR);
+    zoom_factor = (zoom_factor * 10.).round() / 10.;
+    ctx.set_zoom_factor(zoom_factor);
 }
 
-/// Make everything smaller.
+/// Make everything smaller by decreasing [`Context::zoom_factor`].
 pub fn zoom_out(ctx: &Context) {
-    let mut pixels_per_point = ctx.pixels_per_point();
-    pixels_per_point -= 0.1;
-    pixels_per_point = pixels_per_point.clamp(MIN_PIXELS_PER_POINT, MAX_PIXELS_PER_POINT);
-    pixels_per_point = (pixels_per_point * 10.).round() / 10.;
-    ctx.set_pixels_per_point(pixels_per_point);
+    let mut zoom_factor = ctx.zoom_factor();
+    zoom_factor -= 0.1;
+    zoom_factor = zoom_factor.clamp(MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR);
+    zoom_factor = (zoom_factor * 10.).round() / 10.;
+    ctx.set_zoom_factor(zoom_factor);
 }
 
 /// Show buttons for zooming the ui.
 ///
 /// This is meant to be called from within a menu (See [`Ui::menu_button`]).
-///
-/// When using [`eframe`](https://github.com/emilk/egui/tree/master/crates/eframe), you want to call this as:
-/// ```ignore
-/// // On web, the browser controls the gui zoom.
-/// if !frame.is_web() {
-///     ui.menu_button("View", |ui| {
-///         egui::gui_zoom::zoom_menu_buttons(
-///             ui,
-///             frame.info().native_pixels_per_point,
-///         );
-///     });
-/// }
-/// ```
-pub fn zoom_menu_buttons(ui: &mut Ui, native_pixels_per_point: Option<f32>) {
+pub fn zoom_menu_buttons(ui: &mut Ui) {
     if ui
         .add_enabled(
-            ui.ctx().pixels_per_point() < MAX_PIXELS_PER_POINT,
+            ui.ctx().zoom_factor() < MAX_ZOOM_FACTOR,
             Button::new("Zoom In").shortcut_text(ui.ctx().format_shortcut(&kb_shortcuts::ZOOM_IN)),
         )
         .clicked()
@@ -87,7 +72,7 @@ pub fn zoom_menu_buttons(ui: &mut Ui, native_pixels_per_point: Option<f32>) {
 
     if ui
         .add_enabled(
-            ui.ctx().pixels_per_point() > MIN_PIXELS_PER_POINT,
+            ui.ctx().zoom_factor() > MIN_ZOOM_FACTOR,
             Button::new("Zoom Out")
                 .shortcut_text(ui.ctx().format_shortcut(&kb_shortcuts::ZOOM_OUT)),
         )
@@ -97,17 +82,15 @@ pub fn zoom_menu_buttons(ui: &mut Ui, native_pixels_per_point: Option<f32>) {
         ui.close_menu();
     }
 
-    if let Some(native_pixels_per_point) = native_pixels_per_point {
-        if ui
-            .add_enabled(
-                ui.ctx().pixels_per_point() != native_pixels_per_point,
-                Button::new("Reset Zoom")
-                    .shortcut_text(ui.ctx().format_shortcut(&kb_shortcuts::ZOOM_RESET)),
-            )
-            .clicked()
-        {
-            ui.ctx().set_pixels_per_point(native_pixels_per_point);
-            ui.close_menu();
-        }
+    if ui
+        .add_enabled(
+            ui.ctx().zoom_factor() != 1.0,
+            Button::new("Reset Zoom")
+                .shortcut_text(ui.ctx().format_shortcut(&kb_shortcuts::ZOOM_RESET)),
+        )
+        .clicked()
+    {
+        ui.ctx().set_zoom_factor(1.0);
+        ui.close_menu();
     }
 }

--- a/crates/egui/src/input_state.rs
+++ b/crates/egui/src/input_state.rs
@@ -148,6 +148,7 @@ impl InputState {
         mut self,
         mut new: RawInput,
         requested_repaint_last_frame: bool,
+        pixels_per_point: f32,
     ) -> InputState {
         crate::profile_function!();
 
@@ -217,7 +218,7 @@ impl InputState {
             scroll_delta,
             zoom_factor_delta,
             screen_rect,
-            pixels_per_point: new.pixels_per_point.unwrap_or(self.pixels_per_point),
+            pixels_per_point,
             max_texture_side: new.max_texture_side.unwrap_or(self.max_texture_side),
             time,
             unstable_dt,

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -184,7 +184,7 @@ pub struct Options {
     /// presses Cmd+Plus, Cmd+Minus or Cmd+0, just like in a browser.
     ///
     /// This is `true` by default.
-    pub listen_for_zoomn_shortcuts: bool,
+    pub zoom_with_keyboard: bool,
 
     /// Controls the tessellator.
     pub tessellation_options: epaint::TessellationOptions,
@@ -219,7 +219,7 @@ impl Default for Options {
         Self {
             style: Default::default(),
             zoom_factor: 1.0,
-            listen_for_zoomn_shortcuts: true,
+            zoom_with_keyboard: true,
             tessellation_options: Default::default(),
             screen_reader: false,
             preload_font_glyphs: true,

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -71,10 +71,6 @@ pub struct Memory {
     pub caches: crate::util::cache::CacheStorage,
 
     // ------------------------------------------
-    /// new scale that will be applied at the start of the next frame
-    #[cfg_attr(feature = "persistence", serde(skip))]
-    pub(crate) override_pixels_per_point: Option<f32>,
-
     /// new fonts that will be applied at the start of the next frame
     #[cfg_attr(feature = "persistence", serde(skip))]
     pub(crate) new_font_definitions: Option<epaint::text::FontDefinitions>,
@@ -111,7 +107,6 @@ impl Default for Memory {
             options: Default::default(),
             data: Default::default(),
             caches: Default::default(),
-            override_pixels_per_point: Default::default(),
             new_font_definitions: Default::default(),
             interactions: Default::default(),
             viewport_id: Default::default(),
@@ -176,6 +171,15 @@ pub struct Options {
     #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) style: std::sync::Arc<Style>,
 
+    /// Global zoom factor of the UI.
+    ///
+    /// This is used to calculate the `pixels_per_point`
+    /// for the UI as `pixels_per_point = zoom_fator * native_pixels_per_point`.
+    ///
+    /// The default is 1.0.
+    /// Make larger to make everything larger.
+    pub zoom_factor: f32,
+
     /// Controls the tessellator.
     pub tessellation_options: epaint::TessellationOptions,
 
@@ -208,6 +212,7 @@ impl Default for Options {
     fn default() -> Self {
         Self {
             style: Default::default(),
+            zoom_factor: 1.0,
             tessellation_options: Default::default(),
             screen_reader: false,
             preload_font_glyphs: true,

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -180,7 +180,7 @@ pub struct Options {
     /// Make larger to make everything larger.
     pub zoom_factor: f32,
 
-    /// If `true`, egui will change the scale of the ui ([`Context::zoom_factor`]) when the user
+    /// If `true`, egui will change the scale of the ui ([`crate::Context::zoom_factor`]) when the user
     /// presses Cmd+Plus, Cmd+Minus or Cmd+0, just like in a browser.
     ///
     /// This is `true` by default.

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -180,6 +180,12 @@ pub struct Options {
     /// Make larger to make everything larger.
     pub zoom_factor: f32,
 
+    /// If `true`, egui will change the scale of the ui ([`Context::zoom_factor`]) when the user
+    /// presses Cmd+Plus, Cmd+Minus or Cmd+0, just like in a browser.
+    ///
+    /// This is `true` by default.
+    pub listen_for_zoomn_shortcuts: bool,
+
     /// Controls the tessellator.
     pub tessellation_options: epaint::TessellationOptions,
 
@@ -213,6 +219,7 @@ impl Default for Options {
         Self {
             style: Default::default(),
             zoom_factor: 1.0,
+            listen_for_zoomn_shortcuts: true,
             tessellation_options: Default::default(),
             screen_reader: false,
             preload_font_glyphs: true,

--- a/crates/egui_demo_app/Cargo.toml
+++ b/crates/egui_demo_app/Cargo.toml
@@ -24,9 +24,10 @@ web_app = ["http", "persistence", "web_screen_reader"]
 http = ["ehttp", "image", "poll-promise", "egui_extras/image"]
 image_viewer = ["image", "egui_extras/all_loaders", "rfd"]
 persistence = ["eframe/persistence", "egui/persistence", "serde"]
-web_screen_reader = ["eframe/web_screen_reader"]                  # experimental
+puffin = ["eframe/puffin", "dep:puffin", "dep:puffin_http"]
 serde = ["dep:serde", "egui_demo_lib/serde", "egui/serde"]
 syntect = ["egui_demo_lib/syntect"]
+web_screen_reader = ["eframe/web_screen_reader"]                  # experimental
 
 glow = ["eframe/glow"]
 wgpu = ["eframe/wgpu", "bytemuck"]
@@ -45,14 +46,17 @@ egui = { version = "0.23.0", path = "../egui", features = [
 egui_demo_lib = { version = "0.23.0", path = "../egui_demo_lib", features = [
   "chrono",
 ] }
+egui_extras = { version = "0.23.0", path = "../egui_extras", features = [
+  "image",
+] }
 log = { version = "0.4", features = ["std"] }
 
 # Optional dependencies:
 
 bytemuck = { version = "1.7.1", optional = true }
-egui_extras = { version = "0.23.0", path = "../egui_extras", features = [
-  "image",
-] }
+puffin = { version = "0.18", optional = true }
+puffin_http = { version = "0.15", optional = true }
+
 
 # feature "http":
 ehttp = { version = "0.3.1", optional = true }

--- a/crates/egui_demo_app/src/backend_panel.rs
+++ b/crates/egui_demo_app/src/backend_panel.rs
@@ -51,10 +51,6 @@ pub struct BackendPanel {
     // go back to [`RunMode::Reactive`] mode each time we start
     run_mode: RunMode,
 
-    /// current slider value for current gui scale
-    #[cfg_attr(feature = "serde", serde(skip))]
-    pixels_per_point: Option<f32>,
-
     #[cfg_attr(feature = "serde", serde(skip))]
     frame_history: crate::frame_history::FrameHistory,
 
@@ -82,7 +78,7 @@ impl BackendPanel {
     }
 
     pub fn ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
-        self.integration_ui(ui, frame);
+        integration_ui(ui, frame);
 
         ui.separator();
 
@@ -131,118 +127,6 @@ impl BackendPanel {
         }
     }
 
-    fn integration_ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
-        ui.horizontal(|ui| {
-            ui.spacing_mut().item_spacing.x = 0.0;
-            ui.label("egui running inside ");
-            ui.hyperlink_to(
-                "eframe",
-                "https://github.com/emilk/egui/tree/master/crates/eframe",
-            );
-            ui.label(".");
-        });
-
-        #[cfg(target_arch = "wasm32")]
-        ui.collapsing("Web info (location)", |ui| {
-            ui.style_mut().wrap = Some(false);
-            ui.monospace(format!("{:#?}", frame.info().web_info.location));
-        });
-
-        // On web, the browser controls `pixels_per_point`.
-        let integration_controls_pixels_per_point = frame.is_web();
-        if !integration_controls_pixels_per_point {
-            self.pixels_per_point_ui(ui);
-        }
-
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            ui.horizontal(|ui| {
-                {
-                    let mut fullscreen = ui.input(|i| i.viewport().fullscreen.unwrap_or(false));
-                    if ui
-                        .checkbox(&mut fullscreen, "🗖 Fullscreen (F11)")
-                        .on_hover_text("Fullscreen the window")
-                        .changed()
-                    {
-                        ui.ctx()
-                            .send_viewport_cmd(egui::ViewportCommand::Fullscreen(fullscreen));
-                    }
-                }
-
-                if ui
-                    .button("📱 Phone Size")
-                    .on_hover_text("Resize the window to be small like a phone.")
-                    .clicked()
-                {
-                    // let size = egui::vec2(375.0, 812.0); // iPhone 12 mini
-                    let size = egui::vec2(375.0, 667.0); //  iPhone SE 2nd gen
-
-                    ui.ctx()
-                        .send_viewport_cmd(egui::ViewportCommand::InnerSize(size));
-                    ui.ctx()
-                        .send_viewport_cmd(egui::ViewportCommand::Fullscreen(false));
-                    ui.close_menu();
-                }
-            });
-
-            let fullscreen = ui.input(|i| i.viewport().fullscreen.unwrap_or(false));
-            if !fullscreen
-                && ui
-                    .button("Drag me to drag window")
-                    .is_pointer_button_down_on()
-            {
-                ui.ctx().send_viewport_cmd(egui::ViewportCommand::StartDrag);
-            }
-        }
-    }
-
-    fn pixels_per_point_ui(&mut self, ui: &mut egui::Ui) {
-        let pixels_per_point = self
-            .pixels_per_point
-            .get_or_insert_with(|| ui.ctx().pixels_per_point());
-
-        let mut reset = false;
-
-        ui.horizontal(|ui| {
-            ui.spacing_mut().slider_width = 90.0;
-
-            let response = ui
-                .add(
-                    egui::Slider::new(pixels_per_point, 0.5..=5.0)
-                        .logarithmic(true)
-                        .clamp_to_range(true)
-                        .text("Scale"),
-                )
-                .on_hover_text("Physical pixels per point.");
-
-            if response.drag_released() {
-                // We wait until mouse release to activate:
-                ui.ctx().set_pixels_per_point(*pixels_per_point);
-                reset = true;
-            } else if !response.is_pointer_button_down_on() {
-                // When not dragging, show the current pixels_per_point so others can change it.
-                reset = true;
-            }
-
-            if let Some(native_pixels_per_point) = ui.input(|i| i.raw.native_pixels_per_point) {
-                let enabled = ui.ctx().pixels_per_point() != native_pixels_per_point;
-                if ui
-                    .add_enabled(enabled, egui::Button::new("Reset"))
-                    .on_hover_text(format!(
-                        "Reset scale to native value ({native_pixels_per_point:.1})"
-                    ))
-                    .clicked()
-                {
-                    ui.ctx().set_pixels_per_point(native_pixels_per_point);
-                }
-            }
-        });
-
-        if reset {
-            self.pixels_per_point = None;
-        }
-    }
-
     fn run_mode_ui(&mut self, ui: &mut egui::Ui) {
         ui.horizontal(|ui| {
             let run_mode = &mut self.run_mode;
@@ -282,6 +166,65 @@ impl BackendPanel {
                     }
                 });
             }
+        }
+    }
+}
+
+fn integration_ui(ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 0.0;
+        ui.label("egui running inside ");
+        ui.hyperlink_to(
+            "eframe",
+            "https://github.com/emilk/egui/tree/master/crates/eframe",
+        );
+        ui.label(".");
+    });
+
+    #[cfg(target_arch = "wasm32")]
+    ui.collapsing("Web info (location)", |ui| {
+        ui.style_mut().wrap = Some(false);
+        ui.monospace(format!("{:#?}", _frame.info().web_info.location));
+    });
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        ui.horizontal(|ui| {
+            {
+                let mut fullscreen = ui.input(|i| i.viewport().fullscreen.unwrap_or(false));
+                if ui
+                    .checkbox(&mut fullscreen, "🗖 Fullscreen (F11)")
+                    .on_hover_text("Fullscreen the window")
+                    .changed()
+                {
+                    ui.ctx()
+                        .send_viewport_cmd(egui::ViewportCommand::Fullscreen(fullscreen));
+                }
+            }
+
+            if ui
+                .button("📱 Phone Size")
+                .on_hover_text("Resize the window to be small like a phone.")
+                .clicked()
+            {
+                // let size = egui::vec2(375.0, 812.0); // iPhone 12 mini
+                let size = egui::vec2(375.0, 667.0); //  iPhone SE 2nd gen
+
+                ui.ctx()
+                    .send_viewport_cmd(egui::ViewportCommand::InnerSize(size));
+                ui.ctx()
+                    .send_viewport_cmd(egui::ViewportCommand::Fullscreen(false));
+                ui.close_menu();
+            }
+        });
+
+        let fullscreen = ui.input(|i| i.viewport().fullscreen.unwrap_or(false));
+        if !fullscreen
+            && ui
+                .button("Drag me to drag window")
+                .is_pointer_button_down_on()
+        {
+            ui.ctx().send_viewport_cmd(egui::ViewportCommand::StartDrag);
         }
     }
 }

--- a/crates/egui_demo_app/src/main.rs
+++ b/crates/egui_demo_app/src/main.rs
@@ -4,6 +4,22 @@
 
 // When compiling natively:
 fn main() -> Result<(), eframe::Error> {
+    for arg in std::env::args().skip(1) {
+        match arg.as_str() {
+            "--profile" => {
+                #[cfg(feature = "puffin")]
+                start_puffin_server();
+
+                #[cfg(not(feature = "puffin"))]
+                panic!("Unknown argument: {arg} - you need to enable the 'puffin' feature to use this.");
+            }
+
+            _ => {
+                panic!("Unknown argument: {arg}");
+            }
+        }
+    }
+
     {
         // Silence wgpu log spam (https://github.com/gfx-rs/wgpu/issues/3206)
         let mut rust_log = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_owned());
@@ -32,4 +48,29 @@ fn main() -> Result<(), eframe::Error> {
         options,
         Box::new(|cc| Box::new(egui_demo_app::WrapApp::new(cc))),
     )
+}
+
+#[cfg(feature = "puffin")]
+fn start_puffin_server() {
+    puffin::set_scopes_on(true); // tell puffin to collect data
+
+    match puffin_http::Server::new("127.0.0.1:8585") {
+        Ok(puffin_server) => {
+            eprintln!("Run:  cargo install puffin_viewer && puffin_viewer --url 127.0.0.1:8585");
+
+            std::process::Command::new("puffin_viewer")
+                .arg("--url")
+                .arg("127.0.0.1:8585")
+                .spawn()
+                .ok();
+
+            // We can store the server if we want, but in this case we just want
+            // it to keep running. Dropping it closes the server, so let's not drop it!
+            #[allow(clippy::mem_forget)]
+            std::mem::forget(puffin_server);
+        }
+        Err(err) => {
+            eprintln!("Failed to start puffin server: {err}");
+        }
+    };
 }

--- a/crates/egui_demo_app/src/wrap_app.rs
+++ b/crates/egui_demo_app/src/wrap_app.rs
@@ -283,11 +283,6 @@ impl eframe::App for WrapApp {
 
         self.ui_file_drag_and_drop(ctx);
 
-        // On web, the browser controls `pixels_per_point`.
-        if !frame.is_web() {
-            egui::gui_zoom::zoom_with_keyboard_shortcuts(ctx);
-        }
-
         self.run_cmd(ctx, cmd);
     }
 

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -329,10 +329,12 @@ fn file_menu_button(ui: &mut Ui) {
         // On the web the browser controls the zoom
         #[cfg(not(target_arch = "wasm32"))]
         {
-            ui.weak(format!("Zoom {:.0}%", 100.0 * ui.ctx().zoom_factor()))
-                .on_hover_text("The UI zoom level on top of the operating system's default value");
-
             egui::gui_zoom::zoom_menu_buttons(ui);
+            ui.weak(format!(
+                "Current zoom: {:.0}%",
+                100.0 * ui.ctx().zoom_factor()
+            ))
+            .on_hover_text("The UI zoom level, on top of the operating system's default value");
             ui.separator();
         }
 

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -329,7 +329,10 @@ fn file_menu_button(ui: &mut Ui) {
         // On the web the browser controls the zoom
         #[cfg(not(target_arch = "wasm32"))]
         {
-            egui::gui_zoom::zoom_menu_buttons(ui, None);
+            ui.weak(format!("Zoom {:.0}%", 100.0 * ui.ctx().zoom_factor()))
+                .on_hover_text("The UI zoom level on top of the operating system's default value");
+
+            egui::gui_zoom::zoom_menu_buttons(ui);
             ui.separator();
         }
 

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -75,6 +75,7 @@ impl EguiGlow {
         for (_, ViewportOutput { commands, .. }) in viewport_output {
             let mut screenshot_requested = false;
             egui_winit::process_viewport_commands(
+                &self.egui_ctx,
                 &mut self.viewport_info,
                 commands,
                 window,

--- a/examples/puffin_profiler/Cargo.toml
+++ b/examples/puffin_profiler/Cargo.toml
@@ -8,6 +8,10 @@ rust-version = "1.72"
 publish = false
 
 
+[features]
+wgpu = ["eframe/wgpu"]
+
+
 [dependencies]
 eframe = { path = "../../crates/eframe", features = [
     "puffin",

--- a/examples/puffin_profiler/src/main.rs
+++ b/examples/puffin_profiler/src/main.rs
@@ -52,7 +52,7 @@ impl eframe::App for MyApp {
 fn start_puffin_server() {
     puffin::set_scopes_on(true); // tell puffin to collect data
 
-    match puffin_http::Server::new("0.0.0.0:8585") {
+    match puffin_http::Server::new("127.0.0.1:8585") {
         Ok(puffin_server) => {
             eprintln!("Run:  cargo install puffin_viewer && puffin_viewer --url 127.0.0.1:8585");
 

--- a/examples/test_viewports/src/main.rs
+++ b/examples/test_viewports/src/main.rs
@@ -259,7 +259,6 @@ fn generic_ui(ui: &mut egui::Ui, children: &[Arc<RwLock<ViewportState>>]) {
             data.insert_temp(container_id.with("pixels_per_point"), tmp_pixels_per_point);
         });
     }
-    egui::gui_zoom::zoom_with_keyboard_shortcuts(&ctx);
 
     if ctx.viewport_id() != ctx.parent_viewport_id() {
         let parent = ctx.parent_viewport_id();

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -20,41 +20,41 @@ export RUSTDOCFLAGS="-D warnings" # https://github.com/emilk/egui/pull/1454
 typos
 ./scripts/lint.py
 cargo fmt --all -- --check
-cargo doc --lib --no-deps --all-features
-cargo doc --document-private-items --no-deps --all-features
+cargo doc --quiet --lib --no-deps --all-features
+cargo doc --quiet --document-private-items --no-deps --all-features
 
-cargo cranky --all-targets --all-features -- -D warnings
+cargo cranky --quiet --all-targets --all-features -- -D warnings
 ./scripts/clippy_wasm.sh
 
-cargo check --all-targets
-cargo check --all-targets --all-features
-cargo check -p egui_demo_app --lib --target wasm32-unknown-unknown
-cargo check -p egui_demo_app --lib --target wasm32-unknown-unknown --all-features
-cargo test --all-targets --all-features
-cargo test --doc # slow - checks all doc-tests
+cargo check --quiet  --all-targets
+cargo check --quiet  --all-targets --all-features
+cargo check --quiet  -p egui_demo_app --lib --target wasm32-unknown-unknown
+cargo check --quiet  -p egui_demo_app --lib --target wasm32-unknown-unknown --all-features
+cargo test  --quiet --all-targets --all-features
+cargo test  --quiet --doc # slow - checks all doc-tests
 
-(cd crates/eframe && cargo check --no-default-features --features "glow")
-(cd crates/eframe && cargo check --no-default-features --features "wgpu")
-(cd crates/egui && cargo check --no-default-features --features "serde")
-(cd crates/egui_demo_app && cargo check --no-default-features --features "glow")
-(cd crates/egui_demo_app && cargo check --no-default-features --features "wgpu")
-(cd crates/egui_demo_lib && cargo check --no-default-features)
-(cd crates/egui_extras && cargo check --no-default-features)
-(cd crates/egui_glow && cargo check --no-default-features)
-(cd crates/egui-winit && cargo check --no-default-features --features "wayland")
-(cd crates/egui-winit && cargo check --no-default-features --features "x11")
-(cd crates/emath && cargo check --no-default-features)
-(cd crates/epaint && cargo check --no-default-features --release)
-(cd crates/epaint && cargo check --no-default-features)
+(cd crates/eframe && cargo check --quiet --no-default-features --features "glow")
+(cd crates/eframe && cargo check --quiet --no-default-features --features "wgpu")
+(cd crates/egui && cargo check --quiet --no-default-features --features "serde")
+(cd crates/egui_demo_app && cargo check --quiet --no-default-features --features "glow")
+(cd crates/egui_demo_app && cargo check --quiet --no-default-features --features "wgpu")
+(cd crates/egui_demo_lib && cargo check --quiet --no-default-features)
+(cd crates/egui_extras && cargo check --quiet --no-default-features)
+(cd crates/egui_glow && cargo check --quiet --no-default-features)
+(cd crates/egui-winit && cargo check --quiet --no-default-features --features "wayland")
+(cd crates/egui-winit && cargo check --quiet --no-default-features --features "x11")
+(cd crates/emath && cargo check --quiet --no-default-features)
+(cd crates/epaint && cargo check --quiet --no-default-features --release)
+(cd crates/epaint && cargo check --quiet --no-default-features)
 
-(cd crates/eframe && cargo check --all-features)
-(cd crates/egui && cargo check --all-features)
-(cd crates/egui_demo_app && cargo check --all-features)
-(cd crates/egui_extras && cargo check --all-features)
-(cd crates/egui_glow && cargo check --all-features)
-(cd crates/egui-winit && cargo check --all-features)
-(cd crates/emath && cargo check --all-features)
-(cd crates/epaint && cargo check --all-features)
+(cd crates/eframe && cargo check --quiet --all-features)
+(cd crates/egui && cargo check --quiet --all-features)
+(cd crates/egui_demo_app && cargo check --quiet --all-features)
+(cd crates/egui_extras && cargo check --quiet --all-features)
+(cd crates/egui_glow && cargo check --quiet --all-features)
+(cd crates/egui-winit && cargo check --quiet --all-features)
+(cd crates/emath && cargo check --quiet --all-features)
+(cd crates/epaint && cargo check --quiet --all-features)
 
 ./scripts/wasm_bindgen_check.sh
 

--- a/scripts/clippy_wasm.sh
+++ b/scripts/clippy_wasm.sh
@@ -10,4 +10,4 @@ set -x
 # Use scripts/clippy_wasm/clippy.toml
 export CLIPPY_CONF_DIR="scripts/clippy_wasm"
 
-cargo cranky --all-features --target wasm32-unknown-unknown --target-dir target_wasm -p egui_demo_app --lib -- --deny warnings
+cargo cranky --quiet --all-features --target wasm32-unknown-unknown --target-dir target_wasm -p egui_demo_app --lib -- --deny warnings


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/3602

You can now zoom any egui app by pressing Cmd+Plus, Cmd+Minus or Cmd+0, just like in a browser. This will change the current `zoom_factor` (default 1.0) which is persisted in the egui memory, and is the same for all viewports.
You can turn off the keyboard shortcuts with `ctx.options_mut(|o| o.zoom_with_keyboard = false);`

`zoom_factor` can also be explicitly read/written with `ctx.zoom_factor()` and `ctx.set_zoom_factor()`.

This redefines `pixels_per_point` as `zoom_factor * native_pixels_per_point`, where `native_pixels_per_point` is whatever is the native scale factor for the monitor that the current viewport is in.

This adds some complexity to the interaction with winit, since we need to know the current `zoom_factor` in a lot of places, because all egui IO is done in ui points. I'm pretty sure this PR fixes a bunch of subtle bugs though that used to be in this code.

`egui::gui_zoom::zoom_with_keyboard_shortcuts` is now gone, and is no longer needed, as this is now the default behavior.

`Context::set_pixels_per_point` is still there, but it is recommended you use `Context::set_zoom_factor` instead.