### PR TITLE
Allow read access to shapes added to painter this frame

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -701,6 +701,12 @@ impl Context {
         self.write(move |ctx| writer(&mut ctx.viewport().graphics))
     }
 
+    /// Read-only access to [`GraphicLayers`], where painted [`crate::Shape`]s are written to.
+    #[inline]
+    pub(crate) fn graphics<R>(&self, reader: impl FnOnce(&GraphicLayers) -> R) -> R {
+        self.write(move |ctx| reader(&ctx.viewport().graphics))
+    }
+
     /// Read-only access to [`PlatformOutput`].
     ///
     /// This is what egui outputs each frame.

--- a/crates/egui/src/layers.rs
+++ b/crates/egui/src/layers.rs
@@ -158,6 +158,14 @@ impl PaintList {
             shape.translate(delta);
         }
     }
+
+    /// Read-only access to all held shapes.
+    pub fn all_entries(&self) -> impl Iterator<Item = (ShapeIdx, &Shape)> {
+        self.0
+            .iter()
+            .enumerate()
+            .map(|(i, clipped)| (ShapeIdx(i), &clipped.shape))
+    }
 }
 
 #[derive(Clone, Default)]
@@ -168,6 +176,10 @@ impl GraphicLayers {
         self.0[layer_id.order as usize]
             .entry(layer_id.id)
             .or_default()
+    }
+
+    pub fn existing_list(&self, layer_id: LayerId) -> Option<&PaintList> {
+        self.0[layer_id.order as usize].get(&layer_id.id)
     }
 
     pub fn drain(&mut self, area_order: &[LayerId]) -> Vec<ClippedShape> {

--- a/crates/egui/src/painter.rs
+++ b/crates/egui/src/painter.rs
@@ -193,6 +193,17 @@ impl Painter {
         self.transform_shape(&mut shape);
         self.paint_list(|l| l.set(idx, self.clip_rect, shape));
     }
+
+    /// Access all shapes added this frame.
+    pub fn for_each_shape(&self, mut reader: impl FnMut(ShapeIdx, &Shape)) {
+        self.ctx.graphics(|g| {
+            g.existing_list(self.layer_id).map(|l| {
+                for (i, s) in l.all_entries() {
+                    reader(i, s);
+                }
+            })
+        });
+    }
 }
 
 /// ## Debug painting


### PR DESCRIPTION
Hello,

I'm interested in exporting a picture drawn by egui as a vector graphic and thus need access to the picture's shapes.

## Notes on the submitted code:
Ideally i would want to return the result iterator of `PaintList::all_entries` to the user. This however failed because of the required lifetimes.

I was unsure wether to use `Context::graphics_mut` instead of creating `Context::graphics` and `GraphicLayers::existing_list`. Given that `Context` has a mutable and immutable version of these "getters" for other data, i feel it is more consistent to do it this way.