### PR TITLE
Refactor: move text selection logic to own module

### DIFF
--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -364,6 +364,7 @@ pub(crate) mod placer;
 mod response;
 mod sense;
 pub mod style;
+pub mod text_selection;
 mod ui;
 pub mod util;
 pub mod viewport;

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -399,7 +399,7 @@ pub use epaint::{
 };
 
 pub mod text {
-    pub use crate::text_edit::CCursorRange;
+    pub use crate::text_selection::CCursorRange;
     pub use epaint::text::{
         cursor::CCursor, FontData, FontDefinitions, FontFamily, Fonts, Galley, LayoutJob,
         LayoutSection, TextFormat, TextWrapping, TAB_SIZE,

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -399,7 +399,7 @@ pub use epaint::{
 };
 
 pub mod text {
-    pub use crate::text_selection::CCursorRange;
+    pub use crate::text_selection::{CCursorRange, CursorRange};
     pub use epaint::text::{
         cursor::CCursor, FontData, FontDefinitions, FontFamily, Fonts, Galley, LayoutJob,
         LayoutSection, TextFormat, TextWrapping, TAB_SIZE,

--- a/crates/egui/src/text_selection/accesskit_text.rs
+++ b/crates/egui/src/text_selection/accesskit_text.rs
@@ -1,6 +1,6 @@
 use crate::{Context, Galley, Id, Pos2};
 
-use super::{cursor_interaction::is_word_char, CursorRange};
+use super::{text_cursor_state::is_word_char, CursorRange};
 
 /// Update accesskit with the current text state.
 pub fn update_accesskit_for_text_widget(

--- a/crates/egui/src/text_selection/cursor_range.rs
+++ b/crates/egui/src/text_selection/cursor_range.rs
@@ -2,7 +2,7 @@ use epaint::{text::cursor::*, Galley};
 
 use crate::{os::OperatingSystem, Event, Id, Key, Modifiers};
 
-use super::cursor_interaction::{ccursor_next_word, ccursor_previous_word, slice_char_range};
+use super::text_cursor_state::{ccursor_next_word, ccursor_previous_word, slice_char_range};
 
 /// A selected text range (could be a range of length zero).
 #[derive(Clone, Copy, Debug, Default, PartialEq)]

--- a/crates/egui/src/text_selection/label_text_selection.rs
+++ b/crates/egui/src/text_selection/label_text_selection.rs
@@ -1,0 +1,160 @@
+use epaint::{Galley, Pos2};
+
+use crate::{
+    text_edit::{
+        cursor_interaction::cursor_rect, paint_cursor_selection, CursorRange, TextCursorState,
+    },
+    Context, CursorIcon, Event, Id, Response, Ui,
+};
+
+/// Handle text selection state for a label or similar widget.
+///
+/// Make sure the widget senses clicks and drags.
+///
+/// This should be called after painting the text, because this will also
+/// paint the text cursor/selection on top.
+pub fn label_text_selection(ui: &Ui, response: &Response, galley_pos: Pos2, galley: &Galley) {
+    let mut cursor_state = LabelSelectionState::load(ui.ctx(), response.id);
+    let original_cursor = cursor_state.range(galley);
+
+    if response.hovered {
+        ui.ctx().set_cursor_icon(CursorIcon::Text);
+    } else if !cursor_state.is_empty() && ui.input(|i| i.pointer.any_pressed()) {
+        // We clicked somewhere else - deselect this label.
+        cursor_state = Default::default();
+        LabelSelectionState::store(ui.ctx(), response.id, cursor_state);
+    }
+
+    if let Some(pointer_pos) = ui.ctx().pointer_interact_pos() {
+        let cursor_at_pointer = galley.cursor_from_pos(pointer_pos - galley_pos);
+        cursor_state.pointer_interaction(ui, response, cursor_at_pointer, galley);
+    }
+
+    if let Some(mut cursor_range) = cursor_state.range(galley) {
+        process_selection_key_events(ui.ctx(), galley, response.id, &mut cursor_range);
+        cursor_state.set_range(Some(cursor_range));
+    }
+
+    let cursor_range = cursor_state.range(galley);
+
+    if let Some(cursor_range) = cursor_range {
+        // We paint the cursor on top of the text, in case
+        // the text galley has backgrounds (as e.g. `code` snippets in markup do).
+        paint_cursor_selection(
+            ui.visuals(),
+            ui.painter(),
+            galley_pos,
+            galley,
+            &cursor_range,
+        );
+
+        let selection_changed = original_cursor != Some(cursor_range);
+
+        let is_fully_visible = ui.clip_rect().contains_rect(response.rect); // TODO: remove this HACK workaround for https://github.com/emilk/egui/issues/1531
+
+        if selection_changed && !is_fully_visible {
+            // Scroll to keep primary cursor in view:
+            let row_height = estimate_row_height(galley);
+            let primary_cursor_rect =
+                cursor_rect(galley_pos, galley, &cursor_range.primary, row_height);
+            ui.scroll_to_rect(primary_cursor_rect, None);
+        }
+    }
+
+    #[cfg(feature = "accesskit")]
+    crate::text_edit::accesskit_text::update_accesskit_for_text_widget(
+        ui.ctx(),
+        response.id,
+        cursor_range,
+        accesskit::Role::StaticText,
+        galley_pos,
+        galley,
+    );
+
+    if !cursor_state.is_empty() {
+        LabelSelectionState::store(ui.ctx(), response.id, cursor_state);
+    }
+}
+
+/// Handles text selection in labels (NOT in [`crate::TextEdit`])s.
+///
+/// One state for all labels, because we only support text selection in one label at a time.
+#[derive(Clone, Copy, Debug, Default)]
+struct LabelSelectionState {
+    /// Id of the (only) label with a selection, if any
+    id: Option<Id>,
+
+    /// The current selection, if any.
+    selection: TextCursorState,
+}
+
+impl LabelSelectionState {
+    /// Load the range of text of text that is selected for the given widget.
+    fn load(ctx: &Context, id: Id) -> TextCursorState {
+        ctx.data(|data| data.get_temp::<Self>(Id::NULL))
+            .and_then(|state| (state.id == Some(id)).then_some(state.selection))
+            .unwrap_or_default()
+    }
+
+    /// Load the range of text of text that is selected for the given widget.
+    fn store(ctx: &Context, id: Id, selection: TextCursorState) {
+        ctx.data_mut(|data| {
+            data.insert_temp(
+                Id::NULL,
+                Self {
+                    id: Some(id),
+                    selection,
+                },
+            );
+        });
+    }
+}
+
+fn process_selection_key_events(
+    ctx: &Context,
+    galley: &Galley,
+    widget_id: Id,
+    cursor_range: &mut CursorRange,
+) {
+    let mut copy_text = None;
+
+    ctx.input(|i| {
+        // NOTE: we have a lock on ui/ctx here,
+        // so be careful to not call into `ui` or `ctx` again.
+
+        for event in &i.events {
+            match event {
+                Event::Copy | Event::Cut => {
+                    // This logic means we can select everything in an ellided label (including the `…`)
+                    // and still copy the entire un-ellided text!
+                    let everything_is_selected =
+                        cursor_range.contains(&CursorRange::select_all(galley));
+
+                    let copy_everything = cursor_range.is_empty() || everything_is_selected;
+
+                    if copy_everything {
+                        copy_text = Some(galley.text().to_owned());
+                    } else {
+                        copy_text = Some(cursor_range.slice_str(galley).to_owned());
+                    }
+                }
+
+                event => {
+                    cursor_range.on_event(ctx.os(), event, galley, widget_id);
+                }
+            }
+        }
+    });
+
+    if let Some(copy_text) = copy_text {
+        ctx.copy_text(copy_text);
+    }
+}
+
+fn estimate_row_height(galley: &Galley) -> f32 {
+    if let Some(row) = galley.rows.first() {
+        row.rect.height()
+    } else {
+        galley.size().y
+    }
+}

--- a/crates/egui/src/text_selection/label_text_selection.rs
+++ b/crates/egui/src/text_selection/label_text_selection.rs
@@ -1,11 +1,10 @@
 use epaint::{Galley, Pos2};
 
-use crate::{
-    text_edit::{cursor_interaction::cursor_rect, CursorRange, TextCursorState},
-    Context, CursorIcon, Event, Id, Response, Ui,
-};
+use crate::{Context, CursorIcon, Event, Id, Response, Ui};
 
-use super::visuals::paint_text_selection;
+use super::{
+    text_cursor_state::cursor_rect, visuals::paint_text_selection, CursorRange, TextCursorState,
+};
 
 /// Handle text selection state for a label or similar widget.
 ///
@@ -62,7 +61,7 @@ pub fn label_text_selection(ui: &Ui, response: &Response, galley_pos: Pos2, gall
     }
 
     #[cfg(feature = "accesskit")]
-    crate::text_edit::accesskit_text::update_accesskit_for_text_widget(
+    super::accesskit_text::update_accesskit_for_text_widget(
         ui.ctx(),
         response.id,
         cursor_range,

--- a/crates/egui/src/text_selection/label_text_selection.rs
+++ b/crates/egui/src/text_selection/label_text_selection.rs
@@ -1,11 +1,11 @@
 use epaint::{Galley, Pos2};
 
 use crate::{
-    text_edit::{
-        cursor_interaction::cursor_rect, paint_cursor_selection, CursorRange, TextCursorState,
-    },
+    text_edit::{cursor_interaction::cursor_rect, CursorRange, TextCursorState},
     Context, CursorIcon, Event, Id, Response, Ui,
 };
+
+use super::visuals::paint_text_selection;
 
 /// Handle text selection state for a label or similar widget.
 ///
@@ -40,9 +40,9 @@ pub fn label_text_selection(ui: &Ui, response: &Response, galley_pos: Pos2, gall
     if let Some(cursor_range) = cursor_range {
         // We paint the cursor on top of the text, in case
         // the text galley has backgrounds (as e.g. `code` snippets in markup do).
-        paint_cursor_selection(
-            ui.visuals(),
+        paint_text_selection(
             ui.painter(),
+            ui.visuals(),
             galley_pos,
             galley,
             &cursor_range,

--- a/crates/egui/src/text_selection/mod.rs
+++ b/crates/egui/src/text_selection/mod.rs
@@ -1,6 +1,13 @@
 //! Helpers regarding text selection for labels and text edit.
 
+#[cfg(feature = "accesskit")]
+pub mod accesskit_text;
+
+mod cursor_range;
 mod label_text_selection;
+pub mod text_cursor_state;
 pub mod visuals;
 
+pub use cursor_range::{CCursorRange, CursorRange, PCursorRange};
 pub use label_text_selection::label_text_selection;
+pub use text_cursor_state::TextCursorState;

--- a/crates/egui/src/text_selection/mod.rs
+++ b/crates/egui/src/text_selection/mod.rs
@@ -1,5 +1,6 @@
 //! Helpers regarding text selection for labels and text edit.
 
 mod label_text_selection;
+pub mod visuals;
 
 pub use label_text_selection::label_text_selection;

--- a/crates/egui/src/text_selection/mod.rs
+++ b/crates/egui/src/text_selection/mod.rs
@@ -1,0 +1,5 @@
+//! Helpers regarding text selection for labels and text edit.
+
+mod label_text_selection;
+
+pub use label_text_selection::label_text_selection;

--- a/crates/egui/src/text_selection/visuals.rs
+++ b/crates/egui/src/text_selection/visuals.rs
@@ -1,0 +1,69 @@
+use crate::*;
+
+use self::text_edit::CursorRange;
+
+pub fn paint_text_selection(
+    painter: &Painter,
+    visuals: &Visuals,
+    galley_pos: Pos2,
+    galley: &Galley,
+    cursor_range: &CursorRange,
+) {
+    if cursor_range.is_empty() {
+        return;
+    }
+
+    // We paint the cursor selection on top of the text, so make it transparent:
+    let color = visuals.selection.bg_fill.linear_multiply(0.5);
+    let [min, max] = cursor_range.sorted_cursors();
+    let min = min.rcursor;
+    let max = max.rcursor;
+
+    for ri in min.row..=max.row {
+        let row = &galley.rows[ri];
+        let left = if ri == min.row {
+            row.x_offset(min.column)
+        } else {
+            row.rect.left()
+        };
+        let right = if ri == max.row {
+            row.x_offset(max.column)
+        } else {
+            let newline_size = if row.ends_with_newline {
+                row.height() / 2.0 // visualize that we select the newline
+            } else {
+                0.0
+            };
+            row.rect.right() + newline_size
+        };
+        let rect = Rect::from_min_max(
+            galley_pos + vec2(left, row.min_y()),
+            galley_pos + vec2(right, row.max_y()),
+        );
+        painter.rect_filled(rect, 0.0, color);
+    }
+}
+
+/// Paint one end of the selection, e.g. the primary cursor.
+pub fn paint_cursor(painter: &Painter, visuals: &Visuals, cursor_rect: Rect) {
+    let stroke = visuals.text_cursor;
+
+    let top = cursor_rect.center_top();
+    let bottom = cursor_rect.center_bottom();
+
+    painter.line_segment([top, bottom], (stroke.width, stroke.color));
+
+    if false {
+        // Roof/floor:
+        let extrusion = 3.0;
+        let width = 1.0;
+        painter.line_segment(
+            [top - vec2(extrusion, 0.0), top + vec2(extrusion, 0.0)],
+            (width, stroke.color),
+        );
+        painter.line_segment(
+            [bottom - vec2(extrusion, 0.0), bottom + vec2(extrusion, 0.0)],
+            (width, stroke.color),
+        );
+    }
+}

--- a/crates/egui/src/text_selection/visuals.rs
+++ b/crates/egui/src/text_selection/visuals.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-use self::text_edit::CursorRange;
+use super::CursorRange;
 
 pub fn paint_text_selection(
     painter: &Painter,

--- a/crates/egui/src/widgets/hyperlink.rs
+++ b/crates/egui/src/widgets/hyperlink.rs
@@ -53,7 +53,7 @@ impl Widget for Link {
 
             let selectable = ui.style().interaction.selectable_labels;
             if selectable {
-                crate::widgets::label::text_selection(ui, &response, galley_pos, &galley);
+                crate::text_selection::label_text_selection(ui, &response, galley_pos, &galley);
             }
 
             if response.hovered() {

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -1,11 +1,6 @@
 use std::sync::Arc;
 
-use crate::{
-    text_edit::{
-        cursor_interaction::cursor_rect, paint_cursor_selection, CursorRange, TextCursorState,
-    },
-    *,
-};
+use crate::*;
 
 /// Static text.
 ///
@@ -262,160 +257,10 @@ impl Widget for Label {
 
             let selectable = selectable.unwrap_or_else(|| ui.style().interaction.selectable_labels);
             if selectable {
-                text_selection(ui, &response, galley_pos, &galley);
+                crate::text_selection::label_text_selection(ui, &response, galley_pos, &galley);
             }
         }
 
         response
-    }
-}
-
-/// Handle text selection state for a label or similar widget.
-///
-/// Make sure the widget senses to clicks and drags.
-///
-/// This should be called after painting the text, because this will also
-/// paint the text cursor/selection on top.
-pub fn text_selection(ui: &Ui, response: &Response, galley_pos: Pos2, galley: &Galley) {
-    let mut cursor_state = LabelSelectionState::load(ui.ctx(), response.id);
-    let original_cursor = cursor_state.range(galley);
-
-    if response.hovered {
-        ui.ctx().set_cursor_icon(CursorIcon::Text);
-    } else if !cursor_state.is_empty() && ui.input(|i| i.pointer.any_pressed()) {
-        // We clicked somewhere else - deselect this label.
-        cursor_state = Default::default();
-        LabelSelectionState::store(ui.ctx(), response.id, cursor_state);
-    }
-
-    if let Some(pointer_pos) = ui.ctx().pointer_interact_pos() {
-        let cursor_at_pointer = galley.cursor_from_pos(pointer_pos - galley_pos);
-        cursor_state.pointer_interaction(ui, response, cursor_at_pointer, galley);
-    }
-
-    if let Some(mut cursor_range) = cursor_state.range(galley) {
-        process_selection_key_events(ui, galley, response.id, &mut cursor_range);
-        cursor_state.set_range(Some(cursor_range));
-    }
-
-    let cursor_range = cursor_state.range(galley);
-
-    if let Some(cursor_range) = cursor_range {
-        // We paint the cursor on top of the text, in case
-        // the text galley has backgrounds (as e.g. `code` snippets in markup do).
-        paint_cursor_selection(
-            ui.visuals(),
-            ui.painter(),
-            galley_pos,
-            galley,
-            &cursor_range,
-        );
-
-        let selection_changed = original_cursor != Some(cursor_range);
-
-        let is_fully_visible = ui.clip_rect().contains_rect(response.rect); // TODO: remove this HACK workaround for https://github.com/emilk/egui/issues/1531
-
-        if selection_changed && !is_fully_visible {
-            // Scroll to keep primary cursor in view:
-            let row_height = estimate_row_height(galley);
-            let primary_cursor_rect =
-                cursor_rect(galley_pos, galley, &cursor_range.primary, row_height);
-            ui.scroll_to_rect(primary_cursor_rect, None);
-        }
-    }
-
-    #[cfg(feature = "accesskit")]
-    text_edit::accesskit_text::update_accesskit_for_text_widget(
-        ui.ctx(),
-        response.id,
-        cursor_range,
-        accesskit::Role::StaticText,
-        galley_pos,
-        galley,
-    );
-
-    if !cursor_state.is_empty() {
-        LabelSelectionState::store(ui.ctx(), response.id, cursor_state);
-    }
-}
-
-fn estimate_row_height(galley: &Galley) -> f32 {
-    if let Some(row) = galley.rows.first() {
-        row.rect.height()
-    } else {
-        galley.size().y
-    }
-}
-
-fn process_selection_key_events(
-    ui: &Ui,
-    galley: &Galley,
-    widget_id: Id,
-    cursor_range: &mut CursorRange,
-) {
-    let mut copy_text = None;
-
-    ui.input(|i| {
-        // NOTE: we have a lock on ui/ctx here,
-        // so be careful to not call into `ui` or `ctx` again.
-
-        for event in &i.events {
-            match event {
-                Event::Copy | Event::Cut => {
-                    // This logic means we can select everything in an ellided label (including the `…`)
-                    // and still copy the entire un-ellided text!
-                    let everything_is_selected =
-                        cursor_range.contains(&CursorRange::select_all(galley));
-
-                    let copy_everything = cursor_range.is_empty() || everything_is_selected;
-
-                    if copy_everything {
-                        copy_text = Some(galley.text().to_owned());
-                    } else {
-                        copy_text = Some(cursor_range.slice_str(galley).to_owned());
-                    }
-                }
-
-                event => {
-                    cursor_range.on_event(ui.ctx().os(), event, galley, widget_id);
-                }
-            }
-        }
-    });
-
-    if let Some(copy_text) = copy_text {
-        ui.ctx().copy_text(copy_text);
-    }
-}
-
-// ----------------------------------------------------------------------------
-
-/// One state for all labels, because we only support text selection in one label at a time.
-#[derive(Clone, Copy, Debug, Default)]
-struct LabelSelectionState {
-    /// Id of the (only) label with a selection, if any
-    id: Option<Id>,
-
-    /// The current selection, if any.
-    selection: TextCursorState,
-}
-
-impl LabelSelectionState {
-    fn load(ctx: &Context, id: Id) -> TextCursorState {
-        ctx.data(|data| data.get_temp::<Self>(Id::NULL))
-            .and_then(|state| (state.id == Some(id)).then_some(state.selection))
-            .unwrap_or_default()
-    }
-
-    fn store(ctx: &Context, id: Id, selection: TextCursorState) {
-        ctx.data_mut(|data| {
-            data.insert_temp(
-                Id::NULL,
-                Self {
-                    id: Some(id),
-                    selection,
-                },
-            );
-        });
     }
 }

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -5,15 +5,20 @@ use epaint::text::{cursor::*, Galley, LayoutJob};
 use crate::{
     os::OperatingSystem,
     output::OutputEvent,
-    text_edit::cursor_interaction::cursor_rect,
-    text_selection::visuals::{paint_cursor, paint_text_selection},
+    text_selection::{
+        text_cursor_state::cursor_rect,
+        visuals::{paint_cursor, paint_text_selection},
+        CursorRange,
+    },
     *,
 };
 
-use super::{
-    cursor_interaction::{ccursor_next_word, ccursor_previous_word, find_line_start},
-    CCursorRange, CursorRange, TextEditOutput, TextEditState,
+use self::text_selection::{
+    text_cursor_state::{ccursor_next_word, ccursor_previous_word, find_line_start},
+    CCursorRange,
 };
+
+use super::{TextEditOutput, TextEditState};
 
 /// A text region that the user can edit the contents of.
 ///
@@ -726,7 +731,7 @@ impl<'t> TextEdit<'t> {
                 accesskit::Role::TextInput
             };
 
-            super::accesskit_text::update_accesskit_for_text_widget(
+            crate::text_selection::accesskit_text::update_accesskit_for_text_widget(
                 ui.ctx(),
                 id,
                 cursor_range,

--- a/crates/egui/src/widgets/text_edit/mod.rs
+++ b/crates/egui/src/widgets/text_edit/mod.rs
@@ -9,10 +9,6 @@ mod text_buffer;
 pub mod accesskit_text;
 
 pub use {
-    builder::{paint_cursor_selection, TextEdit},
-    cursor_range::*,
-    output::TextEditOutput,
-    state::TextCursorState,
-    state::TextEditState,
-    text_buffer::TextBuffer,
+    builder::TextEdit, cursor_range::*, output::TextEditOutput, state::TextCursorState,
+    state::TextEditState, text_buffer::TextBuffer,
 };

--- a/crates/egui/src/widgets/text_edit/mod.rs
+++ b/crates/egui/src/widgets/text_edit/mod.rs
@@ -1,14 +1,9 @@
 mod builder;
-pub mod cursor_interaction;
-mod cursor_range;
 mod output;
 mod state;
 mod text_buffer;
 
-#[cfg(feature = "accesskit")]
-pub mod accesskit_text;
-
 pub use {
-    builder::TextEdit, cursor_range::*, output::TextEditOutput, state::TextCursorState,
+    crate::text_selection::TextCursorState, builder::TextEdit, output::TextEditOutput,
     state::TextEditState, text_buffer::TextBuffer,
 };

--- a/crates/egui/src/widgets/text_edit/output.rs
+++ b/crates/egui/src/widgets/text_edit/output.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use crate::text_selection::CursorRange;
+
 /// The output from a [`TextEdit`](crate::TextEdit).
 pub struct TextEditOutput {
     /// The interaction response.
@@ -18,7 +20,7 @@ pub struct TextEditOutput {
     pub state: super::TextEditState,
 
     /// Where the text cursor is.
-    pub cursor_range: Option<super::CursorRange>,
+    pub cursor_range: Option<CursorRange>,
 }
 
 impl TextEditOutput {

--- a/crates/egui/src/widgets/text_edit/output.rs
+++ b/crates/egui/src/widgets/text_edit/output.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::text_selection::CursorRange;
+use crate::text::CursorRange;
 
 /// The output from a [`TextEdit`](crate::TextEdit).
 pub struct TextEditOutput {

--- a/crates/egui/src/widgets/text_edit/state.rs
+++ b/crates/egui/src/widgets/text_edit/state.rs
@@ -12,12 +12,11 @@ pub type TextEditUndoer = crate::util::undoer::Undoer<(CCursorRange, String)>;
 ///
 /// Attention: You also need to `store` the updated state.
 /// ```
-/// # use egui::text::CCursor;
-/// # use egui::text_edit::{CCursorRange, TextEditOutput};
-/// # use egui::TextEdit;
 /// # egui::__run_test_ui(|ui| {
 /// # let mut text = String::new();
-/// let mut output = TextEdit::singleline(&mut text).show(ui);
+/// use egui::text::{CCursor, CCursorRange};
+///
+/// let mut output = egui::TextEdit::singleline(&mut text).show(ui);
 ///
 /// // Create a new selection range
 /// let min = CCursor::new(0);
@@ -25,7 +24,7 @@ pub type TextEditUndoer = crate::util::undoer::Undoer<(CCursorRange, String)>;
 /// let new_range = CCursorRange::two(min, max);
 ///
 /// // Update the state
-/// output.state.set_ccursor_range(Some(new_range));
+/// output.state.cursor.set_char_range(Some(new_range));
 /// // Store the updated state
 /// output.state.store(ui.ctx(), output.response.id);
 /// # });

--- a/crates/egui/src/widgets/text_edit/state.rs
+++ b/crates/egui/src/widgets/text_edit/state.rs
@@ -4,71 +4,9 @@ use crate::mutex::Mutex;
 
 use crate::*;
 
-use super::{CCursorRange, CursorRange};
+use self::text_selection::{CCursorRange, CursorRange, TextCursorState};
 
 pub type TextEditUndoer = crate::util::undoer::Undoer<(CCursorRange, String)>;
-
-/// The state of a text cursor selection.
-///
-/// Used for [`crate::TextEdit`] and [`crate::Label`].
-#[derive(Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "serde", serde(default))]
-pub struct TextCursorState {
-    cursor_range: Option<CursorRange>,
-
-    /// This is what is easiest to work with when editing text,
-    /// so users are more likely to read/write this.
-    ccursor_range: Option<CCursorRange>,
-}
-
-impl TextCursorState {
-    pub fn is_empty(&self) -> bool {
-        self.cursor_range.is_none() && self.ccursor_range.is_none()
-    }
-
-    /// The the currently selected range of characters.
-    pub fn char_range(&self) -> Option<CCursorRange> {
-        self.ccursor_range.or_else(|| {
-            self.cursor_range
-                .map(|cursor_range| cursor_range.as_ccursor_range())
-        })
-    }
-
-    pub fn range(&mut self, galley: &Galley) -> Option<CursorRange> {
-        self.cursor_range
-            .map(|cursor_range| {
-                // We only use the PCursor (paragraph number, and character offset within that paragraph).
-                // This is so that if we resize the [`TextEdit`] region, and text wrapping changes,
-                // we keep the same byte character offset from the beginning of the text,
-                // even though the number of rows changes
-                // (each paragraph can be several rows, due to word wrapping).
-                // The column (character offset) should be able to extend beyond the last word so that we can
-                // go down and still end up on the same column when we return.
-                CursorRange {
-                    primary: galley.from_pcursor(cursor_range.primary.pcursor),
-                    secondary: galley.from_pcursor(cursor_range.secondary.pcursor),
-                }
-            })
-            .or_else(|| {
-                self.ccursor_range.map(|ccursor_range| CursorRange {
-                    primary: galley.from_ccursor(ccursor_range.primary),
-                    secondary: galley.from_ccursor(ccursor_range.secondary),
-                })
-            })
-    }
-
-    /// Sets the currently selected range of characters.
-    pub fn set_char_range(&mut self, ccursor_range: Option<CCursorRange>) {
-        self.cursor_range = None;
-        self.ccursor_range = ccursor_range;
-    }
-
-    pub fn set_range(&mut self, cursor_range: Option<CursorRange>) {
-        self.cursor_range = cursor_range;
-        self.ccursor_range = None;
-    }
-}
 
 /// The text edit state stored between frames.
 ///

--- a/crates/egui/src/widgets/text_edit/text_buffer.rs
+++ b/crates/egui/src/widgets/text_edit/text_buffer.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, ops::Range};
 
-use super::cursor_interaction::{byte_index_from_char_index, slice_char_range};
+use crate::text_selection::text_cursor_state::{byte_index_from_char_index, slice_char_range};
 
 /// Trait constraining what types [`crate::TextEdit`] may use as
 /// an underlying buffer.

--- a/crates/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/crates/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -1,4 +1,4 @@
-use egui::{text_edit::CCursorRange, *};
+use egui::{text::CCursorRange, *};
 
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]


### PR DESCRIPTION
This is a follow-up to https://github.com/emilk/egui/issues/3804 and a pre-requisite for https://github.com/emilk/egui/issues/3816