### PR TITLE
Add `local_data()` and `local_data_mut()` to `Ui` for providing `IdTypeMap` tied to `Ui` that is directly accessible without locking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,8 @@ dependencies = [
  "num-traits",
  "once_cell",
  "oorandom",
+ "plotters",
+ "rayon",
  "regex",
  "serde",
  "serde_derive",
@@ -983,6 +985,30 @@ checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset 0.9.0",
+ "scopeguard",
 ]
 
 [[package]]
@@ -1161,6 +1187,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecolor"
+version = "0.24.2"
+source = "git+https://github.com/ryo33/egui.git?rev=937c09f14aaf7dd6dd6291be9e0de3728e3c6f12#937c09f14aaf7dd6dd6291be9e0de3728e3c6f12"
+
+[[package]]
 name = "eframe"
 version = "0.24.2"
 dependencies = [
@@ -1168,7 +1199,7 @@ dependencies = [
  "cocoa",
  "directories-next",
  "document-features",
- "egui",
+ "egui 0.24.2",
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
@@ -1203,8 +1234,10 @@ dependencies = [
  "accesskit",
  "ahash",
  "backtrace",
+ "criterion",
  "document-features",
- "epaint",
+ "egui 0.24.2 (git+https://github.com/ryo33/egui.git?rev=937c09f14aaf7dd6dd6291be9e0de3728e3c6f12)",
+ "epaint 0.24.2",
  "log",
  "nohash-hasher",
  "puffin",
@@ -1213,13 +1246,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui"
+version = "0.24.2"
+source = "git+https://github.com/ryo33/egui.git?rev=937c09f14aaf7dd6dd6291be9e0de3728e3c6f12#937c09f14aaf7dd6dd6291be9e0de3728e3c6f12"
+dependencies = [
+ "ahash",
+ "epaint 0.24.2 (git+https://github.com/ryo33/egui.git?rev=937c09f14aaf7dd6dd6291be9e0de3728e3c6f12)",
+ "nohash-hasher",
+]
+
+[[package]]
 name = "egui-wgpu"
 version = "0.24.2"
 dependencies = [
  "bytemuck",
  "document-features",
- "egui",
- "epaint",
+ "egui 0.24.2",
+ "epaint 0.24.2",
  "log",
  "puffin",
  "thiserror",
@@ -1235,7 +1278,7 @@ dependencies = [
  "accesskit_winit",
  "arboard",
  "document-features",
- "egui",
+ "egui 0.24.2",
  "log",
  "puffin",
  "raw-window-handle 0.5.2",
@@ -1253,7 +1296,7 @@ dependencies = [
  "bytemuck",
  "chrono",
  "eframe",
- "egui",
+ "egui 0.24.2",
  "egui_demo_lib",
  "egui_extras",
  "ehttp",
@@ -1277,7 +1320,7 @@ dependencies = [
  "chrono",
  "criterion",
  "document-features",
- "egui",
+ "egui 0.24.2",
  "egui_extras",
  "egui_plot",
  "log",
@@ -1291,7 +1334,7 @@ version = "0.24.2"
 dependencies = [
  "chrono",
  "document-features",
- "egui",
+ "egui 0.24.2",
  "ehttp",
  "enum-map",
  "image",
@@ -1309,13 +1352,13 @@ version = "0.24.2"
 dependencies = [
  "bytemuck",
  "document-features",
- "egui",
+ "egui 0.24.2",
  "egui-winit",
  "glow",
  "glutin",
  "glutin-winit",
  "log",
- "memoffset",
+ "memoffset 0.7.1",
  "puffin",
  "raw-window-handle 0.5.2",
  "wasm-bindgen",
@@ -1327,7 +1370,7 @@ name = "egui_plot"
 version = "0.24.2"
 dependencies = [
  "document-features",
- "egui",
+ "egui 0.24.2",
  "serde",
 ]
 
@@ -1360,6 +1403,11 @@ dependencies = [
  "mint",
  "serde",
 ]
+
+[[package]]
+name = "emath"
+version = "0.24.2"
+source = "git+https://github.com/ryo33/egui.git?rev=937c09f14aaf7dd6dd6291be9e0de3728e3c6f12#937c09f14aaf7dd6dd6291be9e0de3728e3c6f12"
 
 [[package]]
 name = "enum-map"
@@ -1436,12 +1484,25 @@ dependencies = [
  "bytemuck",
  "criterion",
  "document-features",
- "ecolor",
- "emath",
+ "ecolor 0.24.2",
+ "emath 0.24.2",
  "log",
  "nohash-hasher",
  "parking_lot",
  "serde",
+]
+
+[[package]]
+name = "epaint"
+version = "0.24.2"
+source = "git+https://github.com/ryo33/egui.git?rev=937c09f14aaf7dd6dd6291be9e0de3728e3c6f12#937c09f14aaf7dd6dd6291be9e0de3728e3c6f12"
+dependencies = [
+ "ab_glyph",
+ "ahash",
+ "ecolor 0.24.2 (git+https://github.com/ryo33/egui.git?rev=937c09f14aaf7dd6dd6291be9e0de3728e3c6f12)",
+ "emath 0.24.2 (git+https://github.com/ryo33/egui.git?rev=937c09f14aaf7dd6dd6291be9e0de3728e3c6f12)",
+ "nohash-hasher",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2359,6 +2420,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metal"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2488,7 +2558,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
 ]
 
 [[package]]
@@ -2797,6 +2867,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3010,6 +3108,26 @@ name = "raw-window-handle"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
+
+[[package]]
+name = "rayon"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "rctree"

--- a/benches/local_data.rs
+++ b/benches/local_data.rs
@@ -1,0 +1,68 @@
+use criterion::{
+    black_box, criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion,
+    PlotConfiguration,
+};
+
+fn local_data(n: u64) {
+    let ctx = egui_master::Context::default();
+    egui_master::Area::new("test").show(&ctx, |_ui| {
+        let mut data = None;
+        for i in 0..n {
+            let _ = data
+                .get_or_insert_with(egui_master::util::IdTypeMap::default)
+                .get_temp::<u64>(egui_master::Id::new(i));
+        }
+    });
+}
+
+fn global_data(n: u64) {
+    let ctx = egui_master::Context::default();
+    egui_master::Area::new("test").show(&ctx, |ui| {
+        for i in 0..n {
+            let _ = ui.data_mut(|data| data.get_temp::<u64>(egui_master::Id::new(i)));
+        }
+    });
+}
+
+fn new_local_data(n: u64) {
+    let ctx = egui::Context::default();
+    egui::Area::new("test").show(&ctx, |ui| {
+        for i in 0..n {
+            let _ = ui.local_data_mut().get_temp::<u64>(egui::Id::new(i));
+        }
+    });
+}
+
+fn new_global_data(n: u64) {
+    let ctx = egui::Context::default();
+    egui::Area::new("test").show(&ctx, |ui| {
+        for i in 0..n {
+            let _ = ui.data_mut(|data| data.get_temp::<u64>(egui::Id::new(i)));
+        }
+    });
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("data");
+    // 1, 10, 100, 1000, 10000
+    for i in (0..5).map(|i| 10u64.pow(i)) {
+        group.bench_with_input(BenchmarkId::new("local", i), &i, |b, i| {
+            b.iter(|| local_data(black_box(*i)));
+        });
+        group.bench_with_input(BenchmarkId::new("global", i), &i, |b, i| {
+            b.iter(|| global_data(black_box(*i)));
+        });
+        group.bench_with_input(BenchmarkId::new("new_local", i), &i, |b, i| {
+            b.iter(|| new_local_data(black_box(*i)));
+        });
+        group.bench_with_input(BenchmarkId::new("new_global", i), &i, |b, i| {
+            b.iter(|| new_global_data(black_box(*i)));
+        });
+    }
+    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+    group.plot_config(plot_config);
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/egui/Cargo.toml
+++ b/crates/egui/Cargo.toml
@@ -96,3 +96,12 @@ log = { version = "0.4", optional = true, features = ["std"] }
 puffin = { workspace = true, optional = true }
 ron = { version = "0.8", optional = true }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
+
+[dev-dependencies]
+criterion = "0.5"
+egui_master = { package = "egui", git = "https://github.com/ryo33/egui.git", rev = "937c09f14aaf7dd6dd6291be9e0de3728e3c6f12" }
+
+[[bench]]
+name = "local_data"
+harness = false
+path = "../../benches/local_data.rs"

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -393,7 +393,7 @@ impl Ui {
     /// Read-only access to the ui local [`IdTypeMap`], which stores temporary widget state for
     /// this instance of [`Ui`] and its child Uis. This is not shared between different frames, and this is cloned
     /// and inherited to child ui instance on [`Self::child_ui`]. Compared to `data` this is more efficient since it does not require locking.
-    /// This returns `None` if [`Self::set_local_data()`] is not called yet for this instance or
+    /// This returns `None` if [`Self::local_data_mut()`] is not called yet for this instance or
     /// parent instance.
     /// You can serialize or deserialize this map in any time, so `_persisted` methods on [`IdTypeMap`] has meaning while this is a frame temporary map.
     #[inline]


### PR DESCRIPTION
- [x] read the contributing guide
- [x] `./scripts/check.sh` (but with the attached error that seems not related)
- [ ] self reviewing

I've added two methods `local_data(&self) -> Option<&IdTypeMap>` and `local_data_mut(&mut self) -> &mut IdTypeMap` to `Ui`, to provide directly accessible data that is tied to a `Ui` instance and its child `Ui` instances. It's the local version of `data` and `data_mut` but without locking the ctx nor closure passing style API,
and it has a win in both efficiency and ergonomics.

The immutable one returns `Option<&_>` because the underlying data is `local_data: Option<IdTypeMap>` not to allocate every time even if it's not used. It's documented on both the private field and public methods. Since it's tied to `Ui`, it's not shared with the later frames, just for the current frame. If needs the map even if not used yet, we can just write `ui.local_data().unwrap_or_default()`.

The intended usage of *local data* is sharing contextual data within the same widget and its child widgets or collecting information from child widgets like the Example 1.
Also, there is another use case that uses *local data* as a fast access key values store that will be stored to `egui::Memory` or persisted to somewhere in the later of this frame. (Example 2)

### Example 1 (pseudo code)

```rust
let mut local = ui.local_data_mut();
// shared contextual information
local.insert(Id::new("children count"), children.len());
// a container to collect metrics from child widgets
let metrics = Arc::new(Mutex::new(Metrics::default()));
local.insert(ui.id(), metrics.clone);
for child in children {
    ui.add(child);
}
// use `metrics` and renders something
```

### Example 2 (pseudo code)

```rust
let mut local = ui.local_data_mut();
// get kv from the memory. Arc is used to make it cheap to clone, and can mutate with `Arc::get_mut` for this Ui instance (not accessible to child Ui instances.)
ui.data(|data| local.insert("kv", Arc::new(data.get_temp::<Kv>())));
for child in children {
    // They frequently read/write the Kv with `local.get_temp_mut_or_default("kv")`
    ui.add(child);
}
// then save kv to the memory
ui.data_mut(|data| data.insert(ui.id(), local.get_temp::<Arc<Kv>>("kv").as_ref().clone()));
```

<details>

```rust
+ cargo install --quiet cargo-cranky
+ cargo install --quiet typos-cli
+ export 'RUSTFLAGS=--cfg=web_sys_unstable_apis -D warnings'
+ RUSTFLAGS='--cfg=web_sys_unstable_apis -D warnings'
+ export 'RUSTDOCFLAGS=-D warnings'
+ RUSTDOCFLAGS='-D warnings'
+ typos
+ ./scripts/lint.py
./scripts/lint.py finished without error
+ cargo fmt --all -- --check
+ cargo doc --quiet --lib --no-deps --all-features
+ cargo doc --quiet --document-private-items --no-deps --all-features
+ cargo cranky --quiet --all-targets --all-features -- -D warnings
+ ./scripts/clippy_wasm.sh
+ export CLIPPY_CONF_DIR=scripts/clippy_wasm
+ CLIPPY_CONF_DIR=scripts/clippy_wasm
+ cargo cranky --quiet --all-features --target wasm32-unknown-unknown --target-dir target_wasm -p egui_demo_app --lib -- --deny warnings
+ cargo check --quiet --all-targets
+ cargo check --quiet --all-targets --all-features
+ cargo check --quiet -p egui_demo_app --lib --target wasm32-unknown-unknown
+ cargo check --quiet -p egui_demo_app --lib --target wasm32-unknown-unknown --all-features
+ cargo test --quiet --all-targets --all-features

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 6 tests
.i....
test result: ok. 5 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 14 tests
..............
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 1 test
.
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
...
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.20s

Testing demo_with_tessellate__realistic
Success

Testing demo_no_tessellate
Success

Testing demo_only_tessellate
Success

Testing label &str
Success

Testing label format!
Success

Testing Painter::rect
Success

Testing text_layout_uncached
Success

Testing text_layout_cached
Success

Testing tessellate_text
Success


running 3 tests
...
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
.
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 7 tests
.......
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 23 tests
.......................
test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.20s

Testing single_dashed_lines
Success

Testing many_dashed_lines
Success

Testing tessellate_circles_100k
Success


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

+ cargo test --quiet --doc

running 2 tests
..
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.17s


running 4 tests
....
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.10s


running 148 tests
..................................................................................i..... 88/148
............................................................
test result: ok. 147 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 26.20s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 5 tests
iiii.
test result: ok. 1 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 2.18s


running 5 tests
.....
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.58s


running 2 tests
..
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 5 tests
ii...
test result: ok. 3 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 1.40s


running 11 tests
...........
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.31s


running 5 tests
i....
test result: ok. 4 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.44s

+ cd crates/eframe
+ cargo check --quiet --no-default-features --features glow
+ cd crates/eframe
+ cargo check --quiet --no-default-features --features wgpu
error: The platform you're compiling for is not supported by winit
  --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/platform_impl/mod.rs:67:1
   |
67 | compile_error!("The platform you're compiling for is not supported by winit");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0432]: unresolved import `self::platform`
  --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/platform_impl/mod.rs:26:15
   |
26 | pub use self::platform::*;
   |               ^^^^^^^^ could not find `platform` in `self`

error[E0432]: unresolved import `crate::platform_impl::PlatformIcon`
 --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/icon.rs:1:5
  |
1 | use crate::platform_impl::PlatformIcon;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `PlatformIcon` in `platform_impl`

error[E0433]: failed to resolve: could not find `DeviceId` in `platform_impl`
   --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/event.rs:616:42
    |
616 |         DeviceId(unsafe { platform_impl::DeviceId::dummy() })
    |                                          ^^^^^^^^ could not find `DeviceId` in `platform_impl`

error[E0433]: failed to resolve: could not find `WindowId` in `platform_impl`
  --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/window.rs:99:42
   |
99 |         WindowId(unsafe { platform_impl::WindowId::dummy() })
   |                                          ^^^^^^^^ could not find `WindowId` in `platform_impl`

error[E0433]: failed to resolve: could not find `Window` in `platform_impl`
   --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/window.rs:513:28
    |
513 |             platform_impl::Window::new(&window_target.p, self.window, self.platform_specific)?;
    |                            ^^^^^^ could not find `Window` in `platform_impl`

error[E0412]: cannot find type `OsError` in module `platform_impl`
  --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/error.rs:28:27
   |
28 |     error: platform_impl::OsError,
   |                           ^^^^^^^ not found in `platform_impl`
   |
help: there is an enum variant `crate::window::BadIcon::OsError`; try using the variant's enum
   |
28 |     error: crate::window::BadIcon,
   |            ~~~~~~~~~~~~~~~~~~~~~~

error[E0412]: cannot find type `OsError` in module `platform_impl`
  --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/error.rs:62:76
   |
62 |     pub(crate) fn new(line: u32, file: &'static str, error: platform_impl::OsError) -> OsError {
   |                                                                            ^^^^^^^ not found in `platform_impl`
   |
help: there is an enum variant `crate::window::BadIcon::OsError`; try using the variant's enum
   |
62 |     pub(crate) fn new(line: u32, file: &'static str, error: crate::window::BadIcon) -> OsError {
   |                                                             ~~~~~~~~~~~~~~~~~~~~~~

error[E0412]: cannot find type `DeviceId` in module `platform_impl`
   --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/event.rs:602:47
    |
602 | pub struct DeviceId(pub(crate) platform_impl::DeviceId);
    |                                               ^^^^^^^^ not found in `platform_impl`

error[E0412]: cannot find type `KeyEventExtra` in module `platform_impl`
   --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/event.rs:787:50
    |
787 |     pub(crate) platform_specific: platform_impl::KeyEventExtra,
    |                                                  ^^^^^^^^^^^^^ not found in `platform_impl`

error[E0412]: cannot find type `EventLoop` in module `platform_impl`
  --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/event_loop.rs:41:43
   |
41 |     pub(crate) event_loop: platform_impl::EventLoop<T>,
   |                                           ^^^^^^^^^ not found in `platform_impl`
   |
help: consider importing this struct
   |
10 + use calloop::EventLoop;
   |
help: if you import `EventLoop`, refer to it directly
   |
41 -     pub(crate) event_loop: platform_impl::EventLoop<T>,
41 +     pub(crate) event_loop: EventLoop<T>,
   |

error[E0412]: cannot find type `EventLoopWindowTarget` in module `platform_impl`
  --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/event_loop.rs:52:34
   |
52 |     pub(crate) p: platform_impl::EventLoopWindowTarget<T>,
   |                                  ^^^^^^^^^^^^^^^^^^^^^ not found in `platform_impl`

error[E0412]: cannot find type `PlatformSpecificEventLoopAttributes` in module `platform_impl`
  --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/event_loop.rs:62:50
   |
62 |     pub(crate) platform_specific: platform_impl::PlatformSpecificEventLoopAttributes,
   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in `platform_impl`

error[E0433]: failed to resolve: could not find `EventLoop` in `platform_impl`
   --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/event_loop.rs:128:40
    |
128 |             event_loop: platform_impl::EventLoop::new(&mut self.platform_specific)?,
    |                                        ^^^^^^^^^ could not find `EventLoop` in `platform_impl`
    |
help: consider importing this struct
    |
10  + use calloop::EventLoop;
    |
help: if you import `EventLoop`, refer to it directly
    |
128 -             event_loop: platform_impl::EventLoop::new(&mut self.platform_specific)?,
128 +             event_loop: EventLoop::new(&mut self.platform_specific)?,
    |

error[E0412]: cannot find type `EventLoopProxy` in module `platform_impl`
   --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/event_loop.rs:394:38
    |
394 |     event_loop_proxy: platform_impl::EventLoopProxy<T>,
    |                                      ^^^^^^^^^^^^^^ not found in `platform_impl`

error[E0412]: cannot find type `VideoMode` in module `platform_impl`
  --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/monitor.rs:18:43
   |
18 |     pub(crate) video_mode: platform_impl::VideoMode,
   |                                           ^^^^^^^^^ not found in `platform_impl`

error[E0412]: cannot find type `MonitorHandle` in module `platform_impl`
   --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/monitor.rs:104:38
    |
104 |     pub(crate) inner: platform_impl::MonitorHandle,
    |                                      ^^^^^^^^^^^^^ not found in `platform_impl`

error[E0412]: cannot find type `VideoMode` in this scope
  --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/platform_impl/mod.rs:31:15
   |
31 |     Exclusive(VideoMode),
   |               ^^^^^^^^^ not found in this scope
   |
help: consider importing this struct
   |
1  + use crate::monitor::VideoMode;
   |

error[E0412]: cannot find type `MonitorHandle` in this scope
   --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/platform_impl/mod.rs:32:23
    |
32  |     Borderless(Option<MonitorHandle>),
    |                       ^^^^^^^^^^^^^
    |
   ::: /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/monitor.rs:103:1
    |
103 | pub struct MonitorHandle {
    | ------------------------ similarly named struct `RootMonitorHandle` defined here
    |
help: a struct with a similar name exists
    |
32  |     Borderless(Option<RootMonitorHandle>),
    |                       ~~~~~~~~~~~~~~~~~
help: consider importing this struct
    |
1   + use crate::monitor::MonitorHandle;
    |

error[E0412]: cannot find type `Window` in module `platform_impl`
  --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/window.rs:55:39
   |
55 |     pub(crate) window: platform_impl::Window,
   |                                       ^^^^^^ not found in `platform_impl`

error[E0412]: cannot find type `WindowId` in module `platform_impl`
  --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/window.rs:85:47
   |
85 | pub struct WindowId(pub(crate) platform_impl::WindowId);
   |                                               ^^^^^^^^ not found in `platform_impl`

error[E0412]: cannot find type `PlatformSpecificWindowBuilderAttributes` in module `platform_impl`
   --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/window.rs:123:50
    |
123 |     pub(crate) platform_specific: platform_impl::PlatformSpecificWindowBuilderAttributes,
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in `platform_impl`

error[E0282]: type annotations needed
   --> /home/ryo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.7/src/window.rs:537:17
    |
537 |         builder.build(event_loop)
    |                 ^^^^^ cannot infer type of the type parameter `T` declared on the method `build`
    |
help: consider specifying the generic argument
    |
537 |         builder.build::<T>(event_loop)
    |                      +++++

Some errors have detailed explanations: E0282, E0412, E0432, E0433.
For more information about an error, try `rustc --explain E0282`.
error: could not compile `winit` (lib) due to 23 previous errors
```

</details>