### PR TITLE
Change `Frame::multiply_with_opacity` to multiply in gamma space

### DIFF
--- a/crates/ecolor/src/color32.rs
+++ b/crates/ecolor/src/color32.rs
@@ -212,7 +212,7 @@ impl Color32 {
     /// Multiply with 0.5 to make color half as opaque in linear space.
     ///
     /// This is using linear space, which is not perceptually even.
-    /// You may want to use [`Self::gamma_multiply`] instead.
+    /// You likely want to use [`Self::gamma_multiply`] instead.
     #[inline]
     pub fn linear_multiply(self, factor: f32) -> Self {
         crate::ecolor_assert!(0.0 <= factor && factor <= 1.0);

--- a/crates/egui/src/containers/frame.rs
+++ b/crates/egui/src/containers/frame.rs
@@ -196,11 +196,15 @@ impl Frame {
         self
     }
 
+    /// Opacity multiplier in gamma space.
+    ///
+    /// For instance, multiplying with `0.5`
+    /// will make the frame half transparent.
     #[inline]
     pub fn multiply_with_opacity(mut self, opacity: f32) -> Self {
-        self.fill = self.fill.linear_multiply(opacity);
-        self.stroke.color = self.stroke.color.linear_multiply(opacity);
-        self.shadow.color = self.shadow.color.linear_multiply(opacity);
+        self.fill = self.fill.gamma_multiply(opacity);
+        self.stroke.color = self.stroke.color.gamma_multiply(opacity);
+        self.shadow.color = self.shadow.color.gamma_multiply(opacity);
         self
     }
 }


### PR DESCRIPTION
This produces a more perceptually even change when used in animations, like when fading out a closed window
