### PR TITLE
Prevent egui::Window from becoming larger than Viewport

### DIFF
--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -432,7 +432,7 @@ impl<'open> Window<'open> {
         };
 
         {
-            // Prevent window from becoming larger than the contraint rect and/or screen rect.
+            // Prevent window from becoming larger than the constraint rect and/or screen rect.
             let screen_rect = ctx.screen_rect();
             let max_rect = area.constrain_rect().unwrap_or(screen_rect);
             let max_width = max_rect.width();

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -431,12 +431,15 @@ impl<'open> Window<'open> {
             (0.0, 0.0)
         };
 
-        let screen_rect = ctx.screen_rect();
-        let max_rect = area.constrain_rect().unwrap_or(screen_rect);
-        let max_width = max_rect.width();
-        let max_height = max_rect.height() - title_bar_height;
-        resize.max_size.x = resize.max_size.x.min(max_width);
-        resize.max_size.y = resize.max_size.y.min(max_height);
+        {
+            // Prevent window from becoming larger than the contraint rect and/or screen rect.
+            let screen_rect = ctx.screen_rect();
+            let max_rect = area.constrain_rect().unwrap_or(screen_rect);
+            let max_width = max_rect.width();
+            let max_height = max_rect.height() - title_bar_height;
+            resize.max_size.x = resize.max_size.x.min(max_width);
+            resize.max_size.y = resize.max_size.y.min(max_height);
+        {
 
         // First check for resize to avoid frame delay:
         let last_frame_outer_rect = area.state().rect();

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -439,7 +439,7 @@ impl<'open> Window<'open> {
             let max_height = max_rect.height() - title_bar_height;
             resize.max_size.x = resize.max_size.x.min(max_width);
             resize.max_size.y = resize.max_size.y.min(max_height);
-        {
+        }
 
         // First check for resize to avoid frame delay:
         let last_frame_outer_rect = area.state().rect();

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -431,6 +431,12 @@ impl<'open> Window<'open> {
             (0.0, 0.0)
         };
 
+        let max_rect = ctx.input(|i| i.viewport().inner_rect.unwrap_or(Rect::EVERYTHING));
+        let max_width = max_rect.width();
+        let max_height = max_rect.height() - title_bar_height;
+        resize.max_size.x = resize.max_size.x.min(max_width);
+        resize.max_size.y = resize.max_size.y.min(max_height);
+
         // First check for resize to avoid frame delay:
         let last_frame_outer_rect = area.state().rect();
         let resize_interaction =

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -432,7 +432,7 @@ impl<'open> Window<'open> {
         };
 
         let screen_rect = ctx.screen_rect();
-        let max_rect = area.constrain_rect().unwrap_or_else(|| screen_rect);
+        let max_rect = area.constrain_rect().unwrap_or(screen_rect);
         let max_width = max_rect.width();
         let max_height = max_rect.height() - title_bar_height;
         resize.max_size.x = resize.max_size.x.min(max_width);

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -431,8 +431,8 @@ impl<'open> Window<'open> {
             (0.0, 0.0)
         };
 
-        let max_rect = ctx.input(|i| i.viewport().inner_rect.unwrap_or(Rect::EVERYTHING));
-        let max_width = max_rect.width();
+        let screen_rect = ctx.screen_rect();
+        let max_rect = area.constrain_rect().unwrap_or_else(|| screen_rect);
         let max_height = max_rect.height() - title_bar_height;
         resize.max_size.x = resize.max_size.x.min(max_width);
         resize.max_size.y = resize.max_size.y.min(max_height);

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -433,6 +433,7 @@ impl<'open> Window<'open> {
 
         let screen_rect = ctx.screen_rect();
         let max_rect = area.constrain_rect().unwrap_or_else(|| screen_rect);
+        let max_width = max_rect.width();
         let max_height = max_rect.height() - title_bar_height;
         resize.max_size.x = resize.max_size.x.min(max_width);
         resize.max_size.y = resize.max_size.y.min(max_height);


### PR DESCRIPTION
* Closes #3987  

* Closes #3988

There is a need to prevent egui::Window from becoming larger than the Viewport.
