### PR TITLE
Remove unnecessary allocation in `RepaintCause::new`

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -256,7 +256,7 @@ struct ViewportState {
 #[derive(Clone, Debug)]
 pub struct RepaintCause {
     /// What file had the call that requested the repaint?
-    pub file: String,
+    pub file: &'static str,
 
     /// What line number of the the call that requested the repaint?
     pub line: u32,
@@ -269,7 +269,7 @@ impl RepaintCause {
     pub fn new() -> Self {
         let caller = Location::caller();
         Self {
-            file: caller.file().to_owned(),
+            file: caller.file(),
             line: caller.line(),
         }
     }


### PR DESCRIPTION
Hi!

I'm using egui for the UI of a VST3/Clap plugin, and this kind of environment is rather picky on performance. I use [assert_no_alloc](https://crates.io/crates/assert_no_alloc) to make sure the audio thread is never allocating. The audio thread may request a repaint of the GUI tho, and this is where a saw that it may allocate when tracing the repaint reason.

Turns out it's not necessary, `Location::caller` is `'static`, so using a `&'static str` instead of a `String` in `RepaintCause::file` will just work, so this PR just does that.