### PR TITLE
Fix IME input of  `CompositionEnd` without a `CompositionStart`

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -1050,7 +1050,8 @@ fn events(
             }
 
             Event::CompositionEnd(prediction) => {
-                if prediction != "\n" && prediction != "\r" && state.has_ime {
+                // CompositionEnd only characters may be typed into TextEdit without trigger CompositionStart first, so do not check ```state.has_ime = true``` in the following statement.
+                if prediction != "\n" && prediction != "\r" {
                     state.has_ime = false;
                     let mut ccursor = delete_selected(text, &cursor_range);
                     if !prediction.is_empty() {

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -1050,7 +1050,7 @@ fn events(
             }
 
             Event::CompositionEnd(prediction) => {
-                // CompositionEnd only characters may be typed into TextEdit without trigger CompositionStart first, so do not check ```state.has_ime = true``` in the following statement.
+                // CompositionEnd only characters may be typed into TextEdit without trigger CompositionStart first, so do not check `state.has_ime = true` in the following statement.
                 if prediction != "\n" && prediction != "\r" {
                     state.has_ime = false;
                     let mut ccursor = delete_selected(text, &cursor_range);


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/3766

Add support for type in CompositionEnd only characters without trigger CompositionStart first.
This usually works with no-latin character input.
