### PR TITLE
`epaint`: Add `EllipseShape`

### DIFF
--- a/crates/epaint/src/lib.rs
+++ b/crates/epaint/src/lib.rs
@@ -47,8 +47,8 @@ pub use {
     mesh::{Mesh, Mesh16, Vertex},
     shadow::Shadow,
     shape::{
-        CircleShape, PaintCallback, PaintCallbackInfo, PathShape, RectShape, Rounding, Shape,
-        TextShape,
+        CircleShape, EllipseShape, PaintCallback, PaintCallbackInfo, PathShape, RectShape,
+        Rounding, Shape, TextShape,
     },
     stats::PaintStats,
     stroke::Stroke,

--- a/crates/epaint/src/shape.rs
+++ b/crates/epaint/src/shape.rs
@@ -388,7 +388,7 @@ impl Shape {
             }
             Self::Ellipse(ellipse_shape) => {
                 ellipse_shape.center = transform * ellipse_shape.center;
-                ellipse_shape.size *= transform.scaling;
+                ellipse_shape.radius *= transform.scaling;
                 ellipse_shape.stroke.width *= transform.scaling;
             }
             Self::LineSegment { points, stroke } => {
@@ -505,28 +505,28 @@ impl From<CircleShape> for Shape {
 pub struct EllipseShape {
     pub center: Pos2,
 
-    /// Size is the vector (a, b) where the width of the Ellipse is 2a and the height is 2b
-    pub size: Vec2,
+    /// Radius is the vector (a, b) where the width of the Ellipse is 2a and the height is 2b
+    pub radius: Vec2,
     pub fill: Color32,
     pub stroke: Stroke,
 }
 
 impl EllipseShape {
     #[inline]
-    pub fn filled(center: Pos2, size: Vec2, fill_color: impl Into<Color32>) -> Self {
+    pub fn filled(center: Pos2, radius: Vec2, fill_color: impl Into<Color32>) -> Self {
         Self {
             center,
-            size,
+            radius,
             fill: fill_color.into(),
             stroke: Default::default(),
         }
     }
 
     #[inline]
-    pub fn stroke(center: Pos2, size: Vec2, stroke: impl Into<Stroke>) -> Self {
+    pub fn stroke(center: Pos2, radius: Vec2, stroke: impl Into<Stroke>) -> Self {
         Self {
             center,
-            size,
+            radius,
             fill: Default::default(),
             stroke: stroke.into(),
         }
@@ -539,7 +539,7 @@ impl EllipseShape {
         } else {
             Rect::from_center_size(
                 self.center,
-                self.size * 2.0 + Vec2::splat(self.stroke.width),
+                self.radius * 2.0 + Vec2::splat(self.stroke.width),
             )
         }
     }

--- a/crates/epaint/src/shape.rs
+++ b/crates/epaint/src/shape.rs
@@ -504,6 +504,7 @@ impl From<CircleShape> for Shape {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct EllipseShape {
     pub center: Pos2,
+
     /// Size is the vector (a, b) where the width of the Ellipse is 2a and the height is 2b
     pub size: Vec2,
     pub fill: Color32,

--- a/crates/epaint/src/shape.rs
+++ b/crates/epaint/src/shape.rs
@@ -30,8 +30,8 @@ pub enum Shape {
     /// Circle with optional outline and fill.
     Circle(CircleShape),
 
-    /// Elipse with optional outline and fill.
-    Elipse(ElipseShape),
+    /// Ellipse with optional outline and fill.
+    Ellipse(EllipseShape),
 
     /// A line between two points.
     LineSegment { points: [Pos2; 2], stroke: Stroke },
@@ -327,7 +327,7 @@ impl Shape {
                 rect
             }
             Self::Circle(circle_shape) => circle_shape.visual_bounding_rect(),
-            Self::Elipse(elipse_shape) => elipse_shape.visual_bounding_rect(),
+            Self::Ellipse(ellipse_shape) => ellipse_shape.visual_bounding_rect(),
             Self::LineSegment { points, stroke } => {
                 if stroke.is_empty() {
                     Rect::NOTHING
@@ -376,10 +376,10 @@ impl Shape {
                 circle_shape.radius *= transform.scaling;
                 circle_shape.stroke.width *= transform.scaling;
             }
-            Self::Elipse(elipse_shape) => {
-                elipse_shape.center = transform * elipse_shape.center;
-                elipse_shape.size *= transform.scaling;
-                elipse_shape.stroke.width *= transform.scaling;
+            Self::Ellipse(ellipse_shape) => {
+                ellipse_shape.center = transform * ellipse_shape.center;
+                ellipse_shape.size *= transform.scaling;
+                ellipse_shape.stroke.width *= transform.scaling;
             }
             Self::LineSegment { points, stroke } => {
                 for p in points {
@@ -489,18 +489,18 @@ impl From<CircleShape> for Shape {
 
 // ----------------------------------------------------------------------------
 
-/// How to paint an elipse.
+/// How to paint an ellipse.
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct ElipseShape {
+pub struct EllipseShape {
     pub center: Pos2,
-    /// Size is the vector (a, b) where the width of the Elipse is 2a and the height is 2b
+    /// Size is the vector (a, b) where the width of the Ellipse is 2a and the height is 2b
     pub size: Vec2,
     pub fill: Color32,
     pub stroke: Stroke,
 }
 
-impl ElipseShape {
+impl EllipseShape {
     #[inline]
     pub fn filled(center: Pos2, size: Vec2, fill_color: impl Into<Color32>) -> Self {
         Self {
@@ -534,10 +534,10 @@ impl ElipseShape {
     }
 }
 
-impl From<ElipseShape> for Shape {
+impl From<EllipseShape> for Shape {
     #[inline(always)]
-    fn from(shape: ElipseShape) -> Self {
-        Self::Elipse(shape)
+    fn from(shape: EllipseShape) -> Self {
+        Self::Ellipse(shape)
     }
 }
 

--- a/crates/epaint/src/shape.rs
+++ b/crates/epaint/src/shape.rs
@@ -240,6 +240,16 @@ impl Shape {
     }
 
     #[inline]
+    pub fn ellipse_filled(center: Pos2, size: Vec2, fill_color: impl Into<Color32>) -> Self {
+        Self::Ellipse(EllipseShape::filled(center, size, fill_color))
+    }
+
+    #[inline]
+    pub fn ellipse_stroke(center: Pos2, size: Vec2, stroke: impl Into<Stroke>) -> Self {
+        Self::Ellipse(EllipseShape::stroke(center, size, stroke))
+    }
+
+    #[inline]
     pub fn rect_filled(
         rect: Rect,
         rounding: impl Into<Rounding>,

--- a/crates/epaint/src/shape.rs
+++ b/crates/epaint/src/shape.rs
@@ -240,13 +240,13 @@ impl Shape {
     }
 
     #[inline]
-    pub fn ellipse_filled(center: Pos2, size: Vec2, fill_color: impl Into<Color32>) -> Self {
-        Self::Ellipse(EllipseShape::filled(center, size, fill_color))
+    pub fn ellipse_filled(center: Pos2, radius: Vec2, fill_color: impl Into<Color32>) -> Self {
+        Self::Ellipse(EllipseShape::filled(center, radius, fill_color))
     }
 
     #[inline]
-    pub fn ellipse_stroke(center: Pos2, size: Vec2, stroke: impl Into<Stroke>) -> Self {
-        Self::Ellipse(EllipseShape::stroke(center, size, stroke))
+    pub fn ellipse_stroke(center: Pos2, radius: Vec2, stroke: impl Into<Stroke>) -> Self {
+        Self::Ellipse(EllipseShape::stroke(center, radius, stroke))
     }
 
     #[inline]

--- a/crates/epaint/src/shape_transform.rs
+++ b/crates/epaint/src/shape_transform.rs
@@ -22,7 +22,7 @@ pub fn adjust_colors(shape: &mut Shape, adjust_color: &impl Fn(&mut Color32)) {
         })
         | Shape::Ellipse(EllipseShape {
             center: _,
-            size: _,
+            radius: _,
             fill,
             stroke,
         })

--- a/crates/epaint/src/shape_transform.rs
+++ b/crates/epaint/src/shape_transform.rs
@@ -20,6 +20,12 @@ pub fn adjust_colors(shape: &mut Shape, adjust_color: &impl Fn(&mut Color32)) {
             fill,
             stroke,
         })
+        | Shape::Ellipse(EllipseShape {
+            center: _,
+            size: _,
+            fill,
+            stroke,
+        })
         | Shape::Path(PathShape {
             points: _,
             closed: _,

--- a/crates/epaint/src/stats.rs
+++ b/crates/epaint/src/stats.rs
@@ -201,6 +201,7 @@ impl PaintStats {
             }
             Shape::Noop
             | Shape::Circle { .. }
+            | Shape::Ellipse { .. }
             | Shape::LineSegment { .. }
             | Shape::Rect { .. }
             | Shape::CubicBezier(_)

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -1344,11 +1344,10 @@ impl Tessellator {
         }
 
         // Get the max pixel radius
-        let max_radius = radius.max_elem() * self.pixels_per_point;
-        // Get the power of two below the radius to limit the number of vertices
-        let floored_radius = 2_f32.powf(max_radius.log2().floor()) as u32;
-        // Ensure there is at least 16 points
-        let num_points = u32::max(16, floored_radius) / 4;
+        let max_radius = (radius.max_elem() * self.pixels_per_point) as u32;
+
+        // Ensure there is at least 8 points in each quarter of the ellipse
+        let num_points = u32::max(8, max_radius / 16);
 
         // Create an ease ratio based the ellipses a and b
         let ratio = ((radius.y / radius.x) / 2.0).clamp(0.0, 1.0);

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -1325,33 +1325,33 @@ impl Tessellator {
     pub fn tessellate_ellipse(&mut self, shape: EllipseShape, out: &mut Mesh) {
         let EllipseShape {
             center,
-            size,
+            radius,
             fill,
             stroke,
         } = shape;
 
-        if size.x <= 0.0 || size.y <= 0.0 {
+        if radius.x <= 0.0 || radius.y <= 0.0 {
             return;
         }
 
         if self.options.coarse_tessellation_culling
             && !self
                 .clip_rect
-                .expand2(size + Vec2::splat(stroke.width))
+                .expand2(radius + Vec2::splat(stroke.width))
                 .contains(center)
         {
             return;
         }
 
         // Get the max pixel radius
-        let max_radius = size.max_elem() * self.pixels_per_point;
+        let max_radius = radius.max_elem() * self.pixels_per_point;
         // Get the power of two below the radius to limit the number of vertices
         let floored_radius = 2_f32.powf(max_radius.log2().floor()) as u32;
         // Ensure there is at least 16 points
         let num_points = u32::max(16, floored_radius) / 4;
 
         // Create an ease ratio based the ellipses a and b
-        let ratio = ((size.y / size.x) / 2.0).clamp(0.0, 1.0);
+        let ratio = ((radius.y / radius.x) / 2.0).clamp(0.0, 1.0);
 
         // Generate points between the 0 to pi/2
         let quarter: Vec<Vec2> = (1..num_points)
@@ -1363,20 +1363,20 @@ impl Tessellator {
 
                 // Scale the ease to the quarter
                 let t = eased * std::f32::consts::FRAC_PI_2;
-                Vec2::new(size.x * f32::cos(t), size.y * f32::sin(t))
+                Vec2::new(radius.x * f32::cos(t), radius.y * f32::sin(t))
             })
             .collect();
 
         // Build the ellipse from the 4 known vertices filling arcs between
         // them by mirroring the points between 0 and pi/2
         let mut points = Vec::new();
-        points.push(center + Vec2::new(size.x, 0.0));
+        points.push(center + Vec2::new(radius.x, 0.0));
         points.extend(quarter.iter().map(|p| center + *p));
-        points.push(center + Vec2::new(0.0, size.y));
+        points.push(center + Vec2::new(0.0, radius.y));
         points.extend(quarter.iter().rev().map(|p| center + Vec2::new(-p.x, p.y)));
-        points.push(center + Vec2::new(-size.x, 0.0));
+        points.push(center + Vec2::new(-radius.x, 0.0));
         points.extend(quarter.iter().map(|p| center - *p));
-        points.push(center + Vec2::new(0.0, -size.y));
+        points.push(center + Vec2::new(0.0, -radius.y));
         points.extend(quarter.iter().rev().map(|p| center + Vec2::new(p.x, -p.y)));
 
         self.scratchpad_path.clear();

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -1330,7 +1330,7 @@ impl Tessellator {
             stroke,
         } = shape;
 
-        if size == Vec2::ZERO {
+        if size.x == 0.0 || size.y == 0.0 {
             return;
         }
 
@@ -1343,12 +1343,16 @@ impl Tessellator {
             return;
         }
 
-        let radius_px = (size * self.pixels_per_point).max_elem() as u32;
+        let max_radius = (size / 2.0).max_elem() * self.pixels_per_point;
+        let num_points = 2f32.powf(max_radius.log2().floor());
 
-        let mut points = Vec::new();
-        for i in 0..=radius_px {
-            let t = (i as f32 / radius_px as f32) * std::f32::consts::TAU;
-            let point = Pos2::new(center.x + size.x * f32::cos(t), center.y + size.y * f32::sin(t));
+        let mut points = Vec::with_capacity(num_points as usize);
+        for i in 0..num_points as u32 {
+            let t = (i as f32 / num_points) * std::f32::consts::TAU;
+            let point = Pos2::new(
+                center.x + size.x * f32::cos(t),
+                center.y + size.y * f32::sin(t),
+            );
             points.push(point);
         }
 
@@ -1820,12 +1824,11 @@ impl Tessellator {
 
                 Shape::Path(path_shape) => 32 < path_shape.points.len(),
 
-                Shape::QuadraticBezier(_) | Shape::CubicBezier(_) => true,
+                Shape::QuadraticBezier(_) | Shape::CubicBezier(_) | Shape::Ellipse(_) => true,
 
                 Shape::Noop
                 | Shape::Text(_)
                 | Shape::Circle(_)
-                | Shape::Ellipse(_)
                 | Shape::Mesh(_)
                 | Shape::LineSegment { .. }
                 | Shape::Rect(_)

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -1318,6 +1318,10 @@ impl Tessellator {
             .stroke_closed(self.feathering, stroke, out);
     }
 
+    /// Tessellate a single [`EllipseShape`] into a [`Mesh`].
+    ///
+    /// * `shape`: the ellipse to tessellate.
+    /// * `out`: triangles are appended to this.
     pub fn tesselate_ellipse(&mut self, shape: EllipseShape, out: &mut Mesh) {
         let EllipseShape {
             center,
@@ -1338,6 +1342,21 @@ impl Tessellator {
         {
             return;
         }
+
+        let radius_px = (size * self.pixels_per_point).max_elem() as u32;
+
+        let mut points = Vec::new();
+        for i in 0..=radius_px {
+            let t = (i as f32 / radius_px as f32) * std::f32::consts::TAU;
+            let point = Pos2::new(center.x + size.x * f32::cos(t), center.y + size.y * f32::sin(t));
+            points.push(point);
+        }
+
+        self.scratchpad_path.clear();
+        self.scratchpad_path.add_line_loop(&points);
+        self.scratchpad_path.fill(self.feathering, fill, out);
+        self.scratchpad_path
+            .stroke_closed(self.feathering, stroke, out);
     }
 
     /// Tessellate a single [`Mesh`] into a [`Mesh`].
@@ -1803,11 +1822,10 @@ impl Tessellator {
 
                 Shape::QuadraticBezier(_) | Shape::CubicBezier(_) => true,
 
-                Shape::Ellipse(_) => true,
-
                 Shape::Noop
                 | Shape::Text(_)
                 | Shape::Circle(_)
+                | Shape::Ellipse(_)
                 | Shape::Mesh(_)
                 | Shape::LineSegment { .. }
                 | Shape::Rect(_)


### PR DESCRIPTION
Adds an Ellipse shape draw-able with the Painter, brings egui closer to the SVG Specification.

I've done some optimization towards using less vertices and doing less calculations.

~~Currently the vertices are evenly distributed.
It's possible this could be optimized further taking into account the gradient and increasing the concentration of vertices where the change in gradient is larger.~~

![EllipseTall](https://github.com/emilk/egui/assets/50041841/b105230c-ce68-49c1-b162-d1f066bf9d6a)
![EllipseWide](https://github.com/emilk/egui/assets/50041841/6f9106d2-75cb-4f2a-b0c2-039b3aadec86)



