### PR TITLE
Replace a special `Color32::PLACEHOLDER` with widget fallback color

### DIFF
--- a/crates/ecolor/src/color32.rs
+++ b/crates/ecolor/src/color32.rs
@@ -7,6 +7,8 @@ use crate::{gamma_u8_from_linear_f32, linear_f32_from_gamma_u8, linear_f32_from_
 ///
 /// Internally this uses 0-255 gamma space `sRGBA` color with premultiplied alpha.
 /// Alpha channel is in linear space.
+///
+/// The special value of alpha=0 means the color is to be treated as an additive color.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -61,7 +63,16 @@ impl Color32 {
     pub const DEBUG_COLOR: Color32 = Color32::from_rgba_premultiplied(0, 200, 0, 128);
 
     /// An ugly color that is planned to be replaced before making it to the screen.
-    pub const TEMPORARY_COLOR: Color32 = Color32::from_rgb(64, 254, 0);
+    ///
+    /// This is an invalid color, in that it does not correspond to a valid multiplied color,
+    /// nor to an additive color.
+    ///
+    /// This is used as a special color key,
+    /// i.e. often taken to mean "no color".
+    pub const PLACEHOLDER: Color32 = Color32::from_rgba_premultiplied(64, 254, 0, 128);
+
+    #[deprecated = "Renmaed to PLACEHOLDER"]
+    pub const TEMPORARY_COLOR: Color32 = Self::PLACEHOLDER;
 
     #[inline]
     pub const fn from_rgb(r: u8, g: u8, b: u8) -> Self {

--- a/crates/egui/src/containers/collapsing_header.rs
+++ b/crates/egui/src/containers/collapsing_header.rs
@@ -495,22 +495,22 @@ impl CollapsingHeader {
         let text_pos = available.min + vec2(ui.spacing().indent, 0.0);
         let wrap_width = available.right() - text_pos.x;
         let wrap = Some(false);
-        let text = text.into_galley(ui, wrap, wrap_width, TextStyle::Button);
-        let text_max_x = text_pos.x + text.size().x;
+        let galley = text.into_galley(ui, wrap, wrap_width, TextStyle::Button);
+        let text_max_x = text_pos.x + galley.size().x;
 
         let mut desired_width = text_max_x + button_padding.x - available.left();
         if ui.visuals().collapsing_header_frame {
             desired_width = desired_width.max(available.width()); // fill full width
         }
 
-        let mut desired_size = vec2(desired_width, text.size().y + 2.0 * button_padding.y);
+        let mut desired_size = vec2(desired_width, galley.size().y + 2.0 * button_padding.y);
         desired_size = desired_size.at_least(ui.spacing().interact_size);
         let (_, rect) = ui.allocate_space(desired_size);
 
         let mut header_response = ui.interact(rect, id, Sense::click());
         let text_pos = pos2(
             text_pos.x,
-            header_response.rect.center().y - text.size().y / 2.0,
+            header_response.rect.center().y - galley.size().y / 2.0,
         );
 
         let mut state = CollapsingState::load_with_default_open(ui.ctx(), id, default_open);
@@ -525,7 +525,7 @@ impl CollapsingHeader {
         }
 
         header_response
-            .widget_info(|| WidgetInfo::labeled(WidgetType::CollapsingHeader, text.text()));
+            .widget_info(|| WidgetInfo::labeled(WidgetType::CollapsingHeader, galley.text()));
 
         let openness = state.openness(ui.ctx());
 
@@ -563,7 +563,7 @@ impl CollapsingHeader {
                 }
             }
 
-            text.paint_with_visuals(ui.painter(), text_pos, &visuals);
+            ui.painter().galley(text_pos, galley, visuals.text_color());
         }
 
         Prepared {

--- a/crates/egui/src/containers/combo_box.rs
+++ b/crates/egui/src/containers/combo_box.rs
@@ -327,7 +327,8 @@ fn combo_box_dyn<'c, R>(
             }
 
             let text_rect = Align2::LEFT_CENTER.align_size_within_rect(galley.size(), rect);
-            galley.paint_with_visuals(ui.painter(), text_rect.min, visuals);
+            ui.painter()
+                .galley(text_rect.min, galley, visuals.text_color());
         }
     });
 

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -1,7 +1,9 @@
 // WARNING: the code in here is horrible. It is a behemoth that needs breaking up into simpler parts.
 
+use std::sync::Arc;
+
 use crate::collapsing_header::CollapsingState;
-use crate::{widget_text::WidgetTextGalley, *};
+use crate::*;
 use epaint::*;
 
 use super::*;
@@ -885,7 +887,7 @@ struct TitleBar {
     id: Id,
 
     /// Prepared text in the title
-    title_galley: WidgetTextGalley,
+    title_galley: Arc<Galley>,
 
     /// Size of the title bar in a collapsed state (if window is collapsible),
     /// which includes all necessary space for showing the expand button, the
@@ -984,11 +986,11 @@ impl TitleBar {
         let full_top_rect = Rect::from_x_y_ranges(self.rect.x_range(), self.min_rect.y_range());
         let text_pos =
             emath::align::center_size_in_rect(self.title_galley.size(), full_top_rect).left_top();
-        let text_pos = text_pos - self.title_galley.galley().rect.min.to_vec2();
+        let text_pos = text_pos - self.title_galley.rect.min.to_vec2();
         let text_pos = text_pos - 1.5 * Vec2::Y; // HACK: center on x-height of text (looks better)
-        self.title_galley.paint_with_fallback_color(
-            ui.painter(),
+        ui.painter().galley(
             text_pos,
+            self.title_galley.clone(),
             ui.visuals().text_color(),
         );
 

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -503,8 +503,8 @@ impl SubMenuButton {
             }
 
             let text_color = visuals.text_color();
-            text_galley.paint_with_fallback_color(ui.painter(), text_pos, text_color);
-            icon_galley.paint_with_fallback_color(ui.painter(), icon_pos, text_color);
+            ui.painter().galley(text_pos, text_galley, text_color);
+            ui.painter().galley(icon_pos, icon_galley, text_color);
         }
         response
     }

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2269,7 +2269,8 @@ fn register_rect(ui: &Ui, rect: Rect) {
     if !callstack.is_empty() {
         let font_id = FontId::monospace(12.0);
         let text = format!("{callstack}\n\n(click to copy)");
-        let galley = painter.layout_no_wrap(text, font_id, Color32::WHITE);
+        let text_color = Color32::WHITE;
+        let galley = painter.layout_no_wrap(text, font_id, text_color);
 
         // Position the text either under or above:
         let screen_rect = ui.ctx().screen_rect();
@@ -2299,7 +2300,7 @@ fn register_rect(ui: &Ui, rect: Rect) {
         };
         let text_rect = Rect::from_min_size(text_pos, galley.size());
         painter.rect(text_rect, 0.0, text_bg_color, (1.0, text_rect_stroke_color));
-        painter.galley(text_pos, galley);
+        painter.galley(text_pos, galley, text_color);
 
         if ui.input(|i| i.pointer.any_click()) {
             ui.ctx().copy_text(callstack);

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -210,8 +210,9 @@ impl Widget for Button<'_> {
             text_wrap_width -= 60.0; // Some space for the shortcut text (which we never wrap).
         }
 
-        let text = text.map(|text| text.into_galley(ui, wrap, text_wrap_width, TextStyle::Button));
-        let shortcut_text = (!shortcut_text.is_empty())
+        let galley =
+            text.map(|text| text.into_galley(ui, wrap, text_wrap_width, TextStyle::Button));
+        let shortcut_galley = (!shortcut_text.is_empty())
             .then(|| shortcut_text.into_galley(ui, Some(false), f32::INFINITY, TextStyle::Button));
 
         let mut desired_size = Vec2::ZERO;
@@ -219,14 +220,14 @@ impl Widget for Button<'_> {
             desired_size.x += image_size.x;
             desired_size.y = desired_size.y.max(image_size.y);
         }
-        if image.is_some() && text.is_some() {
+        if image.is_some() && galley.is_some() {
             desired_size.x += ui.spacing().icon_spacing;
         }
-        if let Some(text) = &text {
+        if let Some(text) = &galley {
             desired_size.x += text.size().x;
             desired_size.y = desired_size.y.max(text.size().y);
         }
-        if let Some(shortcut_text) = &shortcut_text {
+        if let Some(shortcut_text) = &shortcut_galley {
             desired_size.x += ui.spacing().item_spacing.x + shortcut_text.size().x;
             desired_size.y = desired_size.y.max(shortcut_text.size().y);
         }
@@ -238,8 +239,8 @@ impl Widget for Button<'_> {
 
         let (rect, mut response) = ui.allocate_at_least(desired_size, sense);
         response.widget_info(|| {
-            if let Some(text) = &text {
-                WidgetInfo::labeled(WidgetType::Button, text.text())
+            if let Some(galley) = &galley {
+                WidgetInfo::labeled(WidgetType::Button, galley.text())
             } else {
                 WidgetInfo::new(WidgetType::Button)
             }
@@ -297,30 +298,30 @@ impl Widget for Button<'_> {
                     widgets::image::texture_load_result_response(image.source(), &tlr, response);
             }
 
-            if image.is_some() && text.is_some() {
+            if image.is_some() && galley.is_some() {
                 cursor_x += ui.spacing().icon_spacing;
             }
 
-            if let Some(text) = text {
-                let text_pos = if image.is_some() || shortcut_text.is_some() {
-                    pos2(cursor_x, rect.center().y - 0.5 * text.size().y)
+            if let Some(galley) = galley {
+                let text_pos = if image.is_some() || shortcut_galley.is_some() {
+                    pos2(cursor_x, rect.center().y - 0.5 * galley.size().y)
                 } else {
                     // Make sure button text is centered if within a centered layout
                     ui.layout()
-                        .align_size_within_rect(text.size(), rect.shrink2(button_padding))
+                        .align_size_within_rect(galley.size(), rect.shrink2(button_padding))
                         .min
                 };
-                text.paint_with_visuals(ui.painter(), text_pos, visuals);
+                ui.painter().galley(text_pos, galley, visuals.text_color());
             }
 
-            if let Some(shortcut_text) = shortcut_text {
+            if let Some(shortcut_galley) = shortcut_galley {
                 let shortcut_text_pos = pos2(
-                    rect.max.x - button_padding.x - shortcut_text.size().x,
-                    rect.center().y - 0.5 * shortcut_text.size().y,
+                    rect.max.x - button_padding.x - shortcut_galley.size().x,
+                    rect.center().y - 0.5 * shortcut_galley.size().y,
                 );
-                shortcut_text.paint_with_fallback_color(
-                    ui.painter(),
+                ui.painter().galley(
                     shortcut_text_pos,
+                    shortcut_galley,
                     ui.visuals().weak_text_color(),
                 );
             }
@@ -378,18 +379,18 @@ impl<'a> Widget for Checkbox<'a> {
         let icon_width = spacing.icon_width;
         let icon_spacing = spacing.icon_spacing;
 
-        let (text, mut desired_size) = if text.is_empty() {
+        let (galley, mut desired_size) = if text.is_empty() {
             (None, vec2(icon_width, 0.0))
         } else {
             let total_extra = vec2(icon_width + icon_spacing, 0.0);
 
             let wrap_width = ui.available_width() - total_extra.x;
-            let text = text.into_galley(ui, None, wrap_width, TextStyle::Button);
+            let galley = text.into_galley(ui, None, wrap_width, TextStyle::Button);
 
-            let mut desired_size = total_extra + text.size();
+            let mut desired_size = total_extra + galley.size();
             desired_size = desired_size.at_least(spacing.interact_size);
 
-            (Some(text), desired_size)
+            (Some(galley), desired_size)
         };
 
         desired_size = desired_size.at_least(Vec2::splat(spacing.interact_size.y));
@@ -404,7 +405,7 @@ impl<'a> Widget for Checkbox<'a> {
             WidgetInfo::selected(
                 WidgetType::Checkbox,
                 *checked,
-                text.as_ref().map_or("", |x| x.text()),
+                galley.as_ref().map_or("", |x| x.text()),
             )
         });
 
@@ -430,12 +431,12 @@ impl<'a> Widget for Checkbox<'a> {
                     visuals.fg_stroke,
                 ));
             }
-            if let Some(text) = text {
+            if let Some(galley) = galley {
                 let text_pos = pos2(
                     rect.min.x + icon_width + icon_spacing,
-                    rect.center().y - 0.5 * text.size().y,
+                    rect.center().y - 0.5 * galley.size().y,
                 );
-                text.paint_with_visuals(ui.painter(), text_pos, visuals);
+                ui.painter().galley(text_pos, galley, visuals.text_color());
             }
         }
 
@@ -487,7 +488,7 @@ impl Widget for RadioButton {
         let icon_width = spacing.icon_width;
         let icon_spacing = spacing.icon_spacing;
 
-        let (text, mut desired_size) = if text.is_empty() {
+        let (galley, mut desired_size) = if text.is_empty() {
             (None, vec2(icon_width, 0.0))
         } else {
             let total_extra = vec2(icon_width + icon_spacing, 0.0);
@@ -509,7 +510,7 @@ impl Widget for RadioButton {
             WidgetInfo::selected(
                 WidgetType::RadioButton,
                 checked,
-                text.as_ref().map_or("", |x| x.text()),
+                galley.as_ref().map_or("", |x| x.text()),
             )
         });
 
@@ -538,12 +539,12 @@ impl Widget for RadioButton {
                 });
             }
 
-            if let Some(text) = text {
+            if let Some(galley) = galley {
                 let text_pos = pos2(
                     rect.min.x + icon_width + icon_spacing,
-                    rect.center().y - 0.5 * text.size().y,
+                    rect.center().y - 0.5 * galley.size().y,
                 );
-                text.paint_with_visuals(ui.painter(), text_pos, visuals);
+                ui.painter().galley(text_pos, galley, visuals.text_color());
             }
         }
 

--- a/crates/egui/src/widgets/hyperlink.rs
+++ b/crates/egui/src/widgets/hyperlink.rs
@@ -34,8 +34,8 @@ impl Widget for Link {
         let Link { text } = self;
         let label = Label::new(text).sense(Sense::click());
 
-        let (pos, text_galley, response) = label.layout_in_ui(ui);
-        response.widget_info(|| WidgetInfo::labeled(WidgetType::Link, text_galley.text()));
+        let (pos, galley, response) = label.layout_in_ui(ui);
+        response.widget_info(|| WidgetInfo::labeled(WidgetType::Link, galley.text()));
 
         if response.hovered() {
             ui.ctx().set_cursor_icon(CursorIcon::PointingHand);
@@ -51,13 +51,8 @@ impl Widget for Link {
                 Stroke::NONE
             };
 
-            ui.painter().add(epaint::TextShape {
-                pos,
-                galley: text_galley.galley,
-                override_text_color: Some(color),
-                underline,
-                angle: 0.0,
-            });
+            ui.painter()
+                .add(epaint::TextShape::new(pos, galley, color).with_underline(underline));
         }
 
         response

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -1,4 +1,6 @@
-use crate::{widget_text::WidgetTextGalley, *};
+use std::sync::Arc;
+
+use crate::*;
 
 /// Static text.
 ///
@@ -94,7 +96,7 @@ impl Label {
 
 impl Label {
     /// Do layout and position the galley in the ui, without painting it or adding widget info.
-    pub fn layout_in_ui(self, ui: &mut Ui) -> (Pos2, WidgetTextGalley, Response) {
+    pub fn layout_in_ui(self, ui: &mut Ui) -> (Pos2, Arc<Galley>, Response) {
         let sense = self.sense.unwrap_or_else(|| {
             // We only want to focus labels if the screen reader is on.
             if ui.memory(|mem| mem.options.screen_reader) {
@@ -111,17 +113,13 @@ impl Label {
                 Align::Center => rect.center_top(),
                 Align::RIGHT => rect.right_top(),
             };
-            let text_galley = WidgetTextGalley {
-                galley,
-                galley_has_color: true,
-            };
-            return (pos, text_galley, response);
+            return (pos, galley, response);
         }
 
         let valign = ui.layout().vertical_align();
-        let mut text_job = self
+        let mut layout_job = self
             .text
-            .into_text_job(ui.style(), FontSelection::Default, valign);
+            .into_layout_job(ui.style(), FontSelection::Default, valign);
 
         let truncate = self.truncate;
         let wrap = !truncate && self.wrap.unwrap_or_else(|| ui.wrap_text());
@@ -139,70 +137,65 @@ impl Label {
             let first_row_indentation = available_width - ui.available_size_before_wrap().x;
             egui_assert!(first_row_indentation.is_finite());
 
-            text_job.job.wrap.max_width = available_width;
-            text_job.job.first_row_min_height = cursor.height();
-            text_job.job.halign = Align::Min;
-            text_job.job.justify = false;
-            if let Some(first_section) = text_job.job.sections.first_mut() {
+            layout_job.wrap.max_width = available_width;
+            layout_job.first_row_min_height = cursor.height();
+            layout_job.halign = Align::Min;
+            layout_job.justify = false;
+            if let Some(first_section) = layout_job.sections.first_mut() {
                 first_section.leading_space = first_row_indentation;
             }
-            let text_galley = ui.fonts(|f| text_job.into_galley(f));
+            let galley = ui.fonts(|fonts| fonts.layout_job(layout_job));
 
             let pos = pos2(ui.max_rect().left(), ui.cursor().top());
-            assert!(
-                !text_galley.galley.rows.is_empty(),
-                "Galleys are never empty"
-            );
+            assert!(!galley.rows.is_empty(), "Galleys are never empty");
             // collect a response from many rows:
-            let rect = text_galley.galley.rows[0]
-                .rect
-                .translate(vec2(pos.x, pos.y));
+            let rect = galley.rows[0].rect.translate(vec2(pos.x, pos.y));
             let mut response = ui.allocate_rect(rect, sense);
-            for row in text_galley.galley.rows.iter().skip(1) {
+            for row in galley.rows.iter().skip(1) {
                 let rect = row.rect.translate(vec2(pos.x, pos.y));
                 response |= ui.allocate_rect(rect, sense);
             }
-            (pos, text_galley, response)
+            (pos, galley, response)
         } else {
             if truncate {
-                text_job.job.wrap.max_width = available_width;
-                text_job.job.wrap.max_rows = 1;
-                text_job.job.wrap.break_anywhere = true;
+                layout_job.wrap.max_width = available_width;
+                layout_job.wrap.max_rows = 1;
+                layout_job.wrap.break_anywhere = true;
             } else if wrap {
-                text_job.job.wrap.max_width = available_width;
+                layout_job.wrap.max_width = available_width;
             } else {
-                text_job.job.wrap.max_width = f32::INFINITY;
+                layout_job.wrap.max_width = f32::INFINITY;
             };
 
             if ui.is_grid() {
                 // TODO(emilk): remove special Grid hacks like these
-                text_job.job.halign = Align::LEFT;
-                text_job.job.justify = false;
+                layout_job.halign = Align::LEFT;
+                layout_job.justify = false;
             } else {
-                text_job.job.halign = ui.layout().horizontal_placement();
-                text_job.job.justify = ui.layout().horizontal_justify();
+                layout_job.halign = ui.layout().horizontal_placement();
+                layout_job.justify = ui.layout().horizontal_justify();
             };
 
-            let text_galley = ui.fonts(|f| text_job.into_galley(f));
-            let (rect, response) = ui.allocate_exact_size(text_galley.size(), sense);
-            let pos = match text_galley.galley.job.halign {
+            let galley = ui.fonts(|fonts| fonts.layout_job(layout_job));
+            let (rect, response) = ui.allocate_exact_size(galley.size(), sense);
+            let pos = match galley.job.halign {
                 Align::LEFT => rect.left_top(),
                 Align::Center => rect.center_top(),
                 Align::RIGHT => rect.right_top(),
             };
-            (pos, text_galley, response)
+            (pos, galley, response)
         }
     }
 }
 
 impl Widget for Label {
     fn ui(self, ui: &mut Ui) -> Response {
-        let (pos, text_galley, mut response) = self.layout_in_ui(ui);
-        response.widget_info(|| WidgetInfo::labeled(WidgetType::Label, text_galley.text()));
+        let (pos, galley, mut response) = self.layout_in_ui(ui);
+        response.widget_info(|| WidgetInfo::labeled(WidgetType::Label, galley.text()));
 
-        if text_galley.galley.elided {
+        if galley.elided {
             // Show the full (non-elided) text on hover:
-            response = response.on_hover_text(text_galley.text());
+            response = response.on_hover_text(galley.text());
         }
 
         if ui.is_rect_visible(response.rect) {
@@ -214,19 +207,8 @@ impl Widget for Label {
                 Stroke::NONE
             };
 
-            let override_text_color = if text_galley.galley_has_color {
-                None
-            } else {
-                Some(response_color)
-            };
-
-            ui.painter().add(epaint::TextShape {
-                pos,
-                galley: text_galley.galley,
-                override_text_color,
-                underline,
-                angle: 0.0,
-            });
+            ui.painter()
+                .add(epaint::TextShape::new(pos, galley, response_color).with_underline(underline));
         }
 
         response

--- a/crates/egui/src/widgets/progress_bar.rs
+++ b/crates/egui/src/widgets/progress_bar.rs
@@ -161,11 +161,9 @@ impl Widget for ProgressBar {
                 let text_color = visuals
                     .override_text_color
                     .unwrap_or(visuals.selection.stroke.color);
-                galley.paint_with_fallback_color(
-                    &ui.painter().with_clip_rect(outer_rect),
-                    text_pos,
-                    text_color,
-                );
+                ui.painter()
+                    .with_clip_rect(outer_rect)
+                    .galley(text_pos, galley, text_color);
             }
         }
 

--- a/crates/egui/src/widgets/selected_label.rs
+++ b/crates/egui/src/widgets/selected_label.rs
@@ -44,19 +44,19 @@ impl Widget for SelectableLabel {
         let total_extra = button_padding + button_padding;
 
         let wrap_width = ui.available_width() - total_extra.x;
-        let text = text.into_galley(ui, None, wrap_width, TextStyle::Button);
+        let galley = text.into_galley(ui, None, wrap_width, TextStyle::Button);
 
-        let mut desired_size = total_extra + text.size();
+        let mut desired_size = total_extra + galley.size();
         desired_size.y = desired_size.y.at_least(ui.spacing().interact_size.y);
         let (rect, response) = ui.allocate_at_least(desired_size, Sense::click());
         response.widget_info(|| {
-            WidgetInfo::selected(WidgetType::SelectableLabel, selected, text.text())
+            WidgetInfo::selected(WidgetType::SelectableLabel, selected, galley.text())
         });
 
         if ui.is_rect_visible(response.rect) {
             let text_pos = ui
                 .layout()
-                .align_size_within_rect(text.size(), rect.shrink2(button_padding))
+                .align_size_within_rect(galley.size(), rect.shrink2(button_padding))
                 .min;
 
             let visuals = ui.style().interact_selectable(&response, selected);
@@ -72,7 +72,7 @@ impl Widget for SelectableLabel {
                 );
             }
 
-            text.paint_with_visuals(ui.painter(), text_pos, &visuals);
+            ui.painter().galley(text_pos, galley, visuals.text_color());
         }
 
         response

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -164,13 +164,14 @@ impl<'t> TextEdit<'t> {
     ///     .desired_width(f32::INFINITY);
     /// let output = text_edit.show(ui);
     /// let painter = ui.painter_at(output.response.rect);
+    /// let text_color = Color32::from_rgba_premultiplied(100, 100, 100, 100);
     /// let galley = painter.layout(
     ///     String::from("Enter text"),
     ///     FontId::default(),
-    ///     Color32::from_rgba_premultiplied(100, 100, 100, 100),
+    ///     text_color,
     ///     f32::INFINITY
     /// );
-    /// painter.galley(output.text_draw_pos, galley);
+    /// painter.galley(output.text_draw_pos, galley, text_color);
     /// # });
     /// ```
     #[inline]
@@ -664,7 +665,7 @@ impl<'t> TextEdit<'t> {
         };
 
         if ui.is_rect_visible(rect) {
-            painter.galley(text_draw_pos, galley.clone());
+            painter.galley(text_draw_pos, galley.clone(), text_color);
 
             if text.as_str().is_empty() && !hint_text.is_empty() {
                 let hint_text_color = ui.visuals().weak_text_color();
@@ -673,7 +674,7 @@ impl<'t> TextEdit<'t> {
                 } else {
                     hint_text.into_galley(ui, Some(false), f32::INFINITY, font_id)
                 };
-                galley.paint_with_fallback_color(&painter, response.rect.min, hint_text_color);
+                painter.galley(response.rect.min, galley, hint_text_color);
             }
 
             if ui.memory(|mem| mem.has_focus(id)) {

--- a/crates/egui_demo_app/src/apps/http_app.rs
+++ b/crates/egui_demo_app/src/apps/http_app.rs
@@ -260,7 +260,11 @@ impl ColoredText {
             job.wrap.max_width = ui.available_width();
             let galley = ui.fonts(|f| f.layout_job(job));
             let (response, painter) = ui.allocate_painter(galley.size(), egui::Sense::hover());
-            painter.add(egui::Shape::galley(response.rect.min, galley));
+            painter.add(egui::Shape::galley(
+                response.rect.min,
+                galley,
+                ui.visuals().text_color(),
+            ));
         }
     }
 }

--- a/crates/egui_demo_lib/benches/benchmark.rs
+++ b/crates/egui_demo_lib/benches/benchmark.rs
@@ -89,7 +89,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let max_texture_side = 8 * 1024;
         let wrap_width = 512.0;
         let font_id = egui::FontId::default();
-        let color = egui::Color32::WHITE;
+        let text_color = egui::Color32::WHITE;
         let fonts = egui::epaint::text::Fonts::new(
             pixels_per_point,
             max_texture_side,
@@ -104,7 +104,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                     let job = LayoutJob::simple(
                         LOREM_IPSUM_LONG.to_owned(),
                         font_id.clone(),
-                        color,
+                        text_color,
                         wrap_width,
                     );
                     layout(&mut locked_fonts.fonts, job.into())
@@ -116,13 +116,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 fonts.layout(
                     LOREM_IPSUM_LONG.to_owned(),
                     font_id.clone(),
-                    color,
+                    text_color,
                     wrap_width,
                 )
             });
         });
 
-        let galley = fonts.layout(LOREM_IPSUM_LONG.to_owned(), font_id, color, wrap_width);
+        let galley = fonts.layout(LOREM_IPSUM_LONG.to_owned(), font_id, text_color, wrap_width);
         let font_image_size = fonts.font_image_size();
         let prepared_discs = fonts.texture_atlas().lock().prepared_discs();
         let mut tessellator = egui::epaint::Tessellator::new(
@@ -132,7 +132,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             prepared_discs,
         );
         let mut mesh = egui::epaint::Mesh::default();
-        let text_shape = TextShape::new(egui::Pos2::ZERO, galley);
+        let text_shape = TextShape::new(egui::Pos2::ZERO, galley, text_color);
         c.bench_function("tessellate_text", |b| {
             b.iter(|| {
                 tessellator.tessellate_text(&text_shape, &mut mesh);

--- a/crates/egui_plot/src/axis.rs
+++ b/crates/egui_plot/src/axis.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, ops::RangeInclusive, sync::Arc};
 
 use egui::emath::{remap_clamp, round_to_decimals, Pos2, Rect};
-use egui::epaint::{Shape, Stroke, TextShape};
+use egui::epaint::{Shape, TextShape};
 
 use crate::{Response, Sense, TextStyle, Ui, WidgetText};
 
@@ -247,14 +247,9 @@ impl AxisWidget {
                     }
                 },
             };
-            let shape = TextShape {
-                pos: text_pos,
-                galley: galley.galley,
-                underline: Stroke::NONE,
-                override_text_color: Some(text_color),
-                angle,
-            };
-            ui.painter().add(shape);
+
+            ui.painter()
+                .add(TextShape::new(text_pos, galley, text_color).with_angle(angle));
 
             // --- add ticks ---
             let font_id = TextStyle::Body.resolve(ui.style());
@@ -311,7 +306,8 @@ impl AxisWidget {
                         }
                     };
 
-                    ui.painter().add(Shape::galley(text_pos, galley));
+                    ui.painter()
+                        .add(Shape::galley(text_pos, galley, text_color));
                 }
             }
         }

--- a/crates/egui_plot/src/items/mod.rs
+++ b/crates/egui_plot/src/items/mod.rs
@@ -732,11 +732,7 @@ impl PlotItem for Text {
             .anchor
             .anchor_rect(Rect::from_min_size(pos, galley.size()));
 
-        let mut text_shape = epaint::TextShape::new(rect.min, galley.galley);
-        if !galley.galley_has_color {
-            text_shape.override_text_color = Some(color);
-        }
-        shapes.push(text_shape.into());
+        shapes.push(epaint::TextShape::new(rect.min, galley, color).into());
 
         if self.highlight {
             shapes.push(Shape::rect_stroke(

--- a/crates/egui_plot/src/legend.rs
+++ b/crates/egui_plot/src/legend.rs
@@ -144,7 +144,7 @@ impl LegendEntry {
         };
 
         let text_position = pos2(text_position_x, rect.center().y - 0.5 * galley.size().y);
-        painter.galley_with_color(text_position, galley, visuals.text_color());
+        painter.galley(text_position, galley, visuals.text_color());
 
         *checked ^= response.clicked_by(PointerButton::Primary);
         *hovered = response.hovered();

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -1473,6 +1473,7 @@ impl Tessellator {
             galley,
             underline,
             override_text_color,
+            fallback_color,
             angle,
         } = text_shape;
 
@@ -1539,10 +1540,15 @@ impl Tessellator {
                         let Vertex { pos, uv, mut color } = *vertex;
 
                         if let Some(override_text_color) = override_text_color {
+                            // Only override the glyph color (not background color, strike-through color, etc)
                             if row.visuals.glyph_vertex_range.contains(&i) {
                                 color = *override_text_color;
                             }
+                        } else if color == Color32::PLACEHOLDER {
+                            color = *fallback_color;
                         }
+
+                        crate::epaint_assert!(color != Color32::PLACEHOLDER, "A placeholder color made it to the tessellator. You forgot to set a fallback color.");
 
                         let offset = if *angle == 0.0 {
                             pos.to_vec2()

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -531,12 +531,7 @@ impl Fonts {
         font_id: FontId,
         wrap_width: f32,
     ) -> Arc<Galley> {
-        self.layout_job(LayoutJob::simple(
-            text,
-            font_id,
-            crate::Color32::TEMPORARY_COLOR,
-            wrap_width,
-        ))
+        self.layout(text, font_id, crate::Color32::PLACEHOLDER, wrap_width)
     }
 }
 

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -509,8 +509,9 @@ pub struct RowVisuals {
     /// Does NOT include leading or trailing whitespace glyphs!!
     pub mesh_bounds: Rect,
 
-    /// The range of vertices in the mesh the contain glyphs.
-    /// Before comes backgrounds (if any), and after any underlines and strikethrough.
+    /// The range of vertices in the mesh that contain glyphs (as opposed to background, underlines, strikethorugh, etc).
+    ///
+    /// The glyph vertices comes before backgrounds (if any), and after any underlines and strikethrough.
     pub glyph_vertex_range: Range<usize>,
 }
 


### PR DESCRIPTION
This introduces a special `Color32::PLACEHOLDER` which, during text painting, will be replaced with `TextShape::fallback_color`.

The fallback color is mandatory to set in all text painting. Usually this comes from the current visual style.

This lets users color only parts of a `WidgetText` (using e.g. a `LayoutJob` or a `Galley`), where the uncolored parts (using `Color32::PLACEHOLDER`) will be replaced by a default widget color (e.g. blue for a hyperlink).

For instance, you can color the `⚠️`-emoji red in a piece of text red and leave the rest of the text uncolored. The color of the rest of the text will then depend on wether or not you put that text in a label, a button, or a hyperlink.

Overall this simplifies a lot of complexity in the code but comes with a few breaking changes:

* `TextShape::new`, `Shape::galley`, and `Painter::galley` now take a fallback color by argument
* `Shape::galley_with_color` has been deprecated (use `Shape::galley` instead)
* `Painter::galley_with_color` has been deprecated (use `Painter::galley` instead)
* `WidgetTextGalley` is gone (use `Arc<Galley>` instead)
* `WidgetTextJob` is gone (use `LayoutJob` instead)
* `RichText::into_text_job` has been replaced with `RichText::into_layout_job`
* `WidgetText::into_text_job` has been replaced with `WidgetText::into_layout_job`