### PR TITLE
Fix Android crash on resume with Glow backend

### DIFF
--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -435,7 +435,7 @@ impl WinitApp for GlowWinitApp {
                         #[cfg(target_os = "android")]
                         glutin.on_resume(self.native_options.viewport.clone(), event_loop)?;
                         #[cfg(not(target_os = "android"))]
-                        glutin.initialize_all_windows(event_loop)
+                        glutin.initialize_all_windows(event_loop);
                     }
 
                     running

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -430,10 +430,14 @@ impl WinitApp for GlowWinitApp {
 
                 let running = if let Some(running) = &mut self.running {
                     // Not the first resume event. Create all outstanding windows.
-                    running
-                        .glutin
-                        .borrow_mut()
-                        .initialize_all_windows(event_loop);
+                    {
+                        let glutin = &mut running.glutin.borrow_mut();
+                        #[cfg(target_os = "android")]
+                        glutin.on_resume(self.native_options.viewport.clone(), event_loop)?;
+                        #[cfg(not(target_os = "android"))]
+                        glutin.initialize_all_windows(event_loop)
+                    }
+
                     running
                 } else {
                     // First resume event. Created our root window etc.
@@ -507,7 +511,9 @@ impl GlowWinitRunning {
 
         {
             let glutin = self.glutin.borrow();
-            let viewport = &glutin.viewports[&viewport_id];
+            let Some(viewport) = glutin.viewports.get(&viewport_id) else {
+                return EventResult::Wait;
+            };
             let is_immediate = viewport.viewport_ui_cb.is_none();
             if is_immediate && viewport_id != ViewportId::ROOT {
                 // This will only happen if this is an immediate viewport.
@@ -524,7 +530,9 @@ impl GlowWinitRunning {
         let (raw_input, viewport_ui_cb) = {
             let mut glutin = self.glutin.borrow_mut();
             let egui_ctx = glutin.egui_ctx.clone();
-            let viewport = glutin.viewports.get_mut(&viewport_id).unwrap();
+            let Some(viewport) = glutin.viewports.get_mut(&viewport_id) else {
+                return EventResult::Wait;
+            };
             let window = viewport.window.as_ref().unwrap();
             egui_winit::update_viewport_info(&mut viewport.info, &egui_ctx, window);
 
@@ -1112,12 +1120,55 @@ impl GlutinWindowContext {
             viewport.gl_surface = None;
             viewport.window = None;
         }
+        #[cfg(target_os = "android")]
+        self.viewports.clear();
+
         if let Some(current) = self.current_gl_context.take() {
             log::debug!("context is current, so making it non-current");
             self.not_current_gl_context = Some(current.make_not_current()?);
         } else {
             log::debug!("context is already not current??? could be duplicate suspend event");
         }
+        Ok(())
+    }
+
+    #[cfg(target_os = "android")]
+    /// only applies for android. but we basically recreate root viewport
+    fn on_resume(
+        &mut self,
+        builder: ViewportBuilder,
+        event_loop: &EventLoopWindowTarget<UserEvent>,
+    ) -> Result<()> {
+        log::debug!("received resume event. initializing new viewport");
+        let GlutinWindowContext {
+            egui_ctx,
+            viewports,
+            ..
+        } = self;
+
+        initialize_or_update_viewport(
+            egui_ctx,
+            viewports,
+            ViewportIdPair::ROOT,
+            ViewportClass::Root,
+            builder,
+            None,
+            None,
+        );
+
+        self.initialize_window(ViewportId::ROOT, event_loop)?;
+
+        if let Some(not_current) = self.not_current_gl_context.take() {
+            log::debug!("context is non-current, so making it current");
+            let surface = self.viewports[&ViewportId::ROOT]
+                .gl_surface
+                .as_ref()
+                .unwrap();
+            self.current_gl_context = Some(not_current.make_current(surface)?);
+        } else {
+            log::debug!("context is already current??? could be duplicate resume event");
+        }
+
         Ok(())
     }
 

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -39,18 +39,6 @@ use super::{
     *,
 };
 
-// Note: that the current Glutin API design tightly couples the GL context with
-// the Window which means it's not practically possible to just destroy the
-// window and re-create a new window while continuing to use the same GL context.
-//
-// For now this means it's not possible to support Android as well as we can with
-// wgpu because we're basically forced to destroy and recreate _everything_ when
-// the application suspends and resumes.
-//
-// There is work in progress to improve the Glutin API so it has a separate Surface
-// API that would allow us to just destroy a Window/Surface when suspending, see:
-// https://github.com/rust-windowing/glutin/pull/1435
-
 // ----------------------------------------------------------------------------
 // Types:
 
@@ -434,7 +422,6 @@ impl WinitApp for GlowWinitApp {
                         .glutin
                         .borrow_mut()
                         .initialize_all_windows(event_loop);
-
                     running
                 } else {
                     // First resume event. Created our root window etc.
@@ -1115,7 +1102,6 @@ impl GlutinWindowContext {
             viewport.gl_surface = None;
             viewport.window = None;
         }
-
         if let Some(current) = self.current_gl_context.take() {
             log::debug!("context is current, so making it non-current");
             self.not_current_gl_context = Some(current.make_not_current()?);


### PR DESCRIPTION
Addition for <https://github.com/emilk/egui/pull/3847>
In previous one i only fixed crash occurring with Wgpu backend. This fixes crash with Glow backend as well.
I only tested this change with android so most things i changed are behind ```#[cfg(target_os = "android")]```.

Both fixes are dirty thought. As <https://github.com/emilk/egui/pull/3172> says that "The root viewport is the original viewport, and cannot be closed without closing the application.". So they break rules i guess? But i can't think about better solution for now.

Closes <https://github.com/emilk/egui/issues/3861>.
