### PR TITLE
[ScrollArea]: Add option to always scroll the only enabled direction

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -161,9 +161,6 @@ pub struct ScrollArea {
     scrolling_enabled: bool,
     drag_to_scroll: bool,
 
-    /// If true and scrolling is enabled for only one direction, allow horizontal scrolling without pressing shift
-    always_scroll_the_only_direction: bool,
-
     /// If true for vertical or horizontal the scroll wheel will stick to the
     /// end position until user manually changes position. It will become true
     /// again once scroll handle makes contact with end.
@@ -210,7 +207,6 @@ impl ScrollArea {
             offset_y: None,
             scrolling_enabled: true,
             drag_to_scroll: true,
-            always_scroll_the_only_direction: true,
             stick_to_end: Vec2b::FALSE,
         }
     }
@@ -364,21 +360,6 @@ impl ScrollArea {
         self
     }
 
-    /// If `true` and scrolling is enabled for only one direction,
-    /// use scroll input from both directions to scroll the enabled direction.
-    ///
-    /// This can be used to allow horizontal scrolling without pressing shift if vertical scrolling is disabled.
-    ///
-    /// Default: `true`.
-    #[inline]
-    pub fn always_scroll_the_only_direction(
-        mut self,
-        always_scroll_the_only_direction: bool,
-    ) -> Self {
-        self.always_scroll_the_only_direction = always_scroll_the_only_direction;
-        self
-    }
-
     /// For each axis, should the containing area shrink if the content is small?
     ///
     /// * If `true`, egui will add blank space outside the scroll area.
@@ -433,8 +414,6 @@ struct Prepared {
     /// Smoothly interpolated boolean of whether or not to show the scroll bars.
     show_bars_factor: Vec2,
 
-    always_scroll_the_only_direction: bool,
-
     /// How much horizontal and vertical space are used up by the
     /// width of the vertical bar, and the height of the horizontal bar?
     ///
@@ -474,7 +453,6 @@ impl ScrollArea {
             offset_y,
             scrolling_enabled,
             drag_to_scroll,
-            always_scroll_the_only_direction,
             stick_to_end,
         } = self;
 
@@ -609,7 +587,6 @@ impl ScrollArea {
             auto_shrink,
             scroll_enabled,
             show_bars_factor,
-            always_scroll_the_only_direction,
             current_bar_use,
             scroll_bar_visibility,
             inner_rect,
@@ -722,7 +699,6 @@ impl Prepared {
             auto_shrink,
             scroll_enabled,
             mut show_bars_factor,
-            always_scroll_the_only_direction,
             current_bar_use,
             scroll_bar_visibility,
             content_ui,
@@ -804,7 +780,7 @@ impl Prepared {
             for d in 0..2 {
                 if scroll_enabled[d] {
                     let scroll_delta = ui.ctx().frame_state(|fs| {
-                        if always_scroll_the_only_direction
+                        if ui.style().always_scroll_the_only_direction
                             && scroll_enabled[0] != scroll_enabled[1]
                         {
                             // no bidirectional scrolling; allow horizontal scrolling without pressing shift
@@ -821,7 +797,7 @@ impl Prepared {
                         state.offset[d] -= scroll_delta;
                         // Clear scroll delta so no parent scroll will use it.
                         ui.ctx().frame_state_mut(|fs| {
-                            if always_scroll_the_only_direction
+                            if ui.style().always_scroll_the_only_direction
                                 && scroll_enabled[0] != scroll_enabled[1]
                             {
                                 fs.scroll_delta[0] = 0.0;

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -777,12 +777,12 @@ impl Prepared {
         let max_offset = content_size - inner_rect.size();
         let is_hovering_outer_rect = ui.rect_contains_pointer(outer_rect);
         if scrolling_enabled && is_hovering_outer_rect {
+            let always_scroll_enabled_direction = ui.style().always_scroll_the_only_direction
+                && scroll_enabled[0] != scroll_enabled[1];
             for d in 0..2 {
                 if scroll_enabled[d] {
                     let scroll_delta = ui.ctx().frame_state(|fs| {
-                        if ui.style().always_scroll_the_only_direction
-                            && scroll_enabled[0] != scroll_enabled[1]
-                        {
+                        if always_scroll_enabled_direction {
                             // no bidirectional scrolling; allow horizontal scrolling without pressing shift
                             fs.scroll_delta[0] + fs.scroll_delta[1]
                         } else {
@@ -797,9 +797,7 @@ impl Prepared {
                         state.offset[d] -= scroll_delta;
                         // Clear scroll delta so no parent scroll will use it.
                         ui.ctx().frame_state_mut(|fs| {
-                            if ui.style().always_scroll_the_only_direction
-                                && scroll_enabled[0] != scroll_enabled[1]
-                            {
+                            if always_scroll_enabled_direction {
                                 fs.scroll_delta[0] = 0.0;
                                 fs.scroll_delta[1] = 0.0;
                             } else {

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -212,6 +212,9 @@ pub struct Style {
     ///
     /// This only affects a few egui widgets.
     pub explanation_tooltips: bool,
+
+    /// If true and scrolling is enabled for only one direction, allow horizontal scrolling without pressing shift
+    pub always_scroll_the_only_direction: bool,
 }
 
 impl Style {
@@ -1070,6 +1073,7 @@ impl Default for Style {
             #[cfg(debug_assertions)]
             debug: Default::default(),
             explanation_tooltips: false,
+            always_scroll_the_only_direction: true,
         }
     }
 }
@@ -1323,6 +1327,7 @@ impl Style {
             #[cfg(debug_assertions)]
             debug,
             explanation_tooltips,
+            always_scroll_the_only_direction,
         } = self;
 
         visuals.light_dark_radio_buttons(ui);
@@ -1390,6 +1395,11 @@ impl Style {
         ui.checkbox(explanation_tooltips, "Explanation tooltips")
             .on_hover_text(
                 "Show explanatory text when hovering DragValue:s and other egui widgets",
+            );
+
+        ui.checkbox(always_scroll_the_only_direction, "Always scroll the onls direction")
+            .on_hover_text(
+                "If scrolling is enabled for only one direction, allow horizontal scrolling without pressing shift",
             );
 
         ui.vertical_centered(|ui| reset_button(ui, self));

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1397,7 +1397,7 @@ impl Style {
                 "Show explanatory text when hovering DragValue:s and other egui widgets",
             );
 
-        ui.checkbox(always_scroll_the_only_direction, "Always scroll the onls direction")
+        ui.checkbox(always_scroll_the_only_direction, "Always scroll the only enabled direction")
             .on_hover_text(
                 "If scrolling is enabled for only one direction, allow horizontal scrolling without pressing shift",
             );

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1073,7 +1073,7 @@ impl Default for Style {
             #[cfg(debug_assertions)]
             debug: Default::default(),
             explanation_tooltips: false,
-            always_scroll_the_only_direction: true,
+            always_scroll_the_only_direction: false,
         }
     }
 }


### PR DESCRIPTION
Add option to use the scroll input from both directions to scroll the enabled direction if scrolling is enabled for only one direction. This can be used to allow horizontal scrolling without pressing shift if vertical scrolling is disabled.

Closes <https://github.com/emilk/egui/issues/3624>.
