### PR TITLE
Hide hover UI when showing the context menu

### DIFF
--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -230,6 +230,13 @@ pub(crate) fn context_menu(
     inner_response
 }
 
+/// Returns `true` if the context menu is opened for this widget.
+pub(crate) fn context_menu_opened(response: &Response) -> bool {
+    let menu_id = Id::new(CONTEXT_MENU_ID_STR);
+    let bar_state = BarState::load(&response.ctx, menu_id);
+    bar_state.is_menu_open(response.id)
+}
+
 /// Stores the state for the context menu.
 #[derive(Clone, Default)]
 pub(crate) struct MenuRootManager {

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -534,6 +534,10 @@ impl Response {
             return true;
         }
 
+        if self.context_menu_opened() {
+            return false;
+        }
+
         if self.enabled {
             if !self.hovered || !self.ctx.input(|i| i.pointer.has_pointer()) {
                 return false;
@@ -847,6 +851,13 @@ impl Response {
     /// See also: [`Ui::menu_button`] and [`Ui::close_menu`].
     pub fn context_menu(&self, add_contents: impl FnOnce(&mut Ui)) -> Option<InnerResponse<()>> {
         menu::context_menu(self, add_contents)
+    }
+
+    /// Returns whether a context menu is currently open for this widget.
+    ///
+    /// See [`Self::context_menu`].
+    pub fn context_menu_opened(&self) -> bool {
+        menu::context_menu_opened(self)
     }
 
     /// Draw a debug rectangle over the response displaying the response's id and whether it is


### PR DESCRIPTION
This PR hides the hover UI for a given widget whenever a corresponding context menu is opened.

Fixes:
- https://github.com/rerun-io/rerun/issues/5310