### PR TITLE
forget exception handling when minimizing on Windows

### DIFF
--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -715,7 +715,6 @@ impl GlowWinitRunning {
         // to resizes anyway, as doing so avoids dropping frames.
         //
         // See: https://github.com/emilk/egui/issues/903
-        let mut repaint_asap = false;
 
         match event {
             winit::event::WindowEvent::Focused(new_focused) => {
@@ -723,16 +722,8 @@ impl GlowWinitRunning {
             }
 
             winit::event::WindowEvent::Resized(physical_size) => {
-                // This solves an issue where the app would panic when minimizing on Windows.
-                // See: https://github.com/rust-windowing/winit/issues/208
                 if let Some(viewport_id) = viewport_id {
-                    if let Some(viewport) = glutin.viewports.get_mut(&viewport_id) {
-                        let is_minimized = viewport.info.minimized.unwrap_or(false);
-                        if !is_minimized {
-                            repaint_asap = true;
-                            glutin.resize(viewport_id, *physical_size);
-                        }
-                    }
+                    glutin.resize(viewport_id, *physical_size);
                 }
             }
 
@@ -788,11 +779,7 @@ impl GlowWinitRunning {
         }
 
         if event_response.repaint {
-            if repaint_asap {
-                EventResult::RepaintNow(window_id)
-            } else {
-                EventResult::RepaintNext(window_id)
-            }
+            EventResult::RepaintNow(window_id)
         } else {
             EventResult::Wait
         }

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -723,13 +723,15 @@ impl GlowWinitRunning {
             }
 
             winit::event::WindowEvent::Resized(physical_size) => {
-                // Resize with 0 width and height is used by winit to signal a minimize event on Windows.
-                // See: https://github.com/rust-windowing/winit/issues/208
                 // This solves an issue where the app would panic when minimizing on Windows.
-                if 0 < physical_size.width && 0 < physical_size.height {
-                    if let Some(viewport_id) = viewport_id {
-                        repaint_asap = true;
-                        glutin.resize(viewport_id, *physical_size);
+                // See: https://github.com/rust-windowing/winit/issues/208
+                if let Some(viewport_id) = viewport_id {
+                    if let Some(viewport) = glutin.viewports.get_mut(&viewport_id) {
+                        let is_minimized = viewport.info.minimized.unwrap_or(false);
+                        if !is_minimized {
+                            repaint_asap = true;
+                            glutin.resize(viewport_id, *physical_size);
+                        }
                     }
                 }
             }

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -197,7 +197,7 @@ fn run_and_return(
                     false
                 } else {
                     window.request_redraw();
-                    true
+                    false
                 }
             } else {
                 log::trace!("No window found for {window_id:?}");
@@ -355,7 +355,7 @@ fn run_and_exit(
                     false
                 } else {
                     window.request_redraw();
-                    true
+                    false
                 }
             } else {
                 log::trace!("No window found for {window_id:?}");

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -743,14 +743,18 @@ impl WgpuWinitRunning {
                 // This solves an issue where the app would panic when minimizing on Windows.
                 // See: https://github.com/rust-windowing/winit/issues/208
                 if let Some(viewport_id) = viewport_id {
-                    let is_minimized = viewport.info.minimized.unwrap_or(false);
-                    if !is_minimized {
-                        repaint_asap = true;
-                        shared.painter.on_window_resized(
-                            viewport_id,
-                            physical_size.width,
-                            physical_size.height,
-                        );
+                    if let Some(viewport) = shared.viewports.get_mut(&viewport_id) {
+                        let is_minimized = viewport.info.minimized.unwrap_or(false);
+                        if !is_minimized {
+                            use std::num::NonZeroU32;
+                            if let (Some(width), Some(height)) = (
+                                NonZeroU32::new(physical_size.width),
+                                NonZeroU32::new(physical_size.height),
+                            ) {
+                                repaint_asap = true;
+                                shared.painter.on_window_resized(viewport_id, width, height);
+                            }
+                        }
                     }
                 }
             }

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -740,17 +740,17 @@ impl WgpuWinitRunning {
             }
 
             winit::event::WindowEvent::Resized(physical_size) => {
-                // Resize with 0 width and height is used by winit to signal a minimize event on Windows.
-                // See: https://github.com/rust-windowing/winit/issues/208
                 // This solves an issue where the app would panic when minimizing on Windows.
+                // See: https://github.com/rust-windowing/winit/issues/208
                 if let Some(viewport_id) = viewport_id {
-                    use std::num::NonZeroU32;
-                    if let (Some(width), Some(height)) = (
-                        NonZeroU32::new(physical_size.width),
-                        NonZeroU32::new(physical_size.height),
-                    ) {
+                    let is_minimized = viewport.info.minimized.unwrap_or(false);
+                    if !is_minimized {
                         repaint_asap = true;
-                        shared.painter.on_window_resized(viewport_id, width, height);
+                        shared.painter.on_window_resized(
+                            viewport_id,
+                            physical_size.width,
+                            physical_size.height,
+                        );
                     }
                 }
             }

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -739,8 +739,6 @@ impl WgpuWinitRunning {
             }
 
             winit::event::WindowEvent::Resized(physical_size) => {
-                // This solves an issue where the app would panic when minimizing on Windows.
-                // See: https://github.com/rust-windowing/winit/issues/208
                 if let Some(viewport_id) = viewport_id {
                     use std::num::NonZeroU32;
                     if let (Some(width), Some(height)) = (

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -732,7 +732,6 @@ impl WgpuWinitRunning {
         // to resizes anyway, as doing so avoids dropping frames.
         //
         // See: https://github.com/emilk/egui/issues/903
-        let mut repaint_asap = false;
 
         match event {
             winit::event::WindowEvent::Focused(new_focused) => {
@@ -743,18 +742,12 @@ impl WgpuWinitRunning {
                 // This solves an issue where the app would panic when minimizing on Windows.
                 // See: https://github.com/rust-windowing/winit/issues/208
                 if let Some(viewport_id) = viewport_id {
-                    if let Some(viewport) = shared.viewports.get_mut(&viewport_id) {
-                        let is_minimized = viewport.info.minimized.unwrap_or(false);
-                        if !is_minimized {
-                            use std::num::NonZeroU32;
-                            if let (Some(width), Some(height)) = (
-                                NonZeroU32::new(physical_size.width),
-                                NonZeroU32::new(physical_size.height),
-                            ) {
-                                repaint_asap = true;
-                                shared.painter.on_window_resized(viewport_id, width, height);
-                            }
-                        }
+                    use std::num::NonZeroU32;
+                    if let (Some(width), Some(height)) = (
+                        NonZeroU32::new(physical_size.width),
+                        NonZeroU32::new(physical_size.height),
+                    ) {
+                        shared.painter.on_window_resized(viewport_id, width, height);
                     }
                 }
             }
@@ -801,11 +794,7 @@ impl WgpuWinitRunning {
         if integration.should_close() {
             EventResult::Exit
         } else if event_response.repaint {
-            if repaint_asap {
-                EventResult::RepaintNow(window_id)
-            } else {
-                EventResult::RepaintNext(window_id)
-            }
+            EventResult::RepaintNow(window_id)
         } else {
             EventResult::Wait
         }


### PR DESCRIPTION
We can forget about it, by #3837.

We returned general way.
