### PR TITLE
`Response.context_menu` now returns the response of the context menu, if open

### DIFF
--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -718,8 +718,8 @@ impl Response {
     /// ```
     ///
     /// See also: [`Ui::menu_button`] and [`Ui::close_menu`].
-    pub fn context_menu(&self, add_contents: impl FnOnce(&mut Ui)) {
-        menu::context_menu(&self, add_contents);
+    pub fn context_menu(&self, add_contents: impl FnOnce(&mut Ui)) -> Option<InnerResponse<()>> {
+        menu::context_menu(&self, add_contents)
     }
 }
 

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -719,7 +719,7 @@ impl Response {
     ///
     /// See also: [`Ui::menu_button`] and [`Ui::close_menu`].
     pub fn context_menu(&self, add_contents: impl FnOnce(&mut Ui)) -> Option<InnerResponse<()>> {
-        menu::context_menu(&self, add_contents)
+        menu::context_menu(self, add_contents)
     }
 }
 

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -718,9 +718,8 @@ impl Response {
     /// ```
     ///
     /// See also: [`Ui::menu_button`] and [`Ui::close_menu`].
-    pub fn context_menu(self, add_contents: impl FnOnce(&mut Ui)) -> Self {
+    pub fn context_menu(&self, add_contents: impl FnOnce(&mut Ui)) {
         menu::context_menu(&self, add_contents);
-        self
     }
 }
 

--- a/crates/egui_demo_lib/src/demo/drag_and_drop.rs
+++ b/crates/egui_demo_lib/src/demo/drag_and_drop.rs
@@ -144,7 +144,7 @@ impl super::View for DragAndDropDemo {
                 })
                 .response;
 
-                let response = response.context_menu(|ui| {
+                response.context_menu(|ui| {
                     if ui.button("New Item").clicked() {
                         self.columns[col_idx].push("New Item".to_owned());
                         ui.close_menu();


### PR DESCRIPTION
Hi everyone! It's a great pleasure to work with such a library. It feels like a breath of fresh air!

**Problem:**

The current implementation of `context_menu` consumes `self` and returns it. However, the underlying `menu::context_menu` requires only a reference to `self`, so it is safe to change the `context_menu` signature. 

**Fix:**

1. Change signature to take a ref to `self`. 
2. Return the `Option<InnerResponse<()>>` from the underlying method call

**Pros:**

1. No `let response =  response.context_menu(|| {...})` pattern
2. Better consistency with other `show`-like methods, as it is in the `Window::show`
3. Less ownership gymnastics

**Cons:**
1. Breaking change
2. Smth else what I don't see ?

**Additional info:**
- This method is also addressed in [this PR](https://github.com/emilk/egui/pull/857). 
- `check.sh` fails only on `cargo check --quiet -p eframe --no-default-features --features wgpu` with `"The platform you're compiling for is not supported by winit"` error, should it be launched at all ?
