### PR TITLE
Fix: images with background color now respects rounding

### DIFF
--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -739,17 +739,7 @@ pub fn paint_texture_at(
     texture: &SizedTexture,
 ) {
     if options.bg_fill != Default::default() {
-        // NOTE(vincent-sparks) originally this was only done with a mesh;
-        // however this created a bug if the image had rounding
-        // I assume the mesh was used in place of the rect for performance reasons
-        // so I have left it in
-        if options.rounding == Rounding::ZERO {
-            let mut mesh = Mesh::default();
-            mesh.add_colored_rect(rect, options.bg_fill);
-            painter.add(Shape::mesh(mesh));
-        } else {
-            painter.add(RectShape::new(rect, options.rounding, options.bg_fill, Stroke::NONE));
-        }
+        painter.add(RectShape::filled(rect, options.rounding, options.bg_fill));
     }
 
     match options.rotation {

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -739,9 +739,17 @@ pub fn paint_texture_at(
     texture: &SizedTexture,
 ) {
     if options.bg_fill != Default::default() {
-        let mut mesh = Mesh::default();
-        mesh.add_colored_rect(rect, options.bg_fill);
-        painter.add(Shape::mesh(mesh));
+        // NOTE(vincent-sparks) originally this was only done with a mesh;
+        // however this created a bug if the image had rounding
+        // I assume the mesh was used in place of the rect for performance reasons
+        // so I have left it in
+        if options.rounding == Rounding::ZERO {
+            let mut mesh = Mesh::default();
+            mesh.add_colored_rect(rect, options.bg_fill);
+            painter.add(Shape::mesh(mesh));
+        } else {
+            painter.add(RectShape::new(rect, options.rounding, options.bg_fill, Stroke::NONE));
+        }
     }
 
     match options.rotation {


### PR DESCRIPTION
Code:
```rust
use egui::{TextureHandle, Image, Vec2, Layout, Direction};

struct App {
    texture: TextureHandle,
}

const ROW_HEIGHT: f32 = 200.0;

impl App {
    fn new(ctx: &eframe::CreationContext) -> Self {
        Self {
            texture: ctx.egui_ctx.load_texture("sample", egui::ColorImage::example(), egui::TextureOptions::default()),
        }
    }
}

impl eframe::App for App {
    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
        egui::CentralPanel::default().frame(egui::Frame::dark_canvas(&ctx.style())).show(ctx, |ui| {
            ui.with_layout(Layout::centered_and_justified(Direction::TopDown), |ui|{
                ui.add(Image::new(&self.texture)
                       .bg_fill(egui::Color32::WHITE)
                       .rounding(30.0)
                      );
            });
        });
    }
}

fn main() -> eframe::Result<()> {
    eframe::run_native("egui test", eframe::NativeOptions{
        viewport: egui::ViewportBuilder::default().with_inner_size((256.,200.)),
        ..Default::default()
    }, Box::new(|cc| Box::new(App::new(cc))))
}
```

Before: 
![before](https://github.com/emilk/egui/assets/155431337/9c7c703e-29f3-4403-8a16-7e407352f8a1)

After:
![after](https://github.com/emilk/egui/assets/155431337/0b29229a-a116-4d77-b02c-4c880d568242)

(please see the comment in the diff -- *definitely* not sure if it's up to code standards.  you might want to change/remove that comment as well as the Mesh codepath if it was not, in fact, done for performance reasons)
