### PR TITLE
Fix: don't open context menu on drag

### DIFF
--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -367,20 +367,18 @@ impl MenuRoot {
         let response = response.interact(Sense::click());
         response.ctx.input(|input| {
             let pointer = &input.pointer;
-            if pointer.any_pressed() {
-                if let Some(pos) = pointer.interact_pos() {
-                    let mut destroy = false;
-                    let mut in_old_menu = false;
-                    if let Some(root) = root {
-                        in_old_menu = root.menu_state.read().area_contains(pos);
-                        destroy = root.id == response.id;
-                    }
-                    if !in_old_menu {
-                        if response.hovered() && pointer.secondary_down() {
-                            return MenuResponse::Create(pos, id);
-                        } else if (response.hovered() && pointer.primary_down()) || destroy {
-                            return MenuResponse::Close;
-                        }
+            if let Some(pos) = pointer.interact_pos() {
+                let mut in_old_menu = false;
+                let mut destroy = false;
+                if let Some(root) = root {
+                    in_old_menu = root.menu_state.read().area_contains(pos);
+                    destroy = !in_old_menu && pointer.any_pressed() && root.id == response.id;
+                }
+                if !in_old_menu {
+                    if response.hovered() && response.secondary_clicked() {
+                        return MenuResponse::Create(pos, id);
+                    } else if (response.hovered() && pointer.primary_down()) || destroy {
+                        return MenuResponse::Close;
                     }
                 }
             }


### PR DESCRIPTION
This fixes a bug where the context menu would open when dragging with the secondary mouse button.

Now the context menu requires a click to open.

This is important for things like plots, where right-click and right-drag means different things.