### PR TITLE
Improve panic message in egui-wgpu when failing to create buffers

### DIFF
--- a/crates/egui-wgpu/src/renderer.rs
+++ b/crates/egui-wgpu/src/renderer.rs
@@ -817,6 +817,7 @@ impl Renderer {
             crate::profile_scope!("indices", index_count.to_string());
 
             self.index_buffer.slices.clear();
+
             let required_index_buffer_size = (std::mem::size_of::<u32>() * index_count) as u64;
             if self.index_buffer.capacity < required_index_buffer_size {
                 // Resize index buffer if needed.
@@ -825,13 +826,16 @@ impl Renderer {
                 self.index_buffer.buffer = create_index_buffer(device, self.index_buffer.capacity);
             }
 
-            let mut index_buffer_staging = queue
-                .write_buffer_with(
-                    &self.index_buffer.buffer,
-                    0,
-                    NonZeroU64::new(required_index_buffer_size).unwrap(),
-                )
-                .expect("Failed to create staging buffer for index data");
+            let index_buffer_staging = queue.write_buffer_with(
+                &self.index_buffer.buffer,
+                0,
+                NonZeroU64::new(required_index_buffer_size).unwrap(),
+            );
+
+            let Some(mut index_buffer_staging) = index_buffer_staging else {
+                panic!("Failed to create staging buffer for index data. Index buffer size: {}, capacity: {} (bytes)", required_index_buffer_size, self.index_buffer.capacity);
+            };
+
             let mut index_offset = 0;
             for epaint::ClippedPrimitive { primitive, .. } in paint_jobs {
                 match primitive {
@@ -851,6 +855,7 @@ impl Renderer {
             crate::profile_scope!("vertices", vertex_count.to_string());
 
             self.vertex_buffer.slices.clear();
+
             let required_vertex_buffer_size = (std::mem::size_of::<Vertex>() * vertex_count) as u64;
             if self.vertex_buffer.capacity < required_vertex_buffer_size {
                 // Resize vertex buffer if needed.
@@ -860,13 +865,16 @@ impl Renderer {
                     create_vertex_buffer(device, self.vertex_buffer.capacity);
             }
 
-            let mut vertex_buffer_staging = queue
-                .write_buffer_with(
-                    &self.vertex_buffer.buffer,
-                    0,
-                    NonZeroU64::new(required_vertex_buffer_size).unwrap(),
-                )
-                .expect("Failed to create staging buffer for vertex data");
+            let vertex_buffer_staging = queue.write_buffer_with(
+                &self.vertex_buffer.buffer,
+                0,
+                NonZeroU64::new(required_vertex_buffer_size).unwrap(),
+            );
+
+            let Some(mut vertex_buffer_staging) = vertex_buffer_staging else {
+                panic!("Failed to create staging buffer for vertex data. Vertex buffer size: {}, capacity: {} (bytes)", required_vertex_buffer_size, self.vertex_buffer.capacity);
+            };
+
             let mut vertex_offset = 0;
             for epaint::ClippedPrimitive { primitive, .. } in paint_jobs {
                 match primitive {

--- a/crates/egui-wgpu/src/renderer.rs
+++ b/crates/egui-wgpu/src/renderer.rs
@@ -833,7 +833,7 @@ impl Renderer {
             );
 
             let Some(mut index_buffer_staging) = index_buffer_staging else {
-                panic!("Failed to create staging buffer for index data. Index buffer size: {}, capacity: {} (bytes)", required_index_buffer_size, self.index_buffer.capacity);
+                panic!("Failed to create staging buffer for index data. Index count: {index_count}. Required index buffer size: {required_index_buffer_size}. Actual size {} and capacity: {} (bytes)", self.index_buffer.buffer.size(), self.index_buffer.capacity);
             };
 
             let mut index_offset = 0;
@@ -872,7 +872,7 @@ impl Renderer {
             );
 
             let Some(mut vertex_buffer_staging) = vertex_buffer_staging else {
-                panic!("Failed to create staging buffer for vertex data. Vertex buffer size: {}, capacity: {} (bytes)", required_vertex_buffer_size, self.vertex_buffer.capacity);
+                panic!("Failed to create staging buffer for vertex data. Vertex count: {vertex_count}. Required vertex buffer size: {required_vertex_buffer_size}. Actual size {} and capacity: {} (bytes)", self.vertex_buffer.buffer.size(), self.vertex_buffer.capacity);
             };
 
             let mut vertex_offset = 0;


### PR DESCRIPTION
Example:

> thread 'main' panicked at 'Failed to create staging buffer for vertex data. Vertex count: 10 011 232. Required vertex buffer size: 200 224 640. Actual size 349 450 240 and capacity: 349 450 240 (bytes)