### PR TITLE
Give each menu `Area` an id distinct from the id of what was clicked 

### DIFF
--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -135,7 +135,7 @@ pub(crate) fn submenu_button<R>(
 /// wrapper for the contents of every menu.
 pub(crate) fn menu_ui<'c, R>(
     ctx: &Context,
-    menu_id: impl Into<Id>,
+    menu_id: Id,
     menu_state_arc: &Arc<RwLock<MenuState>>,
     add_contents: impl FnOnce(&mut Ui) -> R + 'c,
 ) -> InnerResponse<R> {
@@ -145,7 +145,7 @@ pub(crate) fn menu_ui<'c, R>(
         menu_state.rect.min
     };
 
-    let area = Area::new(menu_id)
+    let area = Area::new(menu_id.with("__menu"))
         .order(Order::Foreground)
         .fixed_pos(pos)
         .constrain_to(ctx.screen_rect())

--- a/crates/egui/src/widget_rect.rs
+++ b/crates/egui/src/widget_rect.rs
@@ -105,16 +105,16 @@ impl WidgetRects {
                 // e.g. calling `response.interact(…)` to add more interaction.
                 let (idx_in_layer, existing) = entry.get_mut();
 
+                egui_assert!(
+                    existing.layer_id == widget_rect.layer_id,
+                    "Widget changed layer_id during the frame"
+                );
+
                 // Update it:
                 existing.rect = widget_rect.rect; // last wins
                 existing.interact_rect = widget_rect.interact_rect; // last wins
                 existing.sense |= widget_rect.sense;
                 existing.enabled |= widget_rect.enabled;
-
-                egui_assert!(
-                    existing.layer_id == widget_rect.layer_id,
-                    "Widget changed layer_id during the frame"
-                );
 
                 if existing.layer_id == widget_rect.layer_id {
                     layer_widgets[*idx_in_layer] = *existing;


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/4113

Previously the `Id` of the menu `Area` was using the same id as the thing that was clicked (i.e. the button opening menu), which lead to id clashes