### PR TITLE
ui.label() : `truncate` default value is `true`

### DIFF
--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -33,7 +33,7 @@ impl Label {
         Self {
             text: text.into(),
             wrap: None,
-            truncate: false,
+            truncate: true,
             sense: None,
             selectable: None,
         }


### PR DESCRIPTION
ui.label() :
`truncate` default value is `true` to prevent egui::window size from increasing.
