### PR TITLE
Rename `TextBuffer::replace` to `replace_with`

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -996,7 +996,7 @@ fn events(
                     .lock()
                     .undo(&(cursor_range.as_ccursor_range(), text.as_str().to_owned()))
                 {
-                    text.replace(undo_txt);
+                    text.replace_with(undo_txt);
                     Some(*undo_ccursor_range)
                 } else {
                     None
@@ -1015,7 +1015,7 @@ fn events(
                     .lock()
                     .redo(&(cursor_range.as_ccursor_range(), text.as_str().to_owned()))
                 {
-                    text.replace(redo_txt);
+                    text.replace_with(redo_txt);
                     Some(*redo_ccursor_range)
                 } else {
                     None

--- a/crates/egui/src/widgets/text_edit/text_buffer.rs
+++ b/crates/egui/src/widgets/text_edit/text_buffer.rs
@@ -44,7 +44,7 @@ pub trait TextBuffer {
     }
 
     /// Replaces all contents of this string with `text`
-    fn replace(&mut self, text: &str) {
+    fn replace_with(&mut self, text: &str) {
         self.clear();
         self.insert_text(text, 0);
     }
@@ -91,7 +91,7 @@ impl TextBuffer for String {
         self.clear();
     }
 
-    fn replace(&mut self, text: &str) {
+    fn replace_with(&mut self, text: &str) {
         *self = text.to_owned();
     }
 
@@ -121,7 +121,7 @@ impl<'a> TextBuffer for Cow<'a, str> {
         <String as TextBuffer>::clear(self.to_mut());
     }
 
-    fn replace(&mut self, text: &str) {
+    fn replace_with(&mut self, text: &str) {
         *self = Cow::Owned(text.to_owned());
     }
 


### PR DESCRIPTION
This removes the name conflict with `str::replace`.

* Closes https://github.com/emilk/egui/issues/3746