### PR TITLE
Expose state override for `HeaderResponse`

### DIFF
--- a/crates/egui/src/containers/collapsing_header.rs
+++ b/crates/egui/src/containers/collapsing_header.rs
@@ -281,7 +281,7 @@ impl<'ui, HeaderRet> HeaderResponse<'ui, HeaderRet> {
     }
 
     pub fn toggle(&mut self) {
-        self.state.toggle(&self.ui);
+        self.state.toggle(self.ui);
     }
 
     /// Returns the response of the collapsing button, the custom header, and the custom body.

--- a/crates/egui/src/containers/collapsing_header.rs
+++ b/crates/egui/src/containers/collapsing_header.rs
@@ -272,6 +272,18 @@ pub struct HeaderResponse<'ui, HeaderRet> {
 }
 
 impl<'ui, HeaderRet> HeaderResponse<'ui, HeaderRet> {
+    pub fn is_open(&self) -> bool {
+        self.state.is_open()
+    }
+
+    pub fn set_open(&mut self, open: bool) {
+        self.state.set_open(open);
+    }
+
+    pub fn toggle(&mut self) {
+        self.state.toggle(&self.ui);
+    }
+
     /// Returns the response of the collapsing button, the custom header, and the custom body.
     pub fn body<BodyRet>(
         mut self,


### PR DESCRIPTION
I'm trying to create some custom collapsing headers that add additional buttons inside the header itself. Because of this, I load the `CollapsingState` in my special widget manually. But because `HeaderResponse` owns the `Ui` and the `CollapsingState`, there is no way for me to open/close the collapsing header based on response of the inner widget.

Initially, I considered just exposing `state` member of `HeaderResponse`, but that exposes too much of the API at the wrong time, in my opinion.

So instead I found it'd be safer to just expose the open/close API to the response itself, and that's what this PR does.
