### PR TITLE
Fix bug in `Context::parent_viewport_id`

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -600,11 +600,11 @@ impl ContextImpl {
     ///
     /// For the root viewport this will return [`ViewportId::ROOT`].
     pub(crate) fn parent_viewport_id(&self) -> ViewportId {
-        self.viewport_stack
-            .last()
-            .copied()
-            .unwrap_or_default()
-            .parent
+        let viewport_id = self.viewport_id();
+        *self
+            .viewport_parents
+            .get(&viewport_id)
+            .unwrap_or(&ViewportId::ROOT)
     }
 
     fn all_viewport_ids(&self) -> ViewportIdSet {


### PR DESCRIPTION
* Closes #4084 

Fix : Display parent viewport id Issues 
