### PR TITLE
Implement blinking text cursor in `TextEdit`

### DIFF
--- a/crates/egui/src/widgets/text_edit/state.rs
+++ b/crates/egui/src/widgets/text_edit/state.rs
@@ -51,6 +51,11 @@ pub struct TextEditState {
     // Visual offset when editing singleline text bigger than the width.
     #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) singleline_offset: f32,
+
+    /// When did the user last press a key?
+    /// Used to pause the cursor animation when typing.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub(crate) last_edit_time: f64,
 }
 
 impl TextEditState {


### PR DESCRIPTION
On by default. Can be set with `style.text_cursor.blink`.

* Closes https://github.com/emilk/egui/pull/4121