### PR TITLE
Add `Response::paint_debug_info()` to make it easy to visualize a widget's id and state

### DIFF
--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -798,6 +798,30 @@ impl Response {
     pub fn context_menu(&self, add_contents: impl FnOnce(&mut Ui)) -> Option<InnerResponse<()>> {
         menu::context_menu(self, add_contents)
     }
+
+    /// Draw a debug rectangle over the response displaying the response's id and whether it is
+    /// enabled and/or hovered.
+    ///
+    /// This function is intended for debugging purpose and can be useful, for example, in case of
+    /// widget id instability.
+    ///
+    /// Color code:
+    /// - Blue: Enabled but not hovered
+    /// - Green: Enabled and hovered
+    /// - Red: Disabled
+    pub fn paint_debug_info(&self) {
+        self.ctx.debug_painter().debug_rect(
+            self.rect,
+            if self.hovered {
+                crate::Color32::DARK_GREEN
+            } else if self.enabled {
+                crate::Color32::BLUE
+            } else {
+                crate::Color32::RED
+            },
+            format!("{:?}", self.id),
+        );
+    }
 }
 
 impl Response {


### PR DESCRIPTION
This PR adds a new `paint_debug_info()` debug method to `Response` in order to draw the response's `Rect`, it's id, and some of its state (active, hovered) via a color code:

![Export-1708083028898](https://github.com/emilk/egui/assets/49431240/ce050448-3f11-4bb1-8959-417d106a89ac)
