### PR TITLE
Register callbacks with `Context::on_begin_frame` and `on_end_frame`.

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -68,7 +68,7 @@ need_stdout = true
 [keybindings]
 i = "job:initial"
 c = "job:cranky"
-w = "job:wasm"
+a = "job:wasm"
 d = "job:doc-open"
 t = "job:test"
 r = "job:run"

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1388,6 +1388,7 @@ impl Context {
         };
         self.write(|ctx| ctx.plugins.on_begin_frame.push(named_cb));
     }
+
     /// Call the given callback at the end of each frame
     /// of each viewport.
     ///

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -83,14 +83,14 @@ struct Plugins {
 }
 
 impl Plugins {
-    fn call(ctx: &Context, cb_name: &str, callbacks: &[NamedContextCallback]) {
-        crate::profile_scope!("plugins", cb_name);
+    fn call(ctx: &Context, _cb_name: &str, callbacks: &[NamedContextCallback]) {
+        crate::profile_scope!("plugins", _cb_name);
         for NamedContextCallback {
-            debug_name,
+            debug_name: _name,
             callback,
         } in callbacks
         {
-            crate::profile_scope!(debug_name);
+            crate::profile_scope!(_name);
             (callback)(ctx);
         }
     }

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -599,6 +599,7 @@ impl Default for Context {
 
         // Register built-in plugins:
         crate::debug_text::register(&ctx);
+        crate::text_selection::LabelSelectionState::register(&ctx);
 
         ctx
     }
@@ -665,7 +666,6 @@ impl Context {
     /// ```
     pub fn begin_frame(&self, new_input: RawInput) {
         crate::profile_function!();
-        crate::text_selection::LabelSelectionState::begin_frame(self);
         self.read(|ctx| ctx.plugins.clone()).on_begin_frame(self);
         self.write(|ctx| ctx.begin_frame_mut(new_input));
     }
@@ -1680,7 +1680,6 @@ impl Context {
             crate::gui_zoom::zoom_with_keyboard(self);
         }
 
-        crate::text_selection::LabelSelectionState::end_frame(self);
         self.read(|ctx| ctx.plugins.clone()).on_end_frame(self);
 
         self.write(|ctx| ctx.end_frame())

--- a/crates/egui/src/debug_text.rs
+++ b/crates/egui/src/debug_text.rs
@@ -26,7 +26,7 @@ pub(crate) fn register(ctx: &Context) {
 /// ```
 /// # let ctx = egui::Context::default();
 /// # let state = true;
-/// egui::debug_text::print(format!("State: {state:?}"));
+/// egui::debug_text::print(ctx, format!("State: {state:?}"));
 /// ```
 #[track_caller]
 pub fn print(ctx: &Context, text: impl Into<WidgetText>) {

--- a/crates/egui/src/debug_text.rs
+++ b/crates/egui/src/debug_text.rs
@@ -24,7 +24,7 @@ pub(crate) fn register(ctx: &Context) {
 /// This only works if compiled with `debug_assertions`.
 ///
 /// ```
-/// # let ctx = egui::Context::default();
+/// # let ctx = &egui::Context::default();
 /// # let state = true;
 /// egui::debug_text::print(ctx, format!("State: {state:?}"));
 /// ```

--- a/crates/egui/src/debug_text.rs
+++ b/crates/egui/src/debug_text.rs
@@ -1,0 +1,132 @@
+//! This is an example of how to create a plugin for egui.
+//!
+//! A plugin usually consist of a struct that holds some state,
+//! which is stored using [`Context::data_mut`].
+//! The plugin registers itself onto a specific [`Context`]
+//! to get callbacks on certain events ([`Context::on_begin_frame`], [`Context::on_end_frame`]).
+
+use crate::*;
+
+/// Register this plugin on the given egui context,
+/// so that it will be called every frame.
+///
+/// This is a built-in plugin in egui,
+/// meaning [`Context`] calls this from its `Default` implementation,
+/// so this i marked as `pub(crate)`.
+pub(crate) fn register(ctx: &Context) {
+    ctx.on_end_frame("debug_text", std::sync::Arc::new(State::end_frame));
+}
+
+/// Print this text next to the cursor at the end of the frame.
+///
+/// If you call this multiple times, the text will be appended.
+///
+/// This only works if compiled with `debug_assertions`.
+///
+/// ```
+/// # let ctx = egui::Context::default();
+/// # let state = true;
+/// egui::debug_text::print(format!("State: {state:?}"));
+/// ```
+#[track_caller]
+pub fn print(ctx: &Context, text: impl Into<WidgetText>) {
+    if !cfg!(debug_assertions) {
+        return;
+    }
+
+    let location = std::panic::Location::caller();
+    let location = format!("{}:{}", location.file(), location.line());
+    ctx.data_mut(|data| {
+        let state = data.get_temp_mut_or_default::<State>(Id::NULL);
+        state.entries.push(Entry {
+            location,
+            text: text.into(),
+        });
+    });
+}
+
+#[derive(Clone)]
+struct Entry {
+    location: String,
+    text: WidgetText,
+}
+
+/// A pluging for easily showing debug-text on-screen.
+///
+/// This is a built-in plugin in egui.
+#[derive(Clone, Default)]
+struct State {
+    // This gets re-filled every frame.
+    entries: Vec<Entry>,
+}
+
+impl State {
+    fn end_frame(ctx: &Context) {
+        let state = ctx.data_mut(|data| data.remove_temp::<Self>(Id::NULL));
+        if let Some(state) = state {
+            state.paint(ctx);
+        }
+    }
+
+    fn paint(self, ctx: &Context) {
+        let Self { entries: entires } = self;
+
+        if entires.is_empty() {
+            return;
+        }
+
+        // Show debug-text next to the cursor.
+        let mut pos = ctx
+            .input(|i| i.pointer.latest_pos())
+            .unwrap_or_else(|| ctx.screen_rect().center())
+            + 8.0 * Vec2::Y;
+
+        let painter = ctx.debug_painter();
+        let where_to_put_background = painter.add(Shape::Noop);
+
+        let mut bounding_rect = Rect::from_points(&[pos]);
+
+        let color = Color32::GRAY;
+        let font_id = FontId::new(10.0, FontFamily::Proportional);
+
+        for Entry { location, text } in entires {
+            {
+                // Paint location to left of `pos`:
+                let location_galley =
+                    ctx.fonts(|f| f.layout(location, font_id.clone(), color, f32::INFINITY));
+                let location_rect =
+                    Align2::RIGHT_TOP.anchor_size(pos - 4.0 * Vec2::X, location_galley.size());
+                painter.galley(location_rect.min, location_galley, color);
+                bounding_rect = bounding_rect.union(location_rect);
+            }
+
+            {
+                // Paint `text` to right of `pos`:
+                let wrap = true;
+                let available_width = ctx.screen_rect().max.x - pos.x;
+                let galley = text.into_galley_impl(
+                    ctx,
+                    &ctx.style(),
+                    wrap,
+                    available_width,
+                    font_id.clone().into(),
+                    Align::TOP,
+                );
+                let rect = Align2::LEFT_TOP.anchor_size(pos, galley.size());
+                painter.galley(rect.min, galley, color);
+                bounding_rect = bounding_rect.union(rect);
+            }
+
+            pos.y = bounding_rect.max.y + 4.0;
+        }
+
+        painter.set(
+            where_to_put_background,
+            Shape::rect_filled(
+                bounding_rect.expand(4.0),
+                2.0,
+                Color32::from_black_alpha(192),
+            ),
+        );
+    }
+}

--- a/crates/egui/src/debug_text.rs
+++ b/crates/egui/src/debug_text.rs
@@ -37,6 +37,9 @@ pub fn print(ctx: &Context, text: impl Into<WidgetText>) {
     let location = std::panic::Location::caller();
     let location = format!("{}:{}", location.file(), location.line());
     ctx.data_mut(|data| {
+        // We use `Id::NULL` as the id, since we only have one instance of this plugin.
+        // We use the `temp` version instead of `persisted` since we don't want to
+        // persist state on disk when the egui app is closed.
         let state = data.get_temp_mut_or_default::<State>(Id::NULL);
         state.entries.push(Entry {
             location,
@@ -51,7 +54,7 @@ struct Entry {
     text: WidgetText,
 }
 
-/// A pluging for easily showing debug-text on-screen.
+/// A plugin for easily showing debug-text on-screen.
 ///
 /// This is a built-in plugin in egui.
 #[derive(Clone, Default)]
@@ -69,9 +72,9 @@ impl State {
     }
 
     fn paint(self, ctx: &Context) {
-        let Self { entries: entires } = self;
+        let Self { entries } = self;
 
-        if entires.is_empty() {
+        if entries.is_empty() {
             return;
         }
 
@@ -89,7 +92,7 @@ impl State {
         let color = Color32::GRAY;
         let font_id = FontId::new(10.0, FontFamily::Proportional);
 
-        for Entry { location, text } in entires {
+        for Entry { location, text } in entries {
             {
                 // Paint location to left of `pos`:
                 let location_galley =

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -347,6 +347,7 @@ mod animation_manager;
 pub mod containers;
 mod context;
 mod data;
+pub mod debug_text;
 mod frame_state;
 pub(crate) mod grid;
 pub mod gui_zoom;

--- a/crates/egui/src/text_selection/label_text_selection.rs
+++ b/crates/egui/src/text_selection/label_text_selection.rs
@@ -145,6 +145,14 @@ impl Default for LabelSelectionState {
 }
 
 impl LabelSelectionState {
+    pub(crate) fn register(ctx: &Context) {
+        ctx.on_begin_frame(
+            "LabelSelectionState",
+            std::sync::Arc::new(Self::begin_frame),
+        );
+        ctx.on_end_frame("LabelSelectionState", std::sync::Arc::new(Self::end_frame));
+    }
+
     pub fn load(ctx: &Context) -> Self {
         ctx.data(|data| data.get_temp::<Self>(Id::NULL))
             .unwrap_or_default()
@@ -156,7 +164,7 @@ impl LabelSelectionState {
         });
     }
 
-    pub fn begin_frame(ctx: &Context) {
+    fn begin_frame(ctx: &Context) {
         let mut state = Self::load(ctx);
 
         if ctx.input(|i| i.pointer.any_pressed() && !i.modifiers.shift) {
@@ -177,7 +185,7 @@ impl LabelSelectionState {
         state.store(ctx);
     }
 
-    pub fn end_frame(ctx: &Context) {
+    fn end_frame(ctx: &Context) {
         let mut state = Self::load(ctx);
 
         if state.is_dragging {

--- a/crates/egui/src/util/id_type_map.rs
+++ b/crates/egui/src/util/id_type_map.rs
@@ -485,11 +485,10 @@ impl IdTypeMap {
 
     /// Remove and fetch the state of this type and id.
     #[inline]
-    pub fn remove_temp<T: 'static + Clone>(&mut self, id: Id) -> Option<T> {
+    pub fn remove_temp<T: 'static + Default>(&mut self, id: Id) -> Option<T> {
         let hash = hash(TypeId::of::<T>(), id);
-        self.map
-            .remove(&hash)
-            .and_then(|element| element.get_temp().cloned())
+        let mut element = self.map.remove(&hash)?;
+        Some(std::mem::take(element.get_mut_temp()?))
     }
 
     /// Note all state of the given type.


### PR DESCRIPTION
This can be useful for creating simple plugins for egui.

The state can be stored in the egui data store, or by the user.

An example plugin for painting debug text on screen is provided.