### PR TITLE
adds a image loader for DynamicImage

### DIFF
--- a/crates/egui_extras/src/image.rs
+++ b/crates/egui_extras/src/image.rs
@@ -190,6 +190,8 @@ impl RetainedImage {
 
 // ----------------------------------------------------------------------------
 
+#[cfg(feature = "image")]
+use egui::load::Bytes;
 use egui::ColorImage;
 
 /// Load a (non-svg) image.
@@ -209,6 +211,26 @@ pub fn load_image_bytes(image_bytes: &[u8]) -> Result<egui::ColorImage, String> 
     Ok(egui::ColorImage::from_rgba_unmultiplied(
         size,
         pixels.as_slice(),
+    ))
+}
+#[cfg(feature = "image")]
+pub fn load_rgba(image_bytes: &[u8]) -> Result<egui::ColorImage, String> {
+    crate::profile_function!();
+    let size_of_usize = std::mem::size_of::<usize>();
+    if image_bytes.len() < std::mem::size_of::<usize>() * 2 {
+        return Err("Not enough bytes for image".to_string());
+    }
+
+    let width = usize::from_le_bytes(image_bytes[0..size_of_usize].try_into().unwrap());
+    let height = usize::from_le_bytes(
+        image_bytes[size_of_usize..size_of_usize * 2]
+            .try_into()
+            .unwrap(),
+    );
+    let size = [width, height];
+    Ok(egui::ColorImage::from_rgba_unmultiplied(
+        size,
+        &image_bytes[size_of_usize * 2..],
     ))
 }
 
@@ -278,4 +300,26 @@ pub fn load_svg_bytes_with_size(
     let image = egui::ColorImage::from_rgba_unmultiplied([w as _, h as _], pixmap.data());
 
     Ok(image)
+}
+
+#[cfg(feature = "image")]
+pub fn convert_image_to_bytes(image: image::DynamicImage) -> Bytes {
+    let image_buffer = image.to_rgba8();
+    let pixels = image_buffer.as_flat_samples();
+    let mut result: Vec<u8> = Vec::new();
+    result.extend_from_slice(&(image.width() as usize).to_le_bytes());
+    result.extend_from_slice(&(image.height() as usize).to_le_bytes());
+    result.extend_from_slice(pixels.as_slice());
+    result.into()
+}
+
+#[cfg(feature = "image")]
+#[macro_export]
+macro_rules! include_dynamic_image {
+    ($uri: literal, $image: expr) => {
+        egui::ImageSource::Bytes {
+            uri: ::std::borrow::Cow::Borrowed(concat!("rgba8://", $uri)),
+            bytes: $crate::image::convert_image_to_bytes($image),
+        }
+    };
 }

--- a/crates/egui_extras/src/loaders.rs
+++ b/crates/egui_extras/src/loaders.rs
@@ -78,6 +78,14 @@ pub fn install_image_loaders(ctx: &egui::Context) {
         log::trace!("installed ImageCrateLoader");
     }
 
+    #[cfg(feature = "image")]
+    if !ctx.is_loader_installed(self::raw_image_loader::Rgba8ImageLoader::ID) {
+        ctx.add_image_loader(std::sync::Arc::new(
+            self::raw_image_loader::Rgba8ImageLoader::default(),
+        ));
+        log::trace!("installed ImageCrateLoader");
+    }
+
     #[cfg(feature = "svg")]
     if !ctx.is_loader_installed(self::svg_loader::SvgLoader::ID) {
         ctx.add_image_loader(std::sync::Arc::new(self::svg_loader::SvgLoader::default()));
@@ -103,6 +111,9 @@ mod ehttp_loader;
 
 #[cfg(feature = "image")]
 mod image_loader;
+
+#[cfg(feature = "image")]
+mod raw_image_loader;
 
 #[cfg(feature = "svg")]
 mod svg_loader;

--- a/crates/egui_extras/src/loaders/raw_image_loader.rs
+++ b/crates/egui_extras/src/loaders/raw_image_loader.rs
@@ -1,0 +1,84 @@
+use egui::{
+    ahash::HashMap,
+    load::{BytesPoll, ImageLoadResult, ImageLoader, ImagePoll, LoadError, SizeHint},
+    mutex::Mutex,
+    ColorImage,
+};
+use std::{mem::size_of, sync::Arc};
+
+type Entry = Result<Arc<ColorImage>, String>;
+
+#[derive(Default)]
+pub struct Rgba8ImageLoader {
+    cache: Mutex<HashMap<String, Entry>>,
+}
+
+impl Rgba8ImageLoader {
+    pub const ID: &'static str = egui::generate_loader_id!(DynamicImageCrateLoader);
+}
+
+fn is_supported_uri(uri: &str) -> bool {
+    uri.starts_with("rgba8://")
+}
+
+fn is_unsupported_mime(mime: &str) -> bool {
+    mime.contains("svg")
+}
+
+impl ImageLoader for Rgba8ImageLoader {
+    fn id(&self) -> &str {
+        Self::ID
+    }
+
+    fn load(&self, ctx: &egui::Context, uri: &str, _: SizeHint) -> ImageLoadResult {
+        // three stages of guessing if we support loading the image:
+        // 1. URI extension
+
+        // (1)
+        if !is_supported_uri(uri) {
+            return Err(LoadError::NotSupported);
+        }
+
+        let mut cache = self.cache.lock();
+        if let Some(entry) = cache.get(uri).cloned() {
+            match entry {
+                Ok(image) => Ok(ImagePoll::Ready { image }),
+                Err(err) => Err(LoadError::Loading(err)),
+            }
+        } else {
+            match ctx.try_load_bytes(uri) {
+                Ok(BytesPoll::Ready { bytes, mime, .. }) => {
+                    log::trace!("started loading {uri:?}");
+                    let result = crate::image::load_rgba(&bytes).map(Arc::new);
+                    log::trace!("finished loading {uri:?}");
+                    cache.insert(uri.into(), result.clone());
+                    match result {
+                        Ok(image) => Ok(ImagePoll::Ready { image }),
+                        Err(err) => Err(LoadError::Loading(err)),
+                    }
+                }
+                Ok(BytesPoll::Pending { size }) => Ok(ImagePoll::Pending { size }),
+                Err(err) => Err(err),
+            }
+        }
+    }
+
+    fn forget(&self, uri: &str) {
+        let _ = self.cache.lock().remove(uri);
+    }
+
+    fn forget_all(&self) {
+        self.cache.lock().clear();
+    }
+
+    fn byte_size(&self) -> usize {
+        self.cache
+            .lock()
+            .values()
+            .map(|result| match result {
+                Ok(image) => image.pixels.len() * size_of::<egui::Color32>(),
+                Err(err) => err.len(),
+            })
+            .sum()
+    }
+}


### PR DESCRIPTION
The macro converts the dynamic_image to rgba8 bytes and the rest is handled by the new image loader(only processes Uris that start with "rgba8://"

```
let img = image::load_from_memory(include_bytes!("../../testimg.png").as_slice()).unwrap();
let v = include_dynamic_image!("testimg", img);
let img = Image::new(v);
```