### PR TITLE
egui demo: Fix space reserved for source code link

### DIFF
--- a/crates/egui_demo_lib/src/demo/strip_demo.rs
+++ b/crates/egui_demo_lib/src/demo/strip_demo.rs
@@ -1,4 +1,4 @@
-use egui::Color32;
+use egui::{Color32, TextStyle};
 use egui_extras::{Size, StripBuilder};
 
 /// Shows off a table with dynamic layout
@@ -33,11 +33,12 @@ impl super::View for StripDemo {
             egui::lerp(Rgba::from(color)..=Rgba::from(faded_color), t).into()
         };
 
+        let body_text_size = TextStyle::Body.resolve(ui.style()).size;
         StripBuilder::new(ui)
             .size(Size::exact(50.0))
             .size(Size::remainder())
             .size(Size::relative(0.5).at_least(60.0))
-            .size(Size::exact(10.5))
+            .size(Size::exact(body_text_size))
             .vertical(|mut strip| {
                 strip.cell(|ui| {
                     ui.painter().rect_filled(

--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -109,6 +109,7 @@ impl super::View for TableDemo {
         StripBuilder::new(ui)
             .size(Size::remainder().at_least(100.0)) // for the table
             .size(Size::exact(10.5)) // for the source code link
+            .clip(true)
             .vertical(|mut strip| {
                 strip.cell(|ui| {
                     egui::ScrollArea::horizontal().show(ui, |ui| {

--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -1,3 +1,5 @@
+use egui::TextStyle;
+
 #[derive(PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 enum DemoType {
@@ -105,11 +107,11 @@ impl super::View for TableDemo {
         ui.separator();
 
         // Leave room for the source code link after the table demo:
+        let body_text_size = TextStyle::Body.resolve(ui.style()).size;
         use egui_extras::{Size, StripBuilder};
         StripBuilder::new(ui)
             .size(Size::remainder().at_least(100.0)) // for the table
-            .size(Size::exact(10.5)) // for the source code link
-            .clip(true)
+            .size(Size::exact(body_text_size)) // for the source code link
             .vertical(|mut strip| {
                 strip.cell(|ui| {
                     egui::ScrollArea::horizontal().show(ui, |ui| {


### PR DESCRIPTION
Clip the cell of the source code link to prevent the strip from growing infinitely if the reserved size for the link is not sufficient.

![image](https://github.com/emilk/egui/assets/2380253/0cf214fc-addc-4212-90fc-d68834c1cfe7)

Closes <https://github.com/emilk/egui/issues/3980>.
