### PR TITLE
Don't show URLs when hovering hyperlinks

### DIFF
--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -213,6 +213,9 @@ pub struct Style {
     /// This only affects a few egui widgets.
     pub explanation_tooltips: bool,
 
+    /// Show the URL of hyperlinks in a tooltip when hovered.
+    pub url_in_tooltip: bool,
+
     /// If true and scrolling is enabled for only one direction, allow horizontal scrolling without pressing shift
     pub always_scroll_the_only_direction: bool,
 }
@@ -1212,6 +1215,7 @@ impl Default for Style {
             #[cfg(debug_assertions)]
             debug: Default::default(),
             explanation_tooltips: false,
+            url_in_tooltip: false,
             always_scroll_the_only_direction: false,
         }
     }
@@ -1474,6 +1478,7 @@ impl Style {
             #[cfg(debug_assertions)]
             debug,
             explanation_tooltips,
+            url_in_tooltip,
             always_scroll_the_only_direction,
         } = self;
 
@@ -1543,6 +1548,8 @@ impl Style {
             .on_hover_text(
                 "Show explanatory text when hovering DragValue:s and other egui widgets",
             );
+
+        ui.checkbox(url_in_tooltip, "Show url when hovering links");
 
         ui.checkbox(always_scroll_the_only_direction, "Always scroll the only enabled direction")
             .on_hover_text(

--- a/crates/egui/src/widgets/hyperlink.rs
+++ b/crates/egui/src/widgets/hyperlink.rs
@@ -136,6 +136,11 @@ impl Widget for Hyperlink {
                 new_tab: true,
             });
         }
-        response.on_hover_text(url)
+
+        if ui.style().url_in_tooltip {
+            response.on_hover_text(url)
+        } else {
+            response
+        }
     }
 }


### PR DESCRIPTION
Can be changed with `Style::url_in_tooltip`
