### PR TITLE
Bug fix: framebuffer clear when using glow with multi-viewports

### DIFF
--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -532,12 +532,16 @@ impl GlowWinitRunning {
             (raw_input, viewport_ui_cb)
         };
 
-        {
+        let clear_color = self
+            .app
+            .clear_color(&self.integration.egui_ctx.style().visuals);
+
+        let has_many_viewports = self.glutin.borrow().viewports.len() > 1;
+        let clear_before_update = !has_many_viewports; // HACK: for some reason, an early clear doesn't "take" on Mac with multiple viewports.
+
+        if clear_before_update {
             // clear before we call update, so users can paint between clear-color and egui windows:
 
-            let clear_color = self
-                .app
-                .clear_color(&self.integration.egui_ctx.style().visuals);
             let mut glutin = self.glutin.borrow_mut();
             let GlutinWindowContext {
                 viewports,
@@ -607,6 +611,10 @@ impl GlowWinitRunning {
         change_gl_context(current_gl_context, gl_surface);
 
         let screen_size_in_pixels: [u32; 2] = window.inner_size().into();
+
+        if !clear_before_update {
+            painter.clear(screen_size_in_pixels, clear_color);
+        }
 
         painter.paint_and_update_textures(
             screen_size_in_pixels,


### PR DESCRIPTION
I broke this in https://github.com/emilk/egui/pull/3665

For some reason, when using multiple viewports, the first "clear" doesn't take.

I don't have time to investigate further, so I am adding a hack here which:

* For single-viewport apps, the clear is done before `App::update` so user can paint there
* For multi-viewport apps, the clear is done after `App::update`, so that it works

This means painting in `App::update` won't work with multi-viewports.

Ideally, users should use paint callbacks instead of painting directly in `App::update` anyways.