### PR TITLE
Fix: assign a different id to each table cell, avoiding id clashes

### DIFF
--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -1,4 +1,4 @@
-use egui::{Pos2, Rect, Response, Sense, Ui};
+use egui::{Id, Pos2, Rect, Response, Sense, Ui};
 
 #[derive(Clone, Copy)]
 pub(crate) enum CellSize {
@@ -113,6 +113,7 @@ impl<'l> StripLayout<'l> {
         flags: StripLayoutFlags,
         width: CellSize,
         height: CellSize,
+        child_ui_id_source: Id,
         add_cell_contents: impl FnOnce(&mut Ui),
     ) -> (Rect, Response) {
         let max_rect = self.cell_rect(&width, &height);
@@ -145,7 +146,7 @@ impl<'l> StripLayout<'l> {
             );
         }
 
-        let used_rect = self.cell(flags, max_rect, add_cell_contents);
+        let used_rect = self.cell(flags, max_rect, child_ui_id_source, add_cell_contents);
 
         self.set_pos(max_rect);
 
@@ -186,9 +187,12 @@ impl<'l> StripLayout<'l> {
         &mut self,
         flags: StripLayoutFlags,
         rect: Rect,
+        child_ui_id_source: egui::Id,
         add_cell_contents: impl FnOnce(&mut Ui),
     ) -> Rect {
-        let mut child_ui = self.ui.child_ui(rect, self.cell_layout);
+        let mut child_ui =
+            self.ui
+                .child_ui_with_id_source(rect, self.cell_layout, child_ui_id_source);
 
         if flags.clip {
             let margin = egui::Vec2::splat(self.ui.visuals().clip_rect_margin);

--- a/crates/egui_extras/src/strip.rs
+++ b/crates/egui_extras/src/strip.rs
@@ -194,7 +194,13 @@ impl<'a, 'b> Strip<'a, 'b> {
             clip: self.clip,
             ..Default::default()
         };
-        self.layout.add(flags, width, height, add_contents);
+        self.layout.add(
+            flags,
+            width,
+            height,
+            egui::Id::new(self.size_index),
+            add_contents,
+        );
     }
 
     /// Add an empty cell.

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -1166,7 +1166,13 @@ impl<'a, 'b> TableRow<'a, 'b> {
             selected: self.selected,
         };
 
-        let (used_rect, response) = self.layout.add(flags, width, height, add_cell_contents);
+        let (used_rect, response) = self.layout.add(
+            flags,
+            width,
+            height,
+            egui::Id::new((self.row_index, col_index)),
+            add_cell_contents,
+        );
 
         if let Some(max_w) = self.max_used_widths.get_mut(col_index) {
             *max_w = max_w.max(used_rect.width());


### PR DESCRIPTION
Each cell in a table now has a `Ui` with a unique `Id` based on the row and column.

This avoids Id-clashes, e.g. when putting a `CollapsingHeader` in a table cell.