### PR TITLE
Log all available wgpu adapters during startup 

### DIFF
--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -85,6 +85,11 @@ impl RenderState {
                         instance.enumerate_adapters(wgpu::Backends::all()).collect();
                     if adaptors.is_empty() {
                         log::info!("No wgpu adaptors found");
+                    } else if adaptors.len() == 1 {
+                        log::info!(
+                            "The only available wgpu adaptor was not suitable: {}",
+                            adapter_info_summary(&adaptors[0].get_info())
+                        );
                     } else {
                         log::info!(
                             "No suitable wgpu adapter found out of the {} available ones: {}",

--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -70,7 +70,7 @@ impl RenderState {
         crate::profile_scope!("RenderState::create"); // async yield give bad names using `profile_function`
 
         #[cfg(not(target_arch = "wasm32"))]
-        let adaptors: Vec<_> = instance.enumerate_adapters(wgpu::Backends::all()).collect();
+        let adapters: Vec<_> = instance.enumerate_adapters(wgpu::Backends::all()).collect();
 
         let adapter = {
             crate::profile_scope!("request_adapter");
@@ -83,18 +83,18 @@ impl RenderState {
                 .await
                 .ok_or_else(|| {
                     #[cfg(not(target_arch = "wasm32"))]
-                    if adaptors.is_empty() {
-                        log::info!("No wgpu adaptors found");
-                    } else if adaptors.len() == 1 {
+                    if adapters.is_empty() {
+                        log::info!("No wgpu adapters found");
+                    } else if adapters.len() == 1 {
                         log::info!(
-                            "The only available wgpu adaptor was not suitable: {}",
-                            adapter_info_summary(&adaptors[0].get_info())
+                            "The only available wgpu adapter was not suitable: {}",
+                            adapter_info_summary(&adapters[0].get_info())
                         );
                     } else {
                         log::info!(
                             "No suitable wgpu adapter found out of the {} available ones: {}",
-                            adaptors.len(),
-                            describe_adaptors(&adaptors)
+                            adapters.len(),
+                            describe_adapters(&adapters)
                         );
                     }
 
@@ -104,24 +104,24 @@ impl RenderState {
 
         #[cfg(target_arch = "wasm32")]
         log::debug!(
-            "Picked wgpu adaptor: {}",
+            "Picked wgpu adapter: {}",
             adapter_info_summary(&adapter.get_info())
         );
 
         #[cfg(not(target_arch = "wasm32"))]
-        if adaptors.len() == 1 {
+        if adapters.len() == 1 {
             log::debug!(
-                "Picked the only available wgpu adaptor: {}",
+                "Picked the only available wgpu adapter: {}",
                 adapter_info_summary(&adapter.get_info())
             );
         } else {
             log::info!(
-                "There were {} available wgpu adaptors: {}",
-                adaptors.len(),
-                describe_adaptors(&adaptors)
+                "There were {} available wgpu adapters: {}",
+                adapters.len(),
+                describe_adapters(&adapters)
             );
             log::debug!(
-                "Picked wgpu adaptor: {}",
+                "Picked wgpu adapter: {}",
                 adapter_info_summary(&adapter.get_info())
             );
         }
@@ -152,18 +152,18 @@ impl RenderState {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn describe_adaptors(adaptors: &[wgpu::Adapter]) -> String {
-    if adaptors.is_empty() {
+fn describe_adapters(adapters: &[wgpu::Adapter]) -> String {
+    if adapters.is_empty() {
         "(none)".to_owned()
-    } else if adaptors.len() == 1 {
-        adapter_info_summary(&adaptors[0].get_info())
+    } else if adapters.len() == 1 {
+        adapter_info_summary(&adapters[0].get_info())
     } else {
         let mut list_string = String::new();
-        for adaptor in adaptors {
+        for adapter in adapters {
             if !list_string.is_empty() {
                 list_string += ", ";
             }
-            list_string += &format!("{{{}}}", adapter_info_summary(&adaptor.get_info()));
+            list_string += &format!("{{{}}}", adapter_info_summary(&adapter.get_info()));
         }
         list_string
     }

--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -323,7 +323,7 @@ pub fn adapter_info_summary(info: &wgpu::AdapterInfo) -> String {
         summary += &format!(", driver_info: {driver_info:?}");
     }
     if *vendor != 0 {
-        // TODO(emilk): decode using https://github.com/gfx-rs/wgpu/blob/trunk/wgpu-hal/src/auxil/mod.rs#L7
+        // TODO(emilk): decode using https://github.com/gfx-rs/wgpu/blob/767ac03245ee937d3dc552edc13fe7ab0a860eec/wgpu-hal/src/auxil/mod.rs#L7
         summary += &format!(", vendor: 0x{vendor:04X}");
     }
     if *device != 0 {

--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -298,8 +298,8 @@ pub fn depth_format_from_bits(depth_buffer: u8, stencil_buffer: u8) -> Option<wg
 pub fn adapter_info_summary(info: &wgpu::AdapterInfo) -> String {
     let wgpu::AdapterInfo {
         name,
-        vendor: _, // skip integer id
-        device: _, // skip integer id
+        vendor,
+        device,
         device_type,
         driver,
         driver_info,
@@ -321,6 +321,13 @@ pub fn adapter_info_summary(info: &wgpu::AdapterInfo) -> String {
     }
     if !driver_info.is_empty() {
         summary += &format!(", driver_info: {driver_info:?}");
+    }
+    if *vendor != 0 {
+        // TODO(emilk): decode using https://github.com/gfx-rs/wgpu/blob/trunk/wgpu-hal/src/auxil/mod.rs#L7
+        summary += &format!(", vendor: 0x{vendor:04X}");
+    }
+    if *device != 0 {
+        summary += &format!(", device: 0x{device:02X}");
     }
 
     summary

--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -166,6 +166,10 @@ pub enum SurfaceErrorAction {
 }
 
 /// Configuration for using wgpu with eframe or the egui-wgpu winit feature.
+///
+/// This can be configured with the environment variables:
+/// * `WGPU_BACKEND`: `vulkan`, `dx11`, `dx12`, `metal`, `opengl`, `webgpu`
+/// * `WGPU_POWER_PREF`: `low`, `high` or `none`
 #[derive(Clone)]
 pub struct WgpuConfiguration {
     /// Backends that should be supported (wgpu will pick one of these)
@@ -201,6 +205,7 @@ impl Default for WgpuConfiguration {
             // (note however, that the GL backend needs to be opted-in via a wgpu feature flag)
             supported_backends: wgpu::util::backend_bits_from_env()
                 .unwrap_or(wgpu::Backends::PRIMARY | wgpu::Backends::GL),
+
             device_descriptor: Arc::new(|adapter| {
                 let base_limits = if adapter.get_info().backend == wgpu::Backend::Gl {
                     wgpu::Limits::downlevel_webgl2_defaults()
@@ -219,7 +224,9 @@ impl Default for WgpuConfiguration {
                     },
                 }
             }),
+
             present_mode: wgpu::PresentMode::AutoVsync,
+
             power_preference: wgpu::util::power_preference_from_env()
                 .unwrap_or(wgpu::PowerPreference::HighPerformance),
 


### PR DESCRIPTION
Useful when debugging, e.g. if the default choice is one of many, and perhaps the other ones would be better.

**EDIT**: Oh, `enumerate_adapters` doesn't work on web… will fix.