### PR TITLE
eframe web: Don't throw away frames on click/copy/cut 

### DIFF
--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -241,7 +241,7 @@ impl AppRunner {
                 self.egui_ctx.pixels_per_point(),
                 &textures_delta,
             ) {
-                log::error!("Failed to paint: {err:?}");
+                log::error!("Failed to paint: {}", super::string_from_js_value(&err));
             }
         }
     }

--- a/crates/eframe/src/web/backend.rs
+++ b/crates/eframe/src/web/backend.rs
@@ -73,6 +73,10 @@ impl NeedRepaint {
         *repaint_time = repaint_time.min(super::now_sec() + num_seconds);
     }
 
+    pub fn needs_repaint(&self) -> bool {
+        self.when_to_repaint() <= super::now_sec()
+    }
+
     pub fn repaint_asap(&self) {
         *self.0.lock() = f64::NEG_INFINITY;
     }

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -8,22 +8,19 @@ use super::*;
 fn paint_and_schedule(runner_ref: &WebRunner) -> Result<(), JsValue> {
     // Only paint and schedule if there has been no panic
     if let Some(mut runner_lock) = runner_ref.try_lock() {
-        paint_if_needed(&mut runner_lock)?;
+        paint_if_needed(&mut runner_lock);
         drop(runner_lock);
         request_animation_frame(runner_ref.clone())?;
     }
-
     Ok(())
 }
 
-fn paint_if_needed(runner: &mut AppRunner) -> Result<(), JsValue> {
-    if runner.needs_repaint.when_to_repaint() <= now_sec() {
+fn paint_if_needed(runner: &mut AppRunner) {
+    if runner.needs_repaint.needs_repaint() {
         runner.needs_repaint.clear();
-        let clipped_primitives = runner.logic();
-        runner.paint(&clipped_primitives)?;
+        runner.run_and_paint();
         runner.auto_save_if_needed();
     }
-    Ok(())
 }
 
 pub(crate) fn request_animation_frame(runner_ref: WebRunner) -> Result<(), JsValue> {
@@ -177,10 +174,14 @@ pub(crate) fn install_document_events(runner_ref: &WebRunner) -> Result<(), JsVa
         "cut",
         |event: web_sys::ClipboardEvent, runner| {
             runner.input.raw.events.push(egui::Event::Cut);
+
             // In Safari we are only allowed to write to the clipboard during the
             // event callback, which is why we run the app logic here and now:
-            runner.logic(); // we ignore the returned triangles, but schedule a repaint right after
+            runner.logic();
+
+            // Make sure we paint the output of the above logic call asap:
             runner.needs_repaint.repaint_asap();
+
             event.stop_propagation();
             event.prevent_default();
         },
@@ -192,10 +193,14 @@ pub(crate) fn install_document_events(runner_ref: &WebRunner) -> Result<(), JsVa
         "copy",
         |event: web_sys::ClipboardEvent, runner| {
             runner.input.raw.events.push(egui::Event::Copy);
+
             // In Safari we are only allowed to write to the clipboard during the
             // event callback, which is why we run the app logic here and now:
-            runner.logic(); // we ignore the returned triangles, but schedule a repaint right after
+            runner.logic();
+
+            // Make sure we paint the output of the above logic call asap:
             runner.needs_repaint.repaint_asap();
+
             event.stop_propagation();
             event.prevent_default();
         },
@@ -281,9 +286,12 @@ pub(crate) fn install_canvas_events(runner_ref: &WebRunner) -> Result<(), JsValu
                     pressed: true,
                     modifiers,
                 });
+
                 // In Safari we are only allowed to write to the clipboard during the
                 // event callback, which is why we run the app logic here and now:
-                runner.logic(); // we ignore the returned triangles, but schedule a repaint right after
+                runner.logic();
+
+                // Make sure we paint the output of the above logic call asap:
                 runner.needs_repaint.repaint_asap();
             }
             event.stop_propagation();
@@ -313,9 +321,12 @@ pub(crate) fn install_canvas_events(runner_ref: &WebRunner) -> Result<(), JsValu
                 pressed: false,
                 modifiers,
             });
+
             // In Safari we are only allowed to write to the clipboard during the
             // event callback, which is why we run the app logic here and now:
-            runner.logic(); // we ignore the returned triangles, but schedule a repaint right after
+            runner.logic();
+
+            // Make sure we paint the output of the above logic call asap:
             runner.needs_repaint.repaint_asap();
 
             text_agent::update_text_agent(runner);

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -19,8 +19,8 @@ fn paint_if_needed(runner: &mut AppRunner) {
     if runner.needs_repaint.needs_repaint() {
         runner.needs_repaint.clear();
         runner.run_and_paint();
-        runner.auto_save_if_needed();
     }
+    runner.auto_save_if_needed();
 }
 
 pub(crate) fn request_animation_frame(runner_ref: WebRunner) -> Result<(), JsValue> {

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -49,6 +49,10 @@ use crate::Theme;
 
 // ----------------------------------------------------------------------------
 
+pub(crate) fn string_from_js_value(value: &JsValue) -> String {
+    value.as_string().unwrap_or_else(|| format!("{value:#?}"))
+}
+
 /// Current time in seconds (since undefined point in time).
 ///
 /// Monotonically increasing.
@@ -196,7 +200,7 @@ fn set_clipboard_text(s: &str) {
             let future = wasm_bindgen_futures::JsFuture::from(promise);
             let future = async move {
                 if let Err(err) = future.await {
-                    log::error!("Copy/cut action failed: {err:?}");
+                    log::error!("Copy/cut action failed: {}", string_from_js_value(&err));
                 }
             };
             wasm_bindgen_futures::spawn_local(future);

--- a/crates/eframe/src/web/web_runner.rs
+++ b/crates/eframe/src/web/web_runner.rs
@@ -95,7 +95,10 @@ impl WebRunner {
             log::debug!("Unsubscribing from {} events", events_to_unsubscribe.len());
             for x in events_to_unsubscribe {
                 if let Err(err) = x.unsubscribe() {
-                    log::warn!("Failed to unsubscribe from event: {err:?}");
+                    log::warn!(
+                        "Failed to unsubscribe from event: {}",
+                        super::string_from_js_value(&err)
+                    );
                 }
             }
         }


### PR DESCRIPTION
* Follow-up to https://github.com/emilk/egui/pull/3621 and https://github.com/emilk/egui/pull/3513

To work around a Safari limitation, we run the app logic in the event handler of copy, cut, and mouse up and down.

Previously the output of that frame was discarded, but in this PR it is now saved to be used in the next requestAnimationFrame.

The result is noticeable more distinct clicks on buttons (one more frame of highlight)

Bonus: also fix auto-save of a sleeping web app