### PR TITLE
Fix: fall back to default egui icon if non is set

### DIFF
--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -248,6 +248,9 @@ pub struct NativeOptions {
     /// Controls the native window of the root viewport.
     ///
     /// This is where you set things like window title and size.
+    ///
+    /// If you don't set an icon, a default egui icon will be used.
+    /// To avoid this, set the icon to [`egui::IconData::default`].
     pub viewport: egui::ViewportBuilder,
 
     /// Turn on vertical syncing, limiting the FPS to the display refresh rate.
@@ -379,13 +382,7 @@ impl Clone for NativeOptions {
 impl Default for NativeOptions {
     fn default() -> Self {
         Self {
-            viewport: egui::ViewportBuilder {
-                icon: Some(std::sync::Arc::new(
-                    crate::icon_data::from_png_bytes(&include_bytes!("../data/icon.png")[..])
-                        .unwrap(),
-                )),
-                ..Default::default()
-            },
+            viewport: Default::default(),
 
             vsync: true,
             multisampling: 0,

--- a/crates/eframe/src/native/app_icon.rs
+++ b/crates/eframe/src/native/app_icon.rs
@@ -13,7 +13,13 @@ pub struct AppTitleIconSetter {
 }
 
 impl AppTitleIconSetter {
-    pub fn new(title: String, icon_data: Option<Arc<IconData>>) -> Self {
+    pub fn new(title: String, mut icon_data: Option<Arc<IconData>>) -> Self {
+        if let Some(icon) = &icon_data {
+            if **icon == IconData::default() {
+                icon_data = None;
+            }
+        }
+
         Self {
             title,
             icon_data,

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -169,13 +169,19 @@ impl EpiIntegration {
             raw_window_handle: window.raw_window_handle(),
         };
 
+        let icon = native_options
+            .viewport
+            .icon
+            .clone()
+            .unwrap_or_else(|| std::sync::Arc::new(load_default_egui_icon()));
+
         let app_icon_setter = super::app_icon::AppTitleIconSetter::new(
             native_options
                 .viewport
                 .title
                 .clone()
                 .unwrap_or_else(|| app_name.to_owned()),
-            native_options.viewport.icon.clone(),
+            Some(icon),
         );
 
         Self {
@@ -354,6 +360,11 @@ impl EpiIntegration {
             storage.flush();
         }
     }
+}
+
+fn load_default_egui_icon() -> egui::IconData {
+    crate::profile_function!();
+    crate::icon_data::from_png_bytes(&include_bytes!("../../data/icon.png")[..]).unwrap()
 }
 
 #[cfg(feature = "persistence")]


### PR DESCRIPTION
It broke in one of the recent multi-viewport prs