### PR TITLE
Option to change date picker format

### DIFF
--- a/crates/egui_extras/src/datepicker/button.rs
+++ b/crates/egui_extras/src/datepicker/button.rs
@@ -16,6 +16,7 @@ pub struct DatePickerButton<'a> {
     calendar: bool,
     calendar_week: bool,
     show_icon: bool,
+    format: String,
 }
 
 impl<'a> DatePickerButton<'a> {
@@ -28,6 +29,7 @@ impl<'a> DatePickerButton<'a> {
             calendar: true,
             calendar_week: true,
             show_icon: true,
+            format: "%Y-%m-%d".to_string(),
         }
     }
 
@@ -73,6 +75,14 @@ impl<'a> DatePickerButton<'a> {
         self.show_icon = show_icon;
         self
     }
+
+    /// Change the format shown on the button. (Default: %Y-%m-%d)
+    /// See [chrono::format::strftime] for valid formats.
+    #[inline]
+    pub fn format(mut self, format: &str) -> Self {
+        self.format = format.to_string();
+        self
+    }
 }
 
 impl<'a> Widget for DatePickerButton<'a> {
@@ -83,9 +93,9 @@ impl<'a> Widget for DatePickerButton<'a> {
             .unwrap_or_default();
 
         let mut text = if self.show_icon {
-            RichText::new(format!("{} 📆", self.selection.format("%Y-%m-%d")))
+            RichText::new(format!("{} 📆", self.selection.format(&self.format)))
         } else {
-            RichText::new(format!("{}", self.selection.format("%Y-%m-%d")))
+            RichText::new(format!("{}", self.selection.format(&self.format)))
         };
         let visuals = ui.visuals().widgets.open;
         if button_state.picker_visible {


### PR DESCRIPTION
Simply allows date picker buttons to show other formats than %Y-%m-%d, while keeping that as default to not break compatibility.

I'm not that experienced with Rust, so I was unsure whether you'd prefer `&'a str` or a `String`, let me know if I should change that.