### PR TITLE
Add scroll bar visibility option to Table widget

### DIFF
--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -3,7 +3,10 @@
 //! | fixed size | all available space/minimum | 30% of available width | fixed size |
 //! Takes all available height, so if you want something below the table, put it in a strip.
 
-use egui::{Align, NumExt as _, Rangef, Rect, Response, ScrollArea, Ui, Vec2, Vec2b};
+use egui::{
+    scroll_area::ScrollBarVisibility, Align, NumExt as _, Rangef, Rect, Response, ScrollArea, Ui,
+    Vec2, Vec2b,
+};
 
 use crate::{
     layout::{CellDirection, CellSize, StripLayoutFlags},
@@ -171,6 +174,7 @@ struct TableScrollOptions {
     min_scrolled_height: f32,
     max_scroll_height: f32,
     auto_shrink: Vec2b,
+    scroll_bar_visibility: ScrollBarVisibility,
 }
 
 impl Default for TableScrollOptions {
@@ -184,6 +188,7 @@ impl Default for TableScrollOptions {
             min_scrolled_height: 200.0,
             max_scroll_height: 800.0,
             auto_shrink: Vec2b::TRUE,
+            scroll_bar_visibility: ScrollBarVisibility::VisibleWhenNeeded,
         }
     }
 }
@@ -359,6 +364,15 @@ impl<'a> TableBuilder<'a> {
     #[inline]
     pub fn auto_shrink(mut self, auto_shrink: impl Into<Vec2b>) -> Self {
         self.scroll_options.auto_shrink = auto_shrink.into();
+        self
+    }
+
+    /// Set the visibility of both horizontal and vertical scroll bars.
+    ///
+    /// With `ScrollBarVisibility::VisibleWhenNeeded` (default), the scroll bar will be visible only when needed.
+    #[inline]
+    pub fn scroll_bar_visibility(mut self, scroll_bar_visibility: ScrollBarVisibility) -> Self {
+        self.scroll_options.scroll_bar_visibility = scroll_bar_visibility;
         self
     }
 
@@ -606,6 +620,7 @@ impl<'a> Table<'a> {
             min_scrolled_height,
             max_scroll_height,
             auto_shrink,
+            scroll_bar_visibility,
         } = scroll_options;
 
         let cursor_position = ui.cursor().min;
@@ -616,7 +631,8 @@ impl<'a> Table<'a> {
             .stick_to_bottom(stick_to_bottom)
             .min_scrolled_height(min_scrolled_height)
             .max_height(max_scroll_height)
-            .auto_shrink(auto_shrink);
+            .auto_shrink(auto_shrink)
+            .scroll_bar_visibility(scroll_bar_visibility);
 
         if let Some(scroll_offset_y) = scroll_offset_y {
             scroll_area = scroll_area.vertical_scroll_offset(scroll_offset_y);


### PR DESCRIPTION
There was no way to customize this as ScrollArea gets created inside Table widget, this exposes the functionality, so scroll bars on tables can be customized.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->
