### PR TITLE
Add a tutorials folder with simple tutorials

### DIFF
--- a/crates/eframe/tutorials/layout.md
+++ b/crates/eframe/tutorials/layout.md
@@ -1,0 +1,10 @@
+# Layout tutorials
+
+## Make group fill full height of its parent
+
+```rust
+ui.group(|ui| {
+    // Stuff blah blah blah
+    ui.set_height(ui.available_height());
+});
+```

--- a/crates/eframe/tutorials/miscellaneous.md
+++ b/crates/eframe/tutorials/miscellaneous.md
@@ -1,0 +1,1 @@
+# Miscellaneous tutorials

--- a/crates/eframe/tutorials/technical.md
+++ b/crates/eframe/tutorials/technical.md
@@ -1,0 +1,20 @@
+# Technical tutorials
+
+## Press a button when a key is pressed
+
+If you want to have something that happens when either:
+
+- a button is clicked, or
+- a key is pressed
+
+This is how you can do that:
+
+```rust
+let my_button = ui.button("Press me");
+
+if my_button.clicked() || ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+    // Do awesome stuff
+}
+```
+
+Now, whenever `my_button` is clicked _or_ the `Enter` key is pressed, they will do the same thing.

--- a/crates/eframe/tutorials/tutorials.md
+++ b/crates/eframe/tutorials/tutorials.md
@@ -1,0 +1,11 @@
+# `eframe` Tutorials
+
+This is a list of tutorials to do small things using eframe
+
+- [Layout](./layout.md)
+- [Technical](./technical.md)
+- [Miscellaneous](./miscellaneous.md)
+
+---
+
+These tutorials are a work in progress. You can contribute to them by submitting a PR on GitHub


### PR DESCRIPTION
`tutorials.md` is the "home page"
The other `md` files are different sections (layout, technical, miscellaneous, etc.)

I have found it somewhat difficult getting started with `eframe` and I think it would be immensely helpful to have a collection of how-to's for doing small tasks (e.g. making a `ui.group()` the full available height).

This is (very) obviously not comprehensive, but I think it would be a good starting point. I am also not entirely sure about the layout, I think it's ok, but probably not perfect.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

---

Addresses <https://github.com/emilk/egui/issues/186>.
