### PR TITLE
Emilk/revert workspace deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,18 +48,6 @@ opt-level = 2
 
 
 [workspace.dependencies]
-emath = { version = "0.25.0", path = "crates/emath", default-features = false }
-ecolor = { version = "0.25.0", path = "crates/ecolor", default-features = false }
-epaint = { version = "0.25.0", path = "crates/epaint", default-features = false }
-egui = { version = "0.25.0", path = "crates/egui", default-features = false }
-egui_plot = { version = "0.25.0", path = "crates/egui_plot", default-features = false }
-egui-winit = { version = "0.25.0", path = "crates/egui-winit", default-features = false }
-egui_extras = { version = "0.25.0", path = "crates/egui_extras", default-features = false }
-egui-wgpu = { version = "0.25.0", path = "crates/egui-wgpu", default-features = false }
-egui_demo_lib = { version = "0.25.0", path = "crates/egui_demo_lib", default-features = false }
-egui_glow = { version = "0.25.0", path = "crates/egui_glow", default-features = false }
-eframe = { version = "0.25.0", path = "crates/eframe", default-features = false }
-
 criterion = { version = "0.5.1", default-features = false }
 glow = "0.13"
 puffin = "0.19"

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -88,7 +88,11 @@ puffin = [
 ]
 
 ## Enables wayland support and fixes clipboard issue.
-wayland = ["egui-winit/wayland", "egui-wgpu?/wayland", "egui_glow?/wayland"]
+wayland = [
+  "egui-winit/wayland",
+  "egui-wgpu?/wayland",
+  "egui_glow?/wayland",
+]
 
 ## Enable screen reader support (requires `ctx.options_mut(|o| o.screen_reader = true);`) on web.
 ##
@@ -114,14 +118,18 @@ web_screen_reader = [
 wgpu = ["dep:wgpu", "dep:egui-wgpu", "dep:pollster"]
 
 ## Enables compiling for x11.
-x11 = ["egui-winit/x11", "egui-wgpu?/x11", "egui_glow?/x11"]
+x11 = [
+  "egui-winit/x11",
+  "egui-wgpu?/x11",
+  "egui_glow?/x11",
+]
 
 ## If set, eframe will look for the env-var `EFRAME_SCREENSHOT_TO` and write a screenshot to that location, and then quit.
 ## This is used to generate images for examples.
 __screenshot = []
 
 [dependencies]
-egui = { path = "../egui", default-features = false, features = [
+egui = { version = "0.25.0", path = "../egui", default-features = false, features = [
   "bytemuck",
   "log",
 ] }
@@ -136,7 +144,7 @@ web-time.workspace = true
 ## Enable this when generating docs.
 document-features = { version = "0.2", optional = true }
 
-egui_glow = { path = "../egui_glow", optional = true, default-features = false }
+egui_glow = { version = "0.25.0", path = "../egui_glow", optional = true, default-features = false }
 glow = { workspace = true, optional = true }
 # glutin stuck on old version of raw-window-handle:
 rwh_05 = { package = "raw-window-handle", version = "0.5.2", optional = true, features = [
@@ -148,7 +156,7 @@ serde = { version = "1", optional = true, features = ["derive"] }
 # -------------------------------------------
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-egui-winit = { path = "../egui-winit", default-features = false, features = [
+egui-winit = { version = "0.25.0", path = "../egui-winit", default-features = false, features = [
   "clipboard",
   "links",
 ] }
@@ -159,7 +167,7 @@ winit = { workspace = true, default-features = false, features = ["rwh_06"] }
 
 # optional native:
 directories-next = { version = "2", optional = true }
-egui-wgpu = { path = "../egui-wgpu", optional = true, features = [
+egui-wgpu = { version = "0.25.0", path = "../egui-wgpu", optional = true, features = [
   "winit",
 ] } # if wgpu is used, use it with winit
 pollster = { version = "0.3", optional = true } # needed for wgpu
@@ -238,5 +246,5 @@ web-sys = { version = "0.3.58", features = [
 ] }
 
 # optional web:
-egui-wgpu = { path = "../egui-wgpu", optional = true } # if wgpu is used, use it without (!) winit
+egui-wgpu = { version = "0.25.0", path = "../egui-wgpu", optional = true } # if wgpu is used, use it without (!) winit
 wgpu = { workspace = true, optional = true }

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -121,7 +121,7 @@ x11 = ["egui-winit/x11", "egui-wgpu?/x11", "egui_glow?/x11"]
 __screenshot = []
 
 [dependencies]
-egui = { workspace = true, default-features = false, features = [
+egui = { path = "../egui", default-features = false, features = [
   "bytemuck",
   "log",
 ] }
@@ -136,7 +136,7 @@ web-time.workspace = true
 ## Enable this when generating docs.
 document-features = { version = "0.2", optional = true }
 
-egui_glow = { workspace = true, optional = true, default-features = false }
+egui_glow = { path = "../egui_glow", optional = true, default-features = false }
 glow = { workspace = true, optional = true }
 # glutin stuck on old version of raw-window-handle:
 rwh_05 = { package = "raw-window-handle", version = "0.5.2", optional = true, features = [
@@ -148,7 +148,7 @@ serde = { version = "1", optional = true, features = ["derive"] }
 # -------------------------------------------
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-egui-winit = { workspace = true, default-features = false, features = [
+egui-winit = { path = "../egui-winit", default-features = false, features = [
   "clipboard",
   "links",
 ] }
@@ -159,7 +159,7 @@ winit = { workspace = true, default-features = false, features = ["rwh_06"] }
 
 # optional native:
 directories-next = { version = "2", optional = true }
-egui-wgpu = { workspace = true, optional = true, features = [
+egui-wgpu = { path = "../egui-wgpu", optional = true, features = [
   "winit",
 ] } # if wgpu is used, use it with winit
 pollster = { version = "0.3", optional = true } # needed for wgpu
@@ -238,5 +238,5 @@ web-sys = { version = "0.3.58", features = [
 ] }
 
 # optional web:
-egui-wgpu = { workspace = true, optional = true } # if wgpu is used, use it without (!) winit
+egui-wgpu = { path = "../egui-wgpu", optional = true } # if wgpu is used, use it without (!) winit
 wgpu = { workspace = true, optional = true }

--- a/crates/egui-wgpu/Cargo.toml
+++ b/crates/egui-wgpu/Cargo.toml
@@ -42,8 +42,10 @@ x11 = ["winit?/x11"]
 
 
 [dependencies]
-egui = { workspace = true, default-features = false }
-epaint = { workspace = true, default-features = false, features = ["bytemuck"] }
+egui = { path = "../egui", default-features = false }
+epaint = { path = "../epaint", default-features = false, features = [
+  "bytemuck",
+] }
 
 bytemuck = "1.7"
 log = { version = "0.4", features = ["std"] }

--- a/crates/egui-wgpu/Cargo.toml
+++ b/crates/egui-wgpu/Cargo.toml
@@ -42,8 +42,8 @@ x11 = ["winit?/x11"]
 
 
 [dependencies]
-egui = { path = "../egui", default-features = false }
-epaint = { path = "../epaint", default-features = false, features = [
+egui = { version = "0.25.0", path = "../egui", default-features = false }
+epaint = { version = "0.25.0", path = "../epaint", default-features = false, features = [
   "bytemuck",
 ] }
 

--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -55,7 +55,7 @@ wayland = ["winit/wayland", "bytemuck"]
 x11 = ["winit/x11", "bytemuck"]
 
 [dependencies]
-egui = { workspace = true, default-features = false, features = ["log"] }
+egui = { path = "../egui", default-features = false, features = ["log"] }
 log = { version = "0.4", features = ["std"] }
 raw-window-handle.workspace = true
 web-time.workspace = true

--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -55,7 +55,9 @@ wayland = ["winit/wayland", "bytemuck"]
 x11 = ["winit/x11", "bytemuck"]
 
 [dependencies]
-egui = { path = "../egui", default-features = false, features = ["log"] }
+egui = { version = "0.25.0", path = "../egui", default-features = false, features = [
+  "log",
+] }
 log = { version = "0.4", features = ["std"] }
 raw-window-handle.workspace = true
 web-time.workspace = true

--- a/crates/egui/Cargo.toml
+++ b/crates/egui/Cargo.toml
@@ -81,7 +81,7 @@ unity = ["epaint/unity"]
 
 
 [dependencies]
-epaint = { workspace = true, default-features = false }
+epaint = { path = "../epaint", default-features = false }
 
 ahash = { version = "0.8.6", default-features = false, features = [
     "no-rng", # we don't need DOS-protection, so we let users opt-in to it instead

--- a/crates/egui/Cargo.toml
+++ b/crates/egui/Cargo.toml
@@ -81,7 +81,7 @@ unity = ["epaint/unity"]
 
 
 [dependencies]
-epaint = { path = "../epaint", default-features = false }
+epaint = { version = "0.25.0", path = "../epaint", default-features = false }
 
 ahash = { version = "0.8.6", default-features = false, features = [
     "no-rng", # we don't need DOS-protection, so we let users opt-in to it instead

--- a/crates/egui_demo_app/Cargo.toml
+++ b/crates/egui_demo_app/Cargo.toml
@@ -38,16 +38,20 @@ chrono = { version = "0.4", default-features = false, features = [
   "js-sys",
   "wasmbind",
 ] }
-eframe = { path = "../eframe", default-features = false, features = [
+eframe = { version = "0.25.0", path = "../eframe", default-features = false, features = [
   "web_screen_reader",
 ] }
-egui = { path = "../egui", features = [
+egui = { version = "0.25.0", path = "../egui", features = [
   "callstack",
   "extra_debug_asserts",
   "log",
 ] }
-egui_demo_lib = { path = "../egui_demo_lib", features = ["chrono"] }
-egui_extras = { path = "../egui_extras", features = ["image"] }
+egui_demo_lib = { version = "0.25.0", path = "../egui_demo_lib", features = [
+  "chrono",
+] }
+egui_extras = { version = "0.25.0", path = "../egui_extras", features = [
+  "image",
+] }
 log = { version = "0.4", features = ["std"] }
 
 # Optional dependencies:

--- a/crates/egui_demo_app/Cargo.toml
+++ b/crates/egui_demo_app/Cargo.toml
@@ -38,16 +38,16 @@ chrono = { version = "0.4", default-features = false, features = [
   "js-sys",
   "wasmbind",
 ] }
-eframe = { workspace = true, default-features = false, features = [
+eframe = { path = "../eframe", default-features = false, features = [
   "web_screen_reader",
 ] }
-egui = { workspace = true, features = [
+egui = { path = "../egui", features = [
   "callstack",
   "extra_debug_asserts",
   "log",
 ] }
-egui_demo_lib = { workspace = true, features = ["chrono"] }
-egui_extras = { workspace = true, features = ["image"] }
+egui_demo_lib = { path = "../egui_demo_lib", features = ["chrono"] }
+egui_extras = { path = "../egui_extras", features = ["image"] }
 log = { version = "0.4", features = ["std"] }
 
 # Optional dependencies:

--- a/crates/egui_demo_lib/Cargo.toml
+++ b/crates/egui_demo_lib/Cargo.toml
@@ -38,11 +38,11 @@ syntect = ["egui_extras/syntect"]
 
 
 [dependencies]
-egui = { path = "../egui", default-features = false }
-egui_extras = { path = "../egui_extras" }
-egui_plot = { path = "../egui_plot" }
+egui = { version = "0.25.0", path = "../egui", default-features = false }
+egui_extras = { version = "0.25.0", path = "../egui_extras" }
+egui_plot = { version = "0.25.0", path = "../egui_plot" }
 log = { version = "0.4", features = ["std"] }
-unicode_names2 = { version = "0.6.0", default-features = false } # this old version has fewer dependencies
+unicode_names2 = { version = "0.6.0", default-features = false }          # this old version has fewer dependencies
 
 #! ### Optional dependencies
 chrono = { version = "0.4", optional = true, features = ["js-sys", "wasmbind"] }

--- a/crates/egui_demo_lib/Cargo.toml
+++ b/crates/egui_demo_lib/Cargo.toml
@@ -38,9 +38,9 @@ syntect = ["egui_extras/syntect"]
 
 
 [dependencies]
-egui = { workspace = true, default-features = false }
-egui_extras.workspace = true
-egui_plot.workspace = true
+egui = { path = "../egui", default-features = false }
+egui_extras = { path = "../egui_extras" }
+egui_plot = { path = "../egui_plot" }
 log = { version = "0.4", features = ["std"] }
 unicode_names2 = { version = "0.6.0", default-features = false } # this old version has fewer dependencies
 

--- a/crates/egui_extras/Cargo.toml
+++ b/crates/egui_extras/Cargo.toml
@@ -60,7 +60,7 @@ syntect = ["dep:syntect"]
 
 
 [dependencies]
-egui = { workspace = true, default-features = false, features = ["serde"] }
+egui = { path = "../egui", default-features = false, features = ["serde"] }
 enum-map = { version = "2", features = ["serde"] }
 log = { version = "0.4", features = ["std"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/egui_extras/Cargo.toml
+++ b/crates/egui_extras/Cargo.toml
@@ -60,7 +60,9 @@ syntect = ["dep:syntect"]
 
 
 [dependencies]
-egui = { path = "../egui", default-features = false, features = ["serde"] }
+egui = { version = "0.25.0", path = "../egui", default-features = false, features = [
+  "serde",
+] }
 enum-map = { version = "2", features = ["serde"] }
 log = { version = "0.4", features = ["std"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/egui_glow/Cargo.toml
+++ b/crates/egui_glow/Cargo.toml
@@ -50,7 +50,9 @@ x11 = ["winit?/x11"]
 
 
 [dependencies]
-egui = { path = "../egui", default-features = false, features = ["bytemuck"] }
+egui = { version = "0.25.0", path = "../egui", default-features = false, features = [
+  "bytemuck",
+] }
 
 bytemuck = "1.7"
 glow.workspace = true
@@ -67,7 +69,7 @@ document-features = { version = "0.2", optional = true }
 
 # Native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-egui-winit = { path = "../egui-winit", optional = true, default-features = false }
+egui-winit = { version = "0.25.0", path = "../egui-winit", optional = true, default-features = false }
 puffin = { workspace = true, optional = true }
 winit = { workspace = true, optional = true, default-features = false, features = [
   "rwh_05", # glutin stuck on old version of raw-window-handle

--- a/crates/egui_glow/Cargo.toml
+++ b/crates/egui_glow/Cargo.toml
@@ -50,7 +50,7 @@ x11 = ["winit?/x11"]
 
 
 [dependencies]
-egui = { workspace = true, default-features = false, features = ["bytemuck"] }
+egui = { path = "../egui", default-features = false, features = ["bytemuck"] }
 
 bytemuck = "1.7"
 glow.workspace = true
@@ -67,7 +67,7 @@ document-features = { version = "0.2", optional = true }
 
 # Native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-egui-winit = { workspace = true, optional = true, default-features = false }
+egui-winit = { path = "../egui-winit", optional = true, default-features = false }
 puffin = { workspace = true, optional = true }
 winit = { workspace = true, optional = true, default-features = false, features = [
   "rwh_05", # glutin stuck on old version of raw-window-handle

--- a/crates/egui_plot/Cargo.toml
+++ b/crates/egui_plot/Cargo.toml
@@ -32,7 +32,7 @@ serde = ["dep:serde", "egui/serde"]
 
 
 [dependencies]
-egui = { workspace = true, default-features = false }
+egui = { path = "../egui", default-features = false }
 
 
 #! ### Optional dependencies

--- a/crates/egui_plot/Cargo.toml
+++ b/crates/egui_plot/Cargo.toml
@@ -32,7 +32,7 @@ serde = ["dep:serde", "egui/serde"]
 
 
 [dependencies]
-egui = { path = "../egui", default-features = false }
+egui = { version = "0.25.0", path = "../egui", default-features = false }
 
 
 #! ### Optional dependencies

--- a/crates/epaint/Cargo.toml
+++ b/crates/epaint/Cargo.toml
@@ -80,8 +80,8 @@ serde = ["dep:serde", "ahash/serde", "emath/serde", "ecolor/serde"]
 unity = []
 
 [dependencies]
-emath = { path = "../emath" }
-ecolor = { path = "../ecolor" }
+emath = { version = "0.25.0", path = "../emath" }
+ecolor = { version = "0.25.0", path = "../ecolor" }
 
 ab_glyph = "0.2.11"
 ahash = { version = "0.8.1", default-features = false, features = [

--- a/crates/epaint/Cargo.toml
+++ b/crates/epaint/Cargo.toml
@@ -80,8 +80,8 @@ serde = ["dep:serde", "ahash/serde", "emath/serde", "ecolor/serde"]
 unity = []
 
 [dependencies]
-emath.workspace = true
-ecolor.workspace = true
+emath = { path = "../emath" }
+ecolor = { path = "../ecolor" }
 
 ab_glyph = "0.2.11"
 ahash = { version = "0.8.1", default-features = false, features = [

--- a/examples/confirm_exit/Cargo.toml
+++ b/examples/confirm_exit/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 env_logger = { version = "0.10", default-features = false, features = [

--- a/examples/custom_3d_glow/Cargo.toml
+++ b/examples/custom_3d_glow/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 env_logger = { version = "0.10", default-features = false, features = [

--- a/examples/custom_font/Cargo.toml
+++ b/examples/custom_font/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 env_logger = { version = "0.10", default-features = false, features = [

--- a/examples/custom_font_style/Cargo.toml
+++ b/examples/custom_font_style/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 env_logger = { version = "0.10", default-features = false, features = [

--- a/examples/custom_plot_manipulation/Cargo.toml
+++ b/examples/custom_plot_manipulation/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-egui_plot.workspace = true
+egui_plot = { path = "../../crates/egui_plot" }
 env_logger = { version = "0.10", default-features = false, features = [
     "auto-color",
     "humantime",

--- a/examples/custom_window_frame/Cargo.toml
+++ b/examples/custom_window_frame/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 env_logger = { version = "0.10", default-features = false, features = [

--- a/examples/file_dialog/Cargo.toml
+++ b/examples/file_dialog/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 env_logger = { version = "0.10", default-features = false, features = [

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -9,12 +9,12 @@ publish = false
 
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 
 # For image support:
-egui_extras = { workspace = true, features = ["image"] }
+egui_extras = { path = "../../crates/egui_extras", features = ["image"] }
 
 env_logger = { version = "0.10", default-features = false, features = [
     "auto-color",

--- a/examples/hello_world_par/Cargo.toml
+++ b/examples/hello_world_par/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 
 [dependencies]
-eframe = { workspace = true, default-features = false, features = [
+eframe = { path = "../../crates/eframe", default-features = false, features = [
     # accesskit struggles with threading
     "default_fonts",
     "wgpu",

--- a/examples/hello_world_simple/Cargo.toml
+++ b/examples/hello_world_simple/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 env_logger = { version = "0.10", default-features = false, features = [

--- a/examples/images/Cargo.toml
+++ b/examples/images/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
   "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-egui_extras = { workspace = true, features = ["all_loaders"] }
+egui_extras = { path = "../../crates/egui_extras", features = ["all_loaders"] }
 env_logger = { version = "0.10", default-features = false, features = [
   "auto-color",
   "humantime",

--- a/examples/keyboard_events/Cargo.toml
+++ b/examples/keyboard_events/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 env_logger = { version = "0.10", default-features = false, features = [

--- a/examples/multiple_viewports/Cargo.toml
+++ b/examples/multiple_viewports/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 wgpu = ["eframe/wgpu"]
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 env_logger = { version = "0.10", default-features = false, features = [

--- a/examples/puffin_profiler/Cargo.toml
+++ b/examples/puffin_profiler/Cargo.toml
@@ -13,7 +13,7 @@ wgpu = ["eframe/wgpu"]
 
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
     "puffin",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }

--- a/examples/save_plot/Cargo.toml
+++ b/examples/save_plot/Cargo.toml
@@ -8,10 +8,10 @@ rust-version = "1.72"
 publish = false
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-egui_plot.workspace = true
+egui_plot = { path = "../../crates/egui_plot" }
 image = { version = "0.24", default-features = false, features = ["png"] }
 rfd = "0.11.0"
 env_logger = { version = "0.10", default-features = false, features = [

--- a/examples/screenshot/Cargo.toml
+++ b/examples/screenshot/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
     "wgpu",
 ] }

--- a/examples/serial_windows/Cargo.toml
+++ b/examples/serial_windows/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 env_logger = { version = "0.10", default-features = false, features = [

--- a/examples/test_inline_glow_paint/Cargo.toml
+++ b/examples/test_inline_glow_paint/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-eframe.workspace = true
+eframe = { path = "../../crates/eframe" }
 env_logger = { version = "0.10", default-features = false, features = [
     "auto-color",
     "humantime",

--- a/examples/test_viewports/Cargo.toml
+++ b/examples/test_viewports/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 wgpu = ["eframe/wgpu"]
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 env_logger = { version = "0.10", default-features = false, features = [

--- a/examples/user_attention/Cargo.toml
+++ b/examples/user_attention/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.72"
 publish = false
 
 [dependencies]
-eframe = { workspace = true, features = [
+eframe = { path = "../../crates/eframe", features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 env_logger = { version = "0.10", default-features = false, features = [


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/3941

Workspace dependencies can be annoying.

If you don't set them to `default-features=false`, then you cannot opt out of their default features anywhere else, and get warnings if you try.

So you set `default-features=false`, and then you need to manually opt in to the default features everywhere else.
Or, as in my case, don't.

I don't have the energy to do this tonight, so I'll just revert.