### PR TITLE
✏️ Update doc comment `then` typos to `than`

### DIFF
--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -439,7 +439,7 @@ impl ViewportBuilder {
     ///
     /// If this is not set, some platform-specific dimensions will be used.
     ///
-    /// Should be bigger then 0
+    /// Should be bigger than 0
     /// Look at winit for more details
     #[inline]
     pub fn with_inner_size(mut self, size: impl Into<Vec2>) -> Self {
@@ -452,7 +452,7 @@ impl ViewportBuilder {
     /// If this is not set, the window will have no minimum dimensions (aside
     /// from reserved).
     ///
-    /// Should be bigger then 0
+    /// Should be bigger than 0
     /// Look at winit for more details
     #[inline]
     pub fn with_min_inner_size(mut self, size: impl Into<Vec2>) -> Self {
@@ -465,7 +465,7 @@ impl ViewportBuilder {
     /// If this is not set, the window will have no maximum or will be set to
     /// the primary monitor's dimensions by the platform.
     ///
-    /// Should be bigger then 0
+    /// Should be bigger than 0
     /// Look at winit for more details
     #[inline]
     pub fn with_max_inner_size(mut self, size: impl Into<Vec2>) -> Self {
@@ -854,16 +854,16 @@ pub enum ViewportCommand {
     /// Set the outer position of the viewport, i.e. moves the window.
     OuterPosition(Pos2),
 
-    /// Should be bigger then 0
+    /// Should be bigger than 0
     InnerSize(Vec2),
 
-    /// Should be bigger then 0
+    /// Should be bigger than 0
     MinInnerSize(Vec2),
 
-    /// Should be bigger then 0
+    /// Should be bigger than 0
     MaxInnerSize(Vec2),
 
-    /// Should be bigger then 0
+    /// Should be bigger than 0
     ResizeIncrements(Option<Vec2>),
 
     /// Begin resizing the viewport with the left mouse button until the button is released.


### PR DESCRIPTION
I looked through the new viewport docs and noticed these small typos. This PR fixes them.