### PR TITLE
Release 0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.1 - 2024-03-29
+### 🐛 Fixed
+* Fix visual glitch on the right side of highly rounded rectangles [#4244](https://github.com/emilk/egui/pull/4244)
+* Prevent visual glitch when shadow blur width is very high [#4245](https://github.com/emilk/egui/pull/4245)
+* Fix `InputState::any_touches` and add `InputState::has_touch_screen` [#4247](https://github.com/emilk/egui/pull/4247)
+* Fix `Context::repaint_causes` returning no causes [#4248](https://github.com/emilk/egui/pull/4248)
+* Fix touch-and-hold to open context menu [#4249](https://github.com/emilk/egui/pull/4249)
+* Hide shortcut text on zoom buttons if `zoom_with_keyboard` is false [#4262](https://github.com/emilk/egui/pull/4262)
+
+### 🔧 Changed
+* Don't apply a clip rect to the contents of an `Area` or `Window` [#4258](https://github.com/emilk/egui/pull/4258)
+
+
 ## 0.27.0 - 2024-03-26 - Nicer menus and new hit test logic
 The hit test logic (what is the user clicking on?) has been completely rewritten, and should now be much more accurate and helpful.
 The hit test and interaction logic is run at the start of the frame, using the widgets rects from the previous frame, but the latest mouse coordinates.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,7 +1187,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "ecolor"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bytemuck",
  "cint",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "egui_demo_app"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bytemuck",
  "chrono",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "egui_demo_lib"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "chrono",
  "criterion",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "chrono",
  "document-features",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "egui_plot"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "document-features",
  "egui",
@@ -1394,7 +1394,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "emath"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.72"
-version = "0.27.0"
+version = "0.27.1"
 
 
 [profile.release]
@@ -48,17 +48,17 @@ opt-level = 2
 
 
 [workspace.dependencies]
-emath = { version = "0.27.0", path = "crates/emath", default-features = false }
-ecolor = { version = "0.27.0", path = "crates/ecolor", default-features = false }
-epaint = { version = "0.27.0", path = "crates/epaint", default-features = false }
-egui = { version = "0.27.0", path = "crates/egui", default-features = false }
-egui_plot = { version = "0.27.0", path = "crates/egui_plot", default-features = false }
-egui-winit = { version = "0.27.0", path = "crates/egui-winit", default-features = false }
-egui_extras = { version = "0.27.0", path = "crates/egui_extras", default-features = false }
-egui-wgpu = { version = "0.27.0", path = "crates/egui-wgpu", default-features = false }
-egui_demo_lib = { version = "0.27.0", path = "crates/egui_demo_lib", default-features = false }
-egui_glow = { version = "0.27.0", path = "crates/egui_glow", default-features = false }
-eframe = { version = "0.27.0", path = "crates/eframe", default-features = false }
+emath = { version = "0.27.1", path = "crates/emath", default-features = false }
+ecolor = { version = "0.27.1", path = "crates/ecolor", default-features = false }
+epaint = { version = "0.27.1", path = "crates/epaint", default-features = false }
+egui = { version = "0.27.1", path = "crates/egui", default-features = false }
+egui_plot = { version = "0.27.1", path = "crates/egui_plot", default-features = false }
+egui-winit = { version = "0.27.1", path = "crates/egui-winit", default-features = false }
+egui_extras = { version = "0.27.1", path = "crates/egui_extras", default-features = false }
+egui-wgpu = { version = "0.27.1", path = "crates/egui-wgpu", default-features = false }
+egui_demo_lib = { version = "0.27.1", path = "crates/egui_demo_lib", default-features = false }
+egui_glow = { version = "0.27.1", path = "crates/egui_glow", default-features = false }
+eframe = { version = "0.27.1", path = "crates/eframe", default-features = false }
 
 #TODO(emilk): make more things workspace dependencies
 ahash = { version = "0.8.6", default-features = false, features = [

--- a/crates/ecolor/CHANGELOG.md
+++ b/crates/ecolor/CHANGELOG.md
@@ -6,6 +6,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.1 - 2024-03-29
+* Nothing new
+
+
 ## 0.27.0 - 2024-03-26
 * Nothing new
 

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -7,6 +7,11 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.1 - 2024-03-29
+* Web: repaint if the `#hash` in the URL changes [#4261](https://github.com/emilk/egui/pull/4261)
+* Add web support for `zoom_factor` [#4260](https://github.com/emilk/egui/pull/4260) (thanks [@justusdieckmann](https://github.com/justusdieckmann)!)
+
+
 ## 0.27.0 - 2024-03-26
 * Update to document-features 0.2.8 [#4003](https://github.com/emilk/egui/pull/4003)
 * Added `App::raw_input_hook` allows for the manipulation or filtering of raw input events [#4008](https://github.com/emilk/egui/pull/4008) (thanks [@varphone](https://github.com/varphone)!)

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -60,7 +60,9 @@ impl AppRunner {
         super::storage::load_memory(&egui_ctx);
 
         egui_ctx.options_mut(|o| {
-            // On web, the browser controls the zoom factor:
+            // On web by default egui follows the zoom factor of the browser,
+            // and lets the browser handle the zoom shortscuts.
+            // A user can still zoom egui separately by calling [`egui::Context::set_zoom_factor`].
             o.zoom_with_keyboard = false;
             o.zoom_factor = 1.0;
         });
@@ -183,7 +185,7 @@ impl AppRunner {
     /// The result can be painted later with a call to [`Self::run_and_paint`] or [`Self::paint`].
     pub fn logic(&mut self) {
         super::resize_canvas_to_screen_size(self.canvas(), self.web_options.max_size_points);
-        let canvas_size = super::canvas_size_in_points(self.canvas());
+        let canvas_size = super::canvas_size_in_points(self.canvas(), self.egui_ctx());
         let raw_input = self.input.new_frame(canvas_size);
 
         let full_output = self.egui_ctx.run(raw_input, |egui_ctx| {

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -242,6 +242,7 @@ pub(crate) fn install_window_events(runner_ref: &WebRunner) -> Result<(), JsValu
     runner_ref.add_event_listener(&window, "hashchange", |_: web_sys::Event, runner| {
         // `epi::Frame::info(&self)` clones `epi::IntegrationInfo`, but we need to modify the original here
         runner.frame.info.web_info.location.hash = location_hash();
+        runner.needs_repaint.repaint_asap(); // tell the user about the new hash
     })?;
 
     Ok(())

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -116,8 +116,8 @@ fn canvas_origin(canvas: &web_sys::HtmlCanvasElement) -> egui::Pos2 {
     egui::pos2(rect.left() as f32, rect.top() as f32)
 }
 
-fn canvas_size_in_points(canvas: &web_sys::HtmlCanvasElement) -> egui::Vec2 {
-    let pixels_per_point = native_pixels_per_point();
+fn canvas_size_in_points(canvas: &web_sys::HtmlCanvasElement, ctx: &egui::Context) -> egui::Vec2 {
+    let pixels_per_point = ctx.pixels_per_point();
     egui::vec2(
         canvas.width() as f32 / pixels_per_point,
         canvas.height() as f32 / pixels_per_point,

--- a/crates/egui-wgpu/CHANGELOG.md
+++ b/crates/egui-wgpu/CHANGELOG.md
@@ -6,6 +6,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.1 - 2024-03-29
+* Nothing new
+
+
 ## 0.27.0 - 2024-03-26
 * Improve panic message in egui-wgpu when failing to create buffers [#3986](https://github.com/emilk/egui/pull/3986)
 

--- a/crates/egui-winit/CHANGELOG.md
+++ b/crates/egui-winit/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.1 - 2024-03-29
+* Nothing new
+
+
 ## 0.27.0 - 2024-03-26
 * Update memoffset to 0.9.0, arboard to 3.3.1, and remove egui_glow's needless dependency on pure_glow's deps  [#4036](https://github.com/emilk/egui/pull/4036) (thanks [@Nopey](https://github.com/Nopey)!)
 * Don't clear modifier state on focus change [#4157](https://github.com/emilk/egui/pull/4157) (thanks [@ming08108](https://github.com/ming08108)!)

--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -384,7 +384,7 @@ impl Area {
         let layer_id = LayerId::new(self.order, self.id);
         let area_rect = ctx.memory(|mem| mem.areas().get(self.id).map(|area| area.rect()));
         if let Some(area_rect) = area_rect {
-            let clip_rect = ctx.available_rect();
+            let clip_rect = Rect::EVERYTHING;
             let painter = Painter::new(ctx.clone(), layer_id, clip_rect);
 
             // shrinkage: looks kinda a bad on its own
@@ -437,12 +437,7 @@ impl Prepared {
                 .at_least(self.state.left_top_pos() + Vec2::splat(32.0)),
         );
 
-        let shadow_radius = ctx.style().visuals.window_shadow.margin().sum().max_elem(); // hacky
-        let clip_rect_margin = ctx.style().visuals.clip_rect_margin.max(shadow_radius);
-
-        let clip_rect = Rect::from_min_max(self.state.left_top_pos(), constrain_rect.max)
-            .expand(clip_rect_margin)
-            .intersect(constrain_rect);
+        let clip_rect = constrain_rect; // Don't paint outside our bounds
 
         let mut ui = Ui::new(
             ctx.clone(),

--- a/crates/egui/src/gui_zoom.rs
+++ b/crates/egui/src/gui_zoom.rs
@@ -70,10 +70,20 @@ pub fn zoom_out(ctx: &Context) {
 ///
 /// This is meant to be called from within a menu (See [`Ui::menu_button`]).
 pub fn zoom_menu_buttons(ui: &mut Ui) {
+    fn button(ctx: &Context, text: &str, shortcut: &KeyboardShortcut) -> Button<'static> {
+        let btn = Button::new(text);
+        let zoom_with_keyboard = ctx.options(|o| o.zoom_with_keyboard);
+        if zoom_with_keyboard {
+            btn.shortcut_text(ctx.format_shortcut(shortcut))
+        } else {
+            btn
+        }
+    }
+
     if ui
         .add_enabled(
             ui.ctx().zoom_factor() < MAX_ZOOM_FACTOR,
-            Button::new("Zoom In").shortcut_text(ui.ctx().format_shortcut(&kb_shortcuts::ZOOM_IN)),
+            button(ui.ctx(), "Zoom In", &kb_shortcuts::ZOOM_IN),
         )
         .clicked()
     {
@@ -84,8 +94,7 @@ pub fn zoom_menu_buttons(ui: &mut Ui) {
     if ui
         .add_enabled(
             ui.ctx().zoom_factor() > MIN_ZOOM_FACTOR,
-            Button::new("Zoom Out")
-                .shortcut_text(ui.ctx().format_shortcut(&kb_shortcuts::ZOOM_OUT)),
+            button(ui.ctx(), "Zoom Out", &kb_shortcuts::ZOOM_OUT),
         )
         .clicked()
     {
@@ -96,8 +105,7 @@ pub fn zoom_menu_buttons(ui: &mut Ui) {
     if ui
         .add_enabled(
             ui.ctx().zoom_factor() != 1.0,
-            Button::new("Reset Zoom")
-                .shortcut_text(ui.ctx().format_shortcut(&kb_shortcuts::ZOOM_RESET)),
+            button(ui.ctx(), "Reset Zoom", &kb_shortcuts::ZOOM_RESET),
         )
         .clicked()
     {

--- a/crates/egui/src/input_state.rs
+++ b/crates/egui/src/input_state.rs
@@ -326,6 +326,10 @@ impl InputState {
         self.pointer.wants_repaint()
             || self.unprocessed_scroll_delta.abs().max_elem() > 0.2
             || !self.events.is_empty()
+
+        // We need to wake up and check for press-and-hold for the context menu.
+        // TODO(emilk): wake up after `MAX_CLICK_DURATION` instead of every frame.
+        || (self.any_touches() && !self.pointer.is_decidedly_dragging())
     }
 
     /// Count presses of a key. If non-zero, the presses are consumed, so that this will only return non-zero once.

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -185,6 +185,12 @@ pub struct Options {
     /// presses Cmd+Plus, Cmd+Minus or Cmd+0, just like in a browser.
     ///
     /// This is `true` by default.
+    ///
+    /// On the web-backend of `eframe` this is set to false by default,
+    /// so that the zoom shortcuts are handled exclusively by the browser,
+    /// which will change the `native_pixels_per_point` (`devicePixelRatio`).
+    /// You can still zoom egui independently by calling [`crate::Context::set_zoom_factor`],
+    /// which will be applied on top of the browsers global zoom.
     #[cfg_attr(feature = "serde", serde(skip))]
     pub zoom_with_keyboard: bool,
 

--- a/crates/egui_extras/CHANGELOG.md
+++ b/crates/egui_extras/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.1 - 2024-03-29
+* Nothing new
+
+
 ## 0.27.0 - 2024-03-26
 * Add scroll bar visibility option to `Table` widget [#3981](https://github.com/emilk/egui/pull/3981) (thanks [@richardhozak](https://github.com/richardhozak)!)
 * Update `ehttp` to 0.5 [#4055](https://github.com/emilk/egui/pull/4055)

--- a/crates/egui_glow/CHANGELOG.md
+++ b/crates/egui_glow/CHANGELOG.md
@@ -6,6 +6,10 @@ Changes since the last release can be found at <https://github.com/emilk/egui/co
 
 
 
+## 0.27.1 - 2024-03-29
+* Nothing new
+
+
 ## 0.27.0 - 2024-03-26
 * Only disable sRGB framebuffer on supported platforms [#3994](https://github.com/emilk/egui/pull/3994) (thanks [@Nopey](https://github.com/Nopey)!)
 * Update memoffset to 0.9.0, arboard to 3.3.1, and remove egui_glow's needless dependency on pure_glow's deps  [#4036](https://github.com/emilk/egui/pull/4036) (thanks [@Nopey](https://github.com/Nopey)!)

--- a/crates/egui_plot/CHANGELOG.md
+++ b/crates/egui_plot/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.1 - 2024-03-29
+* Nothing new
+
+
 ## 0.27.0 - 2024-03-26
 * Add `sense` option to `Plot` [#4052](https://github.com/emilk/egui/pull/4052) (thanks [@AmesingFlank](https://github.com/AmesingFlank)!)
 * Plot widget - allow disabling scroll for x and y separately [#4051](https://github.com/emilk/egui/pull/4051) (thanks [@YgorSouza](https://github.com/YgorSouza)!)

--- a/crates/epaint/CHANGELOG.md
+++ b/crates/epaint/CHANGELOG.md
@@ -5,6 +5,11 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.1 - 2024-03-29
+* Fix visual glitch on the right side of highly rounded rectangles [#4244](https://github.com/emilk/egui/pull/4244)
+* Prevent visual glitch when shadow blur width is very high [#4245](https://github.com/emilk/egui/pull/4245)
+
+
 ## 0.27.0 - 2024-03-26
 * Add `ColorImage::from_gray_iter` [#3536](https://github.com/emilk/egui/pull/3536) (thanks [@wangxiaochuTHU](https://github.com/wangxiaochuTHU)!)
 * Convenience const fn for `Margin`, `Rounding` and `Shadow` [#4080](https://github.com/emilk/egui/pull/4080) (thanks [@0Qwel](https://github.com/0Qwel)!)


### PR DESCRIPTION
## egui changelog
### 🐛 Fixed
* Fix visual glitch on the right side of highly rounded rectangles [#4244](https://github.com/emilk/egui/pull/4244)
* Prevent visual glitch when shadow blur width is very high [#4245](https://github.com/emilk/egui/pull/4245)
* Fix `InputState::any_touches` and add `InputState::has_touch_screen` [#4247](https://github.com/emilk/egui/pull/4247)
* Fix `Context::repaint_causes` returning no causes [#4248](https://github.com/emilk/egui/pull/4248)
* Fix touch-and-hold to open context menu [#4249](https://github.com/emilk/egui/pull/4249)
* Hide shortcut text on zoom buttons if `zoom_with_keyboard` is false [#4262](https://github.com/emilk/egui/pull/4262)

### 🔧 Changed
* Don't apply a clip rect to the contents of an `Area` or `Window` [#4258](https://github.com/emilk/egui/pull/4258)


## eframe changelog
* Web: repaint if the `#hash` in the URL changes [#4261](https://github.com/emilk/egui/pull/4261)
* Add web support for `zoom_factor` [#4260](https://github.com/emilk/egui/pull/4260) (thanks [@justusdieckmann](https://github.com/justusdieckmann)!)