### PR TITLE
Fix cursor clipping in `TextEdit` inside a `ScrollArea`

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -499,6 +499,11 @@ struct Prepared {
 
     scrolling_enabled: bool,
     stick_to_end: Vec2b,
+
+    /// If there was a scroll target before the ScrollArea was added this frame, it's
+    /// not for us to handle so we save it and restore it after this ScrollArea is done.
+    saved_scroll_target: [Option<frame_state::ScrollTarget>; 2],
+
     animated: bool,
 }
 
@@ -693,6 +698,10 @@ impl ScrollArea {
             }
         }
 
+        let saved_scroll_target = content_ui
+            .ctx()
+            .frame_state_mut(|state| std::mem::take(&mut state.scroll_target));
+
         Prepared {
             id,
             state,
@@ -707,6 +716,7 @@ impl ScrollArea {
             viewport,
             scrolling_enabled,
             stick_to_end,
+            saved_scroll_target,
             animated,
         }
     }
@@ -820,6 +830,7 @@ impl Prepared {
             viewport: _,
             scrolling_enabled,
             stick_to_end,
+            saved_scroll_target,
             animated,
         } = self;
 
@@ -853,7 +864,7 @@ impl Prepared {
                     let (start, end) = (range.min, range.max);
                     let clip_start = clip_rect.min[d];
                     let clip_end = clip_rect.max[d];
-                    let mut spacing = ui.spacing().item_spacing[d];
+                    let mut spacing = content_ui.spacing().item_spacing[d];
 
                     let delta_update = if let Some(align) = align {
                         let center_factor = align.to_factor();
@@ -901,6 +912,15 @@ impl Prepared {
                 }
             }
         }
+
+        // Restore scroll target meant for ScrollAreas up the stack (if any)
+        ui.ctx().frame_state_mut(|state| {
+            for d in 0..2 {
+                if saved_scroll_target[d].is_some() {
+                    state.scroll_target[d] = saved_scroll_target[d].clone();
+                };
+            }
+        });
 
         let inner_rect = {
             // At this point this is the available size for the inner rect.

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -502,7 +502,7 @@ struct Prepared {
 
     /// If there was a scroll target before the ScrollArea was added this frame, it's
     /// not for us to handle so we save it and restore it after this ScrollArea is done.
-    saved_scroll_target: [Option<frame_state::ScrollTarget>; 2],
+    saved_scroll_target: [Option<pass_state::ScrollTarget>; 2],
 
     animated: bool,
 }
@@ -700,7 +700,7 @@ impl ScrollArea {
 
         let saved_scroll_target = content_ui
             .ctx()
-            .frame_state_mut(|state| std::mem::take(&mut state.scroll_target));
+            .pass_state_mut(|state| std::mem::take(&mut state.scroll_target));
 
         Prepared {
             id,
@@ -914,7 +914,7 @@ impl Prepared {
         }
 
         // Restore scroll target meant for ScrollAreas up the stack (if any)
-        ui.ctx().frame_state_mut(|state| {
+        ui.ctx().pass_state_mut(|state| {
             for d in 0..2 {
                 if saved_scroll_target[d].is_some() {
                     state.scroll_target[d] = saved_scroll_target[d].clone();


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes #1531

### Before
Notice how the cursor hides after third enter and when the line is long.

https://github.com/user-attachments/assets/8e45736e-d6c7-4dc6-94d0-213188c199ff

### After
Cursor is always visible

https://github.com/user-attachments/assets/43200683-3524-471b-990a-eb7b49385fa9


 - `ScrollArea` now checks if there's a `scroll_target` in `begin`, if there is, it saves it because it's not from its children, then restore it in `end`.
 - `TextEdit` now allocates additional space if its galley grows during the frame. This is needed so that any surrounding `ScrollArea` can bring the cursor to view, otherwise the cursor lays outside the the `ScrollArea`'s `content_ui`.