### PR TITLE
Enable winit backends when building egui-wgpu on docs.rs to fix failures

### DIFF
--- a/crates/egui-wgpu/Cargo.toml
+++ b/crates/egui-wgpu/Cargo.toml
@@ -25,6 +25,7 @@ include = [
 
 [package.metadata.docs.rs]
 all-features = true
+features = ["winit/x11", "winit/wayland"]
 
 
 [features]


### PR DESCRIPTION

I tested that this command fails:
```
cargo doc -p egui-wgpu --all-features --no-deps 
```
And that this one, which I think will correspond to these changes, succeeds:
```
cargo doc -p egui-wgpu --all-features --features "winit/x11 winit/wayland" --no-deps 
```

https://github.com/emilk/egui/issues/3492 should be fixed by this


Also, I noticed that the PR template and `CONTRIBUTING.md` mention running `./scripts/check.sh` which in a few cases has the same issue of winit failing to build with no backends enabled. I guess this script hasn't been in use?

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->