### PR TITLE
Add `Context::debug_text`

### DIFF
--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -351,8 +351,6 @@ pub fn popup_above_or_below_widget<R>(
             .fixed_pos(pos)
             .pivot(pivot)
             .show(ui.ctx(), |ui| {
-                // Note: we use a separate clip-rect for this area, so the popup can be outside the parent.
-                // See https://github.com/emilk/egui/issues/825
                 let frame = Frame::popup(ui.style());
                 let frame_margin = frame.total_margin();
                 frame

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1076,7 +1076,7 @@ impl Context {
     /// ```
     /// # let ctx = egui::Context::default();
     /// # let state = true;
-    /// ctx.debug_text(format!("State: {state;?}"));
+    /// ctx.debug_text(format!("State: {state:?}"));
     /// ```
     #[track_caller]
     pub fn debug_text(&self, text: impl Into<WidgetText>) {

--- a/crates/egui/src/painter.rs
+++ b/crates/egui/src/painter.rs
@@ -219,7 +219,9 @@ impl Painter {
         self.debug_text(pos, Align2::LEFT_TOP, color, format!("🔥 {text}"))
     }
 
-    /// text with a background
+    /// Text with a background.
+    ///
+    /// See also [`Context::debug_text`].
     #[allow(clippy::needless_pass_by_value)]
     pub fn debug_text(
         &self,

--- a/crates/egui/src/widget_text.rs
+++ b/crates/egui/src/widget_text.rs
@@ -649,18 +649,39 @@ impl WidgetText {
         fallback_font: impl Into<FontSelection>,
     ) -> Arc<Galley> {
         let wrap = wrap.unwrap_or_else(|| ui.wrap_text());
+        let valign = ui.layout().vertical_align();
+        let style = ui.style();
+
+        self.into_galley_impl(
+            ui.ctx(),
+            style,
+            wrap,
+            available_width,
+            fallback_font.into(),
+            valign,
+        )
+    }
+
+    pub fn into_galley_impl(
+        self,
+        ctx: &crate::Context,
+        style: &Style,
+        wrap: bool,
+        available_width: f32,
+        fallback_font: FontSelection,
+        default_valign: Align,
+    ) -> Arc<Galley> {
         let wrap_width = if wrap { available_width } else { f32::INFINITY };
 
         match self {
             Self::RichText(text) => {
-                let valign = ui.layout().vertical_align();
-                let mut layout_job = text.into_layout_job(ui.style(), fallback_font.into(), valign);
+                let mut layout_job = text.into_layout_job(style, fallback_font, default_valign);
                 layout_job.wrap.max_width = wrap_width;
-                ui.fonts(|f| f.layout_job(layout_job))
+                ctx.fonts(|f| f.layout_job(layout_job))
             }
             Self::LayoutJob(mut job) => {
                 job.wrap.max_width = wrap_width;
-                ui.fonts(|f| f.layout_job(job))
+                ctx.fonts(|f| f.layout_job(job))
             }
             Self::Galley(galley) => galley,
         }


### PR DESCRIPTION
This is a very easy way to show some text under the mouse pointer:

```rs
ctx.debug_text("foo");
```