### PR TITLE
`eframe`: Add `winuser` feature to `winapi` to fix unresolved import

### DIFF
--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -183,7 +183,7 @@ objc = "0.2.7"
 
 # windows:
 [target.'cfg(any(target_os = "windows"))'.dependencies]
-winapi = "0.3.9"
+winapi = { version = "0.3.9", features = ["winuser"] }
 
 # -------------------------------------------
 # web:


### PR DESCRIPTION
After merging PR #4036, build errors occurred in eframe-related applications:

```log
error[E0432]: unresolved import `winapi::um::winuser`
   --> crates\eframe\src\native\app_icon.rs:83:9
    |
83  |     use winapi::um::winuser;
    |         ^^^^^^^^^^^^^^^^^^^ no `winuser` in `um`
    |
note: found an item that was configured out
   --> C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winapi-0.3.9\src\um\mod.rs:290:37
    |
290 | #[cfg(feature = "winuser")] pub mod winuser;
    |                                     ^^^^^^^
    = note: the item is gated behind the `winuser` feature

For more information about this error, try `rustc --explain E0432`.
error: could not compile `eframe` (lib) due to previous error
warning: build failed, waiting for other jobs to finish...
```
