### PR TITLE
Add missing `ResizeDirection::East`

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1249,6 +1249,7 @@ fn process_viewport_command(
             if let Err(err) = window.drag_resize_window(match direction {
                 egui::viewport::ResizeDirection::North => ResizeDirection::North,
                 egui::viewport::ResizeDirection::South => ResizeDirection::South,
+                egui::viewport::ResizeDirection::East => ResizeDirection::East,
                 egui::viewport::ResizeDirection::West => ResizeDirection::West,
                 egui::viewport::ResizeDirection::NorthEast => ResizeDirection::NorthEast,
                 egui::viewport::ResizeDirection::SouthEast => ResizeDirection::SouthEast,

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -808,6 +808,7 @@ pub enum CursorGrab {
 pub enum ResizeDirection {
     North,
     South,
+    East,
     West,
     NorthEast,
     SouthEast,


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->
This adds the missing variant described in below issue.
Closes <https://github.com/emilk/egui/issues/3748>.

If you wish - or even desired - I could look into implement the From conversion between ResizeDirection and CursorInfo in a seperate PR.

I ran into an issue then running `check.sh` however it seems unrelated to this PR.
For clarity I'm running Linux, with a wayland compositor.

```bash
~/dev/rust/egui ❯ cargo clean                                                                                                                                                      [add-missing-resizedirection ≡]
~/dev/rust/egui ❯ ./scripts/check.sh                                                                                                                                               [add-missing-resizedirection ≡]
+ cargo install --quiet cargo-cranky
+ cargo install --quiet typos-cli
+ export 'RUSTFLAGS=--cfg=web_sys_unstable_apis -D warnings'
+ RUSTFLAGS='--cfg=web_sys_unstable_apis -D warnings'
+ export 'RUSTDOCFLAGS=-D warnings'
+ RUSTDOCFLAGS='-D warnings'
+ typos
+ ./scripts/lint.py
./scripts/lint.py finished without error
+ cargo fmt --all -- --check
+ cargo doc --quiet --lib --no-deps --all-features
+ cargo doc --quiet --document-private-items --no-deps --all-features
+ cargo cranky --quiet --all-targets --all-features -- -D warnings
+ ./scripts/clippy_wasm.sh
+ export CLIPPY_CONF_DIR=scripts/clippy_wasm
+ CLIPPY_CONF_DIR=scripts/clippy_wasm
+ cargo cranky --quiet --all-features --target wasm32-unknown-unknown --target-dir target_wasm -p egui_demo_app --lib -- --deny warnings
+ cargo check --quiet --all-targets
+ cargo check --quiet --all-targets --all-features
+ cargo check --quiet -p egui_demo_app --lib --target wasm32-unknown-unknown
+ cargo check --quiet -p egui_demo_app --lib --target wasm32-unknown-unknown --all-features
+ cargo test --quiet --all-targets --all-features

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 4 tests
i...
test result: ok. 3 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 14 tests
..............
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 1 test
.
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
...
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.52s

Testing demo_with_tessellate__realistic
Success

Testing demo_no_tessellate
Success

Testing demo_only_tessellate
Success

Testing label &str
Success

Testing label format!
Success

Testing Painter::rect
Success

Testing text_layout_uncached
Success

Testing text_layout_cached
Success

Testing tessellate_text
Success


running 3 tests
...
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
.
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 7 tests
.......
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 23 tests
.......................
test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.20s

Testing single_dashed_lines
Success

Testing many_dashed_lines
Success

Testing tessellate_circles_100k
Success


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

+ cargo test --quiet --doc

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 4 tests
....
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.26s


running 146 tests
........................................................................................ 88/146
i.........................................................
test result: ok. 145 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 108.27s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 5 tests
iiii.
test result: ok. 1 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 3.65s


running 5 tests
.....
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 11.99s


running 2 tests
..
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s


running 5 tests
ii...
test result: ok. 3 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 2.53s


running 11 tests
...........
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.38s


running 5 tests
i....
test result: ok. 4 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 1.01s

+ cd crates/eframe
+ cargo check --quiet --no-default-features --features glow
+ cd crates/eframe
+ cargo check --quiet --no-default-features --features wgpu
error: The platform you're compiling for is not supported by winit
  --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/platform_impl/mod.rs:67:1
   |
67 | compile_error!("The platform you're compiling for is not supported by winit");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0432]: unresolved import `self::platform`
  --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/platform_impl/mod.rs:26:15
   |
26 | pub use self::platform::*;
   |               ^^^^^^^^ could not find `platform` in `self`

error[E0432]: unresolved import `crate::platform_impl::PlatformIcon`
 --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/icon.rs:1:5
  |
1 | use crate::platform_impl::PlatformIcon;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `PlatformIcon` in `platform_impl`

error[E0433]: failed to resolve: could not find `DeviceId` in `platform_impl`
   --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/event.rs:616:42
    |
616 |         DeviceId(unsafe { platform_impl::DeviceId::dummy() })
    |                                          ^^^^^^^^ could not find `DeviceId` in `platform_impl`

error[E0433]: failed to resolve: could not find `WindowId` in `platform_impl`
  --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/window.rs:99:42
   |
99 |         WindowId(unsafe { platform_impl::WindowId::dummy() })
   |                                          ^^^^^^^^ could not find `WindowId` in `platform_impl`

error[E0433]: failed to resolve: could not find `Window` in `platform_impl`
   --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/window.rs:513:28
    |
513 |             platform_impl::Window::new(&window_target.p, self.window, self.platform_specific)?;
    |                            ^^^^^^ could not find `Window` in `platform_impl`

error[E0412]: cannot find type `OsError` in module `platform_impl`
  --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/error.rs:28:27
   |
28 |     error: platform_impl::OsError,
   |                           ^^^^^^^ not found in `platform_impl`
   |
help: there is an enum variant `crate::window::BadIcon::OsError`; try using the variant's enum
   |
28 |     error: crate::window::BadIcon,
   |            ~~~~~~~~~~~~~~~~~~~~~~

error[E0412]: cannot find type `OsError` in module `platform_impl`
  --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/error.rs:62:76
   |
62 |     pub(crate) fn new(line: u32, file: &'static str, error: platform_impl::OsError) -> OsError {
   |                                                                            ^^^^^^^ not found in `platform_impl`
   |
help: there is an enum variant `crate::window::BadIcon::OsError`; try using the variant's enum
   |
62 |     pub(crate) fn new(line: u32, file: &'static str, error: crate::window::BadIcon) -> OsError {
   |                                                             ~~~~~~~~~~~~~~~~~~~~~~

error[E0412]: cannot find type `DeviceId` in module `platform_impl`
   --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/event.rs:602:47
    |
602 | pub struct DeviceId(pub(crate) platform_impl::DeviceId);
    |                                               ^^^^^^^^ not found in `platform_impl`

error[E0412]: cannot find type `KeyEventExtra` in module `platform_impl`
   --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/event.rs:787:50
    |
787 |     pub(crate) platform_specific: platform_impl::KeyEventExtra,
    |                                                  ^^^^^^^^^^^^^ not found in `platform_impl`

error[E0412]: cannot find type `EventLoop` in module `platform_impl`
  --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/event_loop.rs:41:43
   |
41 |     pub(crate) event_loop: platform_impl::EventLoop<T>,
   |                                           ^^^^^^^^^ not found in `platform_impl`
   |
help: consider importing this struct
   |
10 + use calloop::EventLoop;
   |
help: if you import `EventLoop`, refer to it directly
   |
41 -     pub(crate) event_loop: platform_impl::EventLoop<T>,
41 +     pub(crate) event_loop: EventLoop<T>,
   |

error[E0412]: cannot find type `EventLoopWindowTarget` in module `platform_impl`
  --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/event_loop.rs:52:34
   |
52 |     pub(crate) p: platform_impl::EventLoopWindowTarget<T>,
   |                                  ^^^^^^^^^^^^^^^^^^^^^ not found in `platform_impl`

error[E0412]: cannot find type `PlatformSpecificEventLoopAttributes` in module `platform_impl`
  --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/event_loop.rs:62:50
   |
62 |     pub(crate) platform_specific: platform_impl::PlatformSpecificEventLoopAttributes,
   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in `platform_impl`

error[E0433]: failed to resolve: could not find `EventLoop` in `platform_impl`
   --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/event_loop.rs:128:40
    |
128 |             event_loop: platform_impl::EventLoop::new(&mut self.platform_specific)?,
    |                                        ^^^^^^^^^ could not find `EventLoop` in `platform_impl`
    |
help: consider importing this struct
    |
10  + use calloop::EventLoop;
    |
help: if you import `EventLoop`, refer to it directly
    |
128 -             event_loop: platform_impl::EventLoop::new(&mut self.platform_specific)?,
128 +             event_loop: EventLoop::new(&mut self.platform_specific)?,
    |

error[E0412]: cannot find type `EventLoopProxy` in module `platform_impl`
   --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/event_loop.rs:394:38
    |
394 |     event_loop_proxy: platform_impl::EventLoopProxy<T>,
    |                                      ^^^^^^^^^^^^^^ not found in `platform_impl`

error[E0412]: cannot find type `VideoMode` in module `platform_impl`
  --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/monitor.rs:18:43
   |
18 |     pub(crate) video_mode: platform_impl::VideoMode,
   |                                           ^^^^^^^^^ not found in `platform_impl`

error[E0412]: cannot find type `MonitorHandle` in module `platform_impl`
   --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/monitor.rs:104:38
    |
104 |     pub(crate) inner: platform_impl::MonitorHandle,
    |                                      ^^^^^^^^^^^^^ not found in `platform_impl`

error[E0412]: cannot find type `VideoMode` in this scope
  --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/platform_impl/mod.rs:31:15
   |
31 |     Exclusive(VideoMode),
   |               ^^^^^^^^^ not found in this scope
   |
help: consider importing this struct
   |
1  + use crate::monitor::VideoMode;
   |

error[E0412]: cannot find type `MonitorHandle` in this scope
   --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/platform_impl/mod.rs:32:23
    |
32  |     Borderless(Option<MonitorHandle>),
    |                       ^^^^^^^^^^^^^
    |
   ::: /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/monitor.rs:103:1
    |
103 | pub struct MonitorHandle {
    | ------------------------ similarly named struct `RootMonitorHandle` defined here
    |
help: a struct with a similar name exists
    |
32  |     Borderless(Option<RootMonitorHandle>),
    |                       ~~~~~~~~~~~~~~~~~
help: consider importing this struct
    |
1   + use crate::monitor::MonitorHandle;
    |

error[E0412]: cannot find type `Window` in module `platform_impl`
  --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/window.rs:55:39
   |
55 |     pub(crate) window: platform_impl::Window,
   |                                       ^^^^^^ not found in `platform_impl`

error[E0412]: cannot find type `WindowId` in module `platform_impl`
  --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/window.rs:85:47
   |
85 | pub struct WindowId(pub(crate) platform_impl::WindowId);
   |                                               ^^^^^^^^ not found in `platform_impl`

error[E0412]: cannot find type `PlatformSpecificWindowBuilderAttributes` in module `platform_impl`
   --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/window.rs:123:50
    |
123 |     pub(crate) platform_specific: platform_impl::PlatformSpecificWindowBuilderAttributes,
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in `platform_impl`

error[E0282]: type annotations needed
   --> /home/dbuch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.4/src/window.rs:537:17
    |
537 |         builder.build(event_loop)
    |                 ^^^^^ cannot infer type of the type parameter `T` declared on the method `build`
    |
help: consider specifying the generic argument
    |
537 |         builder.build::<T>(event_loop)
    |                      +++++

Some errors have detailed explanations: E0282, E0412, E0432, E0433.
For more information about an error, try `rustc --explain E0282`.
error: could not compile `winit` (lib) due to 23 previous errors
~/dev/rust/egui ❯                                                                                                                                                                  [add-missing-resizedirection ≡]
```