### PR TITLE
Prevent egui::Window from becoming larger than Viewport

### DIFF
--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -428,7 +428,7 @@ impl<'open> Window<'open> {
         };
 
         let max_width = area.constrain_rect().unwrap_or(Rect::EVERYTHING).width();
-        let max_height = 
+        let max_height =
             area.constrain_rect().unwrap_or(Rect::EVERYTHING).height() - title_bar_height;
         resize.max_size.x = resize.max_size.x.min(max_width);
         resize.max_size.y = resize.max_size.y.min(max_height);

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -427,7 +427,7 @@ impl<'open> Window<'open> {
         };
 
         let viewport_rect =
-            ctx.input(|i| i.clone().viewport().inner_rect.unwrap_or(Rect::EVERYTHING));
+            ctx.input(|i| i.viewport().inner_rect.unwrap_or(Rect::EVERYTHING));
         let max_width = viewport_rect.width();
         let max_height = viewport_rect.height() - title_bar_height;
         resize.max_size.x = resize.max_size.x.min(max_width);

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -426,8 +426,7 @@ impl<'open> Window<'open> {
             0.0
         };
 
-        let viewport_rect =
-            ctx.input(|i| i.viewport().inner_rect.unwrap_or(Rect::EVERYTHING));
+        let viewport_rect = ctx.input(|i| i.viewport().inner_rect.unwrap_or(Rect::EVERYTHING));
         let max_width = viewport_rect.width();
         let max_height = viewport_rect.height() - title_bar_height;
         resize.max_size.x = resize.max_size.x.min(max_width);

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -429,9 +429,9 @@ impl<'open> Window<'open> {
             (0.0, 0.0)
         };
 
-        let viewport_rect = ctx.input(|i| i.viewport().inner_rect.unwrap_or(Rect::EVERYTHING));
-        let max_width = viewport_rect.width();
-        let max_height = viewport_rect.height() - title_bar_height;
+        let max_rect = ctx.input(|i| i.viewport().inner_rect.unwrap_or(ctx.screen_rect()));
+        let max_width = max_rect.width();
+        let max_height = max_rect.height() - title_bar_height;
         resize.max_size.x = resize.max_size.x.min(max_width);
         resize.max_size.y = resize.max_size.y.min(max_height);
 

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -426,7 +426,8 @@ impl<'open> Window<'open> {
             0.0
         };
 
-        let viewport_rect = ctx.input(|i| i.clone().viewport().inner_rect.unwrap_or(Rect::EVERYTHING));
+        let viewport_rect =
+            ctx.input(|i| i.clone().viewport().inner_rect.unwrap_or(Rect::EVERYTHING));
         let max_width = viewport_rect.width();
         let max_height = viewport_rect.height() - title_bar_height;
         resize.max_size.x = resize.max_size.x.min(max_width);

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -427,9 +427,9 @@ impl<'open> Window<'open> {
             (0.0, 0.0)
         };
 
-        let max_width = area.constrain_rect().unwrap_or(Rect::EVERYTHING).width();
-        let max_height =
-            area.constrain_rect().unwrap_or(Rect::EVERYTHING).height() - title_bar_height;
+        let viewport_rect = ctx.input(|i| i.viewport().inner_rect.unwrap_or(Rect::EVERYTHING));
+        let max_width = viewport_rect.width();
+        let max_height = viewport_rect.height() - title_bar_height;
         resize.max_size.x = resize.max_size.x.min(max_width);
         resize.max_size.y = resize.max_size.y.min(max_height);
 

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -426,6 +426,12 @@ impl<'open> Window<'open> {
             0.0
         };
 
+        let viewport_rect = ctx.input(|i| i.clone().viewport().inner_rect.unwrap_or(Rect::EVERYTHING));
+        let max_width = viewport_rect.width();
+        let max_height = viewport_rect.height() - title_bar_height;
+        resize.max_size.x = resize.max_size.x.min(max_width);
+        resize.max_size.y = resize.max_size.y.min(max_height);
+
         // First interact (move etc) to avoid frame delay:
         let last_frame_outer_rect = area.state().rect();
         let interaction = if possible.movable || possible.resizable() {

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -429,7 +429,7 @@ impl<'open> Window<'open> {
             (0.0, 0.0)
         };
 
-        let max_rect = ctx.input(|i| i.viewport().inner_rect.unwrap_or(ctx.screen_rect()));
+        let max_rect = ctx.input(|i| i.viewport().inner_rect.unwrap_or(Rect::EVERYTHING));
         let max_width = max_rect.width();
         let max_height = max_rect.height() - title_bar_height;
         resize.max_size.x = resize.max_size.x.min(max_width);

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -426,9 +426,9 @@ impl<'open> Window<'open> {
             0.0
         };
 
-        let viewport_rect = ctx.input(|i| i.viewport().inner_rect.unwrap_or(Rect::EVERYTHING));
-        let max_width = viewport_rect.width();
-        let max_height = viewport_rect.height() - title_bar_height;
+        let max_width = area.constrain_rect().unwrap_or(Rect::EVERYTHING).width();
+        let max_height = 
+            area.constrain_rect().unwrap_or(Rect::EVERYTHING).height() - title_bar_height;
         resize.max_size.x = resize.max_size.x.min(max_width);
         resize.max_size.y = resize.max_size.y.min(max_height);
 


### PR DESCRIPTION
* Closes #3987  

There is a need to prevent egui::Window from becoming larger than the Viewport.

( This is basic. This alone is not enough. )
