### PR TITLE
Fix bug parsing url query with escaped & or =

### DIFF
--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -718,7 +718,7 @@ pub struct WebInfo {
 #[cfg(target_arch = "wasm32")]
 #[derive(Clone, Debug)]
 pub struct Location {
-    /// The full URL (`location.href`) without the hash.
+    /// The full URL (`location.href`) without the hash, percent-decoded.
     ///
     /// Example: `"http://www.example.com:80/index.html?foo=bar"`.
     pub url: String,

--- a/crates/eframe/src/web/backend.rs
+++ b/crates/eframe/src/web/backend.rs
@@ -103,6 +103,7 @@ pub fn web_location() -> epi::Location {
         .to_owned();
 
     epi::Location {
+        // TODO(emilk): should we really percent-decode the url? 🤷‍♂️
         url: percent_decode(&location.href().unwrap_or_default()),
         protocol: percent_decode(&location.protocol().unwrap_or_default()),
         host: percent_decode(&location.host().unwrap_or_default()),


### PR DESCRIPTION
I have tested this manually:

<img width="727" alt="Screenshot 2024-03-14 at 19 38 34" src="https://github.com/emilk/egui/assets/1148717/fa1f6da4-d9e3-4f08-9812-1d61479dfd52">
