### PR TITLE
Quickly animate scroll when calling `ui.scroll_to_cursor` etc 

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -570,7 +570,7 @@ impl ScrollArea {
                 }
             } else {
                 for d in 0..2 {
-                    let dt = ui.input(|i| i.unstable_dt);
+                    let dt = ui.input(|i| i.stable_dt).at_most(0.1);
 
                     if let Some(target_offset) = state.offset_target[d] {
                         state.vel[d] = 0.0;

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -796,7 +796,7 @@ impl Prepared {
                             // so we don't want to reset the animation, but perhaps update the target:
                             animation.target_offset = target_offset;
                         } else {
-                            // The futher we scroll, the more time we take.
+                            // The further we scroll, the more time we take.
                             // TODO(emilk): let users configure this in `Style`.
                             let now = ui.input(|i| i.time);
                             let points_per_second = 1000.0;

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -745,11 +745,11 @@ impl Prepared {
                 let scroll_target = content_ui
                     .ctx()
                     .frame_state_mut(|state| state.scroll_target[d].take());
-                if let Some((scroll, align)) = scroll_target {
+                if let Some((target_range, align)) = scroll_target {
                     let min = content_ui.min_rect().min[d];
                     let clip_rect = content_ui.clip_rect();
                     let visible_range = min..=min + clip_rect.size()[d];
-                    let (start, end) = (scroll.min, scroll.max);
+                    let (start, end) = (target_range.min, target_range.max);
                     let clip_start = clip_rect.min[d];
                     let clip_end = clip_rect.max[d];
                     let mut spacing = ui.spacing().item_spacing[d];
@@ -758,7 +758,7 @@ impl Prepared {
                         let center_factor = align.to_factor();
 
                         let offset =
-                            lerp(scroll, center_factor) - lerp(visible_range, center_factor);
+                            lerp(target_range, center_factor) - lerp(visible_range, center_factor);
 
                         // Depending on the alignment we need to add or subtract the spacing
                         spacing *= remap(center_factor, 0.0..=1.0, -1.0..=1.0);

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -5,8 +5,7 @@ use crate::*;
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 struct ScrollTarget {
-    start_time: f64,
-    end_time: f64,
+    animation_time_span: (f64, f64),
     target_offset: f32,
 }
 
@@ -590,9 +589,8 @@ impl ScrollArea {
                         } else {
                             // Move towards target
                             let t = emath::interpolation_factor(
-                                scroll_target.start_time,
+                                scroll_target.animation_time_span,
                                 ui.input(|i| i.time),
-                                scroll_target.end_time,
                                 dt,
                                 emath::ease_in_ease_out,
                             );
@@ -803,8 +801,7 @@ impl Prepared {
                             let animation_duration =
                                 (delta.abs() / points_per_second).clamp(0.1, 0.3);
                             state.offset_target[d] = Some(ScrollTarget {
-                                start_time: now,
-                                end_time: now + animation_duration as f64,
+                                animation_time_span: (now, now + animation_duration as f64),
                                 target_offset,
                             });
                         }

--- a/crates/egui/src/input_state.rs
+++ b/crates/egui/src/input_state.rs
@@ -223,7 +223,7 @@ impl InputState {
 
         let mut unprocessed_scroll_delta = self.unprocessed_scroll_delta;
 
-        let smooth_scroll_delta;
+        let mut smooth_scroll_delta = Vec2::ZERO;
 
         {
             // Mouse wheels often go very large steps.
@@ -233,8 +233,15 @@ impl InputState {
             let dt = stable_dt.at_most(0.1);
             let t = crate::emath::exponential_smooth_factor(0.90, 0.1, dt); // reach _% in _ seconds. TODO: parameterize
 
-            smooth_scroll_delta = t * unprocessed_scroll_delta;
-            unprocessed_scroll_delta -= smooth_scroll_delta;
+            for d in 0..2 {
+                if unprocessed_scroll_delta[d].abs() < 1.0 {
+                    smooth_scroll_delta[d] = unprocessed_scroll_delta[d];
+                    unprocessed_scroll_delta[d] = 0.0;
+                } else {
+                    smooth_scroll_delta[d] = t * unprocessed_scroll_delta[d];
+                    unprocessed_scroll_delta[d] -= smooth_scroll_delta[d];
+                }
+            }
         }
 
         let mut modifiers = new.modifiers;

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -679,6 +679,7 @@ impl Response {
 
     /// Adjust the scroll position until this UI becomes visible.
     ///
+    /// If `align` is [`Align::TOP`] it means "put the top of the rect at the top of the scroll area", etc.
     /// If `align` is `None`, it'll scroll enough to bring the UI into view.
     ///
     /// See also: [`Ui::scroll_to_cursor`], [`Ui::scroll_to_rect`]. [`Ui::scroll_with_delta`].

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -202,11 +202,6 @@ pub struct Style {
     /// How many seconds a typical animation should last.
     pub animation_time: f32,
 
-    /// When exponentially animating, reach this fraction in [`Self::animation_time`].
-    ///
-    /// Currently this affects the scroll speed of [`Ui::scroll_to_cursor`] etc.
-    pub animation_exponential_fraction: f32,
-
     /// Options to help debug why egui behaves strangely.
     ///
     /// Only available in debug builds.
@@ -1101,7 +1096,6 @@ impl Default for Style {
             interaction: Interaction::default(),
             visuals: Visuals::default(),
             animation_time: 1.0 / 12.0,
-            animation_exponential_fraction: 0.50,
             #[cfg(debug_assertions)]
             debug: Default::default(),
             explanation_tooltips: false,
@@ -1363,7 +1357,6 @@ impl Style {
             interaction,
             visuals,
             animation_time,
-            animation_exponential_fraction,
             #[cfg(debug_assertions)]
             debug,
             explanation_tooltips,
@@ -1421,10 +1414,6 @@ impl Style {
                     .clamp_to_range(true)
                     .suffix(" s"),
             );
-            ui.end_row();
-
-            ui.label("Animation exponential fraction:");
-            ui.add(Slider::new(animation_exponential_fraction, 0.0..=1.0).clamp_to_range(true));
             ui.end_row();
         });
 

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1101,7 +1101,7 @@ impl Default for Style {
             interaction: Interaction::default(),
             visuals: Visuals::default(),
             animation_time: 1.0 / 12.0,
-            animation_exponential_fraction: 0.99,
+            animation_exponential_fraction: 0.90,
             #[cfg(debug_assertions)]
             debug: Default::default(),
             explanation_tooltips: false,

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1101,7 +1101,7 @@ impl Default for Style {
             interaction: Interaction::default(),
             visuals: Visuals::default(),
             animation_time: 1.0 / 12.0,
-            animation_exponential_fraction: 0.90,
+            animation_exponential_fraction: 0.50,
             #[cfg(debug_assertions)]
             debug: Default::default(),
             explanation_tooltips: false,

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -202,6 +202,11 @@ pub struct Style {
     /// How many seconds a typical animation should last.
     pub animation_time: f32,
 
+    /// When exponentially animating, reach this fraction in [`Self::animation_time`].
+    ///
+    /// Currently this affects the scroll speed of [`Ui::scroll_to_cursor`] etc.
+    pub animation_exponential_fraction: f32,
+
     /// Options to help debug why egui behaves strangely.
     ///
     /// Only available in debug builds.
@@ -1096,6 +1101,7 @@ impl Default for Style {
             interaction: Interaction::default(),
             visuals: Visuals::default(),
             animation_time: 1.0 / 12.0,
+            animation_exponential_fraction: 0.99,
             #[cfg(debug_assertions)]
             debug: Default::default(),
             explanation_tooltips: false,
@@ -1357,6 +1363,7 @@ impl Style {
             interaction,
             visuals,
             animation_time,
+            animation_exponential_fraction,
             #[cfg(debug_assertions)]
             debug,
             explanation_tooltips,
@@ -1414,6 +1421,10 @@ impl Style {
                     .clamp_to_range(true)
                     .suffix(" s"),
             );
+            ui.end_row();
+
+            ui.label("Animation exponential fraction:");
+            ui.add(Slider::new(animation_exponential_fraction, 0.0..=1.0).clamp_to_range(true));
             ui.end_row();
         });
 

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1002,6 +1002,7 @@ impl Ui {
 
     /// Adjust the scroll position of any parent [`ScrollArea`] so that the given [`Rect`] becomes visible.
     ///
+    /// If `align` is [`Align::TOP`] it means "put the top of the rect at the top of the scroll area", etc.
     /// If `align` is `None`, it'll scroll enough to bring the cursor into view.
     ///
     /// See also: [`Response::scroll_to_me`], [`Ui::scroll_to_cursor`]. [`Ui::scroll_with_delta`]..
@@ -1028,6 +1029,7 @@ impl Ui {
 
     /// Adjust the scroll position of any parent [`ScrollArea`] so that the cursor (where the next widget goes) becomes visible.
     ///
+    /// If `align` is [`Align::TOP`] it means "put the top of the rect at the top of the scroll area", etc.
     /// If `align` is not provided, it'll scroll enough to bring the cursor into view.
     ///
     /// See also: [`Response::scroll_to_me`], [`Ui::scroll_to_rect`]. [`Ui::scroll_with_delta`].

--- a/crates/egui_demo_lib/src/demo/scrolling.rs
+++ b/crates/egui_demo_lib/src/demo/scrolling.rs
@@ -252,6 +252,8 @@ impl super::View for ScrollTo {
     fn ui(&mut self, ui: &mut Ui) {
         ui.label("This shows how you can scroll to a specific item or pixel offset");
 
+        let num_items = 500;
+
         let mut track_item = false;
         let mut go_to_scroll_offset = false;
         let mut scroll_top = false;
@@ -260,7 +262,7 @@ impl super::View for ScrollTo {
         ui.horizontal(|ui| {
             ui.label("Scroll to a specific item index:");
             track_item |= ui
-                .add(Slider::new(&mut self.track_item, 1..=50).text("Track Item"))
+                .add(Slider::new(&mut self.track_item, 1..=num_items).text("Track Item"))
                 .dragged();
         });
 
@@ -304,7 +306,7 @@ impl super::View for ScrollTo {
                     ui.scroll_to_cursor(Some(Align::TOP));
                 }
                 ui.vertical(|ui| {
-                    for item in 1..=50 {
+                    for item in 1..=num_items {
                         if track_item && item == self.track_item {
                             let response =
                                 ui.colored_label(Color32::YELLOW, format!("This is item {item}"));

--- a/crates/emath/src/lib.rs
+++ b/crates/emath/src/lib.rs
@@ -390,32 +390,29 @@ pub fn exponential_smooth_factor(
 ///
 /// ``` rs
 /// struct Animation {
-///    current_value: f32,
+///     current_value: f32,
 ///
-///    animation_start_time: f64,
-///    target_value: f32,
+///     animation_time_span: (f64, f64),
+///     target_value: f32,
 /// }
 ///
 /// impl Animation {
 ///     fn update(&mut self, now: f64, dt: f32) {
-///         let animation_duration = 0.5;
-///         let animation_end_time = self.animation_start_time + animation_duration;
-///         let t = interpolation_factor(self.animation_start_time, now, animation_end_time, dt, ease_in_ease_out);
+///         let t = interpolation_factor(self.animation_time_span, now, dt, ease_in_ease_out);
 ///         self.current_value = emath::lerp(self.current_value..=self.target_value, t);
 ///     }
 /// }
 /// ```
 pub fn interpolation_factor(
-    start_time: f64,
+    (start_time, end_time): (f64, f64),
     current_time: f64,
-    end_time: f64,
     dt: f32,
     easing: impl Fn(f32) -> f32,
 ) -> f32 {
-    let animation_time = (end_time - start_time) as f32;
+    let animation_duration = (end_time - start_time) as f32;
     let prev_time = current_time - dt as f64;
-    let prev_t = easing((prev_time - start_time) as f32 / animation_time);
-    let end_t = easing((current_time - start_time) as f32 / animation_time);
+    let prev_t = easing((prev_time - start_time) as f32 / animation_duration);
+    let end_t = easing((current_time - start_time) as f32 / animation_duration);
     if end_t < 1.0 {
         (end_t - prev_t) / (1.0 - prev_t)
     } else {

--- a/crates/emath/src/lib.rs
+++ b/crates/emath/src/lib.rs
@@ -383,6 +383,55 @@ pub fn exponential_smooth_factor(
     1.0 - (1.0 - reach_this_fraction).powf(dt / in_this_many_seconds)
 }
 
+/// If you have a value animating over time,
+/// how much towards its target do you need to move it this frame?
+///
+/// You only need to store the start time and target value in order to animate using this function.
+///
+/// ``` rs
+/// struct Animation {
+///    current_value: f32,
+///
+///    animation_start_time: f64,
+///    target_value: f32,
+/// }
+///
+/// impl Animation {
+///     fn update(&mut self, now: f64, dt: f32) {
+///         let animation_duration = 0.5;
+///         let animation_end_time = self.animation_start_time + animation_duration;
+///         let t = interpolation_factor(self.animation_start_time, now, animation_end_time, dt, ease_in_ease_out);
+///         self.current_value = emath::lerp(self.current_value..=self.target_value, t);
+///     }
+/// }
+/// ```
+pub fn interpolation_factor(
+    start_time: f64,
+    current_time: f64,
+    end_time: f64,
+    dt: f32,
+    easing: impl Fn(f32) -> f32,
+) -> f32 {
+    let animation_time = (end_time - start_time) as f32;
+    let prev_time = current_time - dt as f64;
+    let prev_t = easing((prev_time - start_time) as f32 / animation_time);
+    let end_t = easing((current_time - start_time) as f32 / animation_time);
+    if end_t < 1.0 {
+        (end_t - prev_t) / (1.0 - prev_t)
+    } else {
+        1.0
+    }
+}
+
+/// Ease in, ease out.
+///
+/// `f(0) = 0, f'(0) = 0, f(1) = 1, f'(1) = 0`.
+#[inline]
+pub fn ease_in_ease_out(t: f32) -> f32 {
+    let t = t.clamp(0.0, 1.0);
+    (3.0 * t * t - 2.0 * t * t * t).clamp(0.0, 1.0)
+}
+
 // ----------------------------------------------------------------------------
 
 /// An assert that is only active when `emath` is compiled with the `extra_asserts` feature


### PR DESCRIPTION
Uses ease-in-ease-out interpolation, with a time between 0.1s and 0.3s, depending on the distance needed to scroll.

![smooth-scroll-to-target](https://github.com/emilk/egui/assets/1148717/c5c8556d-476b-4597-842b-aa0e5927fbb9)
