### PR TITLE
Re-try adapter creation if creation with WebGPU enabled fails and WebGL was enabled.

### DIFF
--- a/crates/eframe/src/web/web_painter_wgpu.rs
+++ b/crates/eframe/src/web/web_painter_wgpu.rs
@@ -157,7 +157,7 @@ impl WebPainterWgpu {
                     instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
                         backends,
                         ..Default::default()
-                    })
+                    });
                 } else {
                     return Err(
                         "Failed to create WebGPU adapter and WebGL was not enabled.".to_owned()

--- a/crates/eframe/src/web/web_painter_wgpu.rs
+++ b/crates/eframe/src/web/web_painter_wgpu.rs
@@ -127,12 +127,9 @@ impl WebPainterWgpu {
         // Therefore, we have to first check if it's possible to create a WebGPU adapter,
         // and if it is not, start over with a WebGL instance.
         //
-        // Note that we also might end up here if wgpu didn't detect WebGPU support,
-        // moved on to create a wgpu-core instance and then failed to create a WebGL adapter.
-        // To detect this we'd need to check what kind of instance wgpu created,
-        // but this is currently not easily possible. See https://github.com/gfx-rs/wgpu/issues/5142
-        // In that case we'd be trying the same thing again which isn't ideal, but we're in a
-        // pretty bad situation anyway.
+        // Note that we also might needlessly try this here if wgpu already determined that there's no
+        // WebGPU support in the first place. This is not a huge problem since it fails very fast, but
+        // it would be nice to avoid this. See https://github.com/gfx-rs/wgpu/issues/5142
         if backends.contains(wgpu::Backends::BROWSER_WEBGPU) {
             log::debug!("Attempting to create WebGPU adapter to check for support.");
             if let Some(adapter) = instance


### PR DESCRIPTION
* Filed this in relation to the changes here https://github.com/gfx-rs/wgpu/issues/5142
* Fixes https://github.com/rerun-io/rerun/issues/4915

Draft until fully confirmed this works on Linux Chrome