### PR TITLE
Response Sense Recognition Issue

### DIFF
--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -596,6 +596,15 @@ impl Response {
     /// ```
     #[must_use]
     pub fn interact(&self, sense: Sense) -> Self {
+        self.ctx.interact_with_hovered(
+            self.layer_id,
+            self.id,
+            self.rect,
+            sense,
+            self.enabled,
+            self.hovered,
+        )
+        /*
         self.ctx.interact(
             self.ctx.layer_painter(self.layer_id).clip_rect(),
             self.ctx.style().spacing.item_spacing,
@@ -605,6 +614,7 @@ impl Response {
             sense,
             self.enabled,
         )
+        */
     }
 
     /// Adjust the scroll position until this UI becomes visible.

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -596,13 +596,14 @@ impl Response {
     /// ```
     #[must_use]
     pub fn interact(&self, sense: Sense) -> Self {
-        self.ctx.interact_with_hovered(
+        self.ctx.interact(
+            self.rect,
+            self.ctx.style().spacing.item_spacing,
             self.layer_id,
             self.id,
             self.rect,
             sense,
             self.enabled,
-            self.hovered,
         )
     }
 

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -597,7 +597,7 @@ impl Response {
     #[must_use]
     pub fn interact(&self, sense: Sense) -> Self {
         self.ctx.interact(
-            self.rect,
+            self.ctx.layer_painter(self.layer_id).clip_rect(),
             self.ctx.style().spacing.item_spacing,
             self.layer_id,
             self.id,

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -604,17 +604,6 @@ impl Response {
             self.enabled,
             self.hovered,
         )
-        /*
-        self.ctx.interact(
-            self.ctx.layer_painter(self.layer_id).clip_rect(),
-            self.ctx.style().spacing.item_spacing,
-            self.layer_id,
-            self.id,
-            self.rect,
-            sense,
-            self.enabled,
-        )
-        */
     }
 
     /// Adjust the scroll position until this UI becomes visible.

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -334,7 +334,7 @@ impl<'a> Widget for Image<'a> {
         let original_image_size = tlr.as_ref().ok().and_then(|t| t.size());
         let ui_size = self.calc_size(ui.available_size(), original_image_size);
 
-        let (rect, response) = ui.allocate_exact_size(ui_size, self.sense);
+        let (rect, response) = ui.allocate_exact_size(ui_size, Sense::click_and_drag());
         if ui.is_rect_visible(rect) {
             paint_texture_load_result(
                 ui,

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -334,7 +334,7 @@ impl<'a> Widget for Image<'a> {
         let original_image_size = tlr.as_ref().ok().and_then(|t| t.size());
         let ui_size = self.calc_size(ui.available_size(), original_image_size);
 
-        let (rect, response) = ui.allocate_exact_size(ui_size, Sense::click);
+        let (rect, response) = ui.allocate_exact_size(ui_size, Sense::click());
         if ui.is_rect_visible(rect) {
             paint_texture_load_result(
                 ui,

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -334,7 +334,7 @@ impl<'a> Widget for Image<'a> {
         let original_image_size = tlr.as_ref().ok().and_then(|t| t.size());
         let ui_size = self.calc_size(ui.available_size(), original_image_size);
 
-        let (rect, response) = ui.allocate_exact_size(ui_size, Sense::click_and_drag());
+        let (rect, response) = ui.allocate_exact_size(ui_size, Sense::click);
         if ui.is_rect_visible(rect) {
             paint_texture_load_result(
                 ui,


### PR DESCRIPTION
Closes #3989

@emilk 
Please review to see if there are any problems.

This Pull Request is Invalid `clip_rect`.
(For example, when the image is enlarged.)

self.ctx.layer_painter(self.layer_id).clip_rect() => Invalid
self.ctx.used_rect() => Invalid
self.ctx.available_rect() => Invalid
self.ctx.screen_rect() => Invalid
self.rect => Invalid

Is there a way to include `ui.clip_rect` in `Response` ?
or
Is there a way to not include `ui.clip_rect` in `Response` ?

I think ui.clip_rect needs to be included in Response.
ui.clip_rect To Response.clip_rect
