### PR TITLE
Fix incorrect `Response::interact_rect` for `Area/Window`

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -355,7 +355,8 @@ impl Area {
         state.set_left_top_pos(ctx.round_pos_to_pixels(state.left_top_pos()));
 
         // Update responsbe with posisbly moved/constrained rect:
-        move_response = move_response.with_new_rect(state.rect());
+        move_response.rect = state.rect();
+        move_response.interact_rect = state.rect();
 
         Prepared {
             layer_id,

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -38,9 +38,6 @@ pub struct Response {
     ///
     /// This is sometimes smaller than [`Self::rect`] because of clipping
     /// (e.g. when inside a scroll area).
-    ///
-    /// The interact rect may also be slightly larger than the widget rect,
-    /// because egui adds half if the item spacing to make the interact rect easier to hit.
     pub interact_rect: Rect,
 
     /// The senses (click and/or drag) that the widget was interested in (if any).
@@ -59,7 +56,7 @@ pub struct Response {
     pub enabled: bool,
 
     // OUT:
-    /// The pointer is hovering above this widget.
+    /// The pointer is above this widget with no other blocking it.
     #[doc(hidden)]
     pub contains_pointer: bool,
 
@@ -243,14 +240,13 @@ impl Response {
         self.hovered
     }
 
-    /// Returns true if the pointer is contained by the response rect.
+    /// Returns true if the pointer is contained by the response rect, and no other widget is covering it.
     ///
     /// In contrast to [`Self::hovered`], this can be `true` even if some other widget is being dragged.
     /// This means it is useful for styling things like drag-and-drop targets.
     /// `contains_pointer` can also be `true` for disabled widgets.
     ///
-    /// This is slightly different from [`Ui::rect_contains_pointer`] and [`Context::rect_contains_pointer`],
-    /// The rectangle used here is slightly larger, by half of the current item spacing.
+    /// This is slightly different from [`Ui::rect_contains_pointer`] and [`Context::rect_contains_pointer`], in that
     /// [`Self::contains_pointer`] also checks that no other widget is covering this response rectangle.
     #[inline(always)]
     pub fn contains_pointer(&self) -> bool {

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -197,7 +197,10 @@ impl Response {
         self.clicked && self.ctx.input(|i| i.pointer.button_triple_clicked(button))
     }
 
-    /// `true` if there was a click *outside* this widget this frame.
+    /// `true` if there was a click *outside* the rect of this widget.
+    ///
+    /// Clicks on widgets contained in this one counts as clicks inside this widget,
+    /// so that clicking a button in an area will not be considered as clicking "elsewhere" from the area.
     pub fn clicked_elsewhere(&self) -> bool {
         // We do not use self.clicked(), because we want to catch all clicks within our frame,
         // even if we aren't clickable (or even enabled).


### PR DESCRIPTION
It was wrong for any `Area` or `Window` that was being moved or whose position was constrained