### PR TITLE
Improve multi-viewports across monitors with different scales

### DIFF
--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -229,8 +229,9 @@ impl EpiIntegration {
 
     pub fn on_window_event(
         &mut self,
-        event: &winit::event::WindowEvent<'_>,
+        window: &winit::window::Window,
         egui_winit: &mut egui_winit::State,
+        event: &winit::event::WindowEvent<'_>,
     ) -> EventResponse {
         crate::profile_function!(egui_winit::short_window_event_description(event));
 
@@ -254,6 +255,7 @@ impl EpiIntegration {
             _ => {}
         }
 
+        egui_winit.update_pixels_per_point(&self.egui_ctx, window);
         egui_winit.on_window_event(&self.egui_ctx, event)
     }
 

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -511,8 +511,8 @@ impl GlowWinitRunning {
             let mut glutin = self.glutin.borrow_mut();
             let egui_ctx = glutin.egui_ctx.clone();
             let viewport = glutin.viewports.get_mut(&viewport_id).unwrap();
-            viewport.update_viewport_info(&egui_ctx);
             let window = viewport.window.as_ref().unwrap();
+            egui_winit::update_viewport_info(&mut viewport.info, &egui_ctx, window);
 
             let egui_winit = viewport.egui_winit.as_mut().unwrap();
             egui_winit.update_pixels_per_point(&egui_ctx, window);
@@ -1173,16 +1173,6 @@ impl GlutinWindowContext {
     }
 }
 
-impl Viewport {
-    /// Update the stored `ViewportInfo`.
-    fn update_viewport_info(&mut self, egui_ctx: &egui::Context) {
-        let Some(window) = &self.window else {
-            return;
-        };
-        egui_winit::update_viewport_info(&mut self.info, egui_ctx, window);
-    }
-}
-
 fn initialize_or_update_viewport<'vp>(
     egu_ctx: &'_ egui::Context,
     viewports: &'vp mut ViewportIdMap<Viewport>,
@@ -1297,13 +1287,13 @@ fn render_immediate_viewport(
         let Some(viewport) = glutin.viewports.get_mut(&ids.this) else {
             return;
         };
-        viewport.update_viewport_info(egui_ctx);
         let Some(egui_winit) = &mut viewport.egui_winit else {
             return;
         };
         let Some(window) = &viewport.window else {
             return;
         };
+        egui_winit::update_viewport_info(&mut viewport.info, egui_ctx, window);
 
         egui_winit.update_pixels_per_point(egui_ctx, window);
         let mut raw_input = egui_winit.take_egui_input(window);

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -508,12 +508,12 @@ impl WgpuWinitRunning {
             let Some(viewport) = viewports.get_mut(&viewport_id) else {
                 return EventResult::Wait;
             };
-            viewport.update_viewport_info(&integration.egui_ctx);
 
             let Viewport {
                 viewport_ui_cb,
                 window,
                 egui_winit,
+                info,
                 ..
             } = viewport;
 
@@ -522,6 +522,7 @@ impl WgpuWinitRunning {
             let Some(window) = window else {
                 return EventResult::Wait;
             };
+            egui_winit::update_viewport_info(info, &integration.egui_ctx, window);
 
             {
                 crate::profile_scope!("set_window");
@@ -808,14 +809,6 @@ impl Viewport {
             }
         }
     }
-
-    /// Update the stored `ViewportInfo`.
-    pub fn update_viewport_info(&mut self, egui_ctx: &egui::Context) {
-        let Some(window) = &self.window else {
-            return;
-        };
-        egui_winit::update_viewport_info(&mut self.info, egui_ctx, window);
-    }
 }
 
 fn create_window(
@@ -875,11 +868,11 @@ fn render_immediate_viewport(
         if viewport.window.is_none() {
             viewport.init_window(egui_ctx, viewport_from_window, painter, event_loop);
         }
-        viewport.update_viewport_info(egui_ctx);
 
         let (Some(window), Some(winit_state)) = (&viewport.window, &mut viewport.egui_winit) else {
             return;
         };
+        egui_winit::update_viewport_info(&mut viewport.info, egui_ctx, window);
 
         winit_state.update_pixels_per_point(egui_ctx, window);
         let mut input = winit_state.take_egui_input(window);

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -38,6 +38,13 @@ pub fn screen_size_in_pixels(window: &Window) -> egui::Vec2 {
     egui::vec2(size.width as f32, size.height as f32)
 }
 
+/// Calculate the `pixels_per_point` for a given window, given the current egui zoom factor
+pub fn pixels_per_point(egui_ctx: &egui::Context, window: &Window) -> f32 {
+    let native_pixels_per_point = window.scale_factor() as f32;
+    let egui_zoom_factor = egui_ctx.zoom_factor();
+    egui_zoom_factor * native_pixels_per_point
+}
+
 // ----------------------------------------------------------------------------
 
 #[must_use]
@@ -70,7 +77,7 @@ pub struct State {
     current_cursor_icon: Option<egui::CursorIcon>,
 
     /// What egui uses.
-    current_pixels_per_point: f32,
+    current_pixels_per_point: f32, // TODO: remove - calculate with [`pixels_per_point`] instead
 
     clipboard: clipboard::Clipboard,
 
@@ -164,9 +171,8 @@ impl State {
         self.egui_input.max_texture_side = Some(max_texture_side);
     }
 
-    /// The number of physical pixels per logical point,
-    /// as configured on the current egui context (see [`egui::Context::pixels_per_point`]).
     #[inline]
+    #[deprecated = "Use egui_winit::pixels_per_point instead"]
     pub fn pixels_per_point(&self) -> f32 {
         self.current_pixels_per_point
     }
@@ -188,8 +194,9 @@ impl State {
     /// Update the given viewport info with the current state of the window.
     ///
     /// Call before [`Self::update_viewport_info`]
+    #[deprecated = "Use egui_winit::update_viewport_info instead"]
     pub fn update_viewport_info(&self, info: &mut ViewportInfo, window: &Window) {
-        update_viewport_info(info, window, self.current_pixels_per_point);
+        update_viewport_info_impl(info, window, self.current_pixels_per_point);
     }
 
     /// Prepare for a new frame by extracting the accumulated input,
@@ -224,6 +231,12 @@ impl State {
             .native_pixels_per_point = Some(window.scale_factor() as f32);
 
         self.egui_input.take()
+    }
+
+    // TODO(emilk): remove asap.
+    #[doc(hidden)]
+    pub fn update_pixels_per_point(&mut self, egui_ctx: &egui::Context, window: &Window) {
+        self.current_pixels_per_point = pixels_per_point(egui_ctx, window);
     }
 
     /// Call this when there is a new event.
@@ -511,8 +524,8 @@ impl State {
 
     fn on_cursor_moved(&mut self, pos_in_pixels: winit::dpi::PhysicalPosition<f64>) {
         let pos_in_points = egui::pos2(
-            pos_in_pixels.x as f32 / self.pixels_per_point(),
-            pos_in_pixels.y as f32 / self.pixels_per_point(),
+            pos_in_pixels.x as f32 / self.current_pixels_per_point,
+            pos_in_pixels.y as f32 / self.current_pixels_per_point,
         );
         self.pointer_pos_in_points = Some(pos_in_points);
 
@@ -549,8 +562,8 @@ impl State {
                 winit::event::TouchPhase::Cancelled => egui::TouchPhase::Cancel,
             },
             pos: egui::pos2(
-                touch.location.x as f32 / self.pixels_per_point(),
-                touch.location.y as f32 / self.pixels_per_point(),
+                touch.location.x as f32 / self.current_pixels_per_point,
+                touch.location.y as f32 / self.current_pixels_per_point,
             ),
             force: match touch.force {
                 Some(winit::event::Force::Normalized(force)) => Some(force as f32),
@@ -610,7 +623,7 @@ impl State {
                     y,
                 }) => (
                     egui::MouseWheelUnit::Point,
-                    egui::vec2(x as f32, y as f32) / self.pixels_per_point(),
+                    egui::vec2(x as f32, y as f32) / self.current_pixels_per_point,
                 ),
             };
             let modifiers = self.egui_input.modifiers;
@@ -626,7 +639,7 @@ impl State {
                 egui::vec2(x, y) * points_per_scroll_line
             }
             winit::event::MouseScrollDelta::PixelDelta(delta) => {
-                egui::vec2(delta.x as f32, delta.y as f32) / self.pixels_per_point()
+                egui::vec2(delta.x as f32, delta.y as f32) / self.current_pixels_per_point
             }
         };
 
@@ -758,7 +771,18 @@ impl State {
     }
 }
 
-fn update_viewport_info(viewport_info: &mut ViewportInfo, window: &Window, pixels_per_point: f32) {
+/// Update the given viewport info with the current state of the window.
+///
+/// Call before [`Self::update_viewport_info`]
+pub fn update_viewport_info(info: &mut ViewportInfo, egui_ctx: &egui::Context, window: &Window) {
+    update_viewport_info_impl(info, window, pixels_per_point(egui_ctx, window));
+}
+
+fn update_viewport_info_impl(
+    viewport_info: &mut ViewportInfo,
+    window: &Window,
+    pixels_per_point: f32,
+) {
     crate::profile_function!();
 
     let has_a_position = match window.is_minimized() {
@@ -1072,8 +1096,7 @@ fn process_viewport_command(
 
     log::debug!("Processing ViewportCommand::{command:?}");
 
-    let egui_zoom_factor = egui_ctx.zoom_factor();
-    let pixels_per_point = egui_zoom_factor * window.scale_factor() as f32;
+    let pixels_per_point = pixels_per_point(egui_ctx, window);
 
     match command {
         ViewportCommand::Close => {
@@ -1440,9 +1463,7 @@ pub fn apply_viewport_builder_to_window(
         // how to translate egui ui point to native physical pixels.
         // Now we do know:
 
-        let native_pixels_per_point = window.scale_factor() as f32;
-        let zoom_factor = egui_ctx.zoom_factor();
-        let pixels_per_point = zoom_factor * native_pixels_per_point;
+        let pixels_per_point = pixels_per_point(egui_ctx, window);
 
         if let Some(size) = builder.inner_size {
             window.set_inner_size(PhysicalSize::new(

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -192,8 +192,6 @@ impl State {
     }
 
     /// Update the given viewport info with the current state of the window.
-    ///
-    /// Call before [`Self::update_viewport_info`]
     #[deprecated = "Use egui_winit::update_viewport_info instead"]
     pub fn update_viewport_info(&self, info: &mut ViewportInfo, window: &Window) {
         update_viewport_info_impl(info, window, self.current_pixels_per_point);
@@ -773,7 +771,7 @@ impl State {
 
 /// Update the given viewport info with the current state of the window.
 ///
-/// Call before [`Self::update_viewport_info`]
+/// Call before [`State::take_egui_input`].
 pub fn update_viewport_info(info: &mut ViewportInfo, egui_ctx: &egui::Context, window: &Window) {
     update_viewport_info_impl(info, window, pixels_per_point(egui_ctx, window));
 }

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -262,6 +262,7 @@ pub struct ViewportBuilder {
     /// This is wayland only. See [`Self::with_app_id`].
     pub app_id: Option<String>,
 
+    /// The desired outer position of the window.
     pub position: Option<Pos2>,
     pub inner_size: Option<Vec2>,
     pub min_inner_size: Option<Vec2>,
@@ -506,7 +507,8 @@ impl ViewportBuilder {
         self
     }
 
-    /// This will probably not work as expected!
+    /// The initial "outer" position of the window,
+    /// i.e. where the top-left corner of the frame/chrome should be.
     #[inline]
     pub fn with_position(mut self, pos: impl Into<Pos2>) -> Self {
         self.position = Some(pos.into());

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -40,7 +40,6 @@ impl EguiGlow {
             native_pixels_per_point,
             Some(painter.max_texture_side()),
         );
-        let pixels_per_point = egui_winit.pixels_per_point();
 
         Self {
             egui_ctx: Default::default(),
@@ -48,7 +47,7 @@ impl EguiGlow {
             painter,
             viewport_info: Default::default(),
             shapes: Default::default(),
-            pixels_per_point,
+            pixels_per_point: native_pixels_per_point.unwrap_or(1.0),
             textures_delta: Default::default(),
         }
     }

--- a/crates/epaint/src/util/ordered_float.rs
+++ b/crates/epaint/src/util/ordered_float.rs
@@ -55,6 +55,13 @@ impl<T: Float> Hash for OrderedFloat<T> {
     }
 }
 
+impl<T> From<T> for OrderedFloat<T> {
+    #[inline]
+    fn from(val: T) -> Self {
+        OrderedFloat(val)
+    }
+}
+
 // ----------------------------------------------------------------------------
 
 /// Extension trait to provide `ord()` method.

--- a/examples/test_viewports/src/main.rs
+++ b/examples/test_viewports/src/main.rs
@@ -68,7 +68,7 @@ impl ViewportState {
 
         let viewport = ViewportBuilder::default()
             .with_title(&title)
-            .with_inner_size([450.0, 400.0]);
+            .with_inner_size([500.0, 500.0]);
 
         if immediate {
             let mut vp_state = vp_state.write();
@@ -220,22 +220,36 @@ fn generic_ui(ui: &mut egui::Ui, children: &[Arc<RwLock<ViewportState>>]) {
         ctx.parent_viewport_id()
     ));
 
-    ui.add_space(8.0);
+    ui.collapsing("Info", |ui| {
+        ui.label(format!("zoom_factor: {}", ctx.zoom_factor()));
+        ui.label(format!("pixels_per_point: {}", ctx.pixels_per_point()));
 
-    if let Some(inner_rect) = ctx.input(|i| i.viewport().inner_rect) {
-        ui.label(format!(
-            "Inner Rect: Pos: {:?}, Size: {:?}",
-            inner_rect.min,
-            inner_rect.size()
-        ));
-    }
-    if let Some(outer_rect) = ctx.input(|i| i.viewport().outer_rect) {
-        ui.label(format!(
-            "Outer Rect: Pos: {:?}, Size: {:?}",
-            outer_rect.min,
-            outer_rect.size()
-        ));
-    }
+        if let Some(native_pixels_per_point) = ctx.input(|i| i.viewport().native_pixels_per_point) {
+            ui.label(format!(
+                "native_pixels_per_point: {native_pixels_per_point:?}"
+            ));
+        }
+        if let Some(monitor_size) = ctx.input(|i| i.viewport().monitor_size) {
+            ui.label(format!("monitor_size: {monitor_size:?} (points)"));
+        }
+        if let Some(screen_rect) = ui.input(|i| i.raw.screen_rect) {
+            ui.label(format!("Screen rect size: Pos: {:?}", screen_rect.size()));
+        }
+        if let Some(inner_rect) = ctx.input(|i| i.viewport().inner_rect) {
+            ui.label(format!(
+                "Inner Rect: Pos: {:?}, Size: {:?} (points)",
+                inner_rect.min,
+                inner_rect.size()
+            ));
+        }
+        if let Some(outer_rect) = ctx.input(|i| i.viewport().outer_rect) {
+            ui.label(format!(
+                "Outer Rect: Pos: {:?}, Size: {:?} (points)",
+                outer_rect.min,
+                outer_rect.size()
+            ));
+        }
+    });
 
     if ctx.viewport_id() != ctx.parent_viewport_id() {
         let parent = ctx.parent_viewport_id();

--- a/examples/test_viewports/src/main.rs
+++ b/examples/test_viewports/src/main.rs
@@ -73,6 +73,9 @@ impl ViewportState {
         if immediate {
             let mut vp_state = vp_state.write();
             ctx.show_viewport_immediate(vp_id, viewport, move |ctx, class| {
+                if ctx.input(|i| i.viewport().close_requested()) {
+                    vp_state.visible = false;
+                }
                 show_as_popup(ctx, class, &title, vp_id.into(), |ui: &mut egui::Ui| {
                     generic_child_ui(ui, &mut vp_state);
                 });
@@ -81,6 +84,9 @@ impl ViewportState {
             let count = Arc::new(RwLock::new(0));
             ctx.show_viewport_deferred(vp_id, viewport, move |ctx, class| {
                 let mut vp_state = vp_state.write();
+                if ctx.input(|i| i.viewport().close_requested()) {
+                    vp_state.visible = false;
+                }
                 let count = count.clone();
                 show_as_popup(
                     ctx,


### PR DESCRIPTION
It required some ugly code in `egui-winit` in order to fix this without breaking sem-ver (I want this to land in a 0.24.1 patch release). I'll clean up in time for 0.25.

There is still a font rendering bug when using immediate viewports across multiple viewports, but that's harder to fix.