### PR TITLE
feat: make `eframe::native::FileStorage` creatable from other crates

### DIFF
--- a/crates/eframe/src/native/file_storage.rs
+++ b/crates/eframe/src/native/file_storage.rs
@@ -52,9 +52,10 @@ impl FileStorage {
         let ron_filepath: PathBuf = ron_filepath.into();
         log::debug!("Loading app state from {:?}…", ron_filepath);
         let kv = read_ron(&ron_filepath);
+        let properly_read = kv.is_some();
         Self {
             kv: kv.unwrap_or_default(),
-            properly_read: kv.is_some(),
+            properly_read,
             last_save_success: None,
             ron_filepath,
             dirty: false,
@@ -97,7 +98,7 @@ impl FileStorage {
     /// - [`Self::was_properly_read()`] returns false,
     /// - [`Self::attempt_reinit()`] is used and returns `Some(true)`.
     pub const fn last_save_success(&self) -> Option<bool> {
-        self.last_save_success.as_ref().copied()
+        self.last_save_success
     }
 
     /// Attempts to re-initialize this store, if [`Self::was_properly_read()`] returns false.

--- a/crates/eframe/src/native/file_storage.rs
+++ b/crates/eframe/src/native/file_storage.rs
@@ -86,6 +86,7 @@ impl FileStorage {
     ///Returns true, if the contents of this store were
     ///properly read during initialisation, or if the
     ///contents of this store are empty.
+    #[allow(dead_code)] //part of api
     pub const fn was_properly_read(&self) -> bool {
         self.properly_read
     }
@@ -108,6 +109,7 @@ impl FileStorage {
     /// if this function fails to properly read the app-state `Some(false)` is returned.
     /// if this function can properly read the app-state from the given path `Some(true)` is returned,
     /// and [`Self::last_save_success()`] is reset
+    #[allow(dead_code)] //part of api
     pub fn attempt_reinit(&mut self, ron_filepath: impl Into<PathBuf>) -> Option<bool> {
         if self.was_properly_read() {
             None

--- a/crates/eframe/src/native/file_storage.rs
+++ b/crates/eframe/src/native/file_storage.rs
@@ -106,10 +106,10 @@ impl FileStorage {
     /// if this function fails to properly read the app-state `Some(false)` is returned.
     /// if this function can properly read the app-state from the given path `Some(true)` is returned,
     /// and [`Self::last_save_success()`] is reset
-    pub fn attempt_reinit(&mut self, ron_filepath: impl Into<PathBuf>) -> Option<bool>{
+    pub fn attempt_reinit(&mut self, ron_filepath: impl Into<PathBuf>) -> Option<bool> {
         if self.properly_read {
             None
-        }else {
+        } else {
             crate::profile_function!();
             let ron_filepath: PathBuf = ron_filepath.into();
             log::debug!("Attempting to re-load app state from {:?} instead of from {:?}, because the last attempt to read the app-state failed.", ron_filepath, self.ron_filepath);

--- a/crates/eframe/src/native/file_storage.rs
+++ b/crates/eframe/src/native/file_storage.rs
@@ -41,16 +41,16 @@ impl Drop for FileStorage {
 
 impl FileStorage {
     /// Store the state in this .ron file.
-    fn from_ron_filepath(ron_filepath: impl Into<PathBuf>) -> Self {
+    pub fn from_ron_filepath(ron_filepath: impl Into<PathBuf>) -> Option<Self> {
         crate::profile_function!();
         let ron_filepath: PathBuf = ron_filepath.into();
         log::debug!("Loading app state from {:?}…", ron_filepath);
-        Self {
-            kv: read_ron(&ron_filepath).unwrap_or_default(),
+        Some(Self {
+            kv: read_ron(&ron_filepath)?,
             ron_filepath,
             dirty: false,
             last_save_join_handle: None,
-        }
+        })
     }
 
     /// Find a good place to put the files that the OS likes.
@@ -65,7 +65,7 @@ impl FileStorage {
                 );
                 None
             } else {
-                Some(Self::from_ron_filepath(data_dir.join("app.ron")))
+                Self::from_ron_filepath(data_dir.join("app.ron"))
             }
         } else {
             log::warn!("Saving disabled: Failed to find path to data_dir.");

--- a/crates/eframe/src/native/file_storage.rs
+++ b/crates/eframe/src/native/file_storage.rs
@@ -97,6 +97,7 @@ impl FileStorage {
     /// This will get reset to `None`, if all the following criteria are met:
     /// - [`Self::was_properly_read()`] returns false,
     /// - [`Self::attempt_reinit()`] is used and returns `Some(true)`.
+    #[allow(dead_code)] //part of api
     pub const fn last_save_success(&self) -> Option<bool> {
         self.last_save_success
     }
@@ -108,7 +109,7 @@ impl FileStorage {
     /// if this function can properly read the app-state from the given path `Some(true)` is returned,
     /// and [`Self::last_save_success()`] is reset
     pub fn attempt_reinit(&mut self, ron_filepath: impl Into<PathBuf>) -> Option<bool> {
-        if self.properly_read {
+        if self.was_properly_read() {
             None
         } else {
             crate::profile_function!();


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->
This PR makes `eframe::native::FileStorage` creatable from other crates.
To make `eframe::native::FileStorage` nice to use, some api's have been added.
Closes: #3927
