### PR TITLE
Expose `PlotGeometry` in public API

### DIFF
--- a/crates/egui_plot/src/items/mod.rs
+++ b/crates/egui_plot/src/items/mod.rs
@@ -9,11 +9,11 @@ use crate::*;
 
 use super::{Cursor, LabelFormatter, PlotBounds, PlotTransform};
 use rect_elem::*;
-use values::{ClosestElem, PlotGeometry};
+use values::ClosestElem;
 
 pub use bar::Bar;
 pub use box_elem::{BoxElem, BoxSpread};
-pub use values::{LineStyle, MarkerShape, Orientation, PlotPoint, PlotPoints};
+pub use values::{LineStyle, MarkerShape, Orientation, PlotGeometry, PlotPoint, PlotPoints};
 
 mod bar;
 mod box_elem;

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -23,7 +23,8 @@ pub use crate::{
     axis::{Axis, AxisHints, HPlacement, Placement, VPlacement},
     items::{
         Arrows, Bar, BarChart, BoxElem, BoxPlot, BoxSpread, HLine, Line, LineStyle, MarkerShape,
-        Orientation, PlotGeometry, PlotImage, PlotItem, PlotPoint, PlotPoints, Points, Polygon, Text, VLine,
+        Orientation, PlotGeometry, PlotImage, PlotItem, PlotPoint, PlotPoints, Points, Polygon,
+        Text, VLine,
     },
     legend::{Corner, Legend},
     memory::PlotMemory,

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -23,7 +23,7 @@ pub use crate::{
     axis::{Axis, AxisHints, HPlacement, Placement, VPlacement},
     items::{
         Arrows, Bar, BarChart, BoxElem, BoxPlot, BoxSpread, HLine, Line, LineStyle, MarkerShape,
-        Orientation, PlotImage, PlotItem, PlotPoint, PlotPoints, Points, Polygon, Text, VLine,
+        Orientation, PlotGeometry, PlotImage, PlotItem, PlotPoint, PlotPoints, Points, Polygon, Text, VLine,
     },
     legend::{Corner, Legend},
     memory::PlotMemory,

--- a/crates/egui_plot/src/plot_ui.rs
+++ b/crates/egui_plot/src/plot_ui.rs
@@ -116,6 +116,11 @@ impl PlotUi {
         self.last_plot_transform.value_from_position(position)
     }
 
+    /// Add an arbitrary item.
+    pub fn add(&mut self, item: impl PlotItem + 'static) {
+        self.items.push(Box::new(item));
+    }
+
     /// Add a data line.
     pub fn line(&mut self, mut line: Line) {
         if line.series.is_empty() {


### PR DESCRIPTION
Expose `egui_plot::items::values::PlotGeometry` in public API so that `PlotItem`, which is already public, can actually be implemented by applications. Fixes #3464.