### PR TITLE
Don't treat 'WindowEvent::CloseRequested' as consumed in egui-winit

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -427,18 +427,14 @@ impl State {
             }
 
             // Things that may require repaint:
-            WindowEvent::CloseRequested => EventResponse {
-                consumed: true,
-                repaint: true,
-            },
-
             WindowEvent::CursorEntered { .. }
             | WindowEvent::Destroyed
             | WindowEvent::Occluded(_)
             | WindowEvent::Resized(_)
             | WindowEvent::Moved(_)
             | WindowEvent::ThemeChanged(_)
-            | WindowEvent::TouchpadPressure { .. } => EventResponse {
+            | WindowEvent::TouchpadPressure { .. }
+            | WindowEvent::CloseRequested => EventResponse {
                 repaint: true,
                 consumed: false,
             },


### PR DESCRIPTION
This appears to have been 'consumed' by the viewport changes at one point (by updating `viewport_info`), but this is no longer the case. We should avoid marking this as 'consumed', so that applications know to continue processing this event after passing it to egui.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->
