### PR TITLE
Expand plot axes thickness to fit their labels

### DIFF
--- a/crates/egui/src/painter.rs
+++ b/crates/egui/src/painter.rs
@@ -6,7 +6,7 @@ use crate::{
     Color32, Context, FontId,
 };
 use epaint::{
-    text::{Fonts, Galley},
+    text::{Fonts, Galley, LayoutJob},
     CircleShape, ClippedShape, RectShape, Rounding, Shape, Stroke,
 };
 
@@ -436,9 +436,18 @@ impl Painter {
         self.fonts(|f| f.layout(text, font_id, color, f32::INFINITY))
     }
 
+    /// Lay out this text layut job in a galley.
+    ///
+    /// Paint the results with [`Self::galley`].
+    #[inline]
+    #[must_use]
+    pub fn layout_job(&self, layout_job: LayoutJob) -> Arc<Galley> {
+        self.fonts(|f| f.layout_job(layout_job))
+    }
+
     /// Paint text that has already been laid out in a [`Galley`].
     ///
-    /// You can create the [`Galley`] with [`Self::layout`].
+    /// You can create the [`Galley`] with [`Self::layout`] or [`Self::layout_job`].
     ///
     /// Any uncolored parts of the [`Galley`] (using [`Color32::PLACEHOLDER`]) will be replaced with the given color.
     ///

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -780,11 +780,10 @@ impl Plot {
 
         // Allocate the plot window.
         let response = ui.allocate_rect(plot_rect, Sense::click_and_drag());
-        let rect = plot_rect;
 
         // Load or initialize the memory.
         let plot_id = id.unwrap_or_else(|| ui.make_persistent_id(id_source));
-        ui.ctx().check_for_id_clash(plot_id, rect, "Plot");
+        ui.ctx().check_for_id_clash(plot_id, plot_rect, "Plot");
         let mut mem = if reset {
             if let Some((name, _)) = linked_axes.as_ref() {
                 ui.data_mut(|data| {
@@ -800,7 +799,7 @@ impl Plot {
             auto_bounds: default_auto_bounds,
             hovered_item: None,
             hidden_items: Default::default(),
-            transform: PlotTransform::new(rect, min_auto_bounds, center_axis.x, center_axis.y),
+            transform: PlotTransform::new(plot_rect, min_auto_bounds, center_axis.x, center_axis.y),
             last_click_pos_for_zoom: None,
         });
 
@@ -828,9 +827,9 @@ impl Plot {
         // Background
         if show_background {
             ui.painter()
-                .with_clip_rect(rect)
+                .with_clip_rect(plot_rect)
                 .add(epaint::RectShape::new(
-                    rect,
+                    plot_rect,
                     Rounding::same(2.0),
                     ui.visuals().extreme_bg_color,
                     ui.visuals().widgets.noninteractive.bg_stroke,
@@ -839,7 +838,7 @@ impl Plot {
 
         // --- Legend ---
         let legend = legend_config
-            .and_then(|config| LegendWidget::try_new(rect, config, &items, &mem.hidden_items));
+            .and_then(|config| LegendWidget::try_new(plot_rect, config, &items, &mem.hidden_items));
         // Don't show hover cursor when hovering over legend.
         if mem.hovered_item.is_some() {
             show_x = false;
@@ -963,7 +962,7 @@ impl Plot {
             }
         }
 
-        mem.transform = PlotTransform::new(rect, bounds, center_axis.x, center_axis.y);
+        mem.transform = PlotTransform::new(plot_rect, bounds, center_axis.x, center_axis.y);
 
         // Enforce aspect ratio
         if let Some(data_aspect) = data_aspect {
@@ -1131,8 +1130,12 @@ impl Plot {
         let plot_cursors = prepared.ui(ui, &response);
 
         if let Some(boxed_zoom_rect) = boxed_zoom_rect {
-            ui.painter().with_clip_rect(rect).add(boxed_zoom_rect.0);
-            ui.painter().with_clip_rect(rect).add(boxed_zoom_rect.1);
+            ui.painter()
+                .with_clip_rect(plot_rect)
+                .add(boxed_zoom_rect.0);
+            ui.painter()
+                .with_clip_rect(plot_rect)
+                .add(boxed_zoom_rect.1);
         }
 
         if let Some(mut legend) = legend {

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -1276,8 +1276,8 @@ fn axis_widgets(
     if show_axes.x {
         for cfg in x_axes {
             let size_y = Vec2::new(0.0, cfg.thickness(Axis::X));
-            let rect = match cfg.placement {
-                axis::Placement::LeftBottom => {
+            let rect = match VPlacement::from(cfg.placement) {
+                VPlacement::Bottom => {
                     let off = num_widgets.bottom as f32;
                     num_widgets.bottom += 1;
                     Rect {
@@ -1285,7 +1285,7 @@ fn axis_widgets(
                         max: plot_rect.right_bottom() + size_y * (off + 1.0),
                     }
                 }
-                axis::Placement::RightTop => {
+                VPlacement::Top => {
                     let off = num_widgets.top as f32;
                     num_widgets.top += 1;
                     Rect {
@@ -1300,8 +1300,8 @@ fn axis_widgets(
     if show_axes.y {
         for cfg in y_axes {
             let size_x = Vec2::new(cfg.thickness(Axis::Y), 0.0);
-            let rect = match cfg.placement {
-                axis::Placement::LeftBottom => {
+            let rect = match HPlacement::from(cfg.placement) {
+                HPlacement::Left => {
                     let off = num_widgets.left as f32;
                     num_widgets.left += 1;
                     Rect {
@@ -1309,7 +1309,7 @@ fn axis_widgets(
                         max: plot_rect.left_bottom() - size_x * off,
                     }
                 }
-                axis::Placement::RightTop => {
+                HPlacement::Right => {
                     let off = num_widgets.right as f32;
                     num_widgets.right += 1;
                     Rect {

--- a/crates/egui_plot/src/memory.rs
+++ b/crates/egui_plot/src/memory.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use egui::{ahash, Context, Id, Pos2, Vec2b};
 
 use crate::{PlotBounds, PlotTransform};
@@ -23,6 +25,13 @@ pub struct PlotMemory {
 
     /// Allows to remember the first click position when performing a boxed zoom
     pub(crate) last_click_pos_for_zoom: Option<Pos2>,
+
+    /// The thickness of each of the axes the previous frame.
+    ///
+    /// This is used in the next frame to make the axes thicker
+    /// in order to fit the labels, if necessary.
+    pub(crate) x_axis_thickness: BTreeMap<usize, f32>,
+    pub(crate) y_axis_thickness: BTreeMap<usize, f32>,
 }
 
 impl PlotMemory {

--- a/crates/emath/src/rot2.rs
+++ b/crates/emath/src/rot2.rs
@@ -28,6 +28,7 @@ pub struct Rot2 {
 /// Identity rotation
 impl Default for Rot2 {
     /// Identity rotation
+    #[inline]
     fn default() -> Self {
         Self { s: 0.0, c: 1.0 }
     }
@@ -39,29 +40,35 @@ impl Rot2 {
 
     /// Angle is clockwise in radians.
     /// A 𝞃/4 = 90° rotation means rotating the X axis to the Y axis.
+    #[inline]
     pub fn from_angle(angle: f32) -> Self {
         let (s, c) = angle.sin_cos();
         Self { s, c }
     }
 
+    #[inline]
     pub fn angle(self) -> f32 {
         self.s.atan2(self.c)
     }
 
     /// The factor by which vectors will be scaled.
+    #[inline]
     pub fn length(self) -> f32 {
         self.c.hypot(self.s)
     }
 
+    #[inline]
     pub fn length_squared(self) -> f32 {
         self.c.powi(2) + self.s.powi(2)
     }
 
+    #[inline]
     pub fn is_finite(self) -> bool {
         self.c.is_finite() && self.s.is_finite()
     }
 
     #[must_use]
+    #[inline]
     pub fn inverse(self) -> Self {
         Self {
             s: -self.s,
@@ -70,6 +77,7 @@ impl Rot2 {
     }
 
     #[must_use]
+    #[inline]
     pub fn normalized(self) -> Self {
         let l = self.length();
         let ret = Self {
@@ -95,6 +103,7 @@ impl std::fmt::Debug for Rot2 {
 impl std::ops::Mul<Self> for Rot2 {
     type Output = Self;
 
+    #[inline]
     fn mul(self, r: Self) -> Self {
         /*
         |lc -ls| * |rc -rs|
@@ -111,6 +120,7 @@ impl std::ops::Mul<Self> for Rot2 {
 impl std::ops::Mul<Vec2> for Rot2 {
     type Output = Vec2;
 
+    #[inline]
     fn mul(self, v: Vec2) -> Vec2 {
         Vec2 {
             x: self.c * v.x - self.s * v.y,
@@ -123,6 +133,7 @@ impl std::ops::Mul<Vec2> for Rot2 {
 impl std::ops::Mul<Rot2> for f32 {
     type Output = Rot2;
 
+    #[inline]
     fn mul(self, r: Rot2) -> Rot2 {
         Rot2 {
             c: self * r.c,
@@ -135,6 +146,7 @@ impl std::ops::Mul<Rot2> for f32 {
 impl std::ops::Mul<f32> for Rot2 {
     type Output = Self;
 
+    #[inline]
     fn mul(self, r: f32) -> Self {
         Self {
             c: self.c * r,
@@ -147,6 +159,7 @@ impl std::ops::Mul<f32> for Rot2 {
 impl std::ops::Div<f32> for Rot2 {
     type Output = Self;
 
+    #[inline]
     fn div(self, r: f32) -> Self {
         Self {
             c: self.c / r,


### PR DESCRIPTION
Expand the plot axis thickness as the contained plot axis labels get wider.

This fixes a problem where the plot labels would otherwise get clipped.

![plot-axis-expansion](https://github.com/emilk/egui/assets/1148717/4500a26e-4a11-401d-9e8e-2d98d02ef3b7)
