### PR TITLE
Fix: `Response.interact_pointer_pos` is `Some` on click and drag released

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1217,7 +1217,11 @@ impl Context {
                 }
             }
 
-            if res.is_pointer_button_down_on {
+            // is_pointer_button_down_on is false when released, but we want interact_pointer_pos
+            // to still work.
+            let clicked = res.clicked.iter().any(|c| *c);
+            let is_interacted_with = res.is_pointer_button_down_on || clicked || res.drag_released;
+            if is_interacted_with {
                 res.interact_pointer_pos = input.pointer.interact_pos();
             }
 

--- a/crates/egui_demo_lib/src/demo/tests.rs
+++ b/crates/egui_demo_lib/src/demo/tests.rs
@@ -444,6 +444,9 @@ fn response_summary(response: &egui::Response, show_hovers: bool) -> String {
         if response.is_pointer_button_down_on() {
             writeln!(new_info, "pointer_down_on").ok();
         }
+        if let Some(pos) = response.interact_pointer_pos() {
+            writeln!(new_info, "response.interact_pointer_pos: {pos:?}").ok();
+        }
     }
 
     for &button in &[


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/3999

In 0.26.0 is was accidentally set to `None` on the frame we got a click or drag release