### PR TITLE
Make `egui_wgpu::renderer` a private module

### DIFF
--- a/crates/eframe/src/web/web_painter_wgpu.rs
+++ b/crates/eframe/src/web/web_painter_wgpu.rs
@@ -7,7 +7,7 @@ use raw_window_handle::{
 use wasm_bindgen::JsValue;
 use web_sys::HtmlCanvasElement;
 
-use egui_wgpu::{renderer::ScreenDescriptor, RenderState, SurfaceErrorAction};
+use egui_wgpu::{RenderState, SurfaceErrorAction};
 
 use crate::WebOptions;
 
@@ -233,7 +233,7 @@ impl WebPainter for WebPainterWgpu {
                 });
 
         // Upload all resources for the GPU.
-        let screen_descriptor = ScreenDescriptor {
+        let screen_descriptor = egui_wgpu::ScreenDescriptor {
             size_in_pixels,
             pixels_per_point,
         };

--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -3,7 +3,7 @@
 //! If you're targeting WebGL you also need to turn on the
 //! `webgl` feature of the `wgpu` crate:
 //!
-//! ```ignore
+//! ```toml
 //! # Enable both WebGL and WebGPU backends on web.
 //! wgpu = { version = "*", features = ["webgpu", "webgl"] }
 //! ```
@@ -21,9 +21,9 @@
 pub use wgpu;
 
 /// Low-level painting of [`egui`](https://github.com/emilk/egui) on [`wgpu`].
-pub mod renderer;
-pub use renderer::Renderer;
-pub use renderer::{Callback, CallbackResources, CallbackTrait};
+mod renderer;
+
+pub use renderer::*;
 
 /// Module for painting [`egui`](https://github.com/emilk/egui) with [`wgpu`] on [`winit`].
 #[cfg(feature = "winit")]

--- a/crates/egui-wgpu/src/renderer.rs
+++ b/crates/egui-wgpu/src/renderer.rs
@@ -4,7 +4,6 @@ use std::{borrow::Cow, num::NonZeroU64, ops::Range};
 
 use epaint::{ahash::HashMap, emath::NumExt, PaintCallbackInfo, Primitive, Vertex};
 
-use wgpu;
 use wgpu::util::DeviceExt as _;
 
 /// You can use this for storage when implementing [`CallbackTrait`].

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -73,7 +73,7 @@ impl BufferPadding {
 
 /// Everything you need to paint egui with [`wgpu`] on [`winit`].
 ///
-/// Alternatively you can use [`crate::renderer`] directly.
+/// Alternatively you can use [`crate::Renderer`] directly.
 ///
 /// NOTE: all egui viewports share the same painter.
 pub struct Painter {

--- a/crates/egui_demo_app/src/apps/custom3d_wgpu.rs
+++ b/crates/egui_demo_app/src/apps/custom3d_wgpu.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU64;
 
 use eframe::{
     egui_wgpu::wgpu::util::DeviceExt,
-    egui_wgpu::{self, renderer::ScreenDescriptor, wgpu},
+    egui_wgpu::{self, wgpu},
 };
 
 pub struct Custom3d {
@@ -148,7 +148,7 @@ impl egui_wgpu::CallbackTrait for CustomTriangleCallback {
         &self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        _screen_descriptor: &ScreenDescriptor,
+        _screen_descriptor: &egui_wgpu::ScreenDescriptor,
         _egui_encoder: &mut wgpu::CommandEncoder,
         resources: &mut egui_wgpu::CallbackResources,
     ) -> Vec<wgpu::CommandBuffer> {


### PR DESCRIPTION
All its contents is exported to the top-level
