### PR TITLE
Update kb modifiers from web mouse events

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Please keep pull requests small and focused. The smaller it is, the more likely 
 
 Most PR reviews are done by me, Emil, but I very much appreciate any help I can get reviewing PRs!
 
-It is very easy to add complexity to a project, but remember that each line of code added is code that needs to be maintained in perpituity, so we have a high bar on what get merged!
+It is very easy to add complexity to a project, but remember that each line of code added is code that needs to be maintained in perpetuity, so we have a high bar on what get merged!
 
 When reviewing, we look for:
 * The PR title and description should be helpful
@@ -123,7 +123,7 @@ with `Vec2::X` increasing to the right and `Vec2::Y` increasing downwards.
 
 `egui` uses logical _points_ as its coordinate system.
 Those related to physical _pixels_ by the `pixels_per_point` scale factor.
-For example, a high-dpi screeen can have `pixels_per_point = 2.0`,
+For example, a high-dpi screen can have `pixels_per_point = 2.0`,
 meaning there are two physical screen pixels for each logical point.
 
 Angles are in radians, and are measured clockwise from the X-axis, which has angle=0.

--- a/crates/eframe/src/web/input.rs
+++ b/crates/eframe/src/web/input.rs
@@ -115,7 +115,23 @@ pub fn translate_key(key: &str) -> Option<egui::Key> {
     egui::Key::from_name(key)
 }
 
-pub fn modifiers_from_event(event: &web_sys::KeyboardEvent) -> egui::Modifiers {
+pub fn modifiers_from_kb_event(event: &web_sys::KeyboardEvent) -> egui::Modifiers {
+    egui::Modifiers {
+        alt: event.alt_key(),
+        ctrl: event.ctrl_key(),
+        shift: event.shift_key(),
+
+        // Ideally we should know if we are running or mac or not,
+        // but this works good enough for now.
+        mac_cmd: event.meta_key(),
+
+        // Ideally we should know if we are running or mac or not,
+        // but this works good enough for now.
+        command: event.ctrl_key() || event.meta_key(),
+    }
+}
+
+pub fn modifiers_from_mouse_event(event: &web_sys::MouseEvent) -> egui::Modifiers {
     egui::Modifiers {
         alt: event.alt_key(),
         ctrl: event.ctrl_key(),


### PR DESCRIPTION
Update modifier state from web mouse events. This allows modifiers to be correctly updated when the window is not in focus but the mouse is still moving over the window.