### PR TITLE
Plot widget - allow disabling scroll for x and y separately

### DIFF
--- a/crates/egui_demo_lib/src/demo/plot_demo.rs
+++ b/crates/egui_demo_lib/src/demo/plot_demo.rs
@@ -878,6 +878,7 @@ struct ChartsDemo {
     vertical: bool,
     allow_zoom: Vec2b,
     allow_drag: Vec2b,
+    allow_scroll: Vec2b,
 }
 
 impl Default for ChartsDemo {
@@ -887,6 +888,7 @@ impl Default for ChartsDemo {
             chart: Chart::default(),
             allow_zoom: true.into(),
             allow_drag: true.into(),
+            allow_scroll: true.into(),
         }
     }
 }
@@ -920,6 +922,11 @@ impl ChartsDemo {
                         ui.label("Allow drag:");
                         ui.checkbox(&mut self.allow_drag.x, "X");
                         ui.checkbox(&mut self.allow_drag.y, "Y");
+                    });
+                    ui.horizontal(|ui| {
+                        ui.label("Allow scroll:");
+                        ui.checkbox(&mut self.allow_scroll.x, "X");
+                        ui.checkbox(&mut self.allow_scroll.y, "Y");
                     });
                 });
             });
@@ -958,6 +965,7 @@ impl ChartsDemo {
             .y_axis_width(3)
             .allow_zoom(self.allow_zoom)
             .allow_drag(self.allow_drag)
+            .allow_scroll(self.allow_scroll)
             .show(ui, |plot_ui| plot_ui.bar_chart(chart))
             .response
     }

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -148,7 +148,7 @@ pub struct Plot {
     center_axis: Vec2b,
     allow_zoom: Vec2b,
     allow_drag: Vec2b,
-    allow_scroll: bool,
+    allow_scroll: Vec2b,
     allow_double_click_reset: bool,
     allow_boxed_zoom: bool,
     default_auto_bounds: Vec2b,
@@ -193,7 +193,7 @@ impl Plot {
             center_axis: false.into(),
             allow_zoom: true.into(),
             allow_drag: true.into(),
-            allow_scroll: true,
+            allow_scroll: true.into(),
             allow_double_click_reset: true,
             allow_boxed_zoom: true,
             default_auto_bounds: true.into(),
@@ -325,8 +325,11 @@ impl Plot {
 
     /// Whether to allow scrolling in the plot. Default: `true`.
     #[inline]
-    pub fn allow_scroll(mut self, on: bool) -> Self {
-        self.allow_scroll = on;
+    pub fn allow_scroll<T>(mut self, on: T) -> Self
+    where
+        T: Into<Vec2b>,
+    {
+        self.allow_scroll = on.into();
         self
     }
 
@@ -1077,8 +1080,14 @@ impl Plot {
                     mem.auto_bounds = !allow_zoom;
                 }
             }
-            if allow_scroll {
-                let scroll_delta = ui.input(|i| i.smooth_scroll_delta);
+            if allow_scroll.any() {
+                let mut scroll_delta = ui.input(|i| i.smooth_scroll_delta);
+                if !allow_scroll.x {
+                    scroll_delta.x = 0.0;
+                }
+                if !allow_scroll.y {
+                    scroll_delta.y = 0.0;
+                }
                 if scroll_delta != Vec2::ZERO {
                     mem.transform.translate_bounds(-scroll_delta);
                     mem.auto_bounds = false.into();


### PR DESCRIPTION
To be consistent with the zoom and drag options that were added earlier.
