### PR TITLE
Fix: Let `accesskit` process window events

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -236,6 +236,11 @@ impl State {
     ) -> EventResponse {
         crate::profile_function!(short_window_event_description(event));
 
+        #[cfg(feature = "accesskit")]
+        if let Some(accesskit) = &self.accesskit {
+            accesskit.process_event(window, event);
+        }
+
         use winit::event::WindowEvent;
         match event {
             WindowEvent::ScaleFactorChanged { scale_factor, .. } => {


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

Since accesskit_winit version 0.15.0, it is necessary to call `Adapter::process_events` to let AccessKit fire up window focus events on Unix and macOS. Furthermore this has always been needed on Unix (X11 only) to let AccessKit know about the window bounds, which is needed to perform hit-testing on nodes.