### PR TITLE
Fix continuous repaint on Wayland when TextEdit is focused or IME output is not None

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -99,7 +99,7 @@ pub struct State {
     accesskit: Option<accesskit_winit::Adapter>,
 
     allow_ime: bool,
-    ime_rect: Option<egui::Rect>,
+    ime_rect_px: Option<egui::Rect>,
 }
 
 impl State {
@@ -140,7 +140,7 @@ impl State {
             accesskit: None,
 
             allow_ime: false,
-            ime_rect: None,
+            ime_rect_px: None,
         };
 
         slf.egui_input
@@ -820,23 +820,25 @@ impl State {
 
         if let Some(ime) = ime {
             let pixels_per_point = pixels_per_point(&self.egui_ctx, window);
-            let rect = ime.rect * pixels_per_point;
-            if self.ime_rect != Some(rect) || self.egui_ctx.input(|i| !i.events.is_empty()) {
-                self.ime_rect = Some(rect);
+            let ime_rect_px = pixels_per_point * ime.rect;
+            if self.ime_rect_px != Some(ime_rect_px)
+                || self.egui_ctx.input(|i| !i.events.is_empty())
+            {
+                self.ime_rect_px = Some(ime_rect_px);
                 crate::profile_scope!("set_ime_cursor_area");
                 window.set_ime_cursor_area(
                     winit::dpi::PhysicalPosition {
-                        x: rect.min.x,
-                        y: rect.min.y,
+                        x: ime_rect_px.min.x,
+                        y: ime_rect_px.min.y,
                     },
                     winit::dpi::PhysicalSize {
-                        width: rect.width(),
-                        height: rect.height(),
+                        width: ime_rect_px.width(),
+                        height: ime_rect_px.height(),
                     },
                 );
             }
         } else {
-            self.ime_rect = None;
+            self.ime_rect_px = None;
         }
 
         #[cfg(feature = "accesskit")]

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -99,6 +99,7 @@ pub struct State {
     accesskit: Option<accesskit_winit::Adapter>,
 
     allow_ime: bool,
+    ime_rect: Option<egui::Rect>,
 }
 
 impl State {
@@ -139,6 +140,7 @@ impl State {
             accesskit: None,
 
             allow_ime: false,
+            ime_rect: None,
         };
 
         slf.egui_input
@@ -817,19 +819,24 @@ impl State {
         }
 
         if let Some(ime) = ime {
-            let rect = ime.rect;
             let pixels_per_point = pixels_per_point(&self.egui_ctx, window);
-            crate::profile_scope!("set_ime_cursor_area");
-            window.set_ime_cursor_area(
-                winit::dpi::PhysicalPosition {
-                    x: pixels_per_point * rect.min.x,
-                    y: pixels_per_point * rect.min.y,
-                },
-                winit::dpi::PhysicalSize {
-                    width: pixels_per_point * rect.width(),
-                    height: pixels_per_point * rect.height(),
-                },
-            );
+            let rect = ime.rect * pixels_per_point;
+            if self.ime_rect != Some(rect) || self.egui_ctx.input(|i| !i.events.is_empty()) {
+                self.ime_rect = Some(rect);
+                crate::profile_scope!("set_ime_cursor_area");
+                window.set_ime_cursor_area(
+                    winit::dpi::PhysicalPosition {
+                        x: rect.min.x,
+                        y: rect.min.y,
+                    },
+                    winit::dpi::PhysicalSize {
+                        width: rect.width(),
+                        height: rect.height(),
+                    },
+                );
+            }
+        } else {
+            self.ime_rect = None;
         }
 
         #[cfg(feature = "accesskit")]


### PR DESCRIPTION
* Closes #4254

Changes egui-winit so that it calls `window.set_ime_cursor_area` when the IME rect changes or the user interacts with the application instead of calling it every time the app is rendered. This works around a winit bug that causes the app to continuously repaint under certain circumstances on Wayland.

Tested on Wayland and on X11 using the text edit in the egui_demo_app - no changes in IME functionality as far as I can tell. Untested on non-Linux platforms.