### PR TITLE
Invalidate font atlas on any change to `pixels_per_point`, not matter how small

### DIFF
--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -396,8 +396,7 @@ impl Fonts {
     pub fn begin_frame(&self, pixels_per_point: f32, max_texture_side: usize) {
         let mut fonts_and_cache = self.0.lock();
 
-        let pixels_per_point_changed =
-            (fonts_and_cache.fonts.pixels_per_point - pixels_per_point).abs() > 1e-3;
+        let pixels_per_point_changed = fonts_and_cache.fonts.pixels_per_point != pixels_per_point;
         let max_texture_side_changed = fonts_and_cache.fonts.max_texture_side != max_texture_side;
         let font_atlas_almost_full = fonts_and_cache.fonts.atlas.lock().fill_ratio() > 0.8;
         let needs_recreate =


### PR DESCRIPTION
Apparently the font implementation uses a distance check to decide if the font(or whatever) need recalculations, after dpi changed:
https://github.com/emilk/egui/blob/8d4de866d4da1835b31e85f9068a5257e6ccbccb/crates/epaint/src/text/fonts.rs#L381-L382

This leads to warnings when the pixel_per_point diff is very low and spams the log. (<- this happens for me if i resize my window on kwin, e.g. maximize it)

(I don't want to debate if the float difference generally makes sense, so if you want to rework that instead just close this pr)

