### PR TITLE
epaint: Break up memozation of text layouts into paragraphs

### DIFF
--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, ops::Deref, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 
 use crate::{
     mutex::{Mutex, MutexGuard},
@@ -704,39 +704,97 @@ impl GalleyCache {
             }
             std::collections::hash_map::Entry::Vacant(entry) => {
                 // Optimize by splitting the job into paragraphs, if possible.
-                if job.break_on_newline && job.text.contains('\n') {
-                    let mut iter = job.text.split('\n').map(|paragraph| {
-                        // TODO(dacid44): There is almost definitely more logic required to
-                        // properly split up a LayoutJob (i.e., splitting the LayoutSections).
-                        let job = LayoutJob {
-                            text: paragraph.to_owned(),
-                            ..job.clone()
-                        };
-                        self.layout(fonts, job)
-                    });
-                    let first_galley = iter.next()
-                        .expect("if a '\n' is found there should be at least 2 split parts")
-                        .deref()
-                        .clone();
-                    let galley = Arc::new(iter.fold(first_galley, |galley, next_galley| {
-                        // TODO(dacid44): Figure out merging of Galleys.
-                        todo!()
-                    }));
-                    // Can't use the entry, needed to drop it to recursively call self.layout().
-                    self.cache.insert(hash, CachedGalley {
-                        last_used: self.generation,
-                        galley: galley.clone(),
-                    });
-                    galley
-                } else {
-                    let galley = super::layout(fonts, job.into());
-                    let galley = Arc::new(galley);
-                    entry.insert(CachedGalley {
-                        last_used: self.generation,
-                        galley: galley.clone(),
-                    });
-                    galley
+                if job.break_on_newline {
+                    // let mut newlines = job.text.match_indices('\n').peekable();
+                    // if newlines.peek().filter(|(i, _)| *i != job.text.len() - 1).is_some() {
+                    //     let mut galleys = newlines.map(|(i, _)| Some(i + 1)).chain(std::iter::once(None)).scan(0, |last, i| {
+                    //         let i = i.unwrap_or(job.text.len());
+                    //         // Get the relevant part of the job. Should return None if last ==
+                    //         // job.text.len()
+                    //         let new_job = job.slice(*last..i);
+                    //         *last = i;
+                    //         new_job
+                    //     }).map(|job| self.layout(fonts, job));
+                    //
+                    //     let first_galley = galleys.next().expect("there should be at least one galley");
+                    //     let galley = galleys.try_fold((*first_galley).clone(), |acc_galley, galley| {
+                    //         acc_galley.rows.extend(galley.rows);
+                    //         acc_galley.elided =
+                    //     })
+                    //     self.cache.insert(hash, CachedGalley {
+                    //         last_used: self.generation,
+                    //         galley: first_galley.clone(),
+                    //     });
+                    //     return first_galley;
+                    //
+                    //
+                    // }
+                    let mut newlines = job.text.match_indices('\n').map(|(i, _)| i + 1);
+                    if let Some(first_i) = newlines.next().filter(|i| *i != job.text.len()) {
+                        // TODO(dacid44): remove this .expect()
+                        let mut galley = self
+                            .layout(
+                                fonts,
+                                job.slice(0..first_i, 0)
+                                    .expect("we just ensured that 1 <= i < job.text.len()"),
+                            )
+                            .as_ref()
+                            .clone();
+                        let mut last = first_i;
+                        let mut paragraph_endings = newlines.chain(std::iter::once(job.text.len()));
+                        while let Some(i) = paragraph_endings.next().filter(|_| !galley.elided) {
+                            // job.slice() should return None if lest == job.text.len().
+                            let Some(next_job) = job.slice(last..i, galley.rows.len()) else {
+                                break;
+                            };
+                            let next_galley = self.layout(fonts, next_job);
+                            let offset = emath::vec2(0.0, galley.rect.height());
+                            galley.rows.extend(next_galley.rows.iter().map(|row| {
+                                crate::text::Row {
+                                    rect: row.rect.translate(offset),
+                                    visuals: crate::text::RowVisuals {
+                                        mesh_bounds: row.visuals.mesh_bounds.translate(offset),
+                                        ..row.visuals.clone()
+                                    },
+                                    glyphs: row
+                                        .glyphs
+                                        .iter()
+                                        .map(|glyph| crate::text::Glyph {
+                                            pos: glyph.pos + offset,
+                                            ..*glyph
+                                        })
+                                        .collect(),
+                                    ..row.clone()
+                                }
+                            }));
+                            galley.elided |= next_galley.elided;
+                            galley.rect = galley.rect.union(next_galley.rect.translate(offset));
+                            galley.mesh_bounds = galley
+                                .mesh_bounds
+                                .union(next_galley.mesh_bounds.translate(offset));
+                            galley.num_vertices += next_galley.num_vertices;
+                            galley.num_indices += next_galley.num_indices;
+                            last = i;
+                        }
+                        galley.job = job.into();
+                        let galley = Arc::new(galley);
+                        self.cache.insert(
+                            hash,
+                            CachedGalley {
+                                last_used: self.generation,
+                                galley: galley.clone(),
+                            },
+                        );
+                        return galley;
+                    }
                 }
+                let galley = super::layout(fonts, job.into());
+                let galley = Arc::new(galley);
+                entry.insert(CachedGalley {
+                    last_used: self.generation,
+                    galley: galley.clone(),
+                });
+                galley
             }
         }
     }

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -167,6 +167,38 @@ impl LayoutJob {
         }
         max_height
     }
+
+    /// Get a new `LayoutJob` containing only the text and sections for the given slice. Needs to
+    /// know the number of rows before to calculate text wrapping.
+    pub fn slice(&self, range: Range<usize>, rows_before: usize) -> Option<Self> {
+        if range.is_empty()
+            || range.start >= self.text.len()
+            || range.end > self.text.len()
+            || rows_before > self.wrap.max_rows
+        {
+            return None;
+        }
+        Some(Self {
+            text: self.text[range.clone()].to_owned(),
+            sections: self
+                .sections
+                .iter()
+                .filter_map(|section| {
+                    let new_range = range.start.max(section.byte_range.start)
+                        ..range.end.min(section.byte_range.end);
+                    (!new_range.is_empty()).then(|| LayoutSection {
+                        byte_range: new_range.start - range.start..new_range.end - range.start,
+                        ..section.clone()
+                    })
+                })
+                .collect(),
+            wrap: TextWrapping {
+                max_rows: self.wrap.max_rows - rows_before,
+                ..self.wrap
+            },
+            ..self.clone()
+        })
+    }
 }
 
 impl std::hash::Hash for LayoutJob {


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

Draft for now, I just want to confirm that I'm on the right track for the general logic, and make sure I know about the edge cases when splitting `LayoutJob`s and merging `Galley`s. It looks like I will need to:
- [ ] Filter which `LayoutSection`s go into each `LayoutJob`, and change their offsets
- [ ] Possibly make sure each `LayoutJob` ends with a newline
- [ ] When merging `Galley`s, merge the `rect`s and `mesh_bounds` of each `Galley` together, and possibly offset them?
- [ ] Make sure the `elided` field makes it onto the full `Galley` if set on any paragraph, and stop adding the following `Galley`s if that field is set
- [ ] Sum `num_vertices` and `num_indices`
- [ ] Anything else?

The code compiles right now, but does not pass `cargo cranky` and panics immediately when that codepath is run (byte index out of bounds, probably due to not filtering and offsetting `LayoutSection`s. Also the `todo!()`.)

* Closes <https://github.com/emilk/egui/issues/3086>
