### PR TITLE
Improve the UI for changing the egui theme

### DIFF
--- a/crates/egui/src/containers/frame.rs
+++ b/crates/egui/src/containers/frame.rs
@@ -52,6 +52,7 @@ use epaint::*;
 /// Note that you cannot change the margins after calling `begin`.
 #[doc(alias = "border")]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[must_use = "You should call .show()"]
 pub struct Frame {
     /// Margin within the painted frame.

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1567,7 +1567,7 @@ impl Context {
 
     /// The [`Style`] used by all new windows, panels etc.
     ///
-    /// You can also change this using [`Self::style_mut]`
+    /// You can also change this using [`Self::style_mut`]
     ///
     /// You can use [`Ui::style_mut`] to change the style of a single [`Ui`].
     pub fn set_style(&self, style: impl Into<Arc<Style>>) {

--- a/crates/egui/src/introspection.rs
+++ b/crates/egui/src/introspection.rs
@@ -150,23 +150,33 @@ impl Widget for &mut epaint::TessellationOptions {
                 validate_meshes,
             } = self;
 
-            ui.checkbox(feathering, "Feathering (antialias)")
-                .on_hover_text("Apply feathering to smooth out the edges of shapes. Turn off for small performance gain.");
-            let feathering_slider = crate::Slider::new(feathering_size_in_pixels, 0.0..=10.0)
-                .smallest_positive(0.1)
-                .logarithmic(true)
-                .text("Feathering size in pixels");
-            ui.add_enabled(*feathering, feathering_slider);
+            ui.horizontal(|ui| {
+                ui.checkbox(feathering, "Feathering (antialias)")
+                    .on_hover_text("Apply feathering to smooth out the edges of shapes. Turn off for small performance gain.");
+
+                if *feathering {
+                    ui.add(crate::DragValue::new(feathering_size_in_pixels).clamp_range(0.0..=10.0).speed(0.1).suffix(" px"));
+                }
+            });
 
             ui.checkbox(prerasterized_discs, "Speed up filled circles with pre-rasterization");
 
-            ui.add(
-                crate::widgets::Slider::new(bezier_tolerance, 0.0001..=10.0)
-                    .logarithmic(true)
-                    .show_value(true)
-                    .text("Spline Tolerance"),
-            );
-            ui.collapsing("debug", |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Spline tolerance");
+                let speed = 0.01 * *bezier_tolerance;
+                ui.add(
+                    crate::DragValue::new(bezier_tolerance).clamp_range(0.0001..=10.0)
+                        .speed(speed)
+                );
+            });
+
+            ui.add_enabled(epaint::HAS_RAYON, crate::Checkbox::new(parallel_tessellation, "Parallelize tessellation")
+                ).on_hover_text("Only available if epaint was compiled with the rayon feature")
+                .on_disabled_hover_text("epaint was not compiled with the rayon feature");
+
+            ui.checkbox(validate_meshes, "Validate meshes").on_hover_text("Check that incoming meshes are valid, i.e. that all indices are in range, etc.");
+
+            ui.collapsing("Debug", |ui| {
                 ui.checkbox(
                     coarse_tessellation_culling,
                     "Do coarse culling in the tessellator",
@@ -178,12 +188,6 @@ impl Widget for &mut epaint::TessellationOptions {
                 ui.checkbox(debug_paint_clip_rects, "Paint clip rectangles");
                 ui.checkbox(debug_paint_text_rects, "Paint text bounds");
             });
-
-            ui.add_enabled(epaint::HAS_RAYON, crate::Checkbox::new(parallel_tessellation, "Parallelize tessellation")
-                ).on_hover_text("Only available if epaint was compiled with the rayon feature")
-                .on_disabled_hover_text("epaint was not compiled with the rayon feature");
-
-            ui.checkbox(validate_meshes, "Validate meshes").on_hover_text("Check that incoming meshes are valid, i.e. that all indices are in range, etc.");
         })
         .response
     }

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -431,7 +431,7 @@ pub use epaint::{
     text::{FontData, FontDefinitions, FontFamily, FontId, FontTweak},
     textures::{TextureFilter, TextureOptions, TextureWrapMode, TexturesDelta},
     ClippedPrimitive, ColorImage, FontImage, ImageData, Margin, Mesh, PaintCallback,
-    PaintCallbackInfo, Rounding, Shape, Stroke, TextureHandle, TextureId,
+    PaintCallbackInfo, Rounding, Shadow, Shape, Stroke, TextureHandle, TextureId,
 };
 
 pub mod text {

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -278,7 +278,7 @@ impl Options {
             });
 
         CollapsingHeader::new("✒ Painting")
-            .default_open(true)
+            .default_open(false)
             .show(ui, |ui| {
                 tessellation_options.ui(ui);
                 ui.vertical_centered(|ui| crate::reset_button(ui, tessellation_options));

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -281,10 +281,12 @@ impl Options {
             .default_open(false)
             .show(ui, |ui| {
                 tessellation_options.ui(ui);
-                ui.vertical_centered(|ui| crate::reset_button(ui, tessellation_options));
+                ui.vertical_centered(|ui| {
+                    crate::reset_button(ui, tessellation_options, "Reset paint settings");
+                });
             });
 
-        ui.vertical_centered(|ui| crate::reset_button(ui, self));
+        ui.vertical_centered(|ui| crate::reset_button(ui, self, "Reset all"));
     }
 }
 

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1349,8 +1349,9 @@ impl Style {
 
             ui.label("Animation duration:");
             ui.add(
-                Slider::new(animation_time, 0.0..=1.0)
-                    .clamp_to_range(true)
+                DragValue::new(animation_time)
+                    .clamp_range(0.0..=1.0)
+                    .speed(0.02)
                     .suffix(" s"),
             );
             ui.end_row();
@@ -1627,8 +1628,16 @@ impl Selection {
     pub fn ui(&mut self, ui: &mut crate::Ui) {
         let Self { bg_fill, stroke } = self;
         ui.label("Selectable labels");
-        ui_color(ui, bg_fill, "background fill");
-        stroke_ui(ui, stroke, "stroke");
+
+        Grid::new("selectiom").num_columns(2).show(ui, |ui| {
+            ui.label("Background fill");
+            ui.color_edit_button_srgba(bg_fill);
+            ui.end_row();
+
+            ui.label("Stroke");
+            ui.add(stroke);
+            ui.end_row();
+        });
     }
 }
 
@@ -1831,7 +1840,11 @@ impl Visuals {
         });
 
         ui_color(ui, hyperlink_color, "hyperlink_color");
-        stroke_ui(ui, text_cursor, "Text Cursor");
+
+        ui.horizontal(|ui| {
+            ui.label("Text Cursor");
+            ui.add(text_cursor);
+        });
 
         ui.add(Slider::new(resize_corner_size, 0.0..=20.0).text("resize_corner_size"));
         ui.checkbox(text_cursor_preview, "Preview text cursor on hover");

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1419,72 +1419,85 @@ impl Spacing {
             scroll,
         } = self;
 
-        ui.add(slider_vec2(item_spacing, 0.0..=20.0, "Item spacing"));
+        Grid::new("spacing")
+            .num_columns(2)
+            .spacing([12.0, 8.0])
+            .striped(true)
+            .show(ui, |ui| {
+                ui.label("Item spacing");
+                ui.add(two_drag_values(item_spacing, 0.0..=20.0));
+                ui.end_row();
 
-        margin_ui(ui, "Window margin:", window_margin);
-        margin_ui(ui, "Menu margin:", menu_margin);
+                ui.label("Window margin");
+                ui.add(window_margin);
+                ui.end_row();
 
-        ui.add(slider_vec2(button_padding, 0.0..=20.0, "Button padding"));
-        ui.add(slider_vec2(interact_size, 4.0..=60.0, "Interact size"))
-            .on_hover_text("Minimum size of an interactive widget");
-        ui.horizontal(|ui| {
-            ui.add(DragValue::new(indent).clamp_range(0.0..=100.0));
-            ui.label("Indent");
-        });
-        ui.horizontal(|ui| {
-            ui.add(DragValue::new(slider_width).clamp_range(0.0..=1000.0));
-            ui.label("Slider width");
-        });
-        ui.horizontal(|ui| {
-            ui.add(DragValue::new(slider_rail_height).clamp_range(0.0..=50.0));
-            ui.label("Slider rail height");
-        });
-        ui.horizontal(|ui| {
-            ui.add(DragValue::new(combo_width).clamp_range(0.0..=1000.0));
-            ui.label("ComboBox width");
-        });
-        ui.horizontal(|ui| {
-            ui.add(DragValue::new(text_edit_width).clamp_range(0.0..=1000.0));
-            ui.label("TextEdit width");
-        });
+                ui.label("Menu margin");
+                ui.add(menu_margin);
+                ui.end_row();
 
-        ui.collapsing("Scroll Area", |ui| {
-            scroll.ui(ui);
-        });
+                ui.label("Button padding");
+                ui.add(two_drag_values(button_padding, 0.0..=20.0));
+                ui.end_row();
 
-        ui.horizontal(|ui| {
-            ui.label("Checkboxes etc:");
-            ui.add(
-                DragValue::new(icon_width)
-                    .prefix("outer icon width:")
-                    .clamp_range(0.0..=60.0),
-            );
-            ui.add(
-                DragValue::new(icon_width_inner)
-                    .prefix("inner icon width:")
-                    .clamp_range(0.0..=60.0),
-            );
-            ui.add(
-                DragValue::new(icon_spacing)
-                    .prefix("spacing:")
-                    .clamp_range(0.0..=10.0),
-            );
-        });
+                ui.label("Interact size")
+                    .on_hover_text("Minimum size of an interactive widget");
+                ui.add(two_drag_values(interact_size, 4.0..=60.0));
+                ui.end_row();
 
-        ui.horizontal(|ui| {
-            ui.add(DragValue::new(tooltip_width).clamp_range(0.0..=1000.0));
-            ui.label("Tooltip wrap width");
-        });
+                ui.label("Indent");
+                ui.add(DragValue::new(indent).clamp_range(0.0..=100.0));
+                ui.end_row();
 
-        ui.horizontal(|ui| {
-            ui.add(DragValue::new(menu_width).clamp_range(0.0..=1000.0));
-            ui.label("Default width of a menu");
-        });
+                ui.label("Slider width");
+                ui.add(DragValue::new(slider_width).clamp_range(0.0..=1000.0));
+                ui.end_row();
 
-        ui.horizontal(|ui| {
-            ui.add(DragValue::new(menu_spacing).clamp_range(0.0..=10.0));
-            ui.label("Horizontal spacing between menus");
-        });
+                ui.label("Slider rail height");
+                ui.add(DragValue::new(slider_rail_height).clamp_range(0.0..=50.0));
+                ui.end_row();
+
+                ui.label("ComboBox width");
+                ui.add(DragValue::new(combo_width).clamp_range(0.0..=1000.0));
+                ui.end_row();
+
+                ui.label("TextEdit width");
+                ui.add(DragValue::new(text_edit_width).clamp_range(0.0..=1000.0));
+                ui.end_row();
+
+                ui.label("Tooltip wrap width");
+                ui.add(DragValue::new(tooltip_width).clamp_range(0.0..=1000.0));
+                ui.end_row();
+
+                ui.label("Default menu width");
+                ui.add(DragValue::new(menu_width).clamp_range(0.0..=1000.0));
+                ui.end_row();
+
+                ui.label("Menu spacing")
+                    .on_hover_text("Horizontal spacing between menus");
+                ui.add(DragValue::new(menu_spacing).clamp_range(0.0..=10.0));
+                ui.end_row();
+
+                ui.label("Checkboxes etc");
+                ui.vertical(|ui| {
+                    ui.add(
+                        DragValue::new(icon_width)
+                            .prefix("outer icon width:")
+                            .clamp_range(0.0..=60.0),
+                    );
+                    ui.add(
+                        DragValue::new(icon_width_inner)
+                            .prefix("inner icon width:")
+                            .clamp_range(0.0..=60.0),
+                    );
+                    ui.add(
+                        DragValue::new(icon_spacing)
+                            .prefix("spacing:")
+                            .clamp_range(0.0..=10.0),
+                    );
+                });
+                ui.end_row();
+            });
 
         ui.checkbox(
             indent_ends_with_horizontal_line,
@@ -1496,57 +1509,12 @@ impl Spacing {
             ui.add(DragValue::new(combo_height).clamp_range(0.0..=1000.0));
         });
 
+        ui.collapsing("Scroll Area", |ui| {
+            scroll.ui(ui);
+        });
+
         ui.vertical_centered(|ui| reset_button(ui, self));
     }
-}
-
-pub fn margin_ui(ui: &mut Ui, text: &str, margin: &mut Margin) {
-    let margin_range = 0.0..=20.0;
-
-    ui.horizontal(|ui| {
-        ui.label(text);
-
-        let mut same = margin.is_same();
-        ui.checkbox(&mut same, "Same");
-
-        if same {
-            let mut value = margin.left;
-            ui.add(DragValue::new(&mut value).clamp_range(margin_range.clone()));
-            *margin = Margin::same(value);
-        } else {
-            if margin.is_same() {
-                // HACK: prevent collapse:
-                margin.right = margin.left + 1.0;
-                margin.bottom = margin.left + 2.0;
-                margin.top = margin.left + 3.0;
-            }
-
-            ui.add(
-                DragValue::new(&mut margin.left)
-                    .clamp_range(margin_range.clone())
-                    .prefix("L: "),
-            )
-            .on_hover_text("Left margin");
-            ui.add(
-                DragValue::new(&mut margin.right)
-                    .clamp_range(margin_range.clone())
-                    .prefix("R: "),
-            )
-            .on_hover_text("Right margin");
-            ui.add(
-                DragValue::new(&mut margin.top)
-                    .clamp_range(margin_range.clone())
-                    .prefix("T: "),
-            )
-            .on_hover_text("Top margin");
-            ui.add(
-                DragValue::new(&mut margin.bottom)
-                    .clamp_range(margin_range)
-                    .prefix("B: "),
-            )
-            .on_hover_text("Bottom margin");
-        }
-    });
 }
 
 impl Interaction {
@@ -1857,7 +1825,7 @@ impl Visuals {
             "Paint a vertical line to the left of indented regions",
         );
 
-        ui.checkbox(striped, "By default, add stripes to grids and tables?");
+        ui.checkbox(striped, "Default stripes on grids and tables");
 
         ui.checkbox(slider_trailing_fill, "Add trailing color to sliders");
 
@@ -1930,11 +1898,10 @@ impl DebugOptions {
     }
 }
 
-// TODO(emilk): improve and standardize `slider_vec2`
-fn slider_vec2<'a>(
+// TODO(emilk): improve and standardize
+fn two_drag_values<'a>(
     value: &'a mut Vec2,
     range: std::ops::RangeInclusive<f32>,
-    text: &'a str,
 ) -> impl Widget + 'a {
     move |ui: &mut crate::Ui| {
         ui.horizontal(|ui| {
@@ -1948,7 +1915,6 @@ fn slider_vec2<'a>(
                     .clamp_range(range.clone())
                     .prefix("y: "),
             );
-            ui.label(text);
         })
         .response
     }
@@ -1964,8 +1930,8 @@ fn ui_color(ui: &mut Ui, srgba: &mut Color32, label: impl Into<WidgetText>) -> R
 
 impl HandleShape {
     pub fn ui(&mut self, ui: &mut Ui) {
-        ui.label("Widget handle shape");
         ui.horizontal(|ui| {
+            ui.label("Slider handle");
             ui.radio_value(self, Self::Circle, "Circle");
             if ui
                 .radio(matches!(self, Self::Rect { .. }), "Rectangle")

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1933,10 +1933,7 @@ impl DebugOptions {
 }
 
 // TODO(emilk): improve and standardize
-fn two_drag_values<'a>(
-    value: &'a mut Vec2,
-    range: std::ops::RangeInclusive<f32>,
-) -> impl Widget + 'a {
+fn two_drag_values(value: &mut Vec2, range: std::ops::RangeInclusive<f32>) -> impl Widget + '_ {
     move |ui: &mut crate::Ui| {
         ui.horizontal(|ui| {
             ui.add(

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1530,20 +1530,41 @@ impl Interaction {
             selectable_labels,
             multi_widget_text_select,
         } = self;
-        ui.add(Slider::new(interact_radius, 0.0..=20.0).text("interact_radius"))
-            .on_hover_text("Interact with the closest widget within this radius.");
-        ui.add(Slider::new(resize_grab_radius_side, 0.0..=20.0).text("resize_grab_radius_side"));
-        ui.add(
-            Slider::new(resize_grab_radius_corner, 0.0..=20.0).text("resize_grab_radius_corner"),
-        );
+
+        ui.spacing_mut().item_spacing = vec2(12.0, 8.0);
+
+        Grid::new("interaction")
+            .num_columns(2)
+            .striped(true)
+            .show(ui, |ui| {
+                ui.label("interact_radius")
+                    .on_hover_text("Interact with the closest widget within this radius.");
+                ui.add(DragValue::new(interact_radius).clamp_range(0.0..=20.0));
+                ui.end_row();
+
+                ui.label("resize_grab_radius_side").on_hover_text("Radius of the interactive area of the side of a window during drag-to-resize");
+                ui.add(DragValue::new(resize_grab_radius_side).clamp_range(0.0..=20.0));
+                ui.end_row();
+
+                ui.label("resize_grab_radius_corner").on_hover_text("Radius of the interactive area of the corner of a window during drag-to-resize.");
+                ui.add(DragValue::new(resize_grab_radius_corner).clamp_range(0.0..=20.0));
+                ui.end_row();
+
+                ui.label("Tooltip delay").on_hover_text(
+                    "Delay in seconds before showing tooltips after the mouse stops moving",
+                );
+                ui.add(
+                    DragValue::new(tooltip_delay)
+                        .clamp_range(0.0..=1.0)
+                        .speed(0.05)
+                        .suffix(" s"),
+                );
+                ui.end_row();
+            });
+
         ui.checkbox(
             show_tooltips_only_when_still,
             "Only show tooltips if mouse is still",
-        );
-        ui.add(
-            Slider::new(tooltip_delay, 0.0..=1.0)
-                .suffix(" s")
-                .text("tooltip_delay"),
         );
 
         ui.horizontal(|ui| {

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1379,7 +1379,7 @@ impl Style {
                 "If scrolling is enabled for only one direction, allow horizontal scrolling without pressing shift",
             );
 
-        ui.vertical_centered(|ui| reset_button(ui, self));
+        ui.vertical_centered(|ui| reset_button(ui, self, "Reset style"));
     }
 }
 
@@ -1392,7 +1392,7 @@ fn text_styles_ui(ui: &mut Ui, text_styles: &mut BTreeMap<TextStyle, FontId>) ->
                 ui.end_row();
             }
         });
-        crate::reset_button_with(ui, text_styles, default_text_styles());
+        crate::reset_button_with(ui, text_styles, "Reset text styles", default_text_styles());
     })
     .response
 }
@@ -1515,7 +1515,7 @@ impl Spacing {
             scroll.ui(ui);
         });
 
-        ui.vertical_centered(|ui| reset_button(ui, self));
+        ui.vertical_centered(|ui| reset_button(ui, self, "Reset spacing"));
     }
 }
 
@@ -1574,7 +1574,7 @@ impl Interaction {
             }
         });
 
-        ui.vertical_centered(|ui| reset_button(ui, self));
+        ui.vertical_centered(|ui| reset_button(ui, self, "Reset interaction settings"));
     }
 }
 
@@ -1883,7 +1883,7 @@ impl Visuals {
             });
         });
 
-        ui.vertical_centered(|ui| reset_button(ui, self));
+        ui.vertical_centered(|ui| reset_button(ui, self, "Reset visuals"));
     }
 }
 
@@ -1928,7 +1928,7 @@ impl DebugOptions {
 
         ui.checkbox(show_widget_hits, "Show widgets under mouse pointer");
 
-        ui.vertical_centered(|ui| reset_button(ui, self));
+        ui.vertical_centered(|ui| reset_button(ui, self, "Reset debug options"));
     }
 }
 

--- a/crates/egui/src/widgets/mod.rs
+++ b/crates/egui/src/widgets/mod.rs
@@ -109,19 +109,11 @@ pub fn reset_button_with<T: PartialEq>(ui: &mut Ui, value: &mut T, reset_value: 
 
 // ----------------------------------------------------------------------------
 
+#[deprecated = "Use `ui.add(&mut stroke)` instead"]
 pub fn stroke_ui(ui: &mut crate::Ui, stroke: &mut epaint::Stroke, text: &str) {
-    let epaint::Stroke { width, color } = stroke;
     ui.horizontal(|ui| {
-        ui.add(DragValue::new(width).speed(0.1).clamp_range(0.0..=5.0))
-            .on_hover_text("Width");
-        ui.color_edit_button_srgba(color);
         ui.label(text);
-
-        // stroke preview:
-        let (_id, stroke_rect) = ui.allocate_space(ui.spacing().interact_size);
-        let left = stroke_rect.left_center();
-        let right = stroke_rect.right_center();
-        ui.painter().line_segment([left, right], (*width, *color));
+        ui.add(stroke);
     });
 }
 

--- a/crates/egui/src/widgets/mod.rs
+++ b/crates/egui/src/widgets/mod.rs
@@ -92,15 +92,19 @@ pub trait WidgetWithState {
 
 /// Show a button to reset a value to its default.
 /// The button is only enabled if the value does not already have its original value.
-pub fn reset_button<T: Default + PartialEq>(ui: &mut Ui, value: &mut T) {
-    reset_button_with(ui, value, T::default());
+///
+/// The `text` could be something like "Reset foo".
+pub fn reset_button<T: Default + PartialEq>(ui: &mut Ui, value: &mut T, text: &str) {
+    reset_button_with(ui, value, text, T::default());
 }
 
 /// Show a button to reset a value to its default.
 /// The button is only enabled if the value does not already have its original value.
-pub fn reset_button_with<T: PartialEq>(ui: &mut Ui, value: &mut T, reset_value: T) {
+///
+/// The `text` could be something like "Reset foo".
+pub fn reset_button_with<T: PartialEq>(ui: &mut Ui, value: &mut T, text: &str, reset_value: T) {
     if ui
-        .add_enabled(*value != reset_value, Button::new("Reset"))
+        .add_enabled(*value != reset_value, Button::new(text))
         .clicked()
     {
         *value = reset_value;

--- a/crates/egui/src/widgets/mod.rs
+++ b/crates/egui/src/widgets/mod.rs
@@ -125,49 +125,6 @@ pub fn stroke_ui(ui: &mut crate::Ui, stroke: &mut epaint::Stroke, text: &str) {
     });
 }
 
-pub(crate) fn shadow_ui(ui: &mut Ui, shadow: &mut epaint::Shadow, text: &str) {
-    let epaint::Shadow {
-        offset,
-        blur,
-        spread,
-        color,
-    } = shadow;
-
-    ui.label(text);
-    ui.indent(text, |ui| {
-        crate::Grid::new("shadow_ui").show(ui, |ui| {
-            ui.add(
-                DragValue::new(&mut offset.x)
-                    .speed(1.0)
-                    .clamp_range(-100.0..=100.0)
-                    .prefix("x: "),
-            );
-            ui.add(
-                DragValue::new(&mut offset.y)
-                    .speed(1.0)
-                    .clamp_range(-100.0..=100.0)
-                    .prefix("y: "),
-            );
-            ui.end_row();
-
-            ui.add(
-                DragValue::new(blur)
-                    .speed(1.0)
-                    .clamp_range(0.0..=100.0)
-                    .prefix("Blur:"),
-            );
-
-            ui.add(
-                DragValue::new(spread)
-                    .speed(1.0)
-                    .clamp_range(0.0..=100.0)
-                    .prefix("Spread:"),
-            );
-        });
-        ui.color_edit_button_srgba(color);
-    });
-}
-
 /// Show a small button to switch to/from dark/light mode (globally).
 pub fn global_dark_light_mode_switch(ui: &mut Ui) {
     let style: crate::Style = (*ui.ctx().style()).clone();

--- a/crates/egui_demo_app/src/apps/fractal_clock.rs
+++ b/crates/egui_demo_app/src/apps/fractal_clock.rs
@@ -79,7 +79,7 @@ impl FractalClock {
         ui.add(Slider::new(&mut self.luminance_factor, 0.0..=1.0).text("luminance factor"));
         ui.add(Slider::new(&mut self.width_factor, 0.0..=1.0).text("width factor"));
 
-        egui::reset_button(ui, self);
+        egui::reset_button(ui, self, "Reset");
 
         ui.hyperlink_to(
             "Inspired by a screensaver by Rob Mayoff",

--- a/crates/egui_demo_app/src/wrap_app.rs
+++ b/crates/egui_demo_app/src/wrap_app.rs
@@ -245,7 +245,13 @@ impl eframe::App for WrapApp {
     }
 
     fn clear_color(&self, visuals: &egui::Visuals) -> [f32; 4] {
-        visuals.panel_fill.to_normalized_gamma_f32()
+        // Give the area behind the floating windows a different color, because it looks better:
+        let color = egui::lerp(
+            egui::Rgba::from(visuals.panel_fill)..=egui::Rgba::from(visuals.extreme_bg_color),
+            0.5,
+        );
+        let color = egui::Color32::from(color);
+        color.to_normalized_gamma_f32()
     }
 
     fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -29,6 +29,7 @@ impl Default for Demos {
             Box::<super::drag_and_drop::DragAndDropDemo>::default(),
             Box::<super::extra_viewport::ExtraViewport>::default(),
             Box::<super::font_book::FontBook>::default(),
+            Box::<super::frame_demo::FrameDemo>::default(),
             Box::<super::MiscDemoWindow>::default(),
             Box::<super::multi_touch::MultiTouch>::default(),
             Box::<super::painting::Painting>::default(),

--- a/crates/egui_demo_lib/src/demo/frame_demo.rs
+++ b/crates/egui_demo_lib/src/demo/frame_demo.rs
@@ -48,7 +48,7 @@ impl super::View for FrameDemo {
 
                 ui.add_space(8.0);
                 ui.set_max_width(ui.min_size().x);
-                ui.vertical_centered(|ui| egui::reset_button(ui, self));
+                ui.vertical_centered(|ui| egui::reset_button(ui, self, "Reset"));
             });
 
             ui.separator();

--- a/crates/egui_demo_lib/src/demo/frame_demo.rs
+++ b/crates/egui_demo_lib/src/demo/frame_demo.rs
@@ -1,0 +1,73 @@
+/// Shows off a table with dynamic layout
+#[derive(PartialEq)]
+pub struct FrameDemo {
+    frame: egui::Frame,
+}
+
+impl Default for FrameDemo {
+    fn default() -> Self {
+        Self {
+            frame: egui::Frame {
+                inner_margin: 12.0.into(),
+                outer_margin: 24.0.into(),
+                rounding: 14.0.into(),
+                shadow: egui::Shadow {
+                    offset: [8.0, 12.0].into(),
+                    blur: 16.0,
+                    spread: 0.0,
+                    color: egui::Color32::from_black_alpha(180),
+                },
+                fill: egui::Color32::from_rgba_unmultiplied(97, 0, 255, 128),
+                stroke: egui::Stroke::new(1.0, egui::Color32::GRAY),
+            },
+        }
+    }
+}
+
+impl super::Demo for FrameDemo {
+    fn name(&self) -> &'static str {
+        "▣ Frame"
+    }
+
+    fn show(&mut self, ctx: &egui::Context, open: &mut bool) {
+        egui::Window::new(self.name())
+            .open(open)
+            .resizable(false)
+            .show(ctx, |ui| {
+                use super::View as _;
+                self.ui(ui);
+            });
+    }
+}
+
+impl super::View for FrameDemo {
+    fn ui(&mut self, ui: &mut egui::Ui) {
+        ui.horizontal(|ui| {
+            ui.vertical(|ui| {
+                ui.add(&mut self.frame);
+
+                ui.add_space(8.0);
+                ui.set_max_width(ui.min_size().x);
+                ui.vertical_centered(|ui| egui::reset_button(ui, self));
+            });
+
+            ui.separator();
+
+            ui.vertical(|ui| {
+                // We want to paint a background around the outer margin of the demonstration frame, so we use another frame around it:
+                egui::Frame::default()
+                    .stroke(ui.visuals().widgets.noninteractive.bg_stroke)
+                    .rounding(ui.visuals().widgets.noninteractive.rounding)
+                    .show(ui, |ui| {
+                        self.frame.show(ui, |ui| {
+                            ui.label(egui::RichText::new("Content").color(egui::Color32::WHITE));
+                        });
+                    });
+            });
+        });
+
+        ui.set_max_width(ui.min_size().x);
+        ui.separator();
+        ui.vertical_centered(|ui| ui.add(crate::egui_github_link_file!()));
+    }
+}

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -328,7 +328,7 @@ impl Default for ColorWidgets {
 
 impl ColorWidgets {
     fn ui(&mut self, ui: &mut Ui) {
-        egui::reset_button(ui, self);
+        egui::reset_button(ui, self, "Reset");
 
         ui.label("egui lets you edit colors stored as either sRGBA or linear RGBA and with or without premultiplied alpha");
 

--- a/crates/egui_demo_lib/src/demo/mod.rs
+++ b/crates/egui_demo_lib/src/demo/mod.rs
@@ -13,6 +13,7 @@ pub mod demo_app_windows;
 pub mod drag_and_drop;
 pub mod extra_viewport;
 pub mod font_book;
+pub mod frame_demo;
 pub mod highlighting;
 pub mod layout_test;
 pub mod misc_demo_window;

--- a/crates/egui_demo_lib/src/demo/paint_bezier.rs
+++ b/crates/egui_demo_lib/src/demo/paint_bezier.rs
@@ -43,13 +43,27 @@ impl Default for PaintBezier {
 impl PaintBezier {
     pub fn ui_control(&mut self, ui: &mut egui::Ui) {
         ui.collapsing("Colors", |ui| {
-            ui.horizontal(|ui| {
-                ui.label("Fill color:");
-                ui.color_edit_button_srgba(&mut self.fill);
-            });
-            egui::stroke_ui(ui, &mut self.stroke, "Curve Stroke");
-            egui::stroke_ui(ui, &mut self.aux_stroke, "Auxiliary Stroke");
-            egui::stroke_ui(ui, &mut self.bounding_box_stroke, "Bounding Box Stroke");
+            Grid::new("colors")
+                .num_columns(2)
+                .spacing([12.0, 8.0])
+                .striped(true)
+                .show(ui, |ui| {
+                    ui.label("Fill color");
+                    ui.color_edit_button_srgba(&mut self.fill);
+                    ui.end_row();
+
+                    ui.label("Curve Stroke");
+                    ui.add(&mut self.stroke);
+                    ui.end_row();
+
+                    ui.label("Auxiliary Stroke");
+                    ui.add(&mut self.aux_stroke);
+                    ui.end_row();
+
+                    ui.label("Bounding Box Stroke");
+                    ui.add(&mut self.bounding_box_stroke);
+                    ui.end_row();
+                });
         });
 
         ui.collapsing("Global tessellation options", |ui| {

--- a/crates/egui_demo_lib/src/demo/painting.rs
+++ b/crates/egui_demo_lib/src/demo/painting.rs
@@ -20,7 +20,8 @@ impl Default for Painting {
 impl Painting {
     pub fn ui_control(&mut self, ui: &mut egui::Ui) -> egui::Response {
         ui.horizontal(|ui| {
-            egui::stroke_ui(ui, &mut self.stroke, "Stroke");
+            ui.label("Stroke:");
+            ui.add(&mut self.stroke);
             ui.separator();
             if ui.button("Clear Painting").clicked() {
                 self.lines.clear();

--- a/crates/egui_demo_lib/src/demo/plot_demo.rs
+++ b/crates/egui_demo_lib/src/demo/plot_demo.rs
@@ -62,7 +62,7 @@ impl super::Demo for PlotDemo {
 impl super::View for PlotDemo {
     fn ui(&mut self, ui: &mut Ui) {
         ui.horizontal(|ui| {
-            egui::reset_button(ui, self);
+            egui::reset_button(ui, self, "Reset");
             ui.collapsing("Instructions", |ui| {
                 ui.label("Pan by dragging, or scroll (+ shift = horizontal).");
                 ui.label("Box zooming: Right click to zoom in and zoom out using a selection.");

--- a/crates/egui_demo_lib/src/demo/scrolling.rs
+++ b/crates/egui_demo_lib/src/demo/scrolling.rs
@@ -336,7 +336,7 @@ impl super::View for ScrollTo {
 
         ui.separator();
         ui.vertical_centered(|ui| {
-            egui::reset_button(ui, self);
+            egui::reset_button(ui, self, "Reset");
             ui.add(crate::egui_github_link_file!());
         });
     }

--- a/crates/egui_demo_lib/src/demo/sliders.rs
+++ b/crates/egui_demo_lib/src/demo/sliders.rs
@@ -198,7 +198,7 @@ impl super::View for Sliders {
         ui.add_space(8.0);
 
         ui.vertical_centered(|ui| {
-            egui::reset_button(ui, self);
+            egui::reset_button(ui, self, "Reset");
             ui.add(crate::egui_github_link_file!());
         });
     }

--- a/crates/egui_demo_lib/src/demo/strip_demo.rs
+++ b/crates/egui_demo_lib/src/demo/strip_demo.rs
@@ -8,7 +8,7 @@ pub struct StripDemo {}
 
 impl super::Demo for StripDemo {
     fn name(&self) -> &'static str {
-        "▣ Strip Demo"
+        "▣ Strip"
     }
 
     fn show(&mut self, ctx: &egui::Context, open: &mut bool) {

--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -40,7 +40,7 @@ impl Default for TableDemo {
 
 impl super::Demo for TableDemo {
     fn name(&self) -> &'static str {
-        "☰ Table Demo"
+        "☰ Table"
     }
 
     fn show(&mut self, ctx: &egui::Context, open: &mut bool) {

--- a/crates/egui_demo_lib/src/demo/tests.rs
+++ b/crates/egui_demo_lib/src/demo/tests.rs
@@ -131,7 +131,7 @@ impl super::Demo for ManualLayoutTest {
 
 impl super::View for ManualLayoutTest {
     fn ui(&mut self, ui: &mut egui::Ui) {
-        egui::reset_button(ui, self);
+        egui::reset_button(ui, self, "Reset");
 
         let Self {
             widget_offset,
@@ -298,7 +298,7 @@ impl super::View for TableTest {
         });
 
         ui.vertical_centered(|ui| {
-            egui::reset_button(ui, self);
+            egui::reset_button(ui, self, "Reset");
             ui.add(crate::egui_github_link_file!());
         });
     }

--- a/crates/egui_demo_lib/src/demo/window_options.rs
+++ b/crates/egui_demo_lib/src/demo/window_options.rs
@@ -146,7 +146,7 @@ impl super::View for WindowOptions {
             if ui.button("Disable for 2 seconds").clicked() {
                 self.disabled_time = ui.input(|i| i.time);
             }
-            egui::reset_button(ui, self);
+            egui::reset_button(ui, self, "Reset");
             ui.add(crate::egui_github_link_file!());
         });
     }

--- a/crates/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/crates/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -48,7 +48,7 @@ impl EasyMarkEditor {
             let _ = ui.button("Hotkeys").on_hover_ui(nested_hotkeys_ui);
             ui.checkbox(&mut self.show_rendered, "Show rendered");
             ui.checkbox(&mut self.highlight_editor, "Highlight editor");
-            egui::reset_button(ui, self);
+            egui::reset_button(ui, self, "Reset");
             ui.end_row();
         });
         ui.separator();


### PR DESCRIPTION
I added a new demo - a `Frame` editor:
![frame-editor](https://github.com/emilk/egui/assets/1148717/d0bec169-c211-45a3-9f53-5059fb8fc224)

This whole menu is now just a a bit nicer to use:
<img width="406" alt="Screenshot 2024-03-28 at 09 49 16" src="https://github.com/emilk/egui/assets/1148717/32d12067-7cf0-4312-aa12-42909a5ed5ac">
