### PR TITLE
Add `x11` and `wayland` features to egui-wgpu and egui_glow

### DIFF
--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -88,7 +88,11 @@ puffin = [
 ]
 
 ## Enables wayland support and fixes clipboard issue.
-wayland = ["egui-winit/wayland", "egui-wgpu?/wayland", "egui_glow?/wayland"]
+wayland = [
+  "egui-winit/wayland",
+  "egui-wgpu?/wayland",
+  "egui_glow?/wayland",
+]
 
 ## Enable screen reader support (requires `ctx.options_mut(|o| o.screen_reader = true);`) on web.
 ##
@@ -114,7 +118,11 @@ web_screen_reader = [
 wgpu = ["dep:wgpu", "dep:egui-wgpu", "dep:pollster"]
 
 ## Enables compiling for x11.
-x11 = ["egui-winit/x11", "egui-wgpu?/x11", "egui_glow?/x11"]
+x11 = [
+  "egui-winit/x11",
+  "egui-wgpu?/x11",
+  "egui_glow?/x11",
+]
 
 ## If set, eframe will look for the env-var `EFRAME_SCREENSHOT_TO` and write a screenshot to that location, and then quit.
 ## This is used to generate images for examples.

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -88,7 +88,7 @@ puffin = [
 ]
 
 ## Enables wayland support and fixes clipboard issue.
-wayland = ["egui-winit/wayland"]
+wayland = ["egui-winit/wayland", "egui-wgpu?/wayland", "egui_glow?/wayland"]
 
 ## Enable screen reader support (requires `ctx.options_mut(|o| o.screen_reader = true);`) on web.
 ##
@@ -114,7 +114,7 @@ web_screen_reader = [
 wgpu = ["dep:wgpu", "dep:egui-wgpu", "dep:pollster"]
 
 ## Enables compiling for x11.
-x11 = ["egui-winit/x11"]
+x11 = ["egui-winit/x11", "egui-wgpu?/x11", "egui_glow?/x11"]
 
 ## If set, eframe will look for the env-var `EFRAME_SCREENSHOT_TO` and write a screenshot to that location, and then quit.
 ## This is used to generate images for examples.

--- a/crates/egui-wgpu/Cargo.toml
+++ b/crates/egui-wgpu/Cargo.toml
@@ -31,8 +31,14 @@ all-features = true
 ## Enable profiling with the [`puffin`](https://docs.rs/puffin) crate.
 puffin = ["dep:puffin"]
 
-## Enable [`winit`](https://docs.rs/winit) integration.
+## Enable [`winit`](https://docs.rs/winit) integration. On Linux, requires either `wayland` or `x11`
 winit = ["dep:winit"]
+
+## Enables Wayland support for winit.
+wayland = ["winit?/wayland"]
+
+## Enables x11 support for winit.
+x11 = ["winit?/x11"]
 
 
 [dependencies]

--- a/crates/egui_demo_app/Cargo.toml
+++ b/crates/egui_demo_app/Cargo.toml
@@ -30,6 +30,8 @@ syntect = ["egui_demo_lib/syntect"]
 
 glow = ["eframe/glow"]
 wgpu = ["eframe/wgpu", "bytemuck", "dep:wgpu"]
+wayland = ["eframe/wayland"]
+x11 = ["eframe/x11"]
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = [

--- a/crates/egui_glow/Cargo.toml
+++ b/crates/egui_glow/Cargo.toml
@@ -39,8 +39,14 @@ links = ["egui-winit?/links"]
 ## Enable profiling with the [`puffin`](https://docs.rs/puffin) crate.
 puffin = ["dep:puffin", "egui-winit?/puffin", "egui/puffin"]
 
-## Enable [`winit`](https://docs.rs/winit) integration.
+## Enable [`winit`](https://docs.rs/winit) integration. On Linux, requires either `wayland` or `x11`
 winit = ["egui-winit", "dep:winit"]
+
+## Enables Wayland support for winit.
+wayland = ["winit?/wayland"]
+
+## Enables x11 support for winit.
+x11 = ["winit?/x11"]
 
 
 [dependencies]

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -35,10 +35,23 @@ cargo test  --quiet --all-targets --all-features
 cargo test  --quiet --doc # slow - checks all doc-tests
 
 cargo check --quiet -p eframe --no-default-features --features "glow"
-cargo check --quiet -p eframe --no-default-features --features "wgpu"
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  cargo check --quiet -p eframe --no-default-features --features "wgpu","x11"
+  cargo check --quiet -p eframe --no-default-features --features "wgpu","wayland"
+else
+  cargo check --quiet -p eframe --no-default-features --features "wgpu"
+fi
+
 cargo check --quiet -p egui --no-default-features --features "serde"
-cargo check --quiet -p egui_demo_app --no-default-features --features "glow"
-cargo check --quiet -p egui_demo_app --no-default-features --features "wgpu"
+cargo check --quiet -p egui_demo_app --no-default-features --features "glow","x11"
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  cargo check --quiet -p egui_demo_app --no-default-features --features "wgpu","x11"
+  cargo check --quiet -p egui_demo_app --no-default-features --features "wgpu","wayland"
+else
+  cargo check --quiet -p egui_demo_app --no-default-features --features "wgpu"
+fi
+
 cargo check --quiet -p egui_demo_lib --no-default-features
 cargo check --quiet -p egui_extras --no-default-features
 cargo check --quiet -p egui_glow --no-default-features

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -43,7 +43,7 @@ else
 fi
 
 cargo check --quiet -p egui --no-default-features --features "serde"
-cargo check --quiet -p egui_demo_app --no-default-features --features "glow","x11"
+cargo check --quiet -p egui_demo_app --no-default-features --features "glow"
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   cargo check --quiet -p egui_demo_app --no-default-features --features "wgpu","x11"


### PR DESCRIPTION
This allows them to build correctly on Linux by passing one or both of the features alongside `winit`.

Closes #3492
Closes #2286
