### PR TITLE
Auto-repaint when widgets move or changes id.

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2140,6 +2140,8 @@ impl Context {
     ///
     /// Will return false if some other area is covering the given layer.
     ///
+    /// The given rectangle is assumed to have been clipped by its parent clip rect.
+    ///
     /// See also [`Response::contains_pointer`].
     pub fn rect_contains_pointer(&self, layer_id: LayerId, rect: Rect) -> bool {
         if !rect.is_positive() {
@@ -2169,6 +2171,8 @@ impl Context {
     /// If another widget is covering us and is listening for the same input (click and/or drag),
     /// this will return false.
     ///
+    /// The given rectangle is assumed to have been clipped by its parent clip rect.
+    ///
     /// See also [`Response::contains_pointer`].
     pub fn widget_contains_pointer(
         &self,
@@ -2177,6 +2181,10 @@ impl Context {
         sense: Sense,
         rect: Rect,
     ) -> bool {
+        if !rect.is_positive() {
+            return false; // don't even remember this widget
+        }
+
         let contains_pointer = self.rect_contains_pointer(layer_id, rect);
 
         let mut blocking_widget = None;

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -188,7 +188,7 @@ pub struct WidgetRect {
     /// and also big red warning test on the screen in debug builds
     /// (see [`Options::warn_on_id_clash`]).
     ///
-    /// You can ensure globally unqiue ids using [`Ui::push_id`].
+    /// You can ensure globally unique ids using [`Ui::push_id`].
     pub id: Id,
 
     /// How the widget responds to interaction.

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2348,25 +2348,14 @@ impl Context {
 impl Context {
     /// Show a ui for settings (style and tessellation options).
     pub fn settings_ui(&self, ui: &mut Ui) {
-        use crate::containers::*;
+        let prev_options = self.options(|o| o.clone());
+        let mut options = prev_options.clone();
 
-        CollapsingHeader::new("🎑 Style")
-            .default_open(true)
-            .show(ui, |ui| {
-                self.style_ui(ui);
-            });
+        options.ui(ui);
 
-        CollapsingHeader::new("✒ Painting")
-            .default_open(true)
-            .show(ui, |ui| {
-                let prev_tessellation_options = self.tessellation_options(|o| *o);
-                let mut tessellation_options = prev_tessellation_options;
-                tessellation_options.ui(ui);
-                ui.vertical_centered(|ui| reset_button(ui, &mut tessellation_options));
-                if tessellation_options != prev_tessellation_options {
-                    self.tessellation_options_mut(move |o| *o = tessellation_options);
-                }
-            });
+        if options != prev_options {
+            self.options_mut(move |o| *o = options);
+        }
     }
 
     /// Show the state of egui, including its input and output.

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -410,7 +410,7 @@ pub mod text {
 
 pub use {
     containers::*,
-    context::{Context, RequestRepaintInfo},
+    context::{Context, RequestRepaintInfo, WidgetRect, WidgetRects},
     data::{
         input::*,
         output::{

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -154,7 +154,7 @@ impl FocusDirection {
 // ----------------------------------------------------------------------------
 
 /// Some global options that you can read and write.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct Options {
@@ -183,6 +183,11 @@ pub struct Options {
 
     /// Controls the tessellator.
     pub tessellation_options: epaint::TessellationOptions,
+
+    /// If any widget moves or changes id, repaint everything.
+    ///
+    /// This is `true` by default.
+    pub repaint_on_widget_change: bool,
 
     /// This is a signal to any backend that we want the [`crate::PlatformOutput::events`] read out loud.
     ///
@@ -216,6 +221,7 @@ impl Default for Options {
             zoom_factor: 1.0,
             zoom_with_keyboard: true,
             tessellation_options: Default::default(),
+            repaint_on_widget_change: true,
             screen_reader: false,
             preload_font_glyphs: true,
             warn_on_id_clash: cfg!(debug_assertions),

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -229,6 +229,56 @@ impl Default for Options {
     }
 }
 
+impl Options {
+    /// Show the options in the ui.
+    pub fn ui(&mut self, ui: &mut crate::Ui) {
+        let Self {
+            style,          // covered above
+            zoom_factor: _, // TODO
+            zoom_with_keyboard,
+            tessellation_options,
+            repaint_on_widget_change,
+            screen_reader: _, // needs to come from the integration
+            preload_font_glyphs: _,
+            warn_on_id_clash,
+        } = self;
+
+        use crate::Widget as _;
+
+        CollapsingHeader::new("⚙ Options")
+            .default_open(false)
+            .show(ui, |ui| {
+                ui.checkbox(
+                    repaint_on_widget_change,
+                    "Repaint if any widget moves or changes id",
+                );
+
+                ui.checkbox(
+                    zoom_with_keyboard,
+                    "Zoom with keyboard (Cmd +, Cmd -, Cmd 0)",
+                );
+
+                ui.checkbox(warn_on_id_clash, "Warn if two widgets have the same Id");
+            });
+
+        use crate::containers::*;
+        CollapsingHeader::new("🎑 Style")
+            .default_open(true)
+            .show(ui, |ui| {
+                std::sync::Arc::make_mut(style).ui(ui);
+            });
+
+        CollapsingHeader::new("✒ Painting")
+            .default_open(true)
+            .show(ui, |ui| {
+                tessellation_options.ui(ui);
+                ui.vertical_centered(|ui| crate::reset_button(ui, tessellation_options));
+            });
+
+        ui.vertical_centered(|ui| crate::reset_button(ui, self));
+    }
+}
+
 // ----------------------------------------------------------------------------
 
 /// Say there is a button in a scroll area.


### PR DESCRIPTION
With this PR, if a widget moves or repaints, egui will automatically repaint.

Usually this is what you want: if something is moving we should repaint until it stops moving.

However, this could potentially create false positives in some rare circumstances, so there is an option to turn it off with `Options::repaint_on_widget_change`.