### PR TITLE
Convenience const fn for Margin, Rounding and Shadow

### DIFF
--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -622,7 +622,7 @@ impl Margin {
     };
 
     #[inline]
-    pub fn same(margin: f32) -> Self {
+    pub const fn same(margin: f32) -> Self {
         Self {
             left: margin,
             right: margin,
@@ -633,7 +633,7 @@ impl Margin {
 
     /// Margins with the same size on opposing sides
     #[inline]
-    pub fn symmetric(x: f32, y: f32) -> Self {
+    pub const fn symmetric(x: f32, y: f32) -> Self {
         Self {
             left: x,
             right: x,
@@ -649,12 +649,12 @@ impl Margin {
     }
 
     #[inline]
-    pub fn left_top(&self) -> Vec2 {
+    pub const fn left_top(&self) -> Vec2 {
         vec2(self.left, self.top)
     }
 
     #[inline]
-    pub fn right_bottom(&self) -> Vec2 {
+    pub const fn right_bottom(&self) -> Vec2 {
         vec2(self.right, self.bottom)
     }
 

--- a/crates/epaint/src/shadow.rs
+++ b/crates/epaint/src/shadow.rs
@@ -18,6 +18,10 @@ impl Shadow {
         extrusion: 0.0,
         color: Color32::TRANSPARENT,
     };
+    
+    pub const fn new(extrusion: f32, color: Color32) -> Self {
+        Self { extrusion, color }
+    }
 
     /// Tooltips, menus, …, for dark mode.
     pub const fn small_dark() -> Self {

--- a/crates/epaint/src/shadow.rs
+++ b/crates/epaint/src/shadow.rs
@@ -20,7 +20,7 @@ impl Shadow {
     };
 
     /// Tooltips, menus, …, for dark mode.
-    pub fn small_dark() -> Self {
+    pub const fn small_dark() -> Self {
         Self {
             extrusion: 16.0,
             color: Color32::from_black_alpha(96),
@@ -28,7 +28,7 @@ impl Shadow {
     }
 
     /// Tooltips, menus, …, for light mode.
-    pub fn small_light() -> Self {
+    pub const fn small_light() -> Self {
         Self {
             extrusion: 16.0,
             color: Color32::from_black_alpha(20),
@@ -36,7 +36,7 @@ impl Shadow {
     }
 
     /// Used for egui windows in dark mode.
-    pub fn big_dark() -> Self {
+    pub const fn big_dark() -> Self {
         Self {
             extrusion: 32.0,
             color: Color32::from_black_alpha(96),
@@ -44,7 +44,7 @@ impl Shadow {
     }
 
     /// Used for egui windows in light mode.
-    pub fn big_light() -> Self {
+    pub const fn big_light() -> Self {
         Self {
             extrusion: 32.0,
             color: Color32::from_black_alpha(16),

--- a/crates/epaint/src/shadow.rs
+++ b/crates/epaint/src/shadow.rs
@@ -18,7 +18,7 @@ impl Shadow {
         extrusion: 0.0,
         color: Color32::TRANSPARENT,
     };
-    
+
     pub const fn new(extrusion: f32, color: Color32) -> Self {
         Self { extrusion, color }
     }

--- a/crates/epaint/src/shape.rs
+++ b/crates/epaint/src/shape.rs
@@ -701,7 +701,7 @@ impl Rounding {
     };
 
     #[inline]
-    pub fn same(radius: f32) -> Self {
+    pub const fn same(radius: f32) -> Self {
         Self {
             nw: radius,
             ne: radius,


### PR DESCRIPTION
I often write constants at the top of my widget files, as a "config". I kept writing stuff like that :
```rust
const DEFAULT_INNER_MARGIN: Margin = Margin { left: 17., right: 17., top: 7., bottom: 7. };
```
So I prefixed constructors for `Margin`, `Rounding` and `Shadow` const. No code was changed.

I also added a `Shadow::new()` for similar reasons.