### PR TITLE
Add F21 to F35 key bindings

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1055,6 +1055,21 @@ fn key_from_named_key(named_key: winit::keyboard::NamedKey) -> Option<egui::Key>
         NamedKey::F18 => Key::F18,
         NamedKey::F19 => Key::F19,
         NamedKey::F20 => Key::F20,
+        NamedKey::F21 => Key::F21,
+        NamedKey::F22 => Key::F22,
+        NamedKey::F23 => Key::F23,
+        NamedKey::F24 => Key::F24,
+        NamedKey::F25 => Key::F25,
+        NamedKey::F26 => Key::F26,
+        NamedKey::F27 => Key::F27,
+        NamedKey::F28 => Key::F28,
+        NamedKey::F29 => Key::F29,
+        NamedKey::F30 => Key::F30,
+        NamedKey::F31 => Key::F31,
+        NamedKey::F32 => Key::F32,
+        NamedKey::F33 => Key::F33,
+        NamedKey::F34 => Key::F34,
+        NamedKey::F35 => Key::F35,
         _ => {
             log::trace!("Unknown key: {named_key:?}");
             return None;
@@ -1161,6 +1176,21 @@ fn key_from_key_code(key: winit::keyboard::KeyCode) -> Option<egui::Key> {
         KeyCode::F18 => Key::F18,
         KeyCode::F19 => Key::F19,
         KeyCode::F20 => Key::F20,
+        KeyCode::F21 => Key::F21,
+        KeyCode::F22 => Key::F22,
+        KeyCode::F23 => Key::F23,
+        KeyCode::F24 => Key::F24,
+        KeyCode::F25 => Key::F25,
+        KeyCode::F26 => Key::F26,
+        KeyCode::F27 => Key::F27,
+        KeyCode::F28 => Key::F28,
+        KeyCode::F29 => Key::F29,
+        KeyCode::F30 => Key::F30,
+        KeyCode::F31 => Key::F31,
+        KeyCode::F32 => Key::F32,
+        KeyCode::F33 => Key::F33,
+        KeyCode::F34 => Key::F34,
+        KeyCode::F35 => Key::F35,
 
         _ => {
             return None;

--- a/crates/egui/src/data/key.rs
+++ b/crates/egui/src/data/key.rs
@@ -154,6 +154,21 @@ pub enum Key {
     F18,
     F19,
     F20,
+    F21,
+    F22,
+    F23,
+    F24,
+    F25,
+    F26,
+    F27,
+    F28,
+    F29,
+    F30,
+    F31,
+    F32,
+    F33,
+    F34,
+    F35,
     // When adding keys, remember to also update `crates/egui-winit/src/lib.rs`
     // and [`Self::ALL`].
     // Also: don't add keys last; add them to the group they best belong to.
@@ -254,6 +269,21 @@ impl Key {
         Self::F18,
         Self::F19,
         Self::F20,
+        Self::F21,
+        Self::F22,
+        Self::F23,
+        Self::F24,
+        Self::F25,
+        Self::F26,
+        Self::F27,
+        Self::F28,
+        Self::F29,
+        Self::F30,
+        Self::F31,
+        Self::F32,
+        Self::F33,
+        Self::F34,
+        Self::F35,
     ];
 
     /// Converts `"A"` to `Key::A`, `Space` to `Key::Space`, etc.
@@ -362,6 +392,21 @@ impl Key {
             "F18" => Self::F18,
             "F19" => Self::F19,
             "F20" => Self::F20,
+            "F21" => Self::F21,
+            "F22" => Self::F22,
+            "F23" => Self::F23,
+            "F24" => Self::F24,
+            "F25" => Self::F25,
+            "F26" => Self::F26,
+            "F27" => Self::F27,
+            "F28" => Self::F28,
+            "F29" => Self::F29,
+            "F30" => Self::F30,
+            "F31" => Self::F31,
+            "F32" => Self::F32,
+            "F33" => Self::F33,
+            "F34" => Self::F34,
+            "F35" => Self::F35,
 
             _ => return None,
         })
@@ -494,6 +539,21 @@ impl Key {
             Self::F18 => "F18",
             Self::F19 => "F19",
             Self::F20 => "F20",
+            Self::F21 => "F21",
+            Self::F22 => "F22",
+            Self::F23 => "F23",
+            Self::F24 => "F24",
+            Self::F25 => "F25",
+            Self::F26 => "F26",
+            Self::F27 => "F27",
+            Self::F28 => "F28",
+            Self::F29 => "F29",
+            Self::F30 => "F30",
+            Self::F31 => "F31",
+            Self::F32 => "F32",
+            Self::F33 => "F33",
+            Self::F34 => "F34",
+            Self::F35 => "F35",
         }
     }
 }
@@ -502,7 +562,7 @@ impl Key {
 fn test_key_from_name() {
     assert_eq!(
         Key::ALL.len(),
-        Key::F20 as usize + 1,
+        Key::F35 as usize + 1,
         "Some keys are missing in Key::ALL"
     );
 


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes <https://github.com/emilk/egui/issues/3990>

`winit` supports up to F35, so thought it was better to just add them all.