### PR TITLE
`Context::repaint_causes`: `file:line` of what caused a repaint

### DIFF
--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -410,7 +410,7 @@ pub mod text {
 
 pub use {
     containers::*,
-    context::{Context, RequestRepaintInfo, WidgetRect, WidgetRects},
+    context::{Context, RepaintCause, RequestRepaintInfo, WidgetRect, WidgetRects},
     data::{
         input::*,
         output::{


### PR DESCRIPTION
* Basic version of https://github.com/emilk/egui/issues/3931

This adds `Context::repaint_causes` which returns a `Vec<RepaintCause>`, containing the `file:line` of the call to `ctx.request_repaint()`.

If your application is stuck forever repainting, this could be a useful tool to diagnose it.