### PR TITLE
Fix `StripBuilder` not allocating its used space

### DIFF
--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -145,7 +145,6 @@ impl<'l> StripLayout<'l> {
             );
         }
 
-        let response = self.ui.allocate_rect(max_rect, self.sense);
         let used_rect = self.cell(flags, max_rect, add_cell_contents);
 
         self.set_pos(max_rect);
@@ -156,7 +155,7 @@ impl<'l> StripLayout<'l> {
             max_rect.union(used_rect)
         };
 
-        let response = response.with_new_rect(allocation_rect);
+        let response = self.ui.allocate_rect(allocation_rect, self.sense);
 
         (used_rect, response)
     }


### PR DESCRIPTION
At crates\egui_extras\src\layout.rs :

Allocate allocation_rect instead of max_rect.
Go back from this:
```
let response = self.ui.allocate_rect(max_rect, self.sense);
let response = response.with_new_rect(allocation_rect);
return (used_rect, response)
```

to this:
```
let response = self.ui.allocate_rect(allocation_rect, self.sense);
return (used_rect, response)
```

In order to allocate the

Closes <https://github.com/emilk/egui/issues/3956>.
