### PR TITLE
Fix menubar macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ NOTE: [`epaint`](crates/epaint/CHANGELOG.md), [`egui_plot`](crates/egui_plot/CHA
 This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
+# Unreleased
+* Fixed menubar in macOS
 
 ## 0.25.0 - 2024-01-08 - Better keyboard input
 

--- a/crates/eframe/src/native/app_icon.rs
+++ b/crates/eframe/src/native/app_icon.rs
@@ -3,6 +3,7 @@
 //! TODO(emilk): port this to [`winit`].
 
 use std::sync::Arc;
+use cocoa::appkit::NSEventModifierFlags;
 
 use egui::IconData;
 
@@ -267,7 +268,7 @@ fn set_title_and_icon_mac(_title: &str, icon_data: Option<&IconData>) -> AppIcon
         let hide_prefix = NSString::alloc(nil).init_str("Hide ");
         let hide_title =
             hide_prefix.stringByAppendingString_(NSProcessInfo::processInfo(nil).processName());
-        let hide_action = selector("hideApp:");
+        let hide_action = selector("hide:");
         let hide_key = NSString::alloc(nil).init_str("h");
         let hide_item = NSMenuItem::alloc(nil)
             .initWithTitle_action_keyEquivalent_(hide_title, hide_action, hide_key)
@@ -275,19 +276,16 @@ fn set_title_and_icon_mac(_title: &str, icon_data: Option<&IconData>) -> AppIcon
         app_menu.addItem_(hide_item);
 
         let hide_others_title = NSString::alloc(nil).init_str("Hide Others");
-        let hide_others_action = selector("hideOthers:");
-        let hide_others_key = NSString::alloc(nil).init_str("");
+        let hide_others_action = selector("hideOtherApplications:");
+        let hide_others_key = NSString::alloc(nil).init_str("h");
         let hide_others_item = NSMenuItem::alloc(nil)
-            .initWithTitle_action_keyEquivalent_(
-                hide_others_title,
-                hide_others_action,
-                hide_others_key,
-            )
+            .initWithTitle_action_keyEquivalent_(hide_others_title, hide_others_action, hide_others_key)
             .autorelease();
+        hide_others_item.setKeyEquivalentModifierMask_(NSEventModifierFlags::NSCommandKeyMask | NSEventModifierFlags::NSAlternateKeyMask);
         app_menu.addItem_(hide_others_item);
 
         let show_all_title = NSString::alloc(nil).init_str("Show All");
-        let show_all_action = selector("showAll:");
+        let show_all_action = selector("unhideAllApplications:");
         let show_all_key = NSString::alloc(nil).init_str("");
         let show_all_item = NSMenuItem::alloc(nil)
             .initWithTitle_action_keyEquivalent_(show_all_title, show_all_action, show_all_key)

--- a/crates/eframe/src/native/app_icon.rs
+++ b/crates/eframe/src/native/app_icon.rs
@@ -205,7 +205,7 @@ fn set_title_and_icon_mac(_title: &str, icon_data: Option<&IconData>) -> AppIcon
     use cocoa::{
         appkit::{NSApp, NSApplication, NSImage, NSMenu, NSMenuItem},
         base::{nil, selector},
-        foundation::{NSData, NSString, NSAutoreleasePool, NSProcessInfo},
+        foundation::{NSAutoreleasePool, NSData, NSProcessInfo, NSString},
     };
 
     let png_bytes = if let Some(icon_data) = icon_data {
@@ -278,7 +278,11 @@ fn set_title_and_icon_mac(_title: &str, icon_data: Option<&IconData>) -> AppIcon
         let hide_others_action = selector("hideOthers:");
         let hide_others_key = NSString::alloc(nil).init_str("");
         let hide_others_item = NSMenuItem::alloc(nil)
-            .initWithTitle_action_keyEquivalent_(hide_others_title, hide_others_action, hide_others_key)
+            .initWithTitle_action_keyEquivalent_(
+                hide_others_title,
+                hide_others_action,
+                hide_others_key,
+            )
             .autorelease();
         app_menu.addItem_(hide_others_item);
 

--- a/crates/eframe/src/native/app_icon.rs
+++ b/crates/eframe/src/native/app_icon.rs
@@ -253,6 +253,43 @@ fn set_title_and_icon_mac(_title: &str, icon_data: Option<&IconData>) -> AppIcon
 
         // create Application menu
         let app_menu = NSMenu::new(nil).autorelease();
+
+        let about_prefix = NSString::alloc(nil).init_str("About ");
+        let about_title =
+            about_prefix.stringByAppendingString_(NSProcessInfo::processInfo(nil).processName());
+        let about_action = selector("orderFrontStandardAboutPanel:");
+        let about_key = NSString::alloc(nil).init_str("");
+        let about_item = NSMenuItem::alloc(nil)
+            .initWithTitle_action_keyEquivalent_(about_title, about_action, about_key)
+            .autorelease();
+        app_menu.addItem_(about_item);
+
+        let hide_prefix = NSString::alloc(nil).init_str("Hide ");
+        let hide_title =
+            hide_prefix.stringByAppendingString_(NSProcessInfo::processInfo(nil).processName());
+        let hide_action = selector("hideApp:");
+        let hide_key = NSString::alloc(nil).init_str("h");
+        let hide_item = NSMenuItem::alloc(nil)
+            .initWithTitle_action_keyEquivalent_(hide_title, hide_action, hide_key)
+            .autorelease();
+        app_menu.addItem_(hide_item);
+
+        let hide_others_title = NSString::alloc(nil).init_str("Hide Others");
+        let hide_others_action = selector("hideOthers:");
+        let hide_others_key = NSString::alloc(nil).init_str("");
+        let hide_others_item = NSMenuItem::alloc(nil)
+            .initWithTitle_action_keyEquivalent_(hide_others_title, hide_others_action, hide_others_key)
+            .autorelease();
+        app_menu.addItem_(hide_others_item);
+
+        let show_all_title = NSString::alloc(nil).init_str("Show All");
+        let show_all_action = selector("showAll:");
+        let show_all_key = NSString::alloc(nil).init_str("");
+        let show_all_item = NSMenuItem::alloc(nil)
+            .initWithTitle_action_keyEquivalent_(show_all_title, show_all_action, show_all_key)
+            .autorelease();
+        app_menu.addItem_(show_all_item);
+
         let quit_prefix = NSString::alloc(nil).init_str("Quit ");
         let quit_title =
             quit_prefix.stringByAppendingString_(NSProcessInfo::processInfo(nil).processName());
@@ -262,6 +299,7 @@ fn set_title_and_icon_mac(_title: &str, icon_data: Option<&IconData>) -> AppIcon
             .initWithTitle_action_keyEquivalent_(quit_title, quit_action, quit_key)
             .autorelease();
         app_menu.addItem_(quit_item);
+
         app_menu_item.setSubmenu_(app_menu);
 
         // The title in the Dock apparently can't be changed.

--- a/crates/eframe/src/native/app_icon.rs
+++ b/crates/eframe/src/native/app_icon.rs
@@ -2,7 +2,6 @@
 //!
 //! TODO(emilk): port this to [`winit`].
 
-use cocoa::appkit::NSEventModifierFlags;
 use std::sync::Arc;
 
 use egui::IconData;
@@ -204,7 +203,7 @@ fn set_title_and_icon_mac(_title: &str, icon_data: Option<&IconData>) -> AppIcon
     use crate::icon_data::IconDataExt as _;
     crate::profile_function!();
     use cocoa::{
-        appkit::{NSApp, NSApplication, NSImage, NSMenu, NSMenuItem},
+        appkit::{NSApp, NSApplication, NSEventModifierFlags, NSImage, NSMenu, NSMenuItem},
         base::{nil, selector},
         foundation::{NSAutoreleasePool, NSData, NSProcessInfo, NSString},
     };

--- a/crates/eframe/src/native/app_icon.rs
+++ b/crates/eframe/src/native/app_icon.rs
@@ -2,8 +2,8 @@
 //!
 //! TODO(emilk): port this to [`winit`].
 
-use std::sync::Arc;
 use cocoa::appkit::NSEventModifierFlags;
+use std::sync::Arc;
 
 use egui::IconData;
 
@@ -279,9 +279,15 @@ fn set_title_and_icon_mac(_title: &str, icon_data: Option<&IconData>) -> AppIcon
         let hide_others_action = selector("hideOtherApplications:");
         let hide_others_key = NSString::alloc(nil).init_str("h");
         let hide_others_item = NSMenuItem::alloc(nil)
-            .initWithTitle_action_keyEquivalent_(hide_others_title, hide_others_action, hide_others_key)
+            .initWithTitle_action_keyEquivalent_(
+                hide_others_title,
+                hide_others_action,
+                hide_others_key,
+            )
             .autorelease();
-        hide_others_item.setKeyEquivalentModifierMask_(NSEventModifierFlags::NSCommandKeyMask | NSEventModifierFlags::NSAlternateKeyMask);
+        hide_others_item.setKeyEquivalentModifierMask_(
+            NSEventModifierFlags::NSCommandKeyMask | NSEventModifierFlags::NSAlternateKeyMask,
+        );
         app_menu.addItem_(hide_others_item);
 
         let show_all_title = NSString::alloc(nil).init_str("Show All");


### PR DESCRIPTION
I noticed that on macOS the menubar is not looking right anymore:
<img width="301" alt="Bildschirmfoto 2024-01-26 um 07 43 21" src="https://github.com/emilk/egui/assets/33124824/f43c32d3-17c3-42df-99f5-085a5e59b1af">
This PR applies some changes, it would further also allow for a "Settings" window to be implemented, if there would be an egui container for that (we would only need to create a new item in `app_icons.rs`).
The menu bar now looks like this:
<img width="302" alt="Bildschirmfoto 2024-01-26 um 09 04 00" src="https://github.com/emilk/egui/assets/33124824/e464b4b8-4ad9-4356-b6ae-7b3571717c0d">

TODO:
- I have not yet managed to replicate the separator lines