### PR TITLE
Fix `egui_extras::Table` scrolling bug

### DIFF
--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -592,7 +592,7 @@ impl<'a> Table<'a> {
             auto_shrink,
         } = scroll_options;
 
-        let avail_rect = ui.available_rect_before_wrap();
+        let cursor_position = ui.cursor().min;
 
         let mut scroll_area = ScrollArea::new([false, vscroll])
             .auto_shrink(true)
@@ -613,6 +613,8 @@ impl<'a> Table<'a> {
         scroll_area.show(ui, move |ui| {
             let mut scroll_to_y_range = None;
 
+            let clip_rect = ui.clip_rect();
+
             // Hide first-frame-jitters when auto-sizing.
             ui.add_visible_ui(!first_frame_auto_size_columns, |ui| {
                 let layout = StripLayout::new(ui, CellDirection::Horizontal, cell_layout);
@@ -624,8 +626,8 @@ impl<'a> Table<'a> {
                     max_used_widths: max_used_widths_ref,
                     striped,
                     row_nr: 0,
-                    start_y: avail_rect.top(),
-                    end_y: avail_rect.bottom(),
+                    start_y: clip_rect.top(),
+                    end_y: clip_rect.bottom(),
                     scroll_to_row: scroll_to_row.map(|(r, _)| r),
                     scroll_to_y_range: &mut scroll_to_y_range,
                 });
@@ -647,7 +649,7 @@ impl<'a> Table<'a> {
         let bottom = ui.min_rect().bottom();
 
         let spacing_x = ui.spacing().item_spacing.x;
-        let mut x = avail_rect.left() - spacing_x * 0.5;
+        let mut x = cursor_position.x - spacing_x * 0.5;
         for (i, column_width) in state.column_widths.iter_mut().enumerate() {
             let column = &columns[i];
             let column_is_resizable = column.resizable.unwrap_or(resizable);


### PR DESCRIPTION
`egui_extras::Table` now uses the clip rectangle to decide which rows to draw when using `TableBody::rows()`.

- Closes #3682
- Closes #3670
