### PR TITLE
Postpone call to get_current_texture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,6 +1239,7 @@ dependencies = [
  "puffin",
  "thiserror",
  "type-map",
+ "web-time",
  "wgpu",
  "winit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ glow = "0.13"
 puffin = "0.18"
 raw-window-handle = "0.6.0"
 thiserror = "1.0.37"
+web-time = "0.2" # Timekeeping for native and web
 wgpu = { version = "0.19.1", default-features = false, features = [
     # Make the renderer `Sync` even on wasm32, because it makes the code simpler:
     "fragile-send-sync-non-atomic-wasm",

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -644,7 +644,7 @@ impl WgpuWinitRunning {
             let clipped_primitives = egui_ctx.tessellate(shapes, pixels_per_point);
 
             let screenshot_requested = std::mem::take(&mut viewport.screenshot_requested);
-            let screenshot = painter.paint_and_update_textures(
+            let (_vsync_secs, screenshot) = painter.paint_and_update_textures(
                 viewport_id,
                 pixels_per_point,
                 app.clear_color(&egui_ctx.style().visuals),

--- a/crates/egui-wgpu/Cargo.toml
+++ b/crates/egui-wgpu/Cargo.toml
@@ -45,6 +45,7 @@ bytemuck = "1.7"
 log = { version = "0.4", features = ["std"] }
 thiserror.workspace = true
 type-map = "0.5.0"
+web-time.workspace = true
 wgpu = { workspace = true, features = ["wgsl"] }
 
 #! ### Optional dependencies

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -572,7 +572,7 @@ impl Painter {
 
         let output_frame = {
             crate::profile_scope!("get_current_texture");
-            // This is what vsync-waiting happens everywhere except DX12
+            // This is where vsnc happens:
             let start = web_time::Instant::now();
             let output_frame = surface_state.surface.get_current_texture();
             vsync_sec += start.elapsed().as_secs_f32();
@@ -669,11 +669,9 @@ impl Painter {
         // Submit the commands: both the main buffer and user-defined ones.
         {
             crate::profile_scope!("Queue::submit");
-            let start = web_time::Instant::now();
             render_state
                 .queue
                 .submit(user_cmd_bufs.into_iter().chain([encoded]));
-            vsync_sec += start.elapsed().as_secs_f32(); // Maybe vsync happens here too sometimes?
         };
 
         let screenshot = if capture {
@@ -688,10 +686,7 @@ impl Painter {
 
         {
             crate::profile_scope!("present");
-            // This is where vsync happens in DX12
-            let start = web_time::Instant::now();
             output_frame.present();
-            vsync_sec += start.elapsed().as_secs_f32();
         }
 
         (vsync_sec, screenshot)

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -589,8 +589,11 @@ impl Painter {
                     render_state,
                 );
                 self.screen_capture_state
-                    .as_ref()?
-                    .texture
+                    .as_ref()
+                    .map_or_else(
+                        || &output_frame.texture,
+                        |capture_state| &capture_state.texture,
+                    )
                     .create_view(&wgpu::TextureViewDescriptor::default())
             } else {
                 output_frame
@@ -660,8 +663,11 @@ impl Painter {
         };
 
         let screenshot = if capture {
-            let screen_capture_state = self.screen_capture_state.as_ref()?;
-            Self::read_screen_rgba(screen_capture_state, render_state, &output_frame)
+            self.screen_capture_state
+                .as_ref()
+                .and_then(|screen_capture_state| {
+                    Self::read_screen_rgba(screen_capture_state, render_state, &output_frame)
+                })
         } else {
             None
         };

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -563,7 +563,7 @@ impl Painter {
 
         let output_frame = {
             crate::profile_scope!("get_current_texture");
-            // This is what vsync-waiting happens, at least on Mac.
+            // This is what vsync-waiting happens everywhere except DX12
             surface_state.surface.get_current_texture()
         };
 
@@ -668,6 +668,7 @@ impl Painter {
 
         {
             crate::profile_scope!("present");
+            // This is where vsync happens in DX12
             output_frame.present();
         }
         screenshot

--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -60,7 +60,7 @@ egui = { version = "0.25.0", path = "../egui", default-features = false, feature
 ] }
 log = { version = "0.4", features = ["std"] }
 raw-window-handle.workspace = true
-web-time = { version = "0.2" } # We use web-time so we can (maybe) compile for web
+web-time.workspace = true
 winit = { workspace = true, default-features = false, features = ["rwh_06"] }
 
 #! ### Optional dependencies


### PR DESCRIPTION
This should help slightly with CPU/GPU parallelism when vsync is on.

I also return the time spent on vsync, which can help users figure out how much CPU wall-time was used on non-vsync stuff