### PR TITLE
Add opacity factor to TextShape

### DIFF
--- a/crates/epaint/src/shape.rs
+++ b/crates/epaint/src/shape.rs
@@ -288,6 +288,19 @@ impl Shape {
             .into()
     }
 
+    /// The entire [`Galley`] will be rendered with the given opacity.
+    #[inline]
+    pub fn galley_with_opacity_factor(
+        pos: Pos2,
+        galley: Arc<Galley>,
+        opacity_factor: f32,
+        fallback_color: Color32,
+    ) -> Self {
+        TextShape::new(pos, galley, fallback_color)
+            .with_opacity_factor(opacity_factor)
+            .into()
+    }
+
     #[inline]
     #[deprecated = "Use `Shape::galley` or `Shape::galley_with_override_text_color` instead"]
     pub fn galley_with_color(pos: Pos2, galley: Arc<Galley>, text_color: Color32) -> Self {
@@ -745,6 +758,10 @@ pub struct TextShape {
     /// This only affects the glyphs and will NOT replace background color nor strikethrough/underline color.
     pub override_text_color: Option<Color32>,
 
+    /// If set, the text will be rendered with the given opacity in gamma space
+    /// Affects everything: backgrounds, glyphs, strikethough, underline, etc.
+    pub opacity_factor: f32,
+
     /// Rotate text by this many radians clockwise.
     /// The pivot is `pos` (the upper left corner of the text).
     pub angle: f32,
@@ -762,6 +779,7 @@ impl TextShape {
             underline: Stroke::NONE,
             fallback_color,
             override_text_color: None,
+            opacity_factor: 1.0,
             angle: 0.0,
         }
     }
@@ -790,6 +808,13 @@ impl TextShape {
     #[inline]
     pub fn with_angle(mut self, angle: f32) -> Self {
         self.angle = angle;
+        self
+    }
+
+    /// Render text with this opacity in gamma space
+    #[inline]
+    pub fn with_opacity_factor(mut self, opacity_factor: f32) -> Self {
+        self.opacity_factor = opacity_factor;
         self
     }
 }

--- a/crates/epaint/src/shape_transform.rs
+++ b/crates/epaint/src/shape_transform.rs
@@ -56,6 +56,7 @@ pub fn adjust_colors(shape: &mut Shape, adjust_color: &impl Fn(&mut Color32)) {
             underline,
             fallback_color,
             override_text_color,
+            opacity_factor: _,
             angle: _,
         }) => {
             adjust_color(&mut underline.color);

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -1474,10 +1474,15 @@ impl Tessellator {
             underline,
             override_text_color,
             fallback_color,
+            opacity_factor,
             angle,
         } = text_shape;
 
         if galley.is_empty() {
+            return;
+        }
+
+        if *opacity_factor <= 0.0 {
             return;
         }
 
@@ -1546,6 +1551,10 @@ impl Tessellator {
                             }
                         } else if color == Color32::PLACEHOLDER {
                             color = *fallback_color;
+                        }
+
+                        if *opacity_factor <= 1.0 {
+                            color = color.gamma_multiply(*opacity_factor);
                         }
 
                         crate::epaint_assert!(color != Color32::PLACEHOLDER, "A placeholder color made it to the tessellator. You forgot to set a fallback color.");


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

This PR simply allows you to override the opacity of a Galley when you draw it on screen. Last year I opened #3548 and some changes were requested to the PR, but unfortunately school got really busy and I wasn't able to apply them. This PR supersedes #3548 and applys the changes requested in that PR