### PR TITLE
Fix `InnerSize` command not resizing viewport

### DIFF
--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -1234,6 +1234,7 @@ impl GlutinWindowContext {
 
             if let Some(window) = &viewport.window {
                 let is_viewport_focused = self.focused_viewport == Some(viewport_id);
+                let inner_size = window.inner_size();
                 egui_winit::process_viewport_commands(
                     egui_ctx,
                     &mut viewport.info,
@@ -1242,6 +1243,11 @@ impl GlutinWindowContext {
                     is_viewport_focused,
                     &mut viewport.screenshot_requested,
                 );
+
+                let new_inner_size = window.inner_size();
+                if inner_size != new_inner_size {
+                    self.resize(viewport_id, new_inner_size);
+                }
             }
         }
 


### PR DESCRIPTION
On some platforms changing window size via `request_inner_size` doesn't trigger a `Resized` event, in this case the viewport is not resized.

I'm new to this project and I think that this MR needs work.

What would the correct way to send the return value of `request_inner_size` to the resize function of the glutin surface?
https://github.com/emilk/egui/blob/769199648db30dadbec21cd1845bc325c5c91024/crates/egui-winit/src/lib.rs#L1314

Would setting `viewport.info.inner_rect` and resizing from that be correct?


<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes #4196
