### PR TITLE
Web: repaint if the `#hash` in the URL changes

### DIFF
--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -242,6 +242,7 @@ pub(crate) fn install_window_events(runner_ref: &WebRunner) -> Result<(), JsValu
     runner_ref.add_event_listener(&window, "hashchange", |_: web_sys::Event, runner| {
         // `epi::Frame::info(&self)` clones `epi::IntegrationInfo`, but we need to modify the original here
         runner.frame.info.web_info.location.hash = location_hash();
+        runner.needs_repaint.repaint_asap(); // tell the user about the new hash
     })?;
 
     Ok(())


### PR DESCRIPTION
Fixes a problem in egui.rs where the back-button would not work to switch between the top-level tabs
