### PR TITLE
eframe: Fix window flashing white on launch

### DIFF
--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -154,7 +154,8 @@ impl GlowWinitApp {
             event_loop,
             native_options,
             window_settings,
-        );
+        )
+        .with_visible(false); // Start hidden until we render the first frame
 
         let mut glutin_window_context = unsafe {
             GlutinWindowContext::new(egui_ctx, winit_window_builder, native_options, event_loop)?

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -155,7 +155,7 @@ impl GlowWinitApp {
             native_options,
             window_settings,
         )
-        .with_visible(false); // Start hidden until we render the first frame
+        .with_visible(false); // Start hidden until we render the first frame to fix white flash on startup (https://github.com/emilk/egui/pull/3631)
 
         let mut glutin_window_context = unsafe {
             GlutinWindowContext::new(egui_ctx, winit_window_builder, native_options, event_loop)?

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -838,7 +838,7 @@ fn create_window(
         native_options,
         window_settings,
     )
-    .with_visible(false); // Start hidden until we render the first frame
+    .with_visible(false); // Start hidden until we render the first frame to fix white flash on startup (https://github.com/emilk/egui/pull/3631)
 
     let window = {
         crate::profile_scope!("WindowBuilder::build");

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -837,7 +837,9 @@ fn create_window(
         event_loop,
         native_options,
         window_settings,
-    );
+    )
+    .with_visible(false); // Start hidden until we render the first frame
+
     let window = {
         crate::profile_scope!("WindowBuilder::build");
         create_winit_window_builder(egui_ctx, event_loop, viewport_builder.clone())


### PR DESCRIPTION
This is a bug that can occur on Windows, previously it was fixed by only showing the window after the first frame was rendered, but the bug appeared again with egui 0.24.0. This commit fixes this bug by making the window invisible on startup.

## Before

![window-flash](https://github.com/emilk/egui/assets/108888572/31a675af-8c30-46b1-a1af-653491cf67da)

## After

![no-window-flash](https://github.com/emilk/egui/assets/108888572/e7bfc429-033e-4842-8591-b9229143a60b)

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

Closes https://github.com/emilk/egui/issues/3625.
