### PR TITLE
Fix `Window` positioning bug when bad `pivot` is stored in app data

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -265,7 +265,13 @@ impl Area {
 
         let layer_id = LayerId::new(order, id);
 
-        let state = ctx.memory(|mem| mem.areas().get(id).copied());
+        let state = ctx
+            .memory(|mem| mem.areas().get(id).copied())
+            .map(|mut state| {
+                // override the saved state with the correct value
+                state.pivot = pivot;
+                state
+            });
         let is_new = state.is_none();
         if is_new {
             ctx.request_repaint(); // if we don't know the previous size we are likely drawing the area in the wrong place


### PR DESCRIPTION
This PR fixes an issue where a bad pivot stored in app state would override the pivot actually set from code. The root code of this issue if the `Window`'s `State` containing `pivot` in the first place, as `pivot` is not part of a state to be tracked. It makes the `State` structure more ergonomic though, so this PR leaves the `pivot` field but always overrides it with the value provided by user code.

#### Repro of the original issue

This issue can be reproduced using the `re_ui_example` app from the Rerun repo, at this commit: https://github.com/rerun-io/rerun/pull/4577/commits/fb5add0047f108769c413393d65d52e362cbcc8e. By using this `app.ron` file, the bug will appear:

```
{
    "egui": "(
      areas:{
            ((0)):(
                areas:{
                    (13430889033718688666):(pivot_pos:(x:565.5,y:328.0),pivot:((Min,Min)),size:(x:364.0,y:75.5),interactable:true),
                },
            )
        }
    )",
}
```

The modal is entered based on it's top-left corner even though the code actually specifies a center-center pivot:

<img width="1312" alt="image" src="https://github.com/emilk/egui/assets/49431240/6df1a8bb-d1ea-4e15-866c-5f14138dda0e">

With this PR, the centring is correct even with the "poisoned" `app.ron`:

<img width="1312" alt="image" src="https://github.com/emilk/egui/assets/49431240/7f50b2d4-9245-48f3-91de-c747bbc8c40e">

