### PR TITLE
Fix two `ScrollArea` bugs: leaking scroll target and broken animation to target offset

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -756,11 +756,13 @@ impl Prepared {
         let content_size = content_ui.min_size();
 
         for d in 0..2 {
+            // We always take both scroll targets regardless of which scroll axes are enabled. This
+            // is to avoid them leaking to other scroll areas.
+            let scroll_target = content_ui
+                .ctx()
+                .frame_state_mut(|state| state.scroll_target[d].take());
+
             if scroll_enabled[d] {
-                // We take the scroll target so only this ScrollArea will use it:
-                let scroll_target = content_ui
-                    .ctx()
-                    .frame_state_mut(|state| state.scroll_target[d].take());
                 if let Some((target_range, align)) = scroll_target {
                     let min = content_ui.min_rect().min[d];
                     let clip_rect = content_ui.clip_rect();


### PR DESCRIPTION
This PR fixes two issues related to `ScrollArea`.

1) When a `ScrollArea` would have `drag_to_scroll` set to `false` (e.g. because some custom logic is at play or some other reason), it would not animate to the `target_offset`, effectively making `Response::scroll_to_me()` ineffective. 
2) Single-direction `ScrollArea`s would leak the `scroll_target`'s other direction. In certain specific circumstances (e.g. an horizontal area nested in a vertical one, or inversely), this _could_ work as intended, but in many other cases it could cause unwanted effects. With this PR, both `scroll_target` directions are consumed by nearest enclosing `ScrollArea`, regardless of the actually enabled scroll axes.


