### PR TITLE
Make ecolor::HexColor Serialize to a Hex Code

### DIFF
--- a/crates/ecolor/Cargo.toml
+++ b/crates/ecolor/Cargo.toml
@@ -25,6 +25,12 @@ all-features = true
 [features]
 default = []
 
+## Enable [`serde`](https://docs.rs/serde) serialization and deserialization to hex codes for `HexColor`.
+serde-hexcolor = ["serde"]
+
+## Allow serialization using [`serde`](https://docs.rs/serde).
+serde = ["dep:serde"]
+
 ## Enable additional checks if debug assertions are enabled (debug builds).
 extra_debug_asserts = []
 ## Always enable additional checks.


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

This PR makes `ecolor::HexColor` Serialize/Deserialize to and from a Hex Code. 

- doesn't break any existing code
- new feature flag in the ecolor crate, without flag enabled will exhibit old serde default behavior
- properly serializes and deserializes the each variant of the enum to the respective correct hexcode length

Example of use (ron + serde), taken from my project [eguitty](https://github.com/quinntyx/eguitty): 

Without:
```rust
(
    profiles: {
        "default": (
            terminal_configuration: (
                bg_color: None,
                fg_color: None,
                cursor_trail: true,
                cursor_trail_color: None,
                font: (
                    size: 12.0,
                    family: Monospace,
                ),
                default_focus_cursor: Block(Hex8(((255, 255, 255, 255)))),
                default_unfocus_cursor: OpenBlock(Hex8(((255, 255, 255, 255)))),
                cursor_stroke: (
                    width: 1.0,
                    color: ((255, 255, 255, 255)),
                ),
            ),
            shell_command: "zsh",
        ),
    },
...
)
```

With:
```rust
(
    profiles: {
        "default": (
            terminal_configuration: (
                bg_color: None,
                fg_color: None,
                cursor_trail: true,
                cursor_trail_color: None,
                font: (
                    size: 12.0,
                    family: Monospace,
                ),
                default_focus_cursor: Block("#ffffffff"),
                default_unfocus_cursor: OpenBlock("#ffffffff"),
                cursor_stroke: (
                    width: 1.0,
                    color: ((255, 255, 255, 255)),
                ),
            ),
            shell_command: "zsh",
        ),
    },
...
)
```