### PR TITLE
Fix `TextEdit` being too short whenever there is horizontal margin

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -470,7 +470,7 @@ impl<'t> TextEdit<'t> {
             available_width
         } else {
             desired_width.min(available_width)
-        } - margin.x * 2.0;
+        };
 
         let font_id_clone = font_id.clone();
         let mut default_layouter = move |ui: &Ui, text: &str, wrap_width: f32| {


### PR DESCRIPTION
The allocated width is reduced by the horizontal margin inside `show_content` but the margin is already factored into the content_ui's rect.
This causes both text and frame (not shown here) to be `2.0 * margin.x` too short.

Before:
![image](https://github.com/emilk/egui/assets/23122431/6a9a0264-3fc0-48b7-b462-82120ed47fcf)

After:
![image-1](https://github.com/emilk/egui/assets/23122431/ffef9edc-d571-4fca-96cf-c2e42e2f0057)
(*The blue rect is the TextEdit's (expected) final size.)