### PR TITLE
egui-wgpu: reduce input latency by defaulting to double-buffering

### DIFF
--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -238,8 +238,8 @@ impl Default for WgpuConfiguration {
                 }
             }),
 
-            present_mode: wgpu::PresentMode::AutoVsync,
-
+            present_mode: wgpu::PresentMode::AutoNoVsync, // double-buffered: low-latency, may have tearing
+            // present_mode: wgpu::PresentMode::AutoVsync, // triple-buffered: high-latency, no tearing
             power_preference: wgpu::util::power_preference_from_env()
                 .unwrap_or(wgpu::PowerPreference::HighPerformance),
 


### PR DESCRIPTION
This makes a huge difference in perceived latency on my 60 Hz monitor on macOS on a native build.

There is no difference on web though afaict.

For me this is a much better default. Tearing is mildly annoying in some circumstances, but input latency makes an application feel sluggish all the time.
