### PR TITLE
[discuss] automatically enable egui-winit `clipboard` feature

### DIFF
--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -157,7 +157,6 @@ serde = { version = "1", optional = true, features = ["derive"] }
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 egui-winit = { version = "0.25.0", path = "../egui-winit", default-features = false, features = [
-  "clipboard",
   "links",
 ] }
 image = { version = "0.24", default-features = false, features = [

--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 
 
 [features]
-default = ["clipboard", "links", "wayland", "winit/default", "x11"]
+default = ["links", "wayland", "winit/default", "x11"]
 
 ## Enable platform accessibility API implementations through [AccessKit](https://accesskit.dev/).
 accesskit = ["accesskit_winit", "egui/accesskit"]
@@ -35,9 +35,8 @@ android-native-activity = ["winit/android-native-activity"]
 ## [`bytemuck`](https://docs.rs/bytemuck) enables you to cast [`egui::epaint::Vertex`], [`egui::Vec2`] etc to `&[u8]`.
 bytemuck = ["egui/bytemuck"]
 
-## Enable cut/copy/paste to OS clipboard.
-## If disabled a clipboard will be simulated so you can still copy/paste within the egui app.
-clipboard = ["arboard", "smithay-clipboard"]
+## Deprecated, clipboard is automatically enabled when x11 or wayland is selected
+clipboard = []
 
 ## Enable opening links in a browser when an egui hyperlink is clicked.
 links = ["webbrowser"]
@@ -49,10 +48,10 @@ puffin = ["dep:puffin", "egui/puffin"]
 serde = ["egui/serde", "dep:serde"]
 
 ## Enables Wayland support.
-wayland = ["winit/wayland", "bytemuck"]
+wayland = ["winit/wayland", "bytemuck", "smithay-clipboard"]
 
 ## Enables compiling for x11.
-x11 = ["winit/x11", "bytemuck"]
+x11 = ["winit/x11", "bytemuck", "arboard"]
 
 [dependencies]
 egui = { version = "0.25.0", path = "../egui", default-features = false, features = [

--- a/crates/egui_glow/Cargo.toml
+++ b/crates/egui_glow/Cargo.toml
@@ -26,11 +26,8 @@ all-features = true
 [features]
 default = []
 
-## For the `winit` integration:
-## enable cut/copy/paste to os clipboard.
-##
-## if disabled a clipboard will be simulated so you can still copy/paste within the egui app.
-clipboard = ["egui-winit?/clipboard"]
+## Deprecated, clipboard is automatically enabled with winit integration when x11 or wayland is selected
+clipboard = []
 
 ## For the `winit` integration:
 ## enable opening links in a browser when an egui hyperlink is clicked.


### PR DESCRIPTION
In the same effort that led to #3946, I noticed that enabling `clipboard` leads to lots of wayland dependencies being pulled in even when I just want to build for x11.

I guess, the current design is caused by the fact that it is not possible (I think) to have features declarations in cargo to say "only add this dependency if both of these features are enabled" (e.g. `x11` and `clipboard` in this case).

This chooses a different tradeoff where clipboard gets automatically enabled when choosing `x11` or `wayland` but only for the window system chosen.

Let me know if I'm completely on the wrong track here or something else would be breaking.

(This probably needs a warning about the deprecation?)