### PR TITLE
Add some drag-and-drop-related APIs in `Response` and `Memory`

### DIFF
--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -703,6 +703,12 @@ impl Memory {
         self.interaction().drag_id == Some(id)
     }
 
+    /// Get the id of the widget being dragged, if any.
+    #[inline(always)]
+    pub fn dragged_id(&self) -> Option<Id> {
+        self.interaction().drag_id
+    }
+
     /// Set which widget is being dragged.
     #[inline(always)]
     pub fn set_dragged_id(&mut self, id: Id) {

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -309,6 +309,14 @@ impl Response {
         self.dragged
     }
 
+    /// The Widget is being decidedly dragged.
+    ///
+    /// This helper function checks both the output of [`dragged`] and [`crate::PointerState::is_decidedly_dragging`].
+    #[inline]
+    pub fn decidedly_dragged(&self) -> bool {
+        self.dragged() && self.ctx.input(|i| i.pointer.is_decidedly_dragging())
+    }
+
     #[inline]
     pub fn dragged_by(&self, button: PointerButton) -> bool {
         self.dragged() && self.ctx.input(|i| i.pointer.button_down(button))

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -311,7 +311,7 @@ impl Response {
 
     /// The Widget is being decidedly dragged.
     ///
-    /// This helper function checks both the output of [`dragged`] and [`crate::PointerState::is_decidedly_dragging`].
+    /// This helper function checks both the output of [`Self::dragged`] and [`crate::PointerState::is_decidedly_dragging`].
     #[inline]
     pub fn decidedly_dragged(&self) -> bool {
         self.dragged() && self.ctx.input(|i| i.pointer.is_decidedly_dragging())


### PR DESCRIPTION
This PR adds the following APIs, which I found to be missing while working on https://github.com/rerun-io/rerun/pull/4879:

- `Response::decidedly_dragged()`: tests if the corresponding widget is being decidedly dragged
- `Memory::dragged_id()`: returns the ID of the dragged widget, if any