### PR TITLE
Immediate Viewport in normal operation

### DIFF
--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -503,7 +503,7 @@ impl GlowWinitRunning {
             if is_immediate && viewport_id != ViewportId::ROOT {
                 // This will only happen if this is an immediate viewport.
                 // That means that the viewport cannot be rendered by itself and needs his parent to be rendered.
-                if let Some(parent_viewport) = glutin.viewports.get(&viewport.ids.parent) {
+                if let Some(parent_viewport) = glutin.viewports.get(&ViewportId::ROOT) {
                     viewport_id = parent_viewport.ids.this;
                 } else {
                     // Not actually used. Because there is always a `Some()` value.

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -505,7 +505,7 @@ impl GlowWinitRunning {
                 // That means that the viewport cannot be rendered by itself and needs his parent to be rendered.
                 if let Some(parent_viewport) = glutin.viewports.get(&viewport.ids.parent) {
                     if let Some(window) = parent_viewport.window.as_ref() {
-                        return EventResult::RepaintNext(window.id());
+                        return EventResult::RepaintNow(window.id());
                     }
                 }
                 return EventResult::Wait;

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -506,7 +506,7 @@ impl GlowWinitRunning {
                 if let Some(parent_viewport) = glutin.viewports.get(&viewport.ids.parent) {
                     viewport_id = parent_viewport.ids.this;
                 } else {
-                    // Not actually used.
+                    // Not actually used. Because there is always a `Some()` value.
                     return EventResult::Wait;
                 }
             }

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -496,12 +496,27 @@ impl GlowWinitRunning {
         let mut frame_timer = crate::stopwatch::Stopwatch::new();
         frame_timer.start();
 
-        {
-            let glutin = self.glutin.borrow();
+        let (raw_input, viewport_ui_cb) = {
+            crate::profile_scope!("Prepare");
+            let mut glutin = self.glutin.borrow_mut();
             let viewport = &glutin.viewports[&viewport_id];
 
+            let mut is_change_to_root = false;
             let is_immediate = viewport.viewport_ui_cb.is_none();
+
             if is_immediate && viewport_id != ViewportId::ROOT {
+                is_change_to_root = true;
+
+                if let Some(parent_viewport) = glutin.viewports.get(&viewport.ids.parent) {
+                    let is_differed_parent = parent_viewport.viewport_ui_cb.is_some();
+                    if is_differed_parent {
+                        is_change_to_root = false;
+                        viewport_id = parent_viewport.ids.this;
+                    }
+                }
+            }
+
+            if is_change_to_root {
                 // This will only happen if this is an immediate viewport.
                 // That means that the viewport cannot be rendered by itself and needs his parent to be rendered.
                 if let Some(root_viewport) = glutin.viewports.get(&ViewportId::ROOT) {
@@ -511,10 +526,7 @@ impl GlowWinitRunning {
                     return EventResult::Wait;
                 }
             }
-        }
 
-        let (raw_input, viewport_ui_cb) = {
-            let mut glutin = self.glutin.borrow_mut();
             let egui_ctx = glutin.egui_ctx.clone();
             let viewport = glutin.viewports.get_mut(&viewport_id).unwrap();
             let Some(window) = viewport.window.as_ref() else {
@@ -716,7 +728,6 @@ impl GlowWinitRunning {
         // to resizes anyway, as doing so avoids dropping frames.
         //
         // See: https://github.com/emilk/egui/issues/903
-        let mut repaint_asap = false;
 
         match event {
             winit::event::WindowEvent::Focused(new_focused) => {
@@ -729,7 +740,6 @@ impl GlowWinitRunning {
                 // This solves an issue where the app would panic when minimizing on Windows.
                 if 0 < physical_size.width && 0 < physical_size.height {
                     if let Some(viewport_id) = viewport_id {
-                        repaint_asap = true;
                         glutin.resize(viewport_id, *physical_size);
                     }
                 }
@@ -787,11 +797,7 @@ impl GlowWinitRunning {
         }
 
         if event_response.repaint {
-            if repaint_asap {
-                EventResult::RepaintNow(window_id)
-            } else {
-                EventResult::RepaintNext(window_id)
-            }
+            EventResult::RepaintNow(window_id)
         } else {
             EventResult::Wait
         }

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -504,8 +504,8 @@ impl GlowWinitRunning {
             if is_immediate && viewport_id != ViewportId::ROOT {
                 // This will only happen if this is an immediate viewport.
                 // That means that the viewport cannot be rendered by itself and needs his parent to be rendered.
-                if let Some(parent_viewport) = glutin.viewports.get(&ViewportId::ROOT) {
-                    viewport_id = parent_viewport.ids.this;
+                if let Some(root_viewport) = glutin.viewports.get(&ViewportId::ROOT) {
+                    viewport_id = root_viewport.ids.this;
                 } else {
                     // Not actually used. Because there is always a `Some()` value.
                     return EventResult::Wait;

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -499,6 +499,7 @@ impl GlowWinitRunning {
         {
             let glutin = self.glutin.borrow();
             let viewport = &glutin.viewports[&viewport_id];
+
             let is_immediate = viewport.viewport_ui_cb.is_none();
             if is_immediate && viewport_id != ViewportId::ROOT {
                 // This will only happen if this is an immediate viewport.

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -480,7 +480,7 @@ impl GlowWinitRunning {
     ) -> EventResult {
         crate::profile_function!();
 
-        let Some(viewport_id) = self
+        let Some(mut viewport_id) = self
             .glutin
             .borrow()
             .viewport_from_window
@@ -504,11 +504,8 @@ impl GlowWinitRunning {
                 // This will only happen if this is an immediate viewport.
                 // That means that the viewport cannot be rendered by itself and needs his parent to be rendered.
                 if let Some(parent_viewport) = glutin.viewports.get(&viewport.ids.parent) {
-                    if let Some(window) = parent_viewport.window.as_ref() {
-                        return EventResult::RepaintNow(window.id());
-                    }
+                    viewport_id = parent_viewport.ids.this;
                 }
-                return EventResult::Wait;
             }
         }
 

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -505,6 +505,9 @@ impl GlowWinitRunning {
                 // That means that the viewport cannot be rendered by itself and needs his parent to be rendered.
                 if let Some(parent_viewport) = glutin.viewports.get(&viewport.ids.parent) {
                     viewport_id = parent_viewport.ids.this;
+                } else {
+                    // Not actually used.
+                    return EventResult::Wait;
                 }
             }
         }

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -549,9 +549,7 @@ impl WgpuWinitRunning {
                     // This will only happen if this is an immediate viewport.
                     // That means that the viewport cannot be rendered by itself and needs his parent to be rendered.
                     if let Some(parent_viewport) = viewports.get(&viewport.ids.parent) {
-                        if let Some(window) = viewport.window.as_ref() {
-                            viewport_id = parent_viewport.ids.this;
-                        }
+                        viewport_id = parent_viewport.ids.this;
                     }
                 }
             }

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -549,7 +549,7 @@ impl WgpuWinitRunning {
                     // That means that the viewport cannot be rendered by itself and needs his parent to be rendered.
                     if let Some(viewport) = viewports.get(&viewport.ids.parent) {
                         if let Some(window) = viewport.window.as_ref() {
-                            return EventResult::RepaintNext(window.id());
+                            return EventResult::RepaintNow(window.id());
                         }
                     }
                     return EventResult::Wait;

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -550,6 +550,9 @@ impl WgpuWinitRunning {
                     // That means that the viewport cannot be rendered by itself and needs his parent to be rendered.
                     if let Some(parent_viewport) = viewports.get(&viewport.ids.parent) {
                         viewport_id = parent_viewport.ids.this;
+                    } else {
+                        // Not actually used.
+                        return EventResult::Wait;
                     }
                 }
             }

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -548,7 +548,7 @@ impl WgpuWinitRunning {
                 if is_immediate && viewport_id != ViewportId::ROOT {
                     // This will only happen if this is an immediate viewport.
                     // That means that the viewport cannot be rendered by itself and needs his parent to be rendered.
-                    if let Some(parent_viewport) = viewports.get(&viewport.ids.parent) {
+                    if let Some(parent_viewport) = viewports.get(&ViewportId::ROOT) {
                         viewport_id = parent_viewport.ids.this;
                     } else {
                         // Not actually used. Because there is always a `Some()` value.

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -548,8 +548,8 @@ impl WgpuWinitRunning {
                 if is_immediate && viewport_id != ViewportId::ROOT {
                     // This will only happen if this is an immediate viewport.
                     // That means that the viewport cannot be rendered by itself and needs his parent to be rendered.
-                    if let Some(parent_viewport) = viewports.get(&ViewportId::ROOT) {
-                        viewport_id = parent_viewport.ids.this;
+                    if let Some(root_viewport) = viewports.get(&ViewportId::ROOT) {
+                        viewport_id = root_viewport.ids.this;
                     } else {
                         // Not actually used. Because there is always a `Some()` value.
                         return EventResult::Wait;

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -551,7 +551,7 @@ impl WgpuWinitRunning {
                     if let Some(parent_viewport) = viewports.get(&viewport.ids.parent) {
                         viewport_id = parent_viewport.ids.this;
                     } else {
-                        // Not actually used.
+                        // Not actually used. Because there is always a `Some()` value.
                         return EventResult::Wait;
                     }
                 }

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -509,7 +509,7 @@ impl WgpuWinitRunning {
     fn run_ui_and_paint(&mut self, window_id: WindowId) -> EventResult {
         crate::profile_function!();
 
-        let Some(viewport_id) = self
+        let Some(mut viewport_id) = self
             .shared
             .borrow()
             .viewport_from_window
@@ -544,15 +544,15 @@ impl WgpuWinitRunning {
                     return EventResult::Wait;
                 };
 
-                if viewport.viewport_ui_cb.is_none() {
+                let is_immediate = viewport.viewport_ui_cb.is_none();
+                if is_immediate && viewport_id != ViewportId::ROOT {
                     // This will only happen if this is an immediate viewport.
                     // That means that the viewport cannot be rendered by itself and needs his parent to be rendered.
-                    if let Some(viewport) = viewports.get(&viewport.ids.parent) {
+                    if let Some(parent_viewport) = viewports.get(&viewport.ids.parent) {
                         if let Some(window) = viewport.window.as_ref() {
-                            return EventResult::RepaintNow(window.id());
+                            viewport_id = parent_viewport.ids.this;
                         }
                     }
-                    return EventResult::Wait;
                 }
             }
 

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -539,7 +539,6 @@ impl WgpuWinitRunning {
                 viewports, painter, ..
             } = &mut *shared_lock;
 
-            // if viewport_id != ViewportId::ROOT {
             let Some(viewport) = viewports.get(&viewport_id) else {
                 return EventResult::Wait;
             };

--- a/crates/eframe/src/native/winit_integration.rs
+++ b/crates/eframe/src/native/winit_integration.rs
@@ -102,6 +102,7 @@ pub enum EventResult {
     /// Queues a repaint for once the event loop handles its next redraw. Exists
     /// so that multiple input events can be handled in one frame. Does not
     /// cause any delay like `RepaintNow`.
+    #[allow(dead_code)]
     RepaintNext(WindowId),
 
     RepaintAt(WindowId, Instant),

--- a/crates/eframe/src/native/winit_integration.rs
+++ b/crates/eframe/src/native/winit_integration.rs
@@ -102,7 +102,6 @@ pub enum EventResult {
     /// Queues a repaint for once the event loop handles its next redraw. Exists
     /// so that multiple input events can be handled in one frame. Does not
     /// cause any delay like `RepaintNow`.
-    #[allow(dead_code)]
     RepaintNext(WindowId),
 
     RepaintAt(WindowId, Instant),


### PR DESCRIPTION
Closes #3972  

in case of program is minimized, Immediate Viewport in normal operation.
Even if the program is minimized, `Immediate Viewport` continues to be displayed and operates normally.


Additional explanation :
In this case,
Create `Deffered Viewport` from `Immediate Viewport`, or
Creating an `Immediate Viewport` from an `Deffered Viewport`, then does not work as desired.
If you create other types of viewports within a viewport, it is a good idea to create them at the ROOT.
