### PR TITLE
New widget interaction logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,9 +199,9 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "arboard"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafb29b107435aa276664c1db8954ac27a6e105cdad3c88287a199eb0e313c08"
+checksum = "1faa3c733d9a3dd6fbaf85da5d162a2e03b2e0033a90dceb0e2a90fdd1e5380a"
 dependencies = [
  "clipboard-win",
  "log",
@@ -210,8 +210,7 @@ dependencies = [
  "objc_id",
  "parking_lot",
  "thiserror",
- "winapi",
- "x11rb 0.12.0",
+ "x11rb",
 ]
 
 [[package]]
@@ -789,13 +788,11 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "clipboard-win"
-version = "4.5.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+checksum = "3ec832972fefb8cf9313b45a0d1945e29c9c251f1d4c6eafc5fe2124c02d2e81"
 dependencies = [
  "error-code",
- "str-buf",
- "winapi",
 ]
 
 [[package]]
@@ -1510,13 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "2.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
-dependencies = [
- "libc",
- "str-buf",
-]
+checksum = "281e452d3bad4005426416cdba5ccfd4f5c1280e10099e21db27f7c1c28347fc"
 
 [[package]]
 name = "event-listener"
@@ -1729,16 +1722,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "gethostname"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -3535,12 +3518,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "str-buf"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
-
-[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4383,15 +4360,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi-wsapoll"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4626,7 +4594,7 @@ dependencies = [
  "web-time",
  "windows-sys 0.48.0",
  "x11-dl",
- "x11rb 0.13.0",
+ "x11rb",
  "xkbcommon-dl",
 ]
 
@@ -4652,39 +4620,17 @@ dependencies = [
 
 [[package]]
 name = "x11rb"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a"
-dependencies = [
- "gethostname 0.3.0",
- "nix",
- "winapi",
- "winapi-wsapoll",
- "x11rb-protocol 0.12.0",
-]
-
-[[package]]
-name = "x11rb"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a"
 dependencies = [
  "as-raw-xcb-connection",
- "gethostname 0.4.3",
+ "gethostname",
  "libc",
  "libloading 0.8.0",
  "once_cell",
  "rustix 0.38.21",
- "x11rb-protocol 0.13.0",
-]
-
-[[package]]
-name = "x11rb-protocol"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d6c3f9a0fb6701fab8f6cea9b0c0bd5d6876f1f89f7fada07e558077c344bc"
-dependencies = [
- "nix",
+ "x11rb-protocol",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,9 +199,9 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "arboard"
-version = "3.3.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1faa3c733d9a3dd6fbaf85da5d162a2e03b2e0033a90dceb0e2a90fdd1e5380a"
+checksum = "aafb29b107435aa276664c1db8954ac27a6e105cdad3c88287a199eb0e313c08"
 dependencies = [
  "clipboard-win",
  "log",
@@ -210,7 +210,8 @@ dependencies = [
  "objc_id",
  "parking_lot",
  "thiserror",
- "x11rb",
+ "winapi",
+ "x11rb 0.12.0",
 ]
 
 [[package]]
@@ -788,11 +789,13 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "clipboard-win"
-version = "5.1.0"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ec832972fefb8cf9313b45a0d1945e29c9c251f1d4c6eafc5fe2124c02d2e81"
+checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
 dependencies = [
  "error-code",
+ "str-buf",
+ "winapi",
 ]
 
 [[package]]
@@ -1507,9 +1510,13 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "3.0.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "281e452d3bad4005426416cdba5ccfd4f5c1280e10099e21db27f7c1c28347fc"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
+]
 
 [[package]]
 name = "event-listener"
@@ -1722,6 +1729,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3518,6 +3535,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str-buf"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
+
+[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4360,6 +4383,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-wsapoll"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4594,7 +4626,7 @@ dependencies = [
  "web-time",
  "windows-sys 0.48.0",
  "x11-dl",
- "x11rb",
+ "x11rb 0.13.0",
  "xkbcommon-dl",
 ]
 
@@ -4620,17 +4652,39 @@ dependencies = [
 
 [[package]]
 name = "x11rb"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a"
+dependencies = [
+ "gethostname 0.3.0",
+ "nix",
+ "winapi",
+ "winapi-wsapoll",
+ "x11rb-protocol 0.12.0",
+]
+
+[[package]]
+name = "x11rb"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a"
 dependencies = [
  "as-raw-xcb-connection",
- "gethostname",
+ "gethostname 0.4.3",
  "libc",
  "libloading 0.8.0",
  "once_cell",
  "rustix 0.38.21",
- "x11rb-protocol",
+ "x11rb-protocol 0.13.0",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d6c3f9a0fb6701fab8f6cea9b0c0bd5d6876f1f89f7fada07e558077c344bc"
+dependencies = [
+ "nix",
 ]
 
 [[package]]

--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -320,13 +320,14 @@ impl Area {
                 Sense::hover()
             };
 
-            let move_response = ctx.interact(
-                Rect::EVERYTHING,
+            let move_response = ctx.create_widget(
                 layer_id,
                 interact_id,
                 state.rect(),
+                state.rect(),
                 sense,
                 enabled,
+                true,
             );
 
             if movable && move_response.dragged() {

--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -320,17 +320,14 @@ impl Area {
                 Sense::hover()
             };
 
-            let move_response = ctx.create_widget(
-                WidgetRect {
-                    id: interact_id,
-                    layer_id,
-                    rect: state.rect(),
-                    interact_rect: state.rect(),
-                    sense,
-                    enabled,
-                },
-                true,
-            );
+            let move_response = ctx.create_widget(WidgetRect {
+                id: interact_id,
+                layer_id,
+                rect: state.rect(),
+                interact_rect: state.rect(),
+                sense,
+                enabled,
+            });
 
             if movable && move_response.dragged() {
                 state.pivot_pos += ctx.input(|i| i.pointer.delta());

--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -321,12 +321,14 @@ impl Area {
             };
 
             let move_response = ctx.create_widget(
-                layer_id,
-                interact_id,
-                state.rect(),
-                state.rect(),
-                sense,
-                enabled,
+                WidgetRect {
+                    id: interact_id,
+                    layer_id,
+                    rect: state.rect(),
+                    interact_rect: state.rect(),
+                    sense,
+                    enabled,
+                },
                 true,
             );
 

--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -313,7 +313,7 @@ impl Area {
         let mut move_response = {
             let interact_id = layer_id.id.with("move");
             let sense = if movable {
-                Sense::click_and_drag()
+                Sense::drag()
             } else if interactable {
                 Sense::click() // allow clicks to bring to front
             } else {
@@ -322,7 +322,6 @@ impl Area {
 
             let move_response = ctx.interact(
                 Rect::EVERYTHING,
-                ctx.style().spacing.item_spacing,
                 layer_id,
                 interact_id,
                 state.rect(),

--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -238,40 +238,22 @@ impl SidePanel {
             ui.ctx().check_for_id_clash(id, panel_rect, "SidePanel");
         }
 
+        let resize_id = id.with("__resize");
         let mut resize_hover = false;
         let mut is_resizing = false;
         if resizable {
-            let resize_id = id.with("__resize");
-            if let Some(pointer) = ui.ctx().pointer_latest_pos() {
-                let we_are_on_top = ui
-                    .ctx()
-                    .layer_id_at(pointer)
-                    .map_or(true, |top_layer_id| top_layer_id == ui.layer_id());
+            // First we read the resize interaction results, to avoid frame latency in the resize:
+            if let Some(resize_response) = ui.ctx().read_response(resize_id) {
+                resize_hover = resize_response.hovered();
+                is_resizing = resize_response.dragged();
 
-                let resize_x = side.opposite().side_x(panel_rect);
-                let mouse_over_resize_line = we_are_on_top
-                    && panel_rect.y_range().contains(pointer.y)
-                    && (resize_x - pointer.x).abs()
-                        <= ui.style().interaction.resize_grab_radius_side;
-
-                if ui.input(|i| i.pointer.any_pressed() && i.pointer.any_down())
-                    && mouse_over_resize_line
-                {
-                    ui.memory_mut(|mem| mem.set_dragged_id(resize_id));
-                }
-                is_resizing = ui.memory(|mem| mem.is_being_dragged(resize_id));
                 if is_resizing {
-                    let width = (pointer.x - side.side_x(panel_rect)).abs();
-                    let width = clamp_to_range(width, width_range).at_most(available_rect.width());
-                    side.set_rect_width(&mut panel_rect, width);
-                }
-
-                let dragging_something_else =
-                    ui.input(|i| i.pointer.any_down() || i.pointer.any_pressed());
-                resize_hover = mouse_over_resize_line && !dragging_something_else;
-
-                if resize_hover || is_resizing {
-                    ui.ctx().set_cursor_icon(CursorIcon::ResizeHorizontal);
+                    if let Some(pointer) = resize_response.interact_pointer_pos() {
+                        let width = (pointer.x - side.side_x(panel_rect)).abs();
+                        let width =
+                            clamp_to_range(width, width_range).at_most(available_rect.width());
+                        side.set_rect_width(&mut panel_rect, width);
+                    }
                 }
             }
         }
@@ -300,6 +282,22 @@ impl SidePanel {
             ui.set_cursor(cursor);
         }
         ui.expand_to_include_rect(rect);
+
+        if resizable {
+            // Now we do the actual resize interaction, on top of all the contents.
+            // Otherwise its input could be eaten by the contents, e.g. a
+            // `ScrollArea` on either side of the panel boundary.
+            let resize_x = side.opposite().side_x(panel_rect);
+            let resize_rect = Rect::from_x_y_ranges(resize_x..=resize_x, panel_rect.y_range())
+                .expand2(vec2(ui.style().interaction.resize_grab_radius_side, 0.0));
+            let resize_response = ui.interact(resize_rect, resize_id, Sense::drag());
+            resize_hover = resize_response.hovered();
+            is_resizing = resize_response.dragged();
+        }
+
+        if resize_hover || is_resizing {
+            ui.ctx().set_cursor_icon(CursorIcon::ResizeHorizontal);
+        }
 
         PanelState { rect }.store(ui.ctx(), id);
 
@@ -698,42 +696,22 @@ impl TopBottomPanel {
                 .check_for_id_clash(id, panel_rect, "TopBottomPanel");
         }
 
+        let resize_id = id.with("__resize");
         let mut resize_hover = false;
         let mut is_resizing = false;
         if resizable {
-            let resize_id = id.with("__resize");
-            let latest_pos = ui.input(|i| i.pointer.latest_pos());
-            if let Some(pointer) = latest_pos {
-                let we_are_on_top = ui
-                    .ctx()
-                    .layer_id_at(pointer)
-                    .map_or(true, |top_layer_id| top_layer_id == ui.layer_id());
+            // First we read the resize interaction results, to avoid frame latency in the resize:
+            if let Some(resize_response) = ui.ctx().read_response(resize_id) {
+                resize_hover = resize_response.hovered();
+                is_resizing = resize_response.dragged();
 
-                let resize_y = side.opposite().side_y(panel_rect);
-                let mouse_over_resize_line = we_are_on_top
-                    && panel_rect.x_range().contains(pointer.x)
-                    && (resize_y - pointer.y).abs()
-                        <= ui.style().interaction.resize_grab_radius_side;
-
-                if ui.input(|i| i.pointer.any_pressed() && i.pointer.any_down())
-                    && mouse_over_resize_line
-                {
-                    ui.memory_mut(|mem| mem.set_dragged_id(resize_id));
-                }
-                is_resizing = ui.memory(|mem| mem.is_being_dragged(resize_id));
                 if is_resizing {
-                    let height = (pointer.y - side.side_y(panel_rect)).abs();
-                    let height =
-                        clamp_to_range(height, height_range).at_most(available_rect.height());
-                    side.set_rect_height(&mut panel_rect, height);
-                }
-
-                let dragging_something_else =
-                    ui.input(|i| i.pointer.any_down() || i.pointer.any_pressed());
-                resize_hover = mouse_over_resize_line && !dragging_something_else;
-
-                if resize_hover || is_resizing {
-                    ui.ctx().set_cursor_icon(CursorIcon::ResizeVertical);
+                    if let Some(pointer) = resize_response.interact_pointer_pos() {
+                        let height = (pointer.y - side.side_y(panel_rect)).abs();
+                        let height =
+                            clamp_to_range(height, height_range).at_most(available_rect.height());
+                        side.set_rect_height(&mut panel_rect, height);
+                    }
                 }
             }
         }
@@ -762,6 +740,23 @@ impl TopBottomPanel {
             ui.set_cursor(cursor);
         }
         ui.expand_to_include_rect(rect);
+
+        if resizable {
+            // Now we do the actual resize interaction, on top of all the contents.
+            // Otherwise its input could be eaten by the contents, e.g. a
+            // `ScrollArea` on either side of the panel boundary.
+
+            let resize_y = side.opposite().side_y(panel_rect);
+            let resize_rect = Rect::from_x_y_ranges(panel_rect.x_range(), resize_y..=resize_y)
+                .expand2(vec2(0.0, ui.style().interaction.resize_grab_radius_side));
+            let resize_response = ui.interact(resize_rect, resize_id, Sense::drag());
+            resize_hover = resize_response.hovered();
+            is_resizing = resize_response.dragged();
+        }
+
+        if resize_hover || is_resizing {
+            ui.ctx().set_cursor_icon(CursorIcon::ResizeVertical);
+        }
 
         PanelState { rect }.store(ui.ctx(), id);
 

--- a/crates/egui/src/containers/resize.rs
+++ b/crates/egui/src/containers/resize.rs
@@ -231,6 +231,7 @@ impl Resize {
         if let Some(corner_id) = corner_id {
             if let Some(corner_response) = ui.ctx().read_response(corner_id) {
                 if let Some(pointer_pos) = corner_response.interact_pointer_pos() {
+                    // Respond to the interaction early to avoid frame delay.
                     user_requested_size =
                         Some(pointer_pos - position + 0.5 * corner_response.rect.size());
                 }

--- a/crates/egui/src/containers/resize.rs
+++ b/crates/egui/src/containers/resize.rs
@@ -188,8 +188,8 @@ impl Resize {
 
 struct Prepared {
     id: Id,
+    corner_id: Option<Id>,
     state: State,
-    corner_response: Option<Response>,
     content_ui: Ui,
 }
 
@@ -226,22 +226,16 @@ impl Resize {
 
         let mut user_requested_size = state.requested_size.take();
 
-        let corner_response = if self.resizable {
-            // Resize-corner:
-            let corner_size = Vec2::splat(ui.visuals().resize_corner_size);
-            let corner_rect =
-                Rect::from_min_size(position + state.desired_size - corner_size, corner_size);
-            let corner_response = ui.interact(corner_rect, id.with("corner"), Sense::drag());
+        let corner_id = self.resizable.then(|| id.with("__resize_corner"));
 
-            if let Some(pointer_pos) = corner_response.interact_pointer_pos() {
-                user_requested_size =
-                    Some(pointer_pos - position + 0.5 * corner_response.rect.size());
+        if let Some(corner_id) = corner_id {
+            if let Some(corner_response) = ui.ctx().read_response(corner_id) {
+                if let Some(pointer_pos) = corner_response.interact_pointer_pos() {
+                    user_requested_size =
+                        Some(pointer_pos - position + 0.5 * corner_response.rect.size());
+                }
             }
-
-            Some(corner_response)
-        } else {
-            None
-        };
+        }
 
         if let Some(user_requested_size) = user_requested_size {
             state.desired_size = user_requested_size;
@@ -279,8 +273,8 @@ impl Resize {
 
         Prepared {
             id,
+            corner_id,
             state,
-            corner_response,
             content_ui,
         }
     }
@@ -295,8 +289,8 @@ impl Resize {
     fn end(self, ui: &mut Ui, prepared: Prepared) {
         let Prepared {
             id,
+            corner_id,
             mut state,
-            corner_response,
             content_ui,
         } = prepared;
 
@@ -317,6 +311,20 @@ impl Resize {
             state.last_content_size
         };
         ui.advance_cursor_after_rect(Rect::from_min_size(content_ui.min_rect().min, size));
+
+        // ------------------------------
+
+        let corner_response = if let Some(corner_id) = corner_id {
+            // We do the corner interaction last to place it on top of the content:
+            let corner_size = Vec2::splat(ui.visuals().resize_corner_size);
+            let corner_rect = Rect::from_min_size(
+                content_ui.min_rect().left_top() + size - corner_size,
+                corner_size,
+            );
+            Some(ui.interact(corner_rect, corner_id, Sense::drag()))
+        } else {
+            None
+        };
 
         // ------------------------------
 

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -736,17 +736,14 @@ fn resize_interaction(
     }
 
     let is_dragging = |rect, id| {
-        let response = ctx.create_widget(
-            WidgetRect {
-                layer_id,
-                id,
-                rect,
-                interact_rect: rect,
-                sense: Sense::drag(),
-                enabled: true,
-            },
-            true,
-        );
+        let response = ctx.create_widget(WidgetRect {
+            layer_id,
+            id,
+            rect,
+            interact_rect: rect,
+            sense: Sense::drag(),
+            enabled: true,
+        });
         SideResponse {
             hover: response.hovered(),
             drag: response.dragged(),

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -736,7 +736,17 @@ fn resize_interaction(
     }
 
     let is_dragging = |rect, id| {
-        let response = ctx.create_widget(layer_id, id, rect, rect, Sense::drag(), true, true);
+        let response = ctx.create_widget(
+            WidgetRect {
+                layer_id,
+                id,
+                rect,
+                interact_rect: rect,
+                sense: Sense::drag(),
+                enabled: true,
+            },
+            true,
+        );
         SideResponse {
             hover: response.hovered(),
             drag: response.dragged(),

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -736,8 +736,7 @@ fn resize_interaction(
     }
 
     let is_dragging = |rect, id| {
-        let clip_rect = Rect::EVERYTHING;
-        let response = ctx.interact(clip_rect, layer_id, id, rect, Sense::drag(), true);
+        let response = ctx.create_widget(layer_id, id, rect, rect, Sense::drag(), true, true);
         SideResponse {
             hover: response.hovered(),
             drag: response.dragged(),

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -411,8 +411,7 @@ impl<'open> Window<'open> {
         let is_collapsed = with_title_bar && !collapsing.is_open();
         let possible = PossibleInteractions::new(&area, &resize, is_collapsed);
 
-        let area = area.movable(false); // We move it manually, or the area will move the window when we want to resize it
-        let resize = resize.resizable(false); // We move it manually
+        let resize = resize.resizable(false); // We resize it manually
         let mut resize = resize.id(resize_id);
 
         let on_top = Some(area_layer_id) == ctx.top_layer_id();
@@ -429,34 +428,29 @@ impl<'open> Window<'open> {
             (0.0, 0.0)
         };
 
-        // First interact (move etc) to avoid frame delay:
-        let last_frame_outer_rect = area.state().rect();
-        let interaction = if possible.movable || possible.resizable() {
-            window_interaction(
-                ctx,
-                possible,
-                area_layer_id,
-                area_id.with("frame_resize"),
-                last_frame_outer_rect,
-            )
-            .and_then(|window_interaction| {
+        // First check for resize to avoid frame delay:
+        let resize_interaction = if possible.movable || possible.resizable() {
+            let last_frame_outer_rect = area.state().rect();
+            let resize_interaction =
+                resize_hover(ctx, possible, area_layer_id, last_frame_outer_rect);
+            if let Some(resize_interaction) = resize_interaction {
                 let margins = window_frame.outer_margin.sum()
                     + window_frame.inner_margin.sum()
                     + vec2(0.0, title_bar_height);
 
                 interact(
-                    window_interaction,
+                    resize_interaction,
                     ctx,
                     margins,
                     area_layer_id,
                     &mut area,
                     resize_id,
-                )
-            })
+                );
+            }
+            resize_interaction
         } else {
             None
         };
-        let hover_interaction = resize_hover(ctx, possible, area_layer_id, last_frame_outer_rect);
 
         let mut area_content_ui = area.content_ui(ctx);
 
@@ -550,22 +544,8 @@ impl<'open> Window<'open> {
 
             collapsing.store(ctx);
 
-            if let Some(interaction) = interaction {
-                paint_frame_interaction(
-                    &area_content_ui,
-                    outer_rect,
-                    interaction,
-                    ctx.style().visuals.widgets.active,
-                );
-            } else if let Some(hover_interaction) = hover_interaction {
-                if ctx.input(|i| i.pointer.has_pointer()) {
-                    paint_frame_interaction(
-                        &area_content_ui,
-                        outer_rect,
-                        hover_interaction,
-                        ctx.style().visuals.widgets.hovered,
-                    );
-                }
+            if let Some(resize_interaction) = resize_interaction {
+                paint_frame_interaction(&area_content_ui, outer_rect, resize_interaction);
             }
             content_inner
         };
@@ -635,44 +615,76 @@ impl PossibleInteractions {
     }
 }
 
-/// Either a move or resize
+/// Resizing the window edges.
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct WindowInteraction {
-    pub(crate) area_layer_id: LayerId,
-    pub(crate) start_rect: Rect,
-    pub(crate) left: bool,
-    pub(crate) right: bool,
-    pub(crate) top: bool,
-    pub(crate) bottom: bool,
+struct ResizeInteraction {
+    start_rect: Rect,
+    left: SideResponse,
+    right: SideResponse,
+    top: SideResponse,
+    bottom: SideResponse,
 }
 
-impl WindowInteraction {
+/// A minitature version of `Response`, for each side of the window.
+#[derive(Clone, Copy, Debug, Default)]
+struct SideResponse {
+    hover: bool,
+    drag: bool,
+}
+
+impl SideResponse {
+    pub fn any(&self) -> bool {
+        self.hover || self.drag
+    }
+}
+
+impl std::ops::BitOrAssign for SideResponse {
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = Self {
+            hover: self.hover || rhs.hover,
+            drag: self.drag || rhs.drag,
+        };
+    }
+}
+
+impl ResizeInteraction {
     pub fn set_cursor(&self, ctx: &Context) {
-        if (self.left && self.top) || (self.right && self.bottom) {
+        let left = self.left.any();
+        let right = self.right.any();
+        let top = self.top.any();
+        let bottom = self.bottom.any();
+
+        if (left && top) || (right && bottom) {
             ctx.set_cursor_icon(CursorIcon::ResizeNwSe);
-        } else if (self.right && self.top) || (self.left && self.bottom) {
+        } else if (right && top) || (left && bottom) {
             ctx.set_cursor_icon(CursorIcon::ResizeNeSw);
-        } else if self.left || self.right {
+        } else if left || right {
             ctx.set_cursor_icon(CursorIcon::ResizeHorizontal);
-        } else if self.bottom || self.top {
+        } else if bottom || top {
             ctx.set_cursor_icon(CursorIcon::ResizeVertical);
         }
     }
 
-    pub fn is_resize(&self) -> bool {
-        self.left || self.right || self.top || self.bottom
+    pub fn any_hovered(&self) -> bool {
+        self.left.hover || self.right.hover || self.top.hover || self.bottom.hover
+    }
+
+    pub fn any_dragged(&self) -> bool {
+        self.left.drag || self.right.drag || self.top.drag || self.bottom.drag
     }
 }
 
 fn interact(
-    window_interaction: WindowInteraction,
+    resize_interaction: ResizeInteraction,
     ctx: &Context,
     margins: Vec2,
     area_layer_id: LayerId,
     area: &mut area::Prepared,
     resize_id: Id,
-) -> Option<WindowInteraction> {
-    let new_rect = move_and_resize_window(ctx, &window_interaction)?;
+) {
+    let Some(new_rect) = move_and_resize_window(ctx, &resize_interaction) else {
+        return;
+    };
     let mut new_rect = ctx.round_rect_to_pixels(new_rect);
 
     if area.constrain() {
@@ -682,7 +694,7 @@ fn interact(
     // TODO(emilk): add this to a Window state instead as a command "move here next frame"
     area.state_mut().set_left_top_pos(new_rect.left_top());
 
-    if window_interaction.is_resize() {
+    if resize_interaction.any_dragged() {
         if let Some(mut state) = resize::State::load(ctx, resize_id) {
             state.requested_size = Some(new_rect.size() - margins);
             state.store(ctx, resize_id);
@@ -690,191 +702,169 @@ fn interact(
     }
 
     ctx.memory_mut(|mem| mem.areas_mut().move_to_top(area_layer_id));
-    Some(window_interaction)
 }
 
-fn move_and_resize_window(ctx: &Context, window_interaction: &WindowInteraction) -> Option<Rect> {
-    window_interaction.set_cursor(ctx);
-
-    // Only move/resize windows with primary mouse button:
-    if !ctx.input(|i| i.pointer.primary_down()) {
+fn move_and_resize_window(ctx: &Context, interaction: &ResizeInteraction) -> Option<Rect> {
+    if !interaction.any_dragged() {
         return None;
     }
 
     let pointer_pos = ctx.input(|i| i.pointer.interact_pos())?;
-    let mut rect = window_interaction.start_rect; // prevent drift
+    let mut rect = interaction.start_rect; // prevent drift
 
-    if window_interaction.is_resize() {
-        if window_interaction.left {
-            rect.min.x = ctx.round_to_pixel(pointer_pos.x);
-        } else if window_interaction.right {
-            rect.max.x = ctx.round_to_pixel(pointer_pos.x);
-        }
+    if interaction.left.drag {
+        rect.min.x = ctx.round_to_pixel(pointer_pos.x);
+    } else if interaction.right.drag {
+        rect.max.x = ctx.round_to_pixel(pointer_pos.x);
+    }
 
-        if window_interaction.top {
-            rect.min.y = ctx.round_to_pixel(pointer_pos.y);
-        } else if window_interaction.bottom {
-            rect.max.y = ctx.round_to_pixel(pointer_pos.y);
-        }
-    } else {
-        // Movement.
-
-        // We do window interaction first (to avoid frame delay),
-        // but we want anything interactive in the window (e.g. slider) to steal
-        // the drag from us. It is therefor important not to move the window the first frame,
-        // but instead let other widgets to the steal. HACK.
-        if !ctx.input(|i| i.pointer.any_pressed()) {
-            let press_origin = ctx.input(|i| i.pointer.press_origin())?;
-            let delta = pointer_pos - press_origin;
-            rect = rect.translate(delta);
-        }
+    if interaction.top.drag {
+        rect.min.y = ctx.round_to_pixel(pointer_pos.y);
+    } else if interaction.bottom.drag {
+        rect.max.y = ctx.round_to_pixel(pointer_pos.y);
     }
 
     Some(rect)
 }
 
-/// Returns `Some` if there is a move or resize
-fn window_interaction(
-    ctx: &Context,
-    possible: PossibleInteractions,
-    area_layer_id: LayerId,
-    id: Id,
-    rect: Rect,
-) -> Option<WindowInteraction> {
-    if ctx.memory(|mem| mem.dragging_something_else(id)) {
-        return None;
-    }
-
-    let mut window_interaction = ctx.memory(|mem| mem.window_interaction());
-
-    if window_interaction.is_none() {
-        if let Some(hover_window_interaction) = resize_hover(ctx, possible, area_layer_id, rect) {
-            hover_window_interaction.set_cursor(ctx);
-            if ctx.input(|i| i.pointer.any_pressed() && i.pointer.primary_down()) {
-                ctx.memory_mut(|mem| {
-                    mem.interaction_mut().drag_id = Some(id);
-                    mem.interaction_mut().drag_is_window = true;
-                    window_interaction = Some(hover_window_interaction);
-                    mem.set_window_interaction(window_interaction);
-                });
-            }
-        }
-    }
-
-    if let Some(window_interaction) = window_interaction {
-        let is_active = ctx.memory_mut(|mem| mem.interaction().drag_id == Some(id));
-
-        if is_active && window_interaction.area_layer_id == area_layer_id {
-            return Some(window_interaction);
-        }
-    }
-
-    None
-}
-
 fn resize_hover(
     ctx: &Context,
     possible: PossibleInteractions,
-    area_layer_id: LayerId,
+    layer_id: LayerId,
     rect: Rect,
-) -> Option<WindowInteraction> {
-    let pointer = ctx.input(|i| i.pointer.interact_pos())?;
-
-    if ctx.input(|i| i.pointer.any_down() && !i.pointer.any_pressed()) {
-        return None; // already dragging (something)
-    }
-
-    if let Some(top_layer_id) = ctx.layer_id_at(pointer) {
-        if top_layer_id != area_layer_id && top_layer_id.order != Order::Background {
-            return None; // Another window is on top here
+) -> Option<ResizeInteraction> {
+    let is_dragging = |rect, id| {
+        let clip_rect = Rect::EVERYTHING;
+        let response = ctx.interact(clip_rect, layer_id, id, rect, Sense::drag(), true);
+        SideResponse {
+            hover: response.hovered(),
+            drag: response.dragged(),
         }
-    }
+    };
 
-    if ctx.memory(|mem| mem.interaction().drag_interest) {
-        // Another widget will become active if we drag here
-        return None;
-    }
+    let id = Id::new(layer_id).with("edge_drag");
 
     let side_grab_radius = ctx.style().interaction.resize_grab_radius_side;
     let corner_grab_radius = ctx.style().interaction.resize_grab_radius_corner;
-    if !rect.expand(side_grab_radius).contains(pointer) {
-        return None;
+
+    let corner_rect =
+        |center: Pos2| Rect::from_center_size(center, Vec2::splat(2.0 * corner_grab_radius));
+
+    // What are we dragging/hovering?
+    let [mut left, mut right, mut top, mut bottom] = [SideResponse::default(); 4];
+
+    // ----------------------------------------
+    // Check sides first, so that corners are on top, covering the sides (i.e. corners have priority)
+
+    if possible.resize_right {
+        let response = is_dragging(
+            Rect::from_min_max(rect.right_top(), rect.right_bottom()).expand(side_grab_radius),
+            id.with("right"),
+        );
+        right |= response;
+    }
+    if possible.resize_left {
+        let response = is_dragging(
+            Rect::from_min_max(rect.left_top(), rect.left_bottom()).expand(side_grab_radius),
+            id.with("left"),
+        );
+        left |= response;
+    }
+    if possible.resize_bottom {
+        let response = is_dragging(
+            Rect::from_min_max(rect.left_bottom(), rect.right_bottom()).expand(side_grab_radius),
+            id.with("bottom"),
+        );
+        bottom |= response;
+    }
+    if possible.resize_top {
+        let response = is_dragging(
+            Rect::from_min_max(rect.left_top(), rect.right_top()).expand(side_grab_radius),
+            id.with("top"),
+        );
+        top |= response;
     }
 
-    let mut left = possible.resize_left && (rect.left() - pointer.x).abs() <= side_grab_radius;
-    let mut right = possible.resize_right && (rect.right() - pointer.x).abs() <= side_grab_radius;
-    let mut top = possible.resize_top && (rect.top() - pointer.y).abs() <= side_grab_radius;
-    let mut bottom =
-        possible.resize_bottom && (rect.bottom() - pointer.y).abs() <= side_grab_radius;
+    // ----------------------------------------
+    // Now check corners:
 
-    if possible.resize_right
-        && possible.resize_bottom
-        && rect.right_bottom().distance(pointer) < corner_grab_radius
-    {
-        right = true;
-        bottom = true;
-    }
-    if possible.resize_right
-        && possible.resize_top
-        && rect.right_top().distance(pointer) < corner_grab_radius
-    {
-        right = true;
-        top = true;
-    }
-    if possible.resize_left
-        && possible.resize_top
-        && rect.left_top().distance(pointer) < corner_grab_radius
-    {
-        left = true;
-        top = true;
-    }
-    if possible.resize_left
-        && possible.resize_bottom
-        && rect.left_bottom().distance(pointer) < corner_grab_radius
-    {
-        left = true;
-        bottom = true;
+    if possible.resize_right && possible.resize_bottom {
+        let response = is_dragging(corner_rect(rect.right_bottom()), id.with("right_bottom"));
+        right |= response;
+        bottom |= response;
     }
 
-    let any_resize = left || right || top || bottom;
-
-    if !any_resize && !possible.movable {
-        return None;
+    if possible.resize_right && possible.resize_top {
+        let response = is_dragging(corner_rect(rect.right_top()), id.with("right_top"));
+        right |= response;
+        top |= response;
     }
+
+    if possible.resize_left && possible.resize_bottom {
+        let response = is_dragging(corner_rect(rect.left_bottom()), id.with("left_bottom"));
+        left |= response;
+        bottom |= response;
+    }
+
+    if possible.resize_left && possible.resize_top {
+        let response = is_dragging(corner_rect(rect.left_top()), id.with("left_top"));
+        left |= response;
+        top |= response;
+    }
+
+    let any_resize = left.any() || right.any() || top.any() || bottom.any();
 
     if any_resize || possible.movable {
-        Some(WindowInteraction {
-            area_layer_id,
+        let interaction = ResizeInteraction {
             start_rect: rect,
             left,
             right,
             top,
             bottom,
-        })
+        };
+        interaction.set_cursor(ctx);
+        Some(interaction)
     } else {
-        None
+        None // TODO: return a default ResizeInteraction instead
     }
 }
 
 /// Fill in parts of the window frame when we resize by dragging that part
-fn paint_frame_interaction(
-    ui: &Ui,
-    rect: Rect,
-    interaction: WindowInteraction,
-    visuals: style::WidgetVisuals,
-) {
+fn paint_frame_interaction(ui: &Ui, rect: Rect, interaction: ResizeInteraction) {
     use epaint::tessellator::path::add_circle_quadrant;
+
+    let visuals = if interaction.any_dragged() {
+        ui.style().visuals.widgets.active
+    } else if interaction.any_hovered() {
+        ui.style().visuals.widgets.hovered
+    } else {
+        return;
+    };
+
+    let [left, right, top, bottom]: [bool; 4];
+
+    if interaction.any_dragged() {
+        left = interaction.left.drag;
+        right = interaction.right.drag;
+        top = interaction.top.drag;
+        bottom = interaction.bottom.drag;
+    } else {
+        left = interaction.left.hover;
+        right = interaction.right.hover;
+        top = interaction.top.hover;
+        bottom = interaction.bottom.hover;
+    }
 
     let rounding = ui.visuals().window_rounding;
     let Rect { min, max } = rect;
 
     let mut points = Vec::new();
 
-    if interaction.right && !interaction.bottom && !interaction.top {
+    if right && !bottom && !top {
         points.push(pos2(max.x, min.y + rounding.ne));
         points.push(pos2(max.x, max.y - rounding.se));
     }
-    if interaction.right && interaction.bottom {
+    if right && bottom {
         points.push(pos2(max.x, min.y + rounding.ne));
         points.push(pos2(max.x, max.y - rounding.se));
         add_circle_quadrant(
@@ -884,11 +874,11 @@ fn paint_frame_interaction(
             0.0,
         );
     }
-    if interaction.bottom {
+    if bottom {
         points.push(pos2(max.x - rounding.se, max.y));
         points.push(pos2(min.x + rounding.sw, max.y));
     }
-    if interaction.left && interaction.bottom {
+    if left && bottom {
         add_circle_quadrant(
             &mut points,
             pos2(min.x + rounding.sw, max.y - rounding.sw),
@@ -896,11 +886,11 @@ fn paint_frame_interaction(
             1.0,
         );
     }
-    if interaction.left {
+    if left {
         points.push(pos2(min.x, max.y - rounding.sw));
         points.push(pos2(min.x, min.y + rounding.nw));
     }
-    if interaction.left && interaction.top {
+    if left && top {
         add_circle_quadrant(
             &mut points,
             pos2(min.x + rounding.nw, min.y + rounding.nw),
@@ -908,11 +898,11 @@ fn paint_frame_interaction(
             2.0,
         );
     }
-    if interaction.top {
+    if top {
         points.push(pos2(min.x + rounding.nw, min.y));
         points.push(pos2(max.x - rounding.ne, min.y));
     }
-    if interaction.right && interaction.top {
+    if right && top {
         add_circle_quadrant(
             &mut points,
             pos2(max.x - rounding.ne, min.y + rounding.ne),

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2598,6 +2598,13 @@ impl Context {
                     crate::text_selection::LabelSelectionState::load(ui.ctx())
                 ));
             });
+
+        CollapsingHeader::new("Interaction")
+            .default_open(false)
+            .show(ui, |ui| {
+                let interact_widgets = self.write(|ctx| ctx.viewport().interact_widgets.clone());
+                interact_widgets.ui(ui);
+            });
     }
 
     /// Show stats about the allocated textures.

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1143,6 +1143,7 @@ impl Context {
             self.check_for_id_clash(w.id, w.rect, "widget");
         }
 
+        #[allow(clippy::let_and_return)]
         let res = self.get_response(w);
 
         #[cfg(feature = "accesskit")]

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -3332,6 +3332,8 @@ impl Context {
                 i.dragged = Some(id);
                 i.drag_started = Some(id);
             }
+
+            ctx.memory.interaction_mut().potential_drag_id = Some(id);
         });
     }
 
@@ -3344,6 +3346,8 @@ impl Context {
                 i.drag_ended = i.dragged;
                 i.dragged = None;
             }
+
+            ctx.memory.interaction_mut().potential_drag_id = None;
         });
     }
     /// Is something else being dragged?

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -258,9 +258,11 @@ impl WidgetRects {
             return;
         }
 
-        let layer_widgets = self.by_layer.entry(layer_id).or_default();
+        let Self { by_layer, by_id } = self;
 
-        match self.by_id.entry(widget_rect.id) {
+        let layer_widgets = by_layer.entry(layer_id).or_default();
+
+        match by_id.entry(widget_rect.id) {
             std::collections::hash_map::Entry::Vacant(entry) => {
                 // A new widget
                 entry.insert(widget_rect);
@@ -1173,6 +1175,13 @@ impl Context {
                 .copied()
         })
         .map(|widget_rect| self.get_response(widget_rect))
+    }
+
+    /// Returns `true` if the widget with the given `Id` contains the pointer.
+    #[deprecated = "Use Response.contains_pointer or Context::read_response instead"]
+    pub fn widget_contains_pointer(&self, id: Id) -> bool {
+        self.read_response(id)
+            .map_or(false, |response| response.contains_pointer)
     }
 
     /// Do all interaction for an existing widget, without (re-)registering it.

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -200,11 +200,6 @@ impl ContextImpl {
 /// Used to check for overlaps between widgets when handling events.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WidgetRect {
-    /// Where the widget is.
-    ///
-    /// This is after clipping with the parent ui clip rect.
-    pub interact_rect: Rect,
-
     /// The globally unique widget id.
     ///
     /// For interactive widgets, this better be globally unique.
@@ -214,6 +209,14 @@ pub struct WidgetRect {
     ///
     /// You can ensure globally unique ids using [`Ui::push_id`].
     pub id: Id,
+
+    /// What layer the widget is on.
+    pub layer_id: LayerId,
+
+    /// Where the widget is.
+    ///
+    /// This is after clipping with the parent ui clip rect.
+    pub interact_rect: Rect,
 
     /// How the widget responds to interaction.
     pub sense: Sense,
@@ -1210,6 +1213,7 @@ impl Context {
                 layer_id,
                 WidgetRect {
                     id,
+                    layer_id,
                     interact_rect,
                     sense,
                 },
@@ -2438,6 +2442,7 @@ impl Context {
                 layer_id,
                 WidgetRect {
                     id,
+                    layer_id,
                     interact_rect,
                     sense,
                 },

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1204,7 +1204,7 @@ impl Context {
             triple_clicked: Default::default(),
             drag_started: false,
             dragged: false,
-            drag_released: false,
+            drag_stopped: false,
             is_pointer_button_down_on: false,
             interact_pointer_pos: None,
             changed: false,
@@ -1242,7 +1242,7 @@ impl Context {
                 res.hovered = viewport.interact_widgets.hovered.contains(&id);
                 res.dragged = Some(id) == viewport.interact_widgets.dragged;
                 res.drag_started = Some(id) == viewport.interact_widgets.drag_started;
-                res.drag_released = Some(id) == viewport.interact_widgets.drag_ended;
+                res.drag_stopped = Some(id) == viewport.interact_widgets.drag_stopped;
             }
 
             let clicked = Some(id) == viewport.interact_widgets.clicked;
@@ -1264,7 +1264,7 @@ impl Context {
 
             // is_pointer_button_down_on is false when released, but we want interact_pointer_pos
             // to still work.
-            let is_interacted_with = res.is_pointer_button_down_on || clicked || res.drag_released;
+            let is_interacted_with = res.is_pointer_button_down_on || clicked || res.drag_stopped;
             if is_interacted_with {
                 res.interact_pointer_pos = input.pointer.interact_pos();
             }
@@ -1936,7 +1936,7 @@ impl Context {
                     clicked,
                     drag_started: _,
                     dragged,
-                    drag_ended: _,
+                    drag_stopped: _,
                     contains_pointer,
                     hovered,
                 } = interact_widgets;
@@ -3305,7 +3305,8 @@ impl Context {
     /// not be set until the mouse cursor has moved a certain distance.
     ///
     /// NOTE: if the widget was released this frame, this will be `None`.
-    /// Use [`Self::drag_ended_id`] instead.
+    /// Use [`Self::drag_stopped
+    /// _id`] instead.
     pub fn dragged_id(&self) -> Option<Id> {
         self.interaction_snapshot(|i| i.dragged)
     }
@@ -3318,8 +3319,8 @@ impl Context {
     }
 
     /// This widget was being dragged, but was released this frame
-    pub fn drag_ended_id(&self) -> Option<Id> {
-        self.interaction_snapshot(|i| i.drag_ended)
+    pub fn drag_stopped_id(&self) -> Option<Id> {
+        self.interaction_snapshot(|i| i.drag_stopped)
     }
 
     /// Set which widget is being dragged.
@@ -3328,7 +3329,7 @@ impl Context {
             let vp = ctx.viewport();
             let i = &mut vp.interact_widgets;
             if i.dragged != Some(id) {
-                i.drag_ended = i.dragged.or(i.drag_ended);
+                i.drag_stopped = i.dragged.or(i.drag_stopped);
                 i.dragged = Some(id);
                 i.drag_started = Some(id);
             }
@@ -3343,7 +3344,7 @@ impl Context {
             let vp = ctx.viewport();
             let i = &mut vp.interact_widgets;
             if i.dragged.is_some() {
-                i.drag_ended = i.dragged;
+                i.drag_stopped = i.dragged;
                 i.dragged = None;
             }
 

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -3321,6 +3321,39 @@ impl Context {
     pub fn drag_ended_id(&self) -> Option<Id> {
         self.interaction_snapshot(|i| i.drag_ended)
     }
+
+    /// Set which widget is being dragged.
+    pub fn set_dragged_id(&self, id: Id) {
+        self.write(|ctx| {
+            let vp = ctx.viewport();
+            let i = &mut vp.interact_widgets;
+            if i.dragged != Some(id) {
+                i.drag_ended = i.dragged.or(i.drag_ended);
+                i.dragged = Some(id);
+                i.drag_started = Some(id);
+            }
+        });
+    }
+
+    /// Stop dragging any widget.
+    pub fn stop_dragging(&self) {
+        self.write(|ctx| {
+            let vp = ctx.viewport();
+            let i = &mut vp.interact_widgets;
+            if i.dragged.is_some() {
+                i.drag_ended = i.dragged;
+                i.dragged = None;
+            }
+        });
+    }
+    /// Is something else being dragged?
+    ///
+    /// Returns true if we are dragging something, but not the given widget.
+    #[inline(always)]
+    pub fn dragging_something_else(&self, not_this: Id) -> bool {
+        let dragged = self.dragged_id();
+        dragged.is_some() && dragged != Some(not_this)
+    }
 }
 
 #[test]

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1115,6 +1115,8 @@ impl Context {
     /// If this is not called, the widget doesn't exist.
     ///
     /// You should use [`Ui::interact`] instead.
+    ///
+    /// If the widget already exists, its state (sense, Rect, etc) will be updated.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn create_widget(&self, mut w: WidgetRect) -> Response {
         if !w.enabled {
@@ -1246,7 +1248,7 @@ impl Context {
                 res.clicked[PointerButton::Primary as usize] = true;
             }
 
-            let interaction = memory.interaction_mut();
+            let interaction = memory.interaction();
 
             res.is_pointer_button_down_on = interaction.potential_click_id == Some(id)
                 || interaction.potential_drag_id == Some(id);

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -3350,6 +3350,7 @@ impl Context {
             ctx.memory.interaction_mut().potential_drag_id = None;
         });
     }
+
     /// Is something else being dragged?
     ///
     /// Returns true if we are dragging something, but not the given widget.

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -20,7 +20,7 @@ use crate::{
     TextureHandle, ViewportCommand, *,
 };
 
-use self::hit_test::WidgetHits;
+use self::{hit_test::WidgetHits, interaction::InteractionSnapshot};
 
 /// Information given to the backend about when it is time to repaint the ui.
 ///
@@ -318,6 +318,11 @@ struct ViewportState {
     /// Which widgets are under the pointer?
     hits: WidgetHits,
 
+    /// What widgets are being interacted with this frame?
+    ///
+    /// Based on the widgets from last frame, and input in this frame.
+    interact_widgets: InteractionSnapshot,
+
     // ----------------------
     // The output of a frame:
     //
@@ -555,6 +560,14 @@ impl ContextImpl {
             } else {
                 WidgetHits::default()
             };
+
+            viewport.interact_widgets = crate::interaction::interact(
+                &viewport.interact_widgets,
+                &viewport.widgets_prev_frame,
+                &viewport.hits,
+                &viewport.input,
+                self.memory.interaction_mut(),
+            );
         }
 
         // Ensure we register the background area so panels and background ui can catch clicks:

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -3305,10 +3305,19 @@ impl Context {
     /// not be set until the mouse cursor has moved a certain distance.
     ///
     /// NOTE: if the widget was released this frame, this will be `None`.
-    /// Use [`Self::drag_stopped
-    /// _id`] instead.
+    /// Use [`Self::drag_stopped_id`] instead.
     pub fn dragged_id(&self) -> Option<Id> {
         self.interaction_snapshot(|i| i.dragged)
+    }
+
+    /// Is this specific widget being dragged?
+    ///
+    /// A widget that sense both clicks and drags is only marked as "dragged"
+    /// when the mouse has moved a bit
+    ///
+    /// See also: [`crate::Response::dragged`].
+    pub fn is_being_dragged(&self, id: Id) -> bool {
+        self.dragged_id() == Some(id)
     }
 
     /// This widget just started being dragged this frame.

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1110,7 +1110,7 @@ impl Context {
     ///
     /// You should use [`Ui::interact`] instead.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn create_widget(&self, mut w: WidgetRect, may_contain_pointer: bool) -> Response {
+    pub(crate) fn create_widget(&self, mut w: WidgetRect) -> Response {
         if !w.enabled {
             w.sense.click = false;
             w.sense.drag = false;
@@ -1143,8 +1143,7 @@ impl Context {
             self.check_for_id_clash(w.id, w.rect, "widget");
         }
 
-        let mut res = self.get_response(w);
-        res.contains_pointer &= may_contain_pointer;
+        let res = self.get_response(w);
 
         #[cfg(feature = "accesskit")]
         if w.sense.focusable {

--- a/crates/egui/src/hit_test.rs
+++ b/crates/egui/src/hit_test.rs
@@ -208,11 +208,21 @@ fn hit_test_on_close(mut close: Vec<WidgetRect>, pos: Pos2) -> WidgetHits {
 
         (Some(hit_click), None) => {
             // We have a perfect hit on a click-widget, but not on a drag-widget.
+            //
+            // Note that we don't look for a close drag widget in this case,
+            // because I can't think of a case where that would be helpful.
+            // This is in contrast with the opposite case,
+            // where when hovering directly over a drag-widget (like a big ScrollArea),
+            // we look for close click-widgets (e.g. buttons).
+            // This is because big background drag-widgets (ScrollArea, Window) are common,
+            // but bit clickable things aren't.
+            // Even if they were, I think it would be confusing for a user if clicking
+            // a drag-only widget would click something _behind_ it.
 
             WidgetHits {
                 contains_pointer: hits,
                 click: Some(hit_click),
-                drag: None, // TODO: we should maybe look for close drag widgets?
+                drag: None,
             }
         }
 
@@ -231,7 +241,9 @@ fn hit_test_on_close(mut close: Vec<WidgetRect>, pos: Pos2) -> WidgetHits {
                         drag: Some(hit_click),
                     }
                 } else {
-                    // They are interested in different things.
+                    // They are interested in different things,
+                    // and click is on top. Report both hits,
+                    // e.g. the top Button and the ScrollArea behind it.
                     WidgetHits {
                         contains_pointer: hits,
                         click: Some(hit_click),
@@ -247,7 +259,9 @@ fn hit_test_on_close(mut close: Vec<WidgetRect>, pos: Pos2) -> WidgetHits {
                         drag: Some(hit_drag),
                     }
                 } else {
-                    // The top things senses only drags
+                    // The top things senses only drags,
+                    // so we ignore the click-widget, because it would be confusing
+                    // if clicking a drag-widget would actually click something else below it.
                     WidgetHits {
                         contains_pointer: hits,
                         click: None,

--- a/crates/egui/src/hit_test.rs
+++ b/crates/egui/src/hit_test.rs
@@ -72,13 +72,15 @@ fn hit_test_on_close(mut close: Vec<WidgetRect>, pos: Pos2) -> WidgetHits {
         .copied()
         .collect();
 
-    let top_hit = hits.last().copied();
-    let top_layer = top_hit.map(|w| w.layer_id);
+    {
+        let top_hit = hits.last().copied();
+        let top_layer = top_hit.map(|w| w.layer_id);
 
-    if let Some(top_layer) = top_layer {
-        // Ignore all layers not in the same layer as the top hit.
-        close.retain(|w| w.layer_id == top_layer);
-        hits.retain(|w| w.layer_id == top_layer);
+        if let Some(top_layer) = top_layer {
+            // Ignore all layers not in the same layer as the top hit.
+            close.retain(|w| w.layer_id == top_layer);
+            hits.retain(|w| w.layer_id == top_layer);
+        }
     }
 
     let hit_click = hits.iter().copied().filter(|w| w.sense.click).last();
@@ -103,6 +105,7 @@ fn hit_test_on_close(mut close: Vec<WidgetRect>, pos: Pos2) -> WidgetHits {
                     drag: closest.sense.drag.then_some(closest),
                 }
             } else {
+                // Found nothing
                 WidgetHits {
                     contains_pointer: hits,
                     click: None,
@@ -172,6 +175,7 @@ fn hit_test_on_close(mut close: Vec<WidgetRect>, pos: Pos2) -> WidgetHits {
                 }
             }
         }
+
         (Some(hit_click), None) => {
             // We have a perfect hit on a click-widget, but not on a drag-widget.
 

--- a/crates/egui/src/hit_test.rs
+++ b/crates/egui/src/hit_test.rs
@@ -6,8 +6,6 @@ use crate::*;
 ///
 /// Note that this doesn't care if the mouse button is pressed or not,
 /// or if we're currently already dragging something.
-///
-/// For that you need the [`crate::InteractionState`].
 #[derive(Clone, Debug, Default)]
 pub struct WidgetHits {
     /// All widgets that contains the pointer, back-to-front.

--- a/crates/egui/src/hit_test.rs
+++ b/crates/egui/src/hit_test.rs
@@ -127,7 +127,10 @@ fn hit_test_on_close(mut close: Vec<WidgetRect>, pos: Pos2) -> WidgetHits {
                 if closest_click.sense.drag {
                     // We have something close that sense both clicks and drag.
                     // Should we use it over the direct drag-hit?
-                    if hit_drag.rect.contains_rect(closest_click.interact_rect) {
+                    if hit_drag
+                        .interact_rect
+                        .contains_rect(closest_click.interact_rect)
+                    {
                         // This is a smaller thing on a big background - help the user hit it,
                         // and ignore the big drag background.
                         WidgetHits {
@@ -148,7 +151,10 @@ fn hit_test_on_close(mut close: Vec<WidgetRect>, pos: Pos2) -> WidgetHits {
                     // These is a close pure-click widget.
                     // However, we should be careful to only return two different widgets
                     // when it is absolutely not going to confuse the user.
-                    if hit_drag.rect.contains_rect(closest_click.interact_rect) {
+                    if hit_drag
+                        .interact_rect
+                        .contains_rect(closest_click.interact_rect)
+                    {
                         // The drag widget is a big background thing (scroll area),
                         // so returning a separate click widget should not be confusing
                         WidgetHits {
@@ -167,7 +173,33 @@ fn hit_test_on_close(mut close: Vec<WidgetRect>, pos: Pos2) -> WidgetHits {
                     }
                 }
             } else {
-                // No close drags
+                // No close clicks.
+                // Maybe there is a close drag widget, that is a smaller
+                // widget floating on top of a big background?
+                // If so, it would be nice to help the user click that.
+                let closest_drag = find_closest(
+                    close
+                        .iter()
+                        .copied()
+                        .filter(|w| w.sense.drag && w.id != hit_drag.id),
+                    pos,
+                );
+
+                if let Some(closest_drag) = closest_drag {
+                    if hit_drag
+                        .interact_rect
+                        .contains_rect(closest_drag.interact_rect)
+                    {
+                        // `hit_drag` is a big background thing and `closest_drag` is something small on top of it.
+                        // Be helpful and return the small things:
+                        return WidgetHits {
+                            contains_pointer: hits,
+                            click: None,
+                            drag: Some(closest_drag),
+                        };
+                    }
+                }
+
                 WidgetHits {
                     contains_pointer: hits,
                     click: None,

--- a/crates/egui/src/hit_test.rs
+++ b/crates/egui/src/hit_test.rs
@@ -1,0 +1,115 @@
+use crate::*;
+
+/// Result of a hit-test agains [`WidgetRects`].
+///
+/// Answers the question "what is under the mouse pointer?".
+///
+/// Note that this doesn't care if the mouse button is pressed or not,
+/// or if we're currently already dragging something.
+///
+/// For that you need the `InteractionState`.
+#[derive(Clone, Debug, Default)]
+pub struct WidgetHits {
+    /// All widgets that contains the pointer.
+    ///
+    /// i.e. both a Window and the button in it can ontain the pointer.
+    ///
+    /// Show tooltips for all of these.
+    /// Why? So you can do `ui.scope(|ui| …).response.on_hover_text(…)`
+    /// and get a tooltip for the whole ui, even if individual things
+    /// in the ui also had a tooltip.
+    pub contains_pointer: IdMap<WidgetRect>,
+
+    /// The topmost widget under the pointer, interactive or not.
+    ///
+    /// Used for nothing?
+    pub top: Option<WidgetRect>,
+
+    /// If the user would start a clicking now, this is what would be clicked.
+    ///
+    /// This is the top one under the pointer, or closest one of the top-most.
+    pub click: Option<WidgetRect>,
+
+    /// If the user would start a dragging now, this is what would be dragged.
+    ///
+    /// This is the top one under the pointer, or closest one of the top-most.
+    pub drag: Option<WidgetRect>,
+}
+
+impl WidgetHits {
+    #[inline]
+    pub fn is_tooltip_candidate(&self, id: Id) -> bool {
+        self.contains_pointer.contains_key(&id)
+            || self.top.map_or(false, |w| w.id == id)
+            || self.click.map_or(false, |w| w.id == id)
+            || self.drag.map_or(false, |w| w.id == id)
+    }
+}
+
+/// Find the top or closest widgets to the given position,
+/// None which is closer than `search_radius`.
+pub fn hit_test(
+    widgets: &WidgetRects,
+    layer_order: &[LayerId],
+    pos: Pos2,
+    search_radius: f32,
+) -> WidgetHits {
+    crate::profile_function!();
+
+    let hit_rect = Rect::from_center_size(pos, Vec2::splat(2.0 * search_radius));
+
+    // The few widgets close to the given position, sorted back-to-front.
+    let close: Vec<WidgetRect> = layer_order
+        .iter()
+        .filter_map(|layer_id| widgets.by_layer.get(layer_id))
+        .flatten()
+        .filter(|widget| widget.interact_rect.intersects(hit_rect))
+        .filter(|w| w.interact_rect.distance_to_pos(pos) <= search_radius)
+        .copied()
+        .collect();
+
+    // Only those widgets directly under the `pos`.
+    let hits: Vec<WidgetRect> = close
+        .iter()
+        .filter(|widget| widget.interact_rect.contains(pos))
+        .copied()
+        .collect();
+
+    let hit = hits.last().copied();
+    let hit_click = hits.iter().copied().filter(|w| w.sense.click).last();
+    let hit_drag = hits.iter().copied().filter(|w| w.sense.drag).last();
+
+    let closest = find_closest(close.iter().copied(), pos);
+    let closest_click = find_closest(close.iter().copied().filter(|w| w.sense.click), pos);
+    let closest_drag = find_closest(close.iter().copied().filter(|w| w.sense.drag), pos);
+
+    let top = hit.or(closest);
+    let click = hit_click.or(closest_click);
+    let drag = hit_drag.or(closest_drag);
+
+    // Which widgets which will have tooltips:
+    let contains_pointer = hits.into_iter().map(|w| (w.id, w)).collect();
+
+    WidgetHits {
+        contains_pointer,
+        top,
+        click,
+        drag,
+    }
+}
+
+fn find_closest(widgets: impl Iterator<Item = WidgetRect>, pos: Pos2) -> Option<WidgetRect> {
+    let mut closest = None;
+    let mut cloest_dist_sq = f32::INFINITY;
+    for widget in widgets {
+        let dist_sq = widget.interact_rect.distance_sq_to_pos(pos);
+
+        // In case of a tie, take the last one = the one on top.
+        if dist_sq <= cloest_dist_sq {
+            cloest_dist_sq = dist_sq;
+            closest = Some(widget);
+        }
+    }
+
+    closest
+}

--- a/crates/egui/src/hit_test.rs
+++ b/crates/egui/src/hit_test.rs
@@ -1,18 +1,18 @@
 use crate::*;
 
-/// Result of a hit-test agains [`WidgetRects`].
+/// Result of a hit-test against [`WidgetRects`].
 ///
 /// Answers the question "what is under the mouse pointer?".
 ///
 /// Note that this doesn't care if the mouse button is pressed or not,
 /// or if we're currently already dragging something.
 ///
-/// For that you need the `InteractionState`.
+/// For that you need the [`crate::InteractionState`].
 #[derive(Clone, Debug, Default)]
 pub struct WidgetHits {
     /// All widgets that contains the pointer, back-to-front.
     ///
-    /// i.e. both a Window and the button in it can ontain the pointer.
+    /// i.e. both a Window and the button in it can contain the pointer.
     ///
     /// Some of these may be widgets in a layer below the top-most layer.
     pub contains_pointer: Vec<WidgetRect>,
@@ -31,6 +31,11 @@ pub struct WidgetHits {
     ///
     /// This is the top one under the pointer, or closest one of the top-most.
     pub drag: Option<WidgetRect>,
+
+    /// The closest interactive widget under the pointer.
+    ///
+    /// This is either the same as [`Self::click`] or [`Self::drag`], or both.
+    pub closest_interactive: Option<WidgetRect>,
 }
 
 /// Find the top or closest widgets to the given position,
@@ -43,16 +48,14 @@ pub fn hit_test(
 ) -> WidgetHits {
     crate::profile_function!();
 
-    let hit_rect = Rect::from_center_size(pos, Vec2::splat(2.0 * search_radius));
-
     let search_radius_sq = search_radius * search_radius;
 
     // First pass: find the few widgets close to the given position, sorted back-to-front.
     let mut close: Vec<WidgetRect> = layer_order
         .iter()
+        .filter(|layer| layer.order.allow_interaction())
         .filter_map(|layer_id| widgets.by_layer.get(layer_id))
         .flatten()
-        .filter(|widget| widget.interact_rect.intersects(hit_rect))
         .filter(|w| w.interact_rect.distance_sq_to_pos(pos) <= search_radius_sq)
         .copied()
         .collect();
@@ -68,7 +71,7 @@ pub fn hit_test(
     let top_layer = top_hit.map(|w| w.layer_id);
 
     if let Some(top_layer) = top_layer {
-        // Ignore everything in a layer below the top-most layer:
+        // Ignore all layers not in the same layer as the top hit.
         close.retain(|w| w.layer_id == top_layer);
         hits.retain(|w| w.layer_id == top_layer);
     }
@@ -81,26 +84,54 @@ pub fn hit_test(
     let closest_drag = find_closest(close.iter().copied().filter(|w| w.sense.drag), pos);
 
     let top = top_hit.or(closest);
-    let click = hit_click.or(closest_click);
-    let drag = hit_drag.or(closest_drag);
+    let mut click = hit_click.or(closest_click);
+    let mut drag = hit_drag.or(closest_drag);
+
+    if let (Some(click), Some(drag)) = (&mut click, &mut drag) {
+        // If one of the widgets is interested in both click and drags, let it win.
+        // Otherwise we end up in weird situations where both widgets respond to hover,
+        // but one of the widgets only responds to _one_ of the events.
+
+        if click.sense.click && click.sense.drag {
+            *drag = *click;
+        } else if drag.sense.click && drag.sense.drag {
+            *click = *drag;
+        }
+    }
+
+    let closest_interactive = match (click, drag) {
+        (Some(click), Some(drag)) => {
+            if click.interact_rect.distance_sq_to_pos(pos)
+                < drag.interact_rect.distance_sq_to_pos(pos)
+            {
+                Some(click)
+            } else {
+                Some(drag)
+            }
+        }
+        (Some(click), None) => Some(click),
+        (None, Some(drag)) => Some(drag),
+        (None, None) => None,
+    };
 
     WidgetHits {
         contains_pointer: hits,
         top,
         click,
         drag,
+        closest_interactive,
     }
 }
 
 fn find_closest(widgets: impl Iterator<Item = WidgetRect>, pos: Pos2) -> Option<WidgetRect> {
     let mut closest = None;
-    let mut cloest_dist_sq = f32::INFINITY;
+    let mut closest_dist_sq = f32::INFINITY;
     for widget in widgets {
         let dist_sq = widget.interact_rect.distance_sq_to_pos(pos);
 
         // In case of a tie, take the last one = the one on top.
-        if dist_sq <= cloest_dist_sq {
-            cloest_dist_sq = dist_sq;
+        if dist_sq <= closest_dist_sq {
+            closest_dist_sq = dist_sq;
             closest = Some(widget);
         }
     }

--- a/crates/egui/src/hit_test.rs
+++ b/crates/egui/src/hit_test.rs
@@ -36,16 +36,6 @@ pub struct WidgetHits {
     pub drag: Option<WidgetRect>,
 }
 
-impl WidgetHits {
-    #[inline]
-    pub fn is_tooltip_candidate(&self, id: Id) -> bool {
-        self.contains_pointer.contains_key(&id)
-            || self.top.map_or(false, |w| w.id == id)
-            || self.click.map_or(false, |w| w.id == id)
-            || self.drag.map_or(false, |w| w.id == id)
-    }
-}
-
 /// Find the top or closest widgets to the given position,
 /// None which is closer than `search_radius`.
 pub fn hit_test(

--- a/crates/egui/src/interaction.rs
+++ b/crates/egui/src/interaction.rs
@@ -35,7 +35,20 @@ pub struct InteractionSnapshot {
     /// The widget will not be found in [`Self::dragged`] this frame.
     pub drag_stopped: Option<Id>,
 
+    /// A small set of widgets (usually 0-1) that the pointer is hovering over.
+    ///
+    /// Show these widgets as highlighted, if they are interactive.
+    ///
+    /// While dragging or clicking something, nothing else is hovered.
+    ///
+    /// Use [`Self::contains_pointer`] to find a drop-zone for drag-and-drop.
     pub hovered: IdSet,
+
+    /// All widgets that contain the pointer this frame,
+    /// regardless if the user is currently clicking or dragging.
+    ///
+    /// This is usually a larger set than [`Self::hovered`],
+    /// and can be used for e.g. drag-and-drop zones.
     pub contains_pointer: IdSet,
 }
 

--- a/crates/egui/src/interaction.rs
+++ b/crates/egui/src/interaction.rs
@@ -115,7 +115,6 @@ pub(crate) fn interact(
     let contains_pointer: IdMap<WidgetRect> = hits
         .contains_pointer
         .iter()
-        .chain(&hits.top)
         .chain(&hits.click)
         .chain(&hits.drag)
         .map(|w| (w.id, *w))

--- a/crates/egui/src/interaction.rs
+++ b/crates/egui/src/interaction.rs
@@ -42,6 +42,8 @@ pub(crate) fn interact(
     input: &InputState,
     interaction: &mut InteractionState,
 ) -> InteractionSnapshot {
+    crate::profile_function!();
+
     if let Some(id) = interaction.click_id {
         if !widgets.by_id.contains_key(&id) {
             // The widget we were interested in clicking is gone.
@@ -120,10 +122,10 @@ pub(crate) fn interact(
         .collect();
 
     let hovered = if clicked.is_some() || dragged.is_some() {
-        // If currently clicking or dragging, nother else is hovered.
+        // If currently clicking or dragging, nothing else is hovered.
         clicked.iter().chain(&dragged).map(|w| (w.id, *w)).collect()
     } else if hits.click.is_some() || hits.drag.is_some() {
-        // We are hovering over an interactive widget or two. Just highlight these two.
+        // We are hovering over an interactive widget or two.
         hits.click
             .iter()
             .chain(&hits.drag)

--- a/crates/egui/src/interaction.rs
+++ b/crates/egui/src/interaction.rs
@@ -120,6 +120,7 @@ pub(crate) fn interact(
         .collect();
 
     let hovered = if clicked.is_some() || dragged.is_some() {
+        // If currently clicking or dragging, nother else is hovered.
         clicked.iter().chain(&dragged).map(|w| (w.id, *w)).collect()
     } else {
         contains_pointer.clone()

--- a/crates/egui/src/interaction.rs
+++ b/crates/egui/src/interaction.rs
@@ -1,0 +1,136 @@
+//! How mouse and touch interzcts with widgets.
+
+use crate::*;
+
+use self::{hit_test::WidgetHits, input_state::PointerEvent, memory::InteractionState};
+
+/// Calculated at the start of each frame
+/// based on:
+/// * Widget rects from precious frame
+/// * Mouse/touch input
+/// * Current [`InteractionState`].
+#[derive(Clone, Default)]
+pub struct InteractionSnapshot {
+    /// The widget that got clicked this frame.
+    pub clicked: Option<WidgetRect>,
+
+    /// Drag started on this widget this frame.
+    ///
+    /// This will also be found in `dragged` this frame.
+    pub drag_started: Option<WidgetRect>,
+
+    /// This widget is being dragged this frame.
+    ///
+    /// Set the same frame a drag starts,
+    /// but unset the frame a drag ends.
+    pub dragged: Option<WidgetRect>,
+
+    /// This widget was let go this frame,
+    /// after having been dragged.
+    ///
+    /// The widget will not be found in [`Self::dragged`] this frame.
+    pub drag_ended: Option<WidgetRect>,
+
+    pub contains_pointer: IdMap<WidgetRect>,
+    pub hovered: IdMap<WidgetRect>,
+}
+
+pub(crate) fn interact(
+    prev_snapshot: &InteractionSnapshot,
+    widgets: &WidgetRects,
+    hits: &WidgetHits,
+    input: &InputState,
+    interaction: &mut InteractionState,
+) -> InteractionSnapshot {
+    if let Some(id) = interaction.click_id {
+        if !widgets.by_id.contains_key(&id) {
+            // The widget we were interested in clicking is gone.
+            interaction.click_id = None;
+        }
+    }
+    if let Some(id) = interaction.drag_id {
+        if !widgets.by_id.contains_key(&id) {
+            // The widget we were interested in dragging is gone.
+            interaction.drag_id = None;
+        }
+    }
+
+    let mut clicked = None;
+
+    // Note: in the current code a press-release in the same frame is NOT considered a drag.
+    for pointer_event in &input.pointer.pointer_events {
+        match pointer_event {
+            PointerEvent::Moved(_) => {}
+
+            PointerEvent::Pressed { .. } => {
+                // Maybe new click?
+                if interaction.click_id.is_none() {
+                    interaction.click_id = hits.click.map(|w| w.id);
+                }
+
+                // Maybe new drag?
+                if interaction.drag_id.is_none() {
+                    interaction.drag_id = hits.drag.map(|w| w.id);
+                }
+            }
+
+            PointerEvent::Released { click, button: _ } => {
+                if click.is_some() {
+                    if let Some(widget) = interaction.click_id.and_then(|id| widgets.by_id.get(&id))
+                    {
+                        clicked = Some(*widget);
+                    }
+                }
+
+                interaction.drag_id = None;
+                interaction.click_id = None;
+            }
+        }
+    }
+
+    // Check if we're dragging something:
+    let mut dragged = None;
+    if let Some(widget) = interaction.drag_id.and_then(|id| widgets.by_id.get(&id)) {
+        let is_dragged = if widget.sense.click && widget.sense.drag {
+            // This widget is sensitive to both clicks and drags.
+            // When the mouse first is pressed, it could be either,
+            // so we postpone the decision until we know.
+            input.pointer.is_decidedly_dragging()
+        } else {
+            // This widget is just sensitive to drags, so we can mark it as dragged right away:
+            widget.sense.drag
+        };
+
+        if is_dragged {
+            dragged = Some(*widget);
+        }
+    }
+
+    let drag_changed = dragged != prev_snapshot.dragged;
+    let drag_ended = drag_changed.then_some(prev_snapshot.dragged).flatten();
+    let drag_started = drag_changed.then_some(dragged).flatten();
+
+    let contains_pointer: IdMap<WidgetRect> = hits
+        .contains_pointer
+        .values()
+        .chain(&hits.top)
+        .chain(&hits.click)
+        .chain(&hits.drag)
+        .map(|w| (w.id, *w))
+        .collect();
+
+    let hovered = if clicked.is_some() || dragged.is_some() {
+        clicked.iter().chain(&dragged).map(|w| (w.id, *w)).collect()
+    } else {
+        contains_pointer.clone()
+    };
+
+    InteractionSnapshot {
+        clicked,
+        drag_started,
+        dragged,
+        drag_ended,
+        contains_pointer,
+        hovered,
+    }
+}

--- a/crates/egui/src/interaction.rs
+++ b/crates/egui/src/interaction.rs
@@ -112,7 +112,7 @@ pub(crate) fn interact(
 
     let contains_pointer: IdMap<WidgetRect> = hits
         .contains_pointer
-        .values()
+        .iter()
         .chain(&hits.top)
         .chain(&hits.click)
         .chain(&hits.drag)
@@ -122,8 +122,22 @@ pub(crate) fn interact(
     let hovered = if clicked.is_some() || dragged.is_some() {
         // If currently clicking or dragging, nother else is hovered.
         clicked.iter().chain(&dragged).map(|w| (w.id, *w)).collect()
+    } else if hits.click.is_some() || hits.drag.is_some() {
+        // We are hovering over an interactive widget or two. Just highlight these two.
+        hits.click
+            .iter()
+            .chain(&hits.drag)
+            .map(|w| (w.id, *w))
+            .collect()
     } else {
-        contains_pointer.clone()
+        // Whatever is topmost is what we are hovering.
+        // TODO: consider handle hovering over multiple top-most widgets?
+        // TODO: allow hovering close widgets?
+        hits.contains_pointer
+            .last()
+            .map(|w| (w.id, *w))
+            .into_iter()
+            .collect()
     };
 
     InteractionSnapshot {

--- a/crates/egui/src/interaction.rs
+++ b/crates/egui/src/interaction.rs
@@ -33,7 +33,7 @@ pub struct InteractionSnapshot {
     /// after having been dragged.
     ///
     /// The widget will not be found in [`Self::dragged`] this frame.
-    pub drag_ended: Option<Id>,
+    pub drag_stopped: Option<Id>,
 
     pub hovered: IdSet,
     pub contains_pointer: IdSet,
@@ -45,7 +45,7 @@ impl InteractionSnapshot {
             clicked,
             drag_started,
             dragged,
-            drag_ended,
+            drag_stopped,
             hovered,
             contains_pointer,
         } = self;
@@ -69,8 +69,8 @@ impl InteractionSnapshot {
             id_ui(ui, dragged);
             ui.end_row();
 
-            ui.label("drag_ended");
-            id_ui(ui, drag_ended);
+            ui.label("drag_stopped");
+            id_ui(ui, drag_stopped);
             ui.end_row();
 
             ui.label("hovered");
@@ -170,7 +170,7 @@ pub(crate) fn interact(
     // ------------------------------------------------------------------------
 
     let drag_changed = dragged != prev_snapshot.dragged;
-    let drag_ended = drag_changed.then_some(prev_snapshot.dragged).flatten();
+    let drag_stopped = drag_changed.then_some(prev_snapshot.dragged).flatten();
     let drag_started = drag_changed.then_some(dragged).flatten();
 
     // if let Some(drag_started) = drag_started {
@@ -210,7 +210,7 @@ pub(crate) fn interact(
         clicked,
         drag_started,
         dragged,
-        drag_ended,
+        drag_stopped,
         contains_pointer,
         hovered,
     }

--- a/crates/egui/src/interaction.rs
+++ b/crates/egui/src/interaction.rs
@@ -26,7 +26,7 @@ pub struct InteractionSnapshot {
     ///
     /// NOTE: this may not have a corresponding [`WidgetRect`],
     /// if this for instance is a drag-and-drop widget which
-    /// isn't painted whilest being dragged
+    /// isn't painted whilst being dragged
     pub dragged: Option<Id>,
 
     /// This widget was let go this frame,

--- a/crates/egui/src/introspection.rs
+++ b/crates/egui/src/introspection.rs
@@ -191,12 +191,15 @@ impl Widget for &mut epaint::TessellationOptions {
 
 impl Widget for &memory::InteractionState {
     fn ui(self, ui: &mut Ui) -> Response {
+        let memory::InteractionState {
+            click_id,
+            drag_id,
+            focus: _,
+        } = self;
+
         ui.vertical(|ui| {
-            ui.label(format!("click_id: {:?}", self.click_id));
-            ui.label(format!("drag_id: {:?}", self.drag_id));
-            ui.label(format!("drag_is_window: {:?}", self.drag_is_window));
-            ui.label(format!("click_interest: {:?}", self.click_interest));
-            ui.label(format!("drag_interest: {:?}", self.drag_interest));
+            ui.label(format!("click_id: {click_id:?}"));
+            ui.label(format!("drag_id: {drag_id:?}"));
         })
         .response
     }

--- a/crates/egui/src/introspection.rs
+++ b/crates/egui/src/introspection.rs
@@ -192,14 +192,14 @@ impl Widget for &mut epaint::TessellationOptions {
 impl Widget for &memory::InteractionState {
     fn ui(self, ui: &mut Ui) -> Response {
         let memory::InteractionState {
-            click_id,
-            drag_id,
+            potential_click_id,
+            potential_drag_id,
             focus: _,
         } = self;
 
         ui.vertical(|ui| {
-            ui.label(format!("click_id: {click_id:?}"));
-            ui.label(format!("drag_id: {drag_id:?}"));
+            ui.label(format!("potential_click_id: {potential_click_id:?}"));
+            ui.label(format!("potential_drag_id: {potential_drag_id:?}"));
         })
         .response
     }

--- a/crates/egui/src/introspection.rs
+++ b/crates/egui/src/introspection.rs
@@ -189,7 +189,7 @@ impl Widget for &mut epaint::TessellationOptions {
     }
 }
 
-impl Widget for &memory::Interaction {
+impl Widget for &memory::InteractionState {
     fn ui(self, ui: &mut Ui) -> Response {
         ui.vertical(|ui| {
             ui.label(format!("click_id: {:?}", self.click_id));

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -352,6 +352,7 @@ mod drag_and_drop;
 mod frame_state;
 pub(crate) mod grid;
 pub mod gui_zoom;
+mod hit_test;
 mod id;
 mod input_state;
 pub mod introspection;

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -267,6 +267,37 @@
 //! }
 //! ```
 //!
+//!
+//! ## Widget interaction
+//! Each widget has a [`Sense`], which defines whether or not the widget
+//! is sensitive to clickicking and/or drags.
+//!
+//! For instance, a [`Button`] only has a [`Sense::click`] (by default).
+//! This means if you drag a button it will not respond with [`Response::dragged`].
+//! Instead, the drag will continue through the button to the first
+//! widget behind it that is sensitive to dragging, which for instance could be
+//! a [`ScrollArea`]. This lets you scroll by dragging a scroll area (important
+//! on touch screens), just as long as you don't drag on a widget that is sensitive
+//! to drags (e.g. a [`Slider`]).
+//!
+//! When widgets overlap it is the last added one
+//! that is considered to be on top and which will get input priority.
+//!
+//! The widget interaction logic is run at the _start_ of each frame,
+//! based on the output from the previous frame.
+//! This means that when a new widget shows up you cannot click it in the same
+//! frame (i.e. in the same fraction of a second), but unless the user
+//! is spider-man, they wouldn't be fast enough to do so anyways.
+//!
+//! By running the interaction code early, egui can actually
+//! tell you if a widget is being interacted with _before_ you add it,
+//! as long as you know its [`Id`] before-hand (e.g. using [`Ui::next_auto_id`]),
+//! by calling [`Context::read_response`].
+//! This can be useful in some circumstances in order to style a widget,
+//! or to respond to interactions before adding the widget
+//! (perhaps on top of other widgets).
+//!
+//!
 //! ## Auto-sizing panels and windows
 //! In egui, all panels and windows auto-shrink to fit the content.
 //! If the window or panel is also resizable, this can lead to a weird behavior

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -355,6 +355,7 @@ pub mod gui_zoom;
 mod hit_test;
 mod id;
 mod input_state;
+mod interaction;
 pub mod introspection;
 pub mod layers;
 mod layout;

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -90,7 +90,7 @@ pub struct Memory {
     areas: ViewportIdMap<Areas>,
 
     #[cfg_attr(feature = "persistence", serde(skip))]
-    pub(crate) interactions: ViewportIdMap<Interaction>,
+    pub(crate) interactions: ViewportIdMap<InteractionState>,
 
     #[cfg_attr(feature = "persistence", serde(skip))]
     window_interactions: ViewportIdMap<window::WindowInteraction>,
@@ -290,6 +290,9 @@ impl Options {
 
 // ----------------------------------------------------------------------------
 
+/// The state of the interaction in egui,
+/// i.e. what is being dragged.
+///
 /// Say there is a button in a scroll area.
 /// If the user clicks the button, the button should click.
 /// If the user drags the button we should scroll the scroll area.
@@ -298,7 +301,7 @@ impl Options {
 /// If the user releases the button without moving the mouse we register it as a click on `click_id`.
 /// If the cursor moves too much we clear the `click_id` and start passing move events to `drag_id`.
 #[derive(Clone, Debug, Default)]
-pub(crate) struct Interaction {
+pub(crate) struct InteractionState {
     /// A widget interested in clicks that has a mouse press on it.
     pub click_id: Option<Id>,
 
@@ -373,7 +376,7 @@ impl FocusWidget {
     }
 }
 
-impl Interaction {
+impl InteractionState {
     /// Are we currently clicking or dragging an egui widget?
     pub fn is_using_pointer(&self) -> bool {
         self.click_id.is_some() || self.drag_id.is_some()
@@ -835,13 +838,13 @@ impl Memory {
         }
     }
 
-    pub(crate) fn interaction(&self) -> &Interaction {
+    pub(crate) fn interaction(&self) -> &InteractionState {
         self.interactions
             .get(&self.viewport_id)
             .expect("Failed to get interaction")
     }
 
-    pub(crate) fn interaction_mut(&mut self) -> &mut Interaction {
+    pub(crate) fn interaction_mut(&mut self) -> &mut InteractionState {
         self.interactions.entry(self.viewport_id).or_default()
     }
 }

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -292,7 +292,7 @@ impl Options {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct InteractionState {
     /// A widget interested in clicks that has a mouse press on it.
-    pub click_id: Option<Id>,
+    pub potential_click_id: Option<Id>,
 
     /// A widget interested in drags that has a mouse press on it.
     ///
@@ -300,7 +300,7 @@ pub(crate) struct InteractionState {
     /// so the widget may not yet be marked as "dragged",
     /// as that can only happen after the mouse has moved a bit
     /// (at least if the widget is interesated in both clicks and drags).
-    pub drag_id: Option<Id>,
+    pub potential_drag_id: Option<Id>,
 
     pub focus: Focus,
 }
@@ -353,7 +353,7 @@ impl FocusWidget {
 impl InteractionState {
     /// Are we currently clicking or dragging an egui widget?
     pub fn is_using_pointer(&self) -> bool {
-        self.click_id.is_some() || self.drag_id.is_some()
+        self.potential_click_id.is_some() || self.potential_drag_id.is_some()
     }
 
     fn begin_frame(
@@ -362,13 +362,13 @@ impl InteractionState {
         new_input: &crate::data::input::RawInput,
     ) {
         if !prev_input.pointer.could_any_button_be_click() {
-            self.click_id = None;
+            self.potential_click_id = None;
         }
 
         if !prev_input.pointer.any_down() || prev_input.pointer.latest_pos().is_none() {
             // pointer button was not down last frame
-            self.click_id = None;
-            self.drag_id = None;
+            self.potential_click_id = None;
+            self.potential_drag_id = None;
         }
 
         self.focus.begin_frame(new_input);
@@ -730,9 +730,10 @@ impl Memory {
     }
 
     /// Is any widget being dragged?
+    #[deprecated = "Use `Context::dragged_id` instead"]
     #[inline(always)]
     pub fn is_anything_being_dragged(&self) -> bool {
-        self.interaction().drag_id.is_some()
+        self.interaction().potential_drag_id.is_some()
     }
 
     /// Is this specific widget being dragged?
@@ -741,9 +742,10 @@ impl Memory {
     ///
     /// A widget that sense both clicks and drags is only marked as "dragged"
     /// when the mouse has moved a bit, but `is_being_dragged` will return true immediately.
+    #[deprecated = "Use `Context::dragged_id` instead"]
     #[inline(always)]
     pub fn is_being_dragged(&self, id: Id) -> bool {
-        self.interaction().drag_id == Some(id)
+        self.interaction().potential_drag_id == Some(id)
     }
 
     /// Get the id of the widget being dragged, if any.
@@ -752,21 +754,22 @@ impl Memory {
     /// so the widget may not yet be marked as "dragged",
     /// as that can only happen after the mouse has moved a bit
     /// (at least if the widget is interesated in both clicks and drags).
+    #[deprecated = "Use `Context::dragged_id` instead"]
     #[inline(always)]
     pub fn dragged_id(&self) -> Option<Id> {
-        self.interaction().drag_id
+        self.interaction().potential_drag_id
     }
 
     /// Set which widget is being dragged.
     #[inline(always)]
     pub fn set_dragged_id(&mut self, id: Id) {
-        self.interaction_mut().drag_id = Some(id);
+        self.interaction_mut().potential_drag_id = Some(id);
     }
 
     /// Stop dragging any widget.
     #[inline(always)]
     pub fn stop_dragging(&mut self) {
-        self.interaction_mut().drag_id = None;
+        self.interaction_mut().potential_drag_id = None;
     }
 
     /// Is something else being dragged?
@@ -774,7 +777,7 @@ impl Memory {
     /// Returns true if we are dragging something, but not the given widget.
     #[inline(always)]
     pub fn dragging_something_else(&self, not_this: Id) -> bool {
-        let drag_id = self.interaction().drag_id;
+        let drag_id = self.interaction().potential_drag_id;
         drag_id.is_some() && drag_id != Some(not_this)
     }
 

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -762,12 +762,14 @@ impl Memory {
 
     /// Set which widget is being dragged.
     #[inline(always)]
+    #[deprecated = "Use `Context::set_dragged_id` instead"]
     pub fn set_dragged_id(&mut self, id: Id) {
         self.interaction_mut().potential_drag_id = Some(id);
     }
 
     /// Stop dragging any widget.
     #[inline(always)]
+    #[deprecated = "Use `Context::stop_dragging` instead"]
     pub fn stop_dragging(&mut self) {
         self.interaction_mut().potential_drag_id = None;
     }
@@ -776,6 +778,7 @@ impl Memory {
     ///
     /// Returns true if we are dragging something, but not the given widget.
     #[inline(always)]
+    #[deprecated = "Use `Context::dragging_something_else` instead"]
     pub fn dragging_something_else(&self, not_this: Id) -> bool {
         let drag_id = self.interaction().potential_drag_id;
         drag_id.is_some() && drag_id != Some(not_this)

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -742,7 +742,7 @@ impl Memory {
     ///
     /// A widget that sense both clicks and drags is only marked as "dragged"
     /// when the mouse has moved a bit, but `is_being_dragged` will return true immediately.
-    #[deprecated = "Use `Context::dragged_id` instead"]
+    #[deprecated = "Use `Context::is_being_dragged` instead"]
     #[inline(always)]
     pub fn is_being_dragged(&self, id: Id) -> bool {
         self.interaction().potential_drag_id == Some(id)

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -148,6 +148,8 @@ impl FocusDirection {
 // ----------------------------------------------------------------------------
 
 /// Some global options that you can read and write.
+///
+/// See also [`crate::style::DebugOptions`].
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
@@ -208,9 +210,6 @@ pub struct Options {
     ///
     /// By default this is `true` in debug builds.
     pub warn_on_id_clash: bool,
-
-    /// If true, paint all interactive widgets in the order they were added to each layer.
-    pub debug_paint_interactive_widgets: bool,
 }
 
 impl Default for Options {
@@ -224,7 +223,6 @@ impl Default for Options {
             screen_reader: false,
             preload_font_glyphs: true,
             warn_on_id_clash: cfg!(debug_assertions),
-            debug_paint_interactive_widgets: false,
         }
     }
 }
@@ -241,7 +239,6 @@ impl Options {
             screen_reader: _, // needs to come from the integration
             preload_font_glyphs: _,
             warn_on_id_clash,
-            debug_paint_interactive_widgets,
         } = self;
 
         use crate::Widget as _;
@@ -260,8 +257,6 @@ impl Options {
                 );
 
                 ui.checkbox(warn_on_id_clash, "Warn if two widgets have the same Id");
-
-                ui.checkbox(debug_paint_interactive_widgets, "Debug interactive widgets");
             });
 
         use crate::containers::*;

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -85,7 +85,7 @@ pub struct Response {
 
     /// The widget was being dragged, but now it has been released.
     #[doc(hidden)]
-    pub drag_released: bool,
+    pub drag_stopped: bool,
 
     /// Is the pointer button currently down on this widget?
     /// This is true if the pointer is pressing down or dragging a widget
@@ -317,13 +317,26 @@ impl Response {
 
     /// The widget was being dragged, but now it has been released.
     #[inline]
-    pub fn drag_released(&self) -> bool {
-        self.drag_released
+    pub fn drag_stopped(&self) -> bool {
+        self.drag_stopped
     }
 
     /// The widget was being dragged by the button, but now it has been released.
+    pub fn drag_stopped_by(&self, button: PointerButton) -> bool {
+        self.drag_stopped() && self.ctx.input(|i| i.pointer.button_released(button))
+    }
+
+    /// The widget was being dragged, but now it has been released.
+    #[inline]
+    #[deprecated = "Renamed 'dragged_stopped'"]
+    pub fn drag_released(&self) -> bool {
+        self.drag_stopped
+    }
+
+    /// The widget was being dragged by the button, but now it has been released.
+    #[deprecated = "Renamed 'dragged_stopped_by'"]
     pub fn drag_released_by(&self, button: PointerButton) -> bool {
-        self.drag_released() && self.ctx.input(|i| i.pointer.button_released(button))
+        self.drag_stopped_by(button)
     }
 
     /// If dragged, how many points were we dragged and in what direction?
@@ -858,7 +871,7 @@ impl Response {
             ],
             drag_started: self.drag_started || other.drag_started,
             dragged: self.dragged || other.dragged,
-            drag_released: self.drag_released || other.drag_released,
+            drag_stopped: self.drag_stopped || other.drag_stopped,
             is_pointer_button_down_on: self.is_pointer_button_down_on
                 || other.is_pointer_button_down_on,
             interact_pointer_pos: self.interact_pointer_pos.or(other.interact_pointer_pos),

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -617,7 +617,7 @@ impl Response {
             return self.clone();
         }
 
-        self.ctx.interact_with_hovered(
+        self.ctx.interact_with_existing(
             self.layer_id,
             self.id,
             self.rect,

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -2,7 +2,7 @@ use std::{any::Any, sync::Arc};
 
 use crate::{
     emath::{Align, Pos2, Rect, Vec2},
-    menu, Context, CursorIcon, Id, LayerId, PointerButton, Sense, Ui, WidgetText,
+    menu, Context, CursorIcon, Id, LayerId, PointerButton, Sense, Ui, WidgetRect, WidgetText,
     NUM_POINTER_BUTTONS,
 };
 
@@ -618,12 +618,14 @@ impl Response {
         }
 
         self.ctx.create_widget(
-            self.layer_id,
-            self.id,
-            self.rect,
-            self.interact_rect,
-            sense,
-            self.enabled,
+            WidgetRect {
+                layer_id: self.layer_id,
+                id: self.id,
+                rect: self.rect,
+                interact_rect: self.interact_rect,
+                sense,
+                enabled: self.enabled,
+            },
             self.contains_pointer,
         )
     }

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -639,17 +639,14 @@ impl Response {
             return self.clone();
         }
 
-        self.ctx.create_widget(
-            WidgetRect {
-                layer_id: self.layer_id,
-                id: self.id,
-                rect: self.rect,
-                interact_rect: self.interact_rect,
-                sense,
-                enabled: self.enabled,
-            },
-            self.contains_pointer,
-        )
+        self.ctx.create_widget(WidgetRect {
+            layer_id: self.layer_id,
+            id: self.id,
+            rect: self.rect,
+            interact_rect: self.interact_rect,
+            sense,
+            enabled: self.enabled,
+        })
     }
 
     /// Adjust the scroll position until this UI becomes visible.

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -617,7 +617,7 @@ impl Response {
             return self.clone();
         }
 
-        self.ctx.interact_with_existing(
+        self.ctx.create_widget(
             self.layer_id,
             self.id,
             self.rect,

--- a/crates/egui/src/sense.rs
+++ b/crates/egui/src/sense.rs
@@ -59,6 +59,13 @@ impl Sense {
     }
 
     /// Sense both clicks, drags and hover (e.g. a slider or window).
+    ///
+    /// Note that this will introduce a latency when dragging,
+    /// because when the user starts a press egui can't know if this is the start
+    /// of a click or a drag, and it won't know until the cursor has
+    /// either moved a certain distance, or the user has released the mouse button.
+    ///
+    /// See [`crate::PointerState::is_decidedly_dragging`] for details.
     #[inline]
     pub fn click_and_drag() -> Self {
         Self {

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -715,10 +715,10 @@ pub struct Interaction {
     /// which is important for e.g. touch screens.
     pub interact_radius: f32,
 
-    /// Mouse must be this close to the side of a window to resize
+    /// Radius of the interactive area of the side of a window during drag-to-resize.
     pub resize_grab_radius_side: f32,
 
-    /// Mouse must be this close to the corner of a window to resize
+    /// Radius of the interactive area of the corner of a window during drag-to-resize.
     pub resize_grab_radius_corner: f32,
 
     /// If `false`, tooltips will show up anytime you hover anything, even is mouse is still moving
@@ -1135,9 +1135,9 @@ impl Default for Spacing {
 impl Default for Interaction {
     fn default() -> Self {
         Self {
-            interact_radius: 3.0,
             resize_grab_radius_side: 5.0,
             resize_grab_radius_corner: 10.0,
+            interact_radius: 8.0,
             show_tooltips_only_when_still: true,
             tooltip_delay: 0.3,
             selectable_labels: true,
@@ -1612,7 +1612,7 @@ impl Interaction {
             multi_widget_text_select,
         } = self;
         ui.add(Slider::new(interact_radius, 0.0..=20.0).text("interact_radius"))
-            .on_hover_text("Interact witgh ghe closest widget within this radius.");
+            .on_hover_text("Interact with the closest widget within this radius.");
         ui.add(Slider::new(resize_grab_radius_side, 0.0..=20.0).text("resize_grab_radius_side"));
         ui.add(
             Slider::new(resize_grab_radius_corner, 0.0..=20.0).text("resize_grab_radius_corner"),
@@ -1621,7 +1621,11 @@ impl Interaction {
             show_tooltips_only_when_still,
             "Only show tooltips if mouse is still",
         );
-        ui.add(Slider::new(tooltip_delay, 0.0..=1.0).text("tooltip_delay"));
+        ui.add(
+            Slider::new(tooltip_delay, 0.0..=1.0)
+                .suffix(" s")
+                .text("tooltip_delay"),
+        );
 
         ui.horizontal(|ui| {
             ui.checkbox(selectable_labels, "Selectable text in labels");

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -709,6 +709,12 @@ impl std::ops::Add for Margin {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct Interaction {
+    /// How close a widget must be to the mouse to have a chance to register as a click or drag.
+    ///
+    /// If this is larger than zero, it gets easier to hit widgets,
+    /// which is important for e.g. touch screens.
+    pub interact_radius: f32,
+
     /// Mouse must be this close to the side of a window to resize
     pub resize_grab_radius_side: f32,
 
@@ -1125,6 +1131,7 @@ impl Default for Spacing {
 impl Default for Interaction {
     fn default() -> Self {
         Self {
+            interact_radius: 3.0,
             resize_grab_radius_side: 5.0,
             resize_grab_radius_corner: 10.0,
             show_tooltips_only_when_still: true,
@@ -1592,6 +1599,7 @@ fn margin_ui(ui: &mut Ui, text: &str, margin: &mut Margin) {
 impl Interaction {
     pub fn ui(&mut self, ui: &mut crate::Ui) {
         let Self {
+            interact_radius,
             resize_grab_radius_side,
             resize_grab_radius_corner,
             show_tooltips_only_when_still,
@@ -1599,6 +1607,8 @@ impl Interaction {
             selectable_labels,
             multi_widget_text_select,
         } = self;
+        ui.add(Slider::new(interact_radius, 0.0..=20.0).text("interact_radius"))
+            .on_hover_text("Interact witgh ghe closest widget within this radius.");
         ui.add(Slider::new(resize_grab_radius_side, 0.0..=20.0).text("resize_grab_radius_side"));
         ui.add(
             Slider::new(resize_grab_radius_corner, 0.0..=20.0).text("resize_grab_radius_corner"),

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1047,8 +1047,11 @@ pub struct DebugOptions {
     /// Show an overlay on all interactive widgets.
     pub show_interactive_widgets: bool,
 
-    /// Show what widget blocks the interaction of another widget.
-    pub show_blocking_widget: bool,
+    /// Show interesting widgets under the mouse cursor.
+    pub show_widget_hits: bool,
+
+    /// Show which widgets are being interacted with.
+    pub show_interaction_widgets: bool,
 }
 
 #[cfg(debug_assertions)]
@@ -1063,7 +1066,8 @@ impl Default for DebugOptions {
             show_expand_height: false,
             show_resize: false,
             show_interactive_widgets: false,
-            show_blocking_widget: false,
+            show_widget_hits: false,
+            show_interaction_widgets: false,
         }
     }
 }
@@ -1876,7 +1880,8 @@ impl DebugOptions {
             show_expand_height,
             show_resize,
             show_interactive_widgets,
-            show_blocking_widget,
+            show_widget_hits,
+            show_interaction_widgets,
         } = self;
 
         {
@@ -1904,10 +1909,9 @@ impl DebugOptions {
             "Show an overlay on all interactive widgets",
         );
 
-        ui.checkbox(
-            show_blocking_widget,
-            "Show which widget blocks the interaction of another widget",
-        );
+        ui.checkbox(show_widget_hits, "Show widgets under mouse pointer");
+
+        ui.checkbox(show_interaction_widgets, "Show interaction widgets");
 
         ui.vertical_centered(|ui| reset_button(ui, self));
     }

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1133,7 +1133,7 @@ impl Default for Interaction {
         Self {
             resize_grab_radius_side: 5.0,
             resize_grab_radius_corner: 10.0,
-            interact_radius: 8.0,
+            interact_radius: 5.0,
             show_tooltips_only_when_still: true,
             tooltip_delay: 0.3,
             selectable_labels: true,

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1049,9 +1049,6 @@ pub struct DebugOptions {
 
     /// Show interesting widgets under the mouse cursor.
     pub show_widget_hits: bool,
-
-    /// Show which widgets are being interacted with.
-    pub show_interaction_widgets: bool,
 }
 
 #[cfg(debug_assertions)]
@@ -1067,7 +1064,6 @@ impl Default for DebugOptions {
             show_resize: false,
             show_interactive_widgets: false,
             show_widget_hits: false,
-            show_interaction_widgets: false,
         }
     }
 }
@@ -1885,7 +1881,6 @@ impl DebugOptions {
             show_resize,
             show_interactive_widgets,
             show_widget_hits,
-            show_interaction_widgets,
         } = self;
 
         {
@@ -1914,8 +1909,6 @@ impl DebugOptions {
         );
 
         ui.checkbox(show_widget_hits, "Show widgets under mouse pointer");
-
-        ui.checkbox(show_interaction_widgets, "Show interaction widgets");
 
         ui.vertical_centered(|ui| reset_button(ui, self));
     }

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2163,7 +2163,7 @@ impl Ui {
     where
         Payload: Any + Send + Sync,
     {
-        let is_being_dragged = self.memory(|mem| mem.is_being_dragged(id));
+        let is_being_dragged = self.ctx().dragged_id() == Some(id);
 
         if is_being_dragged {
             crate::DragAndDrop::set_payload(self.ctx(), payload);

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -646,13 +646,15 @@ impl Ui {
 impl Ui {
     /// Check for clicks, drags and/or hover on a specific region of this [`Ui`].
     pub fn interact(&self, rect: Rect, id: Id, sense: Sense) -> Response {
-        self.ctx().interact(
-            self.clip_rect(),
+        let interact_rect = self.clip_rect().intersect(rect);
+        self.ctx().create_widget(
             self.layer_id(),
             id,
             rect,
+            interact_rect,
             sense,
             self.enabled,
+            true,
         )
     }
 
@@ -670,7 +672,7 @@ impl Ui {
         sense: Sense,
     ) -> Response {
         let interact_rect = rect.intersect(self.clip_rect());
-        self.ctx().interact_with_existing(
+        self.ctx().create_widget(
             self.layer_id(),
             id,
             rect,

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -646,14 +646,15 @@ impl Ui {
 impl Ui {
     /// Check for clicks, drags and/or hover on a specific region of this [`Ui`].
     pub fn interact(&self, rect: Rect, id: Id, sense: Sense) -> Response {
-        let interact_rect = self.clip_rect().intersect(rect);
         self.ctx().create_widget(
-            self.layer_id(),
-            id,
-            rect,
-            interact_rect,
-            sense,
-            self.enabled,
+            WidgetRect {
+                id,
+                layer_id: self.layer_id(),
+                rect,
+                interact_rect: self.clip_rect().intersect(rect),
+                sense,
+                enabled: self.enabled,
+            },
             true,
         )
     }
@@ -671,14 +672,15 @@ impl Ui {
         id: Id,
         sense: Sense,
     ) -> Response {
-        let interact_rect = rect.intersect(self.clip_rect());
         self.ctx().create_widget(
-            self.layer_id(),
-            id,
-            rect,
-            interact_rect,
-            sense,
-            self.enabled,
+            WidgetRect {
+                id,
+                layer_id: self.layer_id(),
+                rect,
+                interact_rect: self.clip_rect().intersect(rect),
+                sense,
+                enabled: self.enabled,
+            },
             contains_pointer,
         )
     }

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -646,43 +646,26 @@ impl Ui {
 impl Ui {
     /// Check for clicks, drags and/or hover on a specific region of this [`Ui`].
     pub fn interact(&self, rect: Rect, id: Id, sense: Sense) -> Response {
-        self.ctx().create_widget(
-            WidgetRect {
-                id,
-                layer_id: self.layer_id(),
-                rect,
-                interact_rect: self.clip_rect().intersect(rect),
-                sense,
-                enabled: self.enabled,
-            },
-            true,
-        )
+        self.ctx().create_widget(WidgetRect {
+            id,
+            layer_id: self.layer_id(),
+            rect,
+            interact_rect: self.clip_rect().intersect(rect),
+            sense,
+            enabled: self.enabled,
+        })
     }
 
-    /// Check for clicks, and drags on a specific region that is hovered.
-    /// This can be used once you have checked that some shape you are painting has been hovered,
-    /// and want to check for clicks and drags on hovered items this frame.
-    ///
-    /// The given [`Rect`] should approximately be where the thing is,
-    /// as will be the rectangle for the returned [`Response::rect`].
+    /// Deprecated: use [`Self::interact`] instead.
+    #[deprecated = "The contains_pointer argument is ignored. Use `ui.interact` instead."]
     pub fn interact_with_hovered(
         &self,
         rect: Rect,
-        contains_pointer: bool,
+        _contains_pointer: bool,
         id: Id,
         sense: Sense,
     ) -> Response {
-        self.ctx().create_widget(
-            WidgetRect {
-                id,
-                layer_id: self.layer_id(),
-                rect,
-                interact_rect: self.clip_rect().intersect(rect),
-                sense,
-                enabled: self.enabled,
-            },
-            contains_pointer,
-        )
+        self.interact(rect, id, sense)
     }
 
     /// Is the pointer (mouse/touch) above this rectangle in this [`Ui`]?

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -648,7 +648,6 @@ impl Ui {
     pub fn interact(&self, rect: Rect, id: Id, sense: Sense) -> Response {
         self.ctx().interact(
             self.clip_rect(),
-            self.spacing().item_spacing,
             self.layer_id(),
             id,
             rect,

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -670,7 +670,7 @@ impl Ui {
         sense: Sense,
     ) -> Response {
         let interact_rect = rect.intersect(self.clip_rect());
-        self.ctx().interact_with_hovered(
+        self.ctx().interact_with_existing(
             self.layer_id(),
             id,
             rect,

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2146,7 +2146,7 @@ impl Ui {
     where
         Payload: Any + Send + Sync,
     {
-        let is_being_dragged = self.ctx().dragged_id() == Some(id);
+        let is_being_dragged = self.ctx().is_being_dragged(id);
 
         if is_being_dragged {
             crate::DragAndDrop::set_payload(self.ctx(), payload);

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2166,6 +2166,8 @@ impl Ui {
         let is_being_dragged = self.memory(|mem| mem.is_being_dragged(id));
 
         if is_being_dragged {
+            crate::DragAndDrop::set_payload(self.ctx(), payload);
+
             // Paint the body to a new layer:
             let layer_id = LayerId::new(Order::Tooltip, id);
             let InnerResponse { inner, response } = self.with_layer_id(layer_id, add_contents);
@@ -2187,9 +2189,9 @@ impl Ui {
             let InnerResponse { inner, response } = self.scope(add_contents);
 
             // Check for drags:
-            let dnd_response = self.interact(response.rect, id, Sense::drag());
-
-            dnd_response.dnd_set_drag_payload(payload);
+            let dnd_response = self
+                .interact(response.rect, id, Sense::drag())
+                .on_hover_cursor(CursorIcon::Grab);
 
             InnerResponse::new(inner, dnd_response | response)
         }

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -374,7 +374,7 @@ impl<'a> Widget for DragValue<'a> {
         let shift = ui.input(|i| i.modifiers.shift_only());
         // The widget has the same ID whether it's in edit or button mode.
         let id = ui.next_auto_id();
-        let is_slow_speed = shift && ui.memory(|mem| mem.is_being_dragged(id));
+        let is_slow_speed = shift && ui.ctx().dragged_id() == Some(id);
 
         // The following ensures that when a `DragValue` receives focus,
         // it is immediately rendered in edit mode, rather than being rendered

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -374,7 +374,7 @@ impl<'a> Widget for DragValue<'a> {
         let shift = ui.input(|i| i.modifiers.shift_only());
         // The widget has the same ID whether it's in edit or button mode.
         let id = ui.next_auto_id();
-        let is_slow_speed = shift && ui.ctx().dragged_id() == Some(id);
+        let is_slow_speed = shift && ui.ctx().is_being_dragged(id);
 
         // The following ensures that when a `DragValue` receives focus,
         // it is immediately rendered in edit mode, rather than being rendered

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -551,7 +551,7 @@ impl<'t> TextEdit<'t> {
                     paint_cursor(&painter, ui.visuals(), cursor_rect);
                 }
 
-                let is_being_dragged = ui.ctx().memory(|m| m.is_being_dragged(response.id));
+                let is_being_dragged = ui.ctx().dragged_id() == Some(response.id);
                 let did_interact = state.cursor.pointer_interaction(
                     ui,
                     &response,

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -551,7 +551,7 @@ impl<'t> TextEdit<'t> {
                     paint_cursor(&painter, ui.visuals(), cursor_rect);
                 }
 
-                let is_being_dragged = ui.ctx().dragged_id() == Some(response.id);
+                let is_being_dragged = ui.ctx().is_being_dragged(response.id);
                 let did_interact = state.cursor.pointer_interaction(
                     ui,
                     &response,

--- a/crates/egui_demo_lib/src/demo/tests.rs
+++ b/crates/egui_demo_lib/src/demo/tests.rs
@@ -475,8 +475,8 @@ fn response_summary(response: &egui::Response, show_hovers: bool) -> String {
             writeln!(new_info, "Clicked{button_suffix}").ok();
         }
 
-        if response.drag_released_by(button) {
-            writeln!(new_info, "Drag ended{button_suffix}").ok();
+        if response.drag_stopped_by(button) {
+            writeln!(new_info, "Drag stopped{button_suffix}").ok();
         }
         if response.dragged_by(button) {
             writeln!(new_info, "Dragged{button_suffix}").ok();

--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -203,6 +203,7 @@ impl<'l> StripLayout<'l> {
         }
 
         add_cell_contents(&mut child_ui);
+
         child_ui.min_rect()
     }
 

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -1052,7 +1052,7 @@ impl Plot {
                     ));
                 }
                 // when the click is release perform the zoom
-                if response.drag_released() {
+                if response.drag_stopped() {
                     let box_start_pos = mem.transform.value_from_position(box_start_pos);
                     let box_end_pos = mem.transform.value_from_position(box_end_pos);
                     let new_bounds = PlotBounds {

--- a/examples/test_viewports/src/main.rs
+++ b/examples/test_viewports/src/main.rs
@@ -386,7 +386,7 @@ fn drag_and_drop_test(ui: &mut egui::Ui) {
                 for (id, value) in data.read().cols(container_id, col) {
                     drag_source(ui, id, |ui| {
                         ui.add(egui::Label::new(value).sense(egui::Sense::click()));
-                        if ui.memory(|mem| mem.is_being_dragged(id)) {
+                        if ui.ctx().dragged_id() == Some(id) {
                             is_dragged = Some(id);
                         }
                     });
@@ -408,7 +408,7 @@ fn drag_source<R>(
     id: egui::Id,
     body: impl FnOnce(&mut egui::Ui) -> R,
 ) -> InnerResponse<R> {
-    let is_being_dragged = ui.memory(|mem| mem.is_being_dragged(id));
+    let is_being_dragged = ui.ctx().dragged_id() == Some(id);
 
     if !is_being_dragged {
         let res = ui.scope(body);
@@ -435,12 +435,12 @@ fn drag_source<R>(
     }
 }
 
-// This is taken from crates/egui_demo_lib/src/debo/drag_and_drop.rs
+// TODO: Update to be more like `crates/egui_demo_lib/src/debo/drag_and_drop.rs`
 fn drop_target<R>(
     ui: &mut egui::Ui,
     body: impl FnOnce(&mut egui::Ui) -> R,
 ) -> egui::InnerResponse<R> {
-    let is_being_dragged = ui.memory(|mem| mem.is_anything_being_dragged());
+    let is_being_dragged = ui.ctx().dragged_id().is_some();
 
     let margin = egui::Vec2::splat(ui.visuals().clip_rect_margin); // 3.0
 

--- a/examples/test_viewports/src/main.rs
+++ b/examples/test_viewports/src/main.rs
@@ -386,7 +386,7 @@ fn drag_and_drop_test(ui: &mut egui::Ui) {
                 for (id, value) in data.read().cols(container_id, col) {
                     drag_source(ui, id, |ui| {
                         ui.add(egui::Label::new(value).sense(egui::Sense::click()));
-                        if ui.ctx().dragged_id() == Some(id) {
+                        if ui.ctx().is_being_dragged(id) {
                             is_dragged = Some(id);
                         }
                     });
@@ -408,7 +408,7 @@ fn drag_source<R>(
     id: egui::Id,
     body: impl FnOnce(&mut egui::Ui) -> R,
 ) -> InnerResponse<R> {
-    let is_being_dragged = ui.ctx().dragged_id() == Some(id);
+    let is_being_dragged = ui.ctx().is_being_dragged(id);
 
     if !is_being_dragged {
         let res = ui.scope(body);


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/3936
* Closes https://github.com/emilk/egui/issues/3923
* Closes https://github.com/emilk/egui/pull/4058

The interaction code is now done at the start of the frame, using stored `WidgetRect`s from the previous frame.

The intention is that the new interaction code should be more accurate, making it easier to hit widgets, and better respecting the rules of overlapping widgets.

There is a new `style::Interaction::interact_radius` controlling how far away from a widget the cursor can be and still hit it. This helps big fat fingers hit small widgets on touch screens.

This PR adds a new `Context::read_response` which lets you read the `Response` of a `Widget` _before_ you create the widget. This can be used for styling, or for reading the result of an interaction early (to prevent frame-delay) for a widget you add late (so it is on top of other widgets).

# ⚠️ BREAKING CHANGES
`Memory::dragged_id`, `Memory::set_dragged_id` etc have been moved to `Context`.
The semantics for `Context::dragged_id` is slightly different: a widget is not considered dragged until egui it is sure this is not a click-in-progress. For a widget that is only sensitive to drags, that is right away, but for widgets sensitive to both clicks and drags it is not until the mouse has moved a certain distance.

# TODO
* [x] Fix panel resizing
* [x] Fix scroll hover weirdness
* [x] Fix Resize widget
* [x] Fix drag-and-drop
* [x] Test all of egui_demo_app
* [x] Change `is_dragging` API
* [x] Consistent naming of start/stop or begin/end drag
* [x] Test `egui_tiles`
* [x] Test Rerun
* [x] Document
* [x] Document breaking changes in PR description
* [x] Test one final time

# Saving for a later PR
* [ ] Fix https://github.com/emilk/egui/issues/4047
* [ ] Specify what the response order for e.g. `ui.horizontal` is

I think both these can be fixed if each `Ui` registers themselves as a `WidgetRect`, with the possibility to interact with it later, as if the interaction was under all widgets on top of it.