### PR TITLE
Implement `custom_window_frame` resize support example

### DIFF
--- a/crates/egui/src/data/output.rs
+++ b/crates/egui/src/data/output.rs
@@ -408,6 +408,21 @@ impl Default for CursorIcon {
     }
 }
 
+impl Into<CursorIcon> for crate::ResizeDirection {
+    fn into(self) -> CursorIcon {
+        match self {
+            crate::ResizeDirection::North => CursorIcon::ResizeNorth,
+            crate::ResizeDirection::South => CursorIcon::ResizeSouth,
+            crate::ResizeDirection::West => CursorIcon::ResizeWest,
+            crate::ResizeDirection::East => CursorIcon::ResizeEast,
+            crate::ResizeDirection::NorthEast => CursorIcon::ResizeNorthEast,
+            crate::ResizeDirection::SouthEast => CursorIcon::ResizeSouthEast,
+            crate::ResizeDirection::NorthWest => CursorIcon::ResizeNorthWest,
+            crate::ResizeDirection::SouthWest => CursorIcon::ResizeSouthWest,
+        }
+    }
+}
+
 /// Things that happened during this frame that the integration may be interested in.
 ///
 /// In particular, these events may be useful for accessibility, i.e. for screen readers.

--- a/examples/custom_window_frame/src/main.rs
+++ b/examples/custom_window_frame/src/main.rs
@@ -53,6 +53,8 @@ fn custom_window_frame(ctx: &egui::Context, title: &str, add_contents: impl FnOn
     };
 
     CentralPanel::default().frame(panel_frame).show(ctx, |ui| {
+        handle_resize(ui);
+
         let app_rect = ui.max_rect();
 
         let title_bar_height = 32.0;
@@ -73,6 +75,48 @@ fn custom_window_frame(ctx: &egui::Context, title: &str, add_contents: impl FnOn
         let mut content_ui = ui.child_ui(content_rect, *ui.layout());
         add_contents(&mut content_ui);
     });
+}
+
+fn handle_resize(ui: &mut egui::Ui) -> bool {
+    let Some(pos) = ui.input(|i| i.pointer.interact_pos()) else {
+        return false;
+    };
+
+    let screen_rect = ui.ctx().screen_rect();
+
+    // Since this is the outermost layer of the viewport hence we cannot use extend on
+    // screen_rect to check if pointer is at an interaction position.
+    const SNAP_DIST: f32 = 5.0;
+
+    let east_snap = (screen_rect.right() - pos.x).abs() <= SNAP_DIST;
+    let west_snap = !east_snap && (screen_rect.left() - pos.x).abs() <= SNAP_DIST;
+    let south_snap = (screen_rect.bottom() - pos.y).abs() <= SNAP_DIST;
+    let north_snap = !south_snap && (screen_rect.top() - pos.y).abs() <= SNAP_DIST;
+
+    let posible_resize_direction = match (north_snap, east_snap, west_snap, south_snap) {
+        (true, true, false, false) => Some(egui::ResizeDirection::NorthEast),
+        (false, true, false, true) => Some(egui::ResizeDirection::SouthEast),
+        (true, false, true, false) => Some(egui::ResizeDirection::NorthWest),
+        (false, false, true, true) => Some(egui::ResizeDirection::SouthWest),
+        (true, false, false, false) => Some(egui::ResizeDirection::North),
+        (false, true, false, false) => Some(egui::ResizeDirection::East),
+        (false, false, true, false) => Some(egui::ResizeDirection::West),
+        (false, false, false, true) => Some(egui::ResizeDirection::South),
+        _ => None,
+    };
+
+    let Some(resize_direction) = posible_resize_direction else {
+        return false;
+    };
+
+    ui.output_mut(|o| o.cursor_icon = resize_direction.into());
+    if ui.input(|i| i.pointer.primary_pressed()) {
+        ui.ctx()
+            .send_viewport_cmd(ViewportCommand::BeginResize(resize_direction));
+        true
+    } else {
+        false
+    }
 }
 
 fn title_bar_ui(ui: &mut egui::Ui, title_bar_rect: eframe::epaint::Rect, title: &str) {


### PR DESCRIPTION
It includes a convenience helper `Into` to map `ResizeDirection` to `CursorIcon` in Egui crate.

This is tested on linux with glow and wgpu.

Glow has a render glich best show by a video.
[Glow Screencast](https://github.com/emilk/egui/assets/1972049/8a0c80f8-8d8f-4fe1-870e-ad07d4d724da)
Where wgpu works fine
[Wgpu Screencast](https://github.com/emilk/egui/assets/1972049/e406c5cd-eb3b-4d9d-bb50-fa0527c0efa8)

Closes https://github.com/emilk/egui/issues/3761
