### PR TITLE
Support order on windows

### DIFF
--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -104,7 +104,7 @@ impl<'open> Window<'open> {
         self
     }
 
-    /// `order(Order::Foreground)` for an Area that should always be on top
+    /// `order(Order::Foreground)` for a Window that should always be on top
     #[inline]
     pub fn order(mut self, order: Order) -> Self {
         self.area = self.area.order(order);

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -104,6 +104,13 @@ impl<'open> Window<'open> {
         self
     }
 
+    /// `order(Order::Foreground)` for an Area that should always be on top
+    #[inline]
+    pub fn order(mut self, order: Order) -> Self {
+        self.area = self.area.order(order);
+        self
+    }
+
     /// Usage: `Window::new(…).mutate(|w| w.resize = w.resize.auto_expand_width(true))`
     // TODO(emilk): I'm not sure this is a good interface for this.
     #[inline]


### PR DESCRIPTION
Adds support for the ordering of windows passing through to the underlying area.

Needed for a specific usecase of adding debug tools using windows with the bevy integration.
