### PR TITLE
Consider all non-interactie widgets under the mouse pointer hovered

### DIFF
--- a/crates/egui/src/widget_rect.rs
+++ b/crates/egui/src/widget_rect.rs
@@ -72,6 +72,11 @@ impl WidgetRects {
         self.by_id.get(&id).map(|(_, w)| w)
     }
 
+    /// In which layer, and in which order in that layer?
+    pub fn order(&self, id: Id) -> Option<(LayerId, usize)> {
+        self.by_id.get(&id).map(|(idx, w)| (w.layer_id, *idx))
+    }
+
     #[inline]
     pub fn contains(&self, id: Id) -> bool {
         self.by_id.contains_key(&id)


### PR DESCRIPTION
At least all those above any interactive widget.

* Closes https://github.com/emilk/egui/issues/4286

I feel there is still more thinking to be done about what is considered `hovered` and how it relates to `contains_pointer`, but this PR at least fixes tooltips for uninteractive widgets