### PR TITLE
Refactor response bools to bitflags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,6 +1229,7 @@ dependencies = [
  "accesskit",
  "ahash",
  "backtrace",
+ "bitflags 2.4.0",
  "document-features",
  "epaint",
  "log",

--- a/crates/egui/Cargo.toml
+++ b/crates/egui/Cargo.toml
@@ -92,6 +92,7 @@ backtrace = { version = "0.3", optional = true }
 ## Enable this when generating docs.
 document-features = { version = "0.2", optional = true }
 
+bitflags = "2.4"
 log = { version = "0.4", optional = true, features = ["std"] }
 puffin = { workspace = true, optional = true }
 ron = { version = "0.8", optional = true }

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1065,7 +1065,7 @@ impl Context {
                                     interaction.drag_id = Some(id);
                                     interaction.drag_is_window = false;
                                     memory.set_window_interaction(None); // HACK: stop moving windows (if any)
-                                    response
+                                    res
                                         .state
                                         .insert(ResponseState::IS_POINTER_BUTTON_DOWN_ON);
 
@@ -1082,13 +1082,10 @@ impl Context {
                         }
 
                         PointerEvent::Released { click, button } => {
-                            res.drag_released = res.dragged;
-                            res.dragged = false;
                             res
                                 .state
-                                .set(ResponseState::DRAG_RELEASED, response.dragged());
+                                .set(ResponseState::DRAG_RELEASED, res.dragged());
                             res.state.remove(ResponseState::DRAGGED);
-
 
                             if sense.click && res.hovered() && res.is_pointer_button_down_on() {
                                 if let Some(click) = click {

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -960,7 +960,10 @@ impl Context {
         state.set(ResponseState::ENABLED, enabled);
         state.set(ResponseState::CONTAINS_POINTER, contains_pointer);
         state.set(ResponseState::HOVERED, contains_pointer && enabled);
-        state.set(ResponseState::HIGHLIGHTED, self.frame_state(|fs| fs.highlight_this_frame.contains(&id)));
+        state.set(
+            ResponseState::HIGHLIGHTED,
+            self.frame_state(|fs| fs.highlight_this_frame.contains(&id)),
+        );
 
         // This is the start - we'll fill in the fields below:
         let mut res = Response {
@@ -1022,20 +1025,29 @@ impl Context {
                 interaction.click_interest |= contains_pointer && sense.click;
                 interaction.drag_interest |= contains_pointer && sense.drag;
 
-                res.state.set(ResponseState::IS_POINTER_BUTTON_DOWN_ON, interaction.click_id == Some(id) || interaction.drag_id == Some(id));
+                res.state.set(
+                    ResponseState::IS_POINTER_BUTTON_DOWN_ON,
+                    interaction.click_id == Some(id) || interaction.drag_id == Some(id),
+                );
 
                 if sense.click && sense.drag {
                     // This widget is sensitive to both clicks and drags.
                     // When the mouse first is pressed, it could be either,
                     // so we postpone the decision until we know.
-                    res.state.set(ResponseState::DRAGGED, interaction.drag_id == Some(id) && input.pointer.is_decidedly_dragging());
-                    res.state.set(ResponseState::DRAG_STARTED, res.dragged() && input.pointer.started_decidedly_dragging);
+                    res.state.set(
+                        ResponseState::DRAGGED,
+                        interaction.drag_id == Some(id) && input.pointer.is_decidedly_dragging(),
+                    );
+                    res.state.set(
+                        ResponseState::DRAG_STARTED,
+                        res.dragged() && input.pointer.started_decidedly_dragging,
+                    );
                 } else if sense.drag {
                     // We are just sensitive to drags, so we can mark ourself as dragged right away:
-                    res.state.set(ResponseState::DRAGGED, interaction.drag_id == Some(id));
+                    res.state
+                        .set(ResponseState::DRAGGED, interaction.drag_id == Some(id));
                     // res.drag_started will be filled below if applicable
                 }
-
 
                 for pointer_event in &input.pointer.pointer_events {
                     match pointer_event {
@@ -1048,9 +1060,7 @@ impl Context {
                                 if sense.click && interaction.click_id.is_none() {
                                     // potential start of a click
                                     interaction.click_id = Some(id);
-                                    res
-                                        .state
-                                        .insert(ResponseState::IS_POINTER_BUTTON_DOWN_ON);
+                                    res.state.insert(ResponseState::IS_POINTER_BUTTON_DOWN_ON);
                                 }
 
                                 // HACK: windows have low priority on dragging.
@@ -1065,9 +1075,8 @@ impl Context {
                                     interaction.drag_id = Some(id);
                                     interaction.drag_is_window = false;
                                     memory.set_window_interaction(None); // HACK: stop moving windows (if any)
-                                    res
-                                        .state
-                                        .insert(ResponseState::IS_POINTER_BUTTON_DOWN_ON);
+
+                                    res.state.insert(ResponseState::IS_POINTER_BUTTON_DOWN_ON);
 
                                     // Again, only if we are ONLY sensitive to drags can we decide that this is a drag now.
                                     if sense.click {
@@ -1082,9 +1091,7 @@ impl Context {
                         }
 
                         PointerEvent::Released { click, button } => {
-                            res
-                                .state
-                                .set(ResponseState::DRAG_RELEASED, res.dragged());
+                            res.state.set(ResponseState::DRAG_RELEASED, res.dragged());
                             res.state.remove(ResponseState::DRAGGED);
 
                             if sense.click && res.hovered() && res.is_pointer_button_down_on() {
@@ -1098,9 +1105,7 @@ impl Context {
                                 }
                             }
 
-                            res
-                                .state
-                                .remove(ResponseState::IS_POINTER_BUTTON_DOWN_ON);
+                            res.state.remove(ResponseState::IS_POINTER_BUTTON_DOWN_ON);
                         }
                     }
                 }

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -999,7 +999,7 @@ impl Context {
                                     interaction.click_id = Some(id);
                                     response
                                         .state
-                                        .set(ResponseState::IS_POINTER_BUTTON_DOWN_ON, true);
+                                        .insert(ResponseState::IS_POINTER_BUTTON_DOWN_ON);
                                 }
 
                                 // HACK: windows have low priority on dragging.
@@ -1016,8 +1016,8 @@ impl Context {
                                     memory.set_window_interaction(None); // HACK: stop moving windows (if any)
                                     response
                                         .state
-                                        .set(ResponseState::IS_POINTER_BUTTON_DOWN_ON, true);
-                                    response.state.set(ResponseState::DRAGGED, true);
+                                        .insert(ResponseState::IS_POINTER_BUTTON_DOWN_ON);
+                                    response.state.insert(ResponseState::DRAGGED);
                                 }
                             }
                         }
@@ -1025,7 +1025,7 @@ impl Context {
                             response
                                 .state
                                 .set(ResponseState::DRAG_RELEASED, response.dragged());
-                            response.state.set(ResponseState::DRAGGED, false);
+                            response.state.remove(ResponseState::DRAGGED);
 
                             if hovered && response.is_pointer_button_down_on() {
                                 if let Some(click) = click {
@@ -1040,7 +1040,7 @@ impl Context {
 
                             response
                                 .state
-                                .set(ResponseState::IS_POINTER_BUTTON_DOWN_ON, false);
+                                .remove(ResponseState::IS_POINTER_BUTTON_DOWN_ON);
                         }
                     }
                 }
@@ -1052,7 +1052,7 @@ impl Context {
 
             if input.pointer.any_down() && !response.is_pointer_button_down_on() {
                 // We don't hover widgets while interacting with *other* widgets:
-                response.state.set(ResponseState::HOVERED, false);
+                response.state.remove(ResponseState::HOVERED);
             }
 
             if memory.has_focus(response.id) && clicked_elsewhere {

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -424,7 +424,7 @@ pub use {
     load::SizeHint,
     memory::{Memory, Options},
     painter::Painter,
-    response::{InnerResponse, Response},
+    response::{InnerResponse, Response, ResponseState},
     sense::Sense,
     style::{FontSelection, Margin, Style, TextStyle, Visuals},
     text::{Galley, TextFormat},

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -9,7 +9,7 @@ use crate::{
 bitflags::bitflags! {
     /// The state of a widget.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct ResponseState: u8 {
+    pub struct ResponseState: u16 {
         /// Was the widget enabled?
         /// If `false`, there was no interaction attempted (not even hover).
         const ENABLED = 1;
@@ -23,21 +23,24 @@ bitflags::bitflags! {
         /// The widget is highlighted via a call to [`Response::highlight`] or [`Context::highlight_widget`].
         const HIGHLIGHTED = 1 << 3;
 
+        /// The widget started being dragged this frame.
+        const DRAG_STARTED = 1 << 4;
+
         /// The widgets is being dragged
-        const DRAGGED = 1 << 4;
+        const DRAGGED = 1 << 5;
 
         /// The widget was being dragged, but now it has been released.
-        const DRAG_RELEASED = 1 << 5;
+        const DRAG_RELEASED = 1 << 6;
 
         /// Is the pointer button currently down on this widget?
         /// This is true if the pointer is pressing down or dragging a widget
-        const IS_POINTER_BUTTON_DOWN_ON = 1 << 6;
+        const IS_POINTER_BUTTON_DOWN_ON = 1 << 7;
 
         /// Was the underlying data changed?
         ///
         /// e.g. the slider was dragged, text was entered in a [`TextEdit`](crate::TextEdit) etc.
         /// Always `false` for something like a [`Button`](crate::Button).
-        const CHANGED = 1 << 7;
+        const CHANGED = 1 << 8;
     }
 }
 
@@ -264,7 +267,7 @@ impl Response {
     /// This will only be true for a single frame.
     #[inline]
     pub fn drag_started(&self) -> bool {
-        self.drag_started
+        self.state.contains(ResponseState::DRAG_STARTED)
     }
 
     /// Did a drag on this widgets by the button begin this frame?

--- a/crates/egui/src/text_selection/label_text_selection.rs
+++ b/crates/egui/src/text_selection/label_text_selection.rs
@@ -469,7 +469,7 @@ impl LabelSelectionState {
     fn on_label(&mut self, ui: &Ui, response: &Response, galley_pos: Pos2, galley: &Galley) {
         let widget_id = response.id;
 
-        if response.hovered {
+        if response.hovered() {
             ui.ctx().set_cursor_icon(CursorIcon::Text);
         }
 

--- a/crates/egui/src/text_selection/label_text_selection.rs
+++ b/crates/egui/src/text_selection/label_text_selection.rs
@@ -16,7 +16,7 @@ pub fn label_text_selection(ui: &Ui, response: &Response, galley_pos: Pos2, gall
     let mut cursor_state = LabelSelectionState::load(ui.ctx(), response.id);
     let original_cursor = cursor_state.range(galley);
 
-    if response.hovered {
+    if response.hovered() {
         ui.ctx().set_cursor_icon(CursorIcon::Text);
     } else if !cursor_state.is_empty() && ui.input(|i| i.pointer.any_pressed()) {
         // We clicked somewhere else - deselect this label.

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1527,7 +1527,7 @@ impl Ui {
         // only touch `*radians` if we actually changed the degree value
         if degrees != radians.to_degrees() {
             *radians = degrees.to_radians();
-            response.changed = true;
+            response.state.set(ResponseState::CHANGED, true);
         }
 
         response
@@ -1550,7 +1550,7 @@ impl Ui {
         // only touch `*radians` if we actually changed the value
         if taus != *radians / TAU {
             *radians = taus * TAU;
-            response.changed = true;
+            response.state.set(ResponseState::CHANGED, true);
         }
 
         response

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1527,7 +1527,7 @@ impl Ui {
         // only touch `*radians` if we actually changed the degree value
         if degrees != radians.to_degrees() {
             *radians = degrees.to_radians();
-            response.state.set(ResponseState::CHANGED, true);
+            response.state.insert(ResponseState::CHANGED);
         }
 
         response
@@ -1550,7 +1550,7 @@ impl Ui {
         // only touch `*radians` if we actually changed the value
         if taus != *radians / TAU {
             *radians = taus * TAU;
-            response.state.set(ResponseState::CHANGED, true);
+            response.state.insert(ResponseState::CHANGED);
         }
 
         response

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -328,7 +328,7 @@ impl Widget for Button<'_> {
         }
 
         if let Some(cursor) = ui.visuals().interact_cursor {
-            if response.hovered {
+            if response.hovered() {
                 ui.ctx().set_cursor_icon(cursor);
             }
         }

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -582,7 +582,9 @@ impl<'a> Widget for DragValue<'a> {
             response
         };
 
-        response.changed = get(&mut get_set_value) != old_value;
+        response
+            .state
+            .set(ResponseState::CHANGED, get(&mut get_set_value) != old_value);
 
         response.widget_info(|| WidgetInfo::drag_value(value));
 

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -868,7 +868,9 @@ impl<'a> Slider<'a> {
         self.slider_ui(ui, &response);
 
         let value = self.get_value();
-        response.changed = value != old_value;
+        response
+            .state
+            .set(ResponseState::CHANGED, value != old_value);
         response.widget_info(|| WidgetInfo::slider(value, self.text.text()));
 
         #[cfg(feature = "accesskit")]

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -667,7 +667,7 @@ impl<'t> TextEdit<'t> {
                         cursor_rect(galley_pos, &galley, &cursor_range.primary, row_height);
 
                     let is_fully_visible = ui.clip_rect().contains_rect(rect); // TODO: remove this HACK workaround for https://github.com/emilk/egui/issues/1531
-                    if (response.changed || selection_changed) && !is_fully_visible {
+                    if (response.changed() || selection_changed) && !is_fully_visible {
                         // Scroll to keep primary cursor in view:
                         ui.scroll_to_rect(primary_cursor_rect, None);
                     }
@@ -691,7 +691,7 @@ impl<'t> TextEdit<'t> {
 
         state.clone().store(ui.ctx(), id);
 
-        if response.changed {
+        if response.changed() {
             response.widget_info(|| {
                 WidgetInfo::text_edit(
                     mask_if_password(password, prev_text.as_str()),


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

This PR focuses primarily on adding the `bitflags` dependency and converting the immediate `bool`s in `Response` into bitflags. I'm mainly looking for style feedback before diving into the `[bool; NUM_POINTER_BUTTONS]` and `Sense` bitflags.

Tested manually with some basic sanity testing as well as `cargo test`.

Partially fixes #3862
