### PR TITLE
`epaint`: Added `Shape::{scale,translate}` wrappers

### DIFF
--- a/crates/epaint/src/shape.rs
+++ b/crates/epaint/src/shape.rs
@@ -355,6 +355,22 @@ impl Shape {
         }
     }
 
+    /// Scale the shape by `factor`, in-place.
+    ///
+    /// A wrapper around [`Self::transform`].
+    #[inline(always)]
+    pub fn scale(&mut self, factor: f32) {
+        self.transform(TSTransform::from_scaling(factor));
+    }
+
+    /// Move the shape by `delta`, in-place.
+    ///
+    /// A wrapper around [`Self::transform`].
+    #[inline(always)]
+    pub fn translate(&mut self, delta: Vec2) {
+        self.transform(TSTransform::from_translation(delta));
+    }
+
     /// Move the shape by this many points, in-place.
     ///
     /// If using a [`PaintCallback`], note that only the rect is scaled as opposed


### PR DESCRIPTION
The `Shape::translate` method has been replaced with `Shape::transform`, which introduces breaking changes that could negatively impact existing users.

This patch adds a `Shape::translate` wrapper to prevent these breaking changes.
