### PR TITLE
Avoid interacting twice when not required

### DIFF
--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -610,6 +610,13 @@ impl Response {
     /// ```
     #[must_use]
     pub fn interact(&self, sense: Sense) -> Self {
+        // Test if we must sense something new compared to what we have already sensed. If not, then
+        // we can return early. This may avoid unnecessarily "masking" some widgets with unneeded
+        // interactions.
+        if (self.sense | sense) == self.sense {
+            return self.clone();
+        }
+
         self.ctx.interact_with_hovered(
             self.layer_id,
             self.id,


### PR DESCRIPTION
This PR short-circuits `Response::interact()` when the `Response` has already been sufficiently "sensed" already. In some circumstance, this can avoid unnecessarily registering another widget rect that may mask some other widget.

One such instance is Rerun's `ListItem`. Calling `context_menu()` on its response would call `interact` and, in turn, mask its sub-widget (collapsing triangle, show/hide buttons, etc.).
