### PR TITLE
`egui-wgpu`: turn off the default features of `wgpu`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4261,6 +4261,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bitflags 2.4.0",
+ "block",
  "cfg_aliases",
  "core-graphics-types",
  "glow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,17 +1077,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "d3d12"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3d747f100290a1ca24b752186f61f6637e1deffe3bf6320de6fcb29510a307"
-dependencies = [
- "bitflags 2.4.0",
- "libloading 0.8.0",
- "winapi",
-]
-
-[[package]]
 name = "data-url"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2998,12 +2987,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "range-alloc"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
-
-[[package]]
 name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4277,12 +4260,9 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
  "bitflags 2.4.0",
- "block",
  "cfg_aliases",
  "core-graphics-types",
- "d3d12",
  "glow",
  "glutin_wgl_sys",
  "gpu-alloc",
@@ -4300,7 +4280,6 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "profiling",
- "range-alloc",
  "raw-window-handle 0.6.0",
  "renderdoc-sys",
  "rustc-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4219,9 +4219,9 @@ checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "wgpu"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b71d2ded29e2161db50ab731d6cb42c037bd7ab94864a98fa66ff36b4721a8"
+checksum = "0bfe9a310dcf2e6b85f00c46059aaeaf4184caa8e29a1ecd4b7a704c3482332d"
 dependencies = [
  "arrayvec",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ glow = "0.13"
 puffin = "0.18"
 raw-window-handle = "0.6.0"
 thiserror = "1.0.37"
-wgpu = { version = "0.19", features = [
+wgpu = { version = "0.19.1", features = [
     # Make the renderer `Sync` even on wasm32, because it makes the code simpler:
     "fragile-send-sync-non-atomic-wasm",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ glow = "0.13"
 puffin = "0.18"
 raw-window-handle = "0.6.0"
 thiserror = "1.0.37"
-wgpu = { version = "0.19.1", features = [
+wgpu = { version = "0.19.1", default-features = false, features = [
     # Make the renderer `Sync` even on wasm32, because it makes the code simpler:
     "fragile-send-sync-non-atomic-wasm",
 ] }

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -168,7 +168,12 @@ pollster = { version = "0.3", optional = true } # needed for wgpu
 glutin = { version = "0.31", optional = true }
 glutin-winit = { version = "0.4", optional = true }
 puffin = { workspace = true, optional = true }
-wgpu = { workspace = true, optional = true }
+wgpu = { workspace = true, optional = true, features = [
+  # Let's enable some backends so that users can use `eframe` out-of-the-box
+  # without having to explicitly opt-in to backends
+  "metal",
+  "webgpu",
+] }
 
 # mac:
 [target.'cfg(any(target_os = "macos"))'.dependencies]

--- a/crates/egui-wgpu/Cargo.toml
+++ b/crates/egui-wgpu/Cargo.toml
@@ -45,7 +45,7 @@ bytemuck = "1.7"
 log = { version = "0.4", features = ["std"] }
 thiserror.workspace = true
 type-map = "0.5.0"
-wgpu.workspace = true
+wgpu = { workspace = true, features = ["wgsl"] }
 
 #! ### Optional dependencies
 ## Enable this when generating docs.


### PR DESCRIPTION
This makes all `wgpu` features opt-in for `egui-wgpu` users.

For `eframe`, I opted to enable some `wgpu` features so users can still use `eframe` without having to also opt-in to extra ewgpu features (eframe is batteries-included).