### PR TITLE
Fix scaling of rounded corners for rect shape (#4152)

### DIFF
--- a/crates/epaint/src/shape.rs
+++ b/crates/epaint/src/shape.rs
@@ -403,6 +403,7 @@ impl Shape {
             Self::Rect(rect_shape) => {
                 rect_shape.rect = transform * rect_shape.rect;
                 rect_shape.stroke.width *= transform.scaling;
+                rect_shape.rounding *= transform.scaling;
             }
             Self::Text(text_shape) => {
                 text_shape.pos = transform * text_shape.pos;


### PR DESCRIPTION
When scaling an `egui::Shape` of variant `Rect` using the new `transform` function, corner rounding isn't taken into account.

The fix is to multiply the rounding by the scaling factor.

* Closes <https://github.com/emilk/egui/issues/4152>
