### PR TITLE
TextEdit: fix crash when hitting SHIFT + TAB around non-ASCII text

### DIFF
--- a/crates/egui/src/widgets/text_edit/text_buffer.rs
+++ b/crates/egui/src/widgets/text_edit/text_buffer.rs
@@ -89,10 +89,12 @@ pub trait TextBuffer {
     fn decrease_indentation(&mut self, ccursor: &mut CCursor) {
         let line_start = find_line_start(self.as_str(), *ccursor);
 
-        let remove_len = if self.as_str()[line_start.index..].starts_with('\t') {
+        let remove_len = if self.as_str().chars().nth(line_start.index) == Some('\t') {
             Some(1)
-        } else if self.as_str()[line_start.index..]
+        } else if self
+            .as_str()
             .chars()
+            .skip(line_start.index)
             .take(TAB_SIZE)
             .all(|c| c == ' ')
         {


### PR DESCRIPTION
* Closes #3846 
* Closes #3878

Dear emilk.

Leaving aside other function,
I think this is all you need to fix to patch the panic that occurs when Shift + TAB.

Thank you, emilk.
