### PR TITLE
Don't clear modifier state on focus change

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -376,9 +376,6 @@ impl State {
             }
             WindowEvent::Focused(focused) => {
                 self.egui_input.focused = *focused;
-                // We will not be given a KeyboardInput event when the modifiers are released while
-                // the window does not have focus. Unset all modifier state to be safe.
-                self.egui_input.modifiers = egui::Modifiers::default();
                 self.egui_input
                     .events
                     .push(egui::Event::WindowFocused(*focused));

--- a/crates/egui/src/input_state.rs
+++ b/crates/egui/src/input_state.rs
@@ -244,20 +244,6 @@ impl InputState {
             }
         }
 
-        let mut modifiers = new.modifiers;
-
-        let focused_changed = self.focused != new.focused
-            || new
-                .events
-                .iter()
-                .any(|e| matches!(e, Event::WindowFocused(_)));
-        if focused_changed {
-            // It is very common for keys to become stuck when we alt-tab, or a save-dialog opens by Ctrl+S.
-            // Therefore we clear all the modifiers and down keys here to avoid that.
-            modifiers = Default::default();
-            keys_down = Default::default();
-        }
-
         Self {
             pointer,
             touch_states: self.touch_states,
@@ -273,7 +259,7 @@ impl InputState {
             predicted_dt: new.predicted_dt,
             stable_dt,
             focused: new.focused,
-            modifiers,
+            modifiers: new.modifiers,
             keys_down,
             events: new.events.clone(), // TODO(emilk): remove clone() and use raw.events
             raw: new,


### PR DESCRIPTION
I believe that the underlying issue that caused the stuck modifier keys was resolved in the 0.29 winit keyboard refactor.

This probably needs to tested on other desktop platforms however since I am only able to test this on windows 11.

* Closes <https://github.com/emilk/egui/issues/2332>