### PR TITLE
add with_taskbar to viewport builder

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1498,7 +1498,7 @@ pub fn create_winit_window_builder<T>(
 
         // Windows:
         drag_and_drop: _drag_and_drop,
-        skip_taskbar: _skip_taskbar,
+        taskbar: _taskbar,
 
         // wayland:
         app_id: _app_id,
@@ -1581,8 +1581,8 @@ pub fn create_winit_window_builder<T>(
         if let Some(enable) = _drag_and_drop {
             window_builder = window_builder.with_drag_and_drop(enable);
         }
-        if let Some(skip) = _skip_taskbar {
-            window_builder = window_builder.with_skip_taskbar(skip);
+        if let Some(show) = _taskbar {
+            window_builder = window_builder.with_skip_taskbar(!show);
         }
     }
 

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1498,6 +1498,7 @@ pub fn create_winit_window_builder<T>(
 
         // Windows:
         drag_and_drop: _drag_and_drop,
+        skip_taskbar: _skip_taskbar,
 
         // wayland:
         app_id: _app_id,
@@ -1575,9 +1576,14 @@ pub fn create_winit_window_builder<T>(
     }
 
     #[cfg(target_os = "windows")]
-    if let Some(enable) = _drag_and_drop {
+    {
         use winit::platform::windows::WindowBuilderExtWindows as _;
-        window_builder = window_builder.with_drag_and_drop(enable);
+        if let Some(enable) = _drag_and_drop {
+            window_builder = window_builder.with_drag_and_drop(enable);
+        }
+        if let Some(skip) = _skip_taskbar {
+            window_builder = window_builder.with_skip_taskbar(skip);
+        }
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -186,7 +186,9 @@ pub struct Options {
 
     /// If any widget moves or changes id, repaint everything.
     ///
-    /// This is `true` by default.
+    /// It is recommended you keep this OFF, because
+    /// it is know to cause endless repaints, for unknown reasons
+    /// (https://github.com/rerun-io/rerun/issues/5018)
     pub repaint_on_widget_change: bool,
 
     /// This is a signal to any backend that we want the [`crate::PlatformOutput::events`] read out loud.
@@ -221,7 +223,7 @@ impl Default for Options {
             zoom_factor: 1.0,
             zoom_with_keyboard: true,
             tessellation_options: Default::default(),
-            repaint_on_widget_change: true,
+            repaint_on_widget_change: false,
             screen_reader: false,
             preload_font_glyphs: true,
             warn_on_id_clash: cfg!(debug_assertions),

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -292,7 +292,7 @@ pub struct ViewportBuilder {
 
     // windows:
     pub drag_and_drop: Option<bool>,
-    pub skip_taskbar: Option<bool>,
+    pub taskbar: Option<bool>,
 
     pub close_button: Option<bool>,
     pub minimize_button: Option<bool>,
@@ -447,8 +447,8 @@ impl ViewportBuilder {
 
     /// windows: Whether show or hide the window icon in the taskbar.
     #[inline]
-    pub fn with_skip_taskbar(mut self, skip: bool) -> Self {
-        self.skip_taskbar = Some(skip);
+    pub fn with_taskbar(mut self, show: bool) -> Self {
+        self.taskbar = Some(show);
         self
     }
 
@@ -612,7 +612,7 @@ impl ViewportBuilder {
             maximize_button: new_maximize_button,
             window_level: new_window_level,
             mouse_passthrough: new_mouse_passthrough,
-            skip_taskbar: new_skip_taskbar,
+            taskbar: new_taskbar,
         } = new_vp_builder;
 
         let mut commands = Vec::new();
@@ -769,8 +769,8 @@ impl ViewportBuilder {
             recreate_window = true;
         }
 
-        if new_skip_taskbar.is_some() && self.skip_taskbar != new_skip_taskbar {
-            self.skip_taskbar = new_skip_taskbar;
+        if new_taskbar.is_some() && self.taskbar != new_taskbar {
+            self.taskbar = new_taskbar;
             recreate_window = true;
         }
 

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -283,13 +283,16 @@ pub struct ViewportBuilder {
     pub icon: Option<Arc<IconData>>,
     pub active: Option<bool>,
     pub visible: Option<bool>,
-    pub drag_and_drop: Option<bool>,
 
     // macOS:
     pub fullsize_content_view: Option<bool>,
     pub title_shown: Option<bool>,
     pub titlebar_buttons_shown: Option<bool>,
     pub titlebar_shown: Option<bool>,
+
+    // windows:
+    pub drag_and_drop: Option<bool>,
+    pub skip_taskbar: Option<bool>,
 
     pub close_button: Option<bool>,
     pub minimize_button: Option<bool>,
@@ -439,6 +442,13 @@ impl ViewportBuilder {
     #[inline]
     pub fn with_titlebar_shown(mut self, shown: bool) -> Self {
         self.titlebar_shown = Some(shown);
+        self
+    }
+
+    /// windows: Whether show or hide the window icon in the taskbar.
+    #[inline]
+    pub fn with_skip_taskbar(mut self, skip: bool) -> Self {
+        self.skip_taskbar = Some(skip);
         self
     }
 
@@ -602,6 +612,7 @@ impl ViewportBuilder {
             maximize_button: new_maximize_button,
             window_level: new_window_level,
             mouse_passthrough: new_mouse_passthrough,
+            skip_taskbar: new_skip_taskbar,
         } = new_vp_builder;
 
         let mut commands = Vec::new();
@@ -755,6 +766,11 @@ impl ViewportBuilder {
 
         if new_titlebar_shown.is_some() && self.titlebar_shown != new_titlebar_shown {
             self.titlebar_shown = new_titlebar_shown;
+            recreate_window = true;
+        }
+
+        if new_skip_taskbar.is_some() && self.skip_taskbar != new_skip_taskbar {
+            self.skip_taskbar = new_skip_taskbar;
             recreate_window = true;
         }
 


### PR DESCRIPTION
Allows removing the taskbar icon of a viewport.

This can be useful when making an overlay type viewport (window is always on top).
