### PR TITLE
Fixes build of examples/hello_world_par on Linux

### DIFF
--- a/examples/hello_world_par/Cargo.toml
+++ b/examples/hello_world_par/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 
 [dependencies]
-eframe = { path = "../../crates/eframe", default-features = false, features = [
+eframe = { path = "../../crates/eframe", features = [
     # accesskit struggles with threading
     "default_fonts",
     "wgpu",


### PR DESCRIPTION
Adds default-features to the `eframe` dependency in `hello-world-par`, fixing `winit`'s  build error ("The platform you're compiling for is not supported by winit")