### PR TITLE
TAB key in TextEdit, fill the space with different sizes

### DIFF
--- a/crates/egui/Cargo.toml
+++ b/crates/egui/Cargo.toml
@@ -96,3 +96,4 @@ log = { version = "0.4", optional = true, features = ["std"] }
 puffin = { workspace = true, optional = true }
 ron = { version = "0.8", optional = true }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
+unicode-width = "0.1.11"

--- a/crates/egui/src/text_selection/text_cursor_state.rs
+++ b/crates/egui/src/text_selection/text_cursor_state.rs
@@ -300,18 +300,10 @@ pub fn find_line_start(text: &str, current_index: CCursor) -> CCursor {
     // number of multi byte chars.
     // We need to know the char index to be able to correctly set the cursor
     // later.
-    let chars_count = text.chars().count();
+    let mut char_line_indexes: Vec<usize> = create_char_line_indexes(text);
+    let line_start_index = get_line_start_index(&mut char_line_indexes, current_index.index);
 
-    let position = text
-        .chars()
-        .rev()
-        .skip(chars_count - current_index.index)
-        .position(|x| x == '\n');
-
-    match position {
-        Some(pos) => CCursor::new(current_index.index - pos),
-        None => CCursor::new(0),
-    }
+    CCursor::new(line_start_index)
 }
 
 pub fn create_char_line_indexes(text: &str) -> Vec<usize> {

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -855,7 +855,7 @@ fn events(
                     // TODO(emilk): support removing indentation over a selection?
                     text.decrease_indentation(&mut ccursor);
                 } else {
-                    text.insert_text_at(&mut ccursor, "\t", char_limit);
+                    text.insert_tab_to_space(&mut ccursor, "\t", char_limit);
                 }
                 Some(CCursorRange::one(ccursor))
             }

--- a/crates/egui/src/widgets/text_edit/text_buffer.rs
+++ b/crates/egui/src/widgets/text_edit/text_buffer.rs
@@ -86,6 +86,31 @@ pub trait TextBuffer {
         }
     }
 
+    fn insert_tab_to_space(
+        &mut self,
+        ccursor: &mut CCursor,
+        text_to_insert: &str,
+        char_limit: usize,
+    ) {
+        let tab_size: usize = TAB_SIZE;
+        let mut text_to_insert: String = text_to_insert.to_owned();
+        if text_to_insert == "\t" {
+            let mut line_indexes: Vec<usize> =
+                crate::text_selection::text_cursor_state::create_char_line_indexes(self.as_str());
+            let current_column = crate::text_selection::text_cursor_state::get_current_column(
+                self.as_str(),
+                &mut line_indexes,
+                ccursor.index,
+            );
+            let tab_size_gap = (current_column - 1) % tab_size;
+            let add_space_size = tab_size - tab_size_gap;
+
+            text_to_insert = " ".repeat(add_space_size);
+        }
+
+        self.insert_text_at(ccursor, &text_to_insert, char_limit);
+    }
+
     fn decrease_indentation(&mut self, ccursor: &mut CCursor) {
         let line_start = find_line_start(self.as_str(), *ccursor);
 


### PR DESCRIPTION
https://github.com/emilk/egui/issues/3850

I want to use the following for accurate usage:
egui\src\text_selection\text_cursor_state.rs 360 lines
let width = unicode_width::UnicodeWidthChar::width_cjk(c).unwrap_or(2);
