### PR TITLE
Fix disabled sliders being interactive.

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1182,7 +1182,7 @@ impl Context {
                         PointerEvent::Moved(_) => {}
 
                         PointerEvent::Pressed { .. } => {
-                            if contains_pointer {
+                            if res.hovered {
                                 let interaction = memory.interaction_mut();
 
                                 if sense.click && interaction.click_id.is_none() {


### PR DESCRIPTION
This also fixes buttons being highlighted when clicked even when disabled.

Before:
![before](https://github.com/emilk/egui/assets/4228461/34e8d09e-4f90-42b9-90ad-8f664d8d9b45)
After:
![after](https://github.com/emilk/egui/assets/4228461/15b68182-2618-4fe4-b048-9e7b71158118)

Unfortunately the app I used to capture the screen didn't capture the mouse, but try to imagine a cursor frantically trying to move sliders and click buttons to no avail in the latter gif.