### PR TITLE
Update viewport.rs, fix comment typo: "vieweport" -> "viewport"

### DIFF
--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -255,7 +255,7 @@ pub type ImmediateViewportRendererCallback = dyn for<'a> Fn(&Context, ImmediateV
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[allow(clippy::option_option)]
 pub struct ViewportBuilder {
-    /// The title of the vieweport.
+    /// The title of the viewport.
     /// `eframe` will use this as the title of the native window.
     pub title: Option<String>,
 


### PR DESCRIPTION
No code changes.  Just fixing a typo in a comment.

Closes #3637.
