### PR TITLE
Fix `Ui::scroll_with_delta` only scrolling if the `ScrollArea` is focused

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -787,7 +787,8 @@ impl Prepared {
             .frame_state_mut(|state| std::mem::take(&mut state.scroll_delta));
 
         for d in 0..2 {
-            let mut delta = scroll_delta[d];
+            // FrameState::scroll_delta is inverted from the way we apply the delta, so we need to negate it.
+            let mut delta = -scroll_delta[d];
 
             // We always take both scroll targets regardless of which scroll axes are enabled. This
             // is to avoid them leaking to other scroll areas.

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -870,7 +870,8 @@ impl Prepared {
 
         let max_offset = content_size - inner_rect.size();
         let is_hovering_outer_rect = ui.rect_contains_pointer(outer_rect);
-        if scrolling_enabled && is_hovering_outer_rect {
+        let force_current_scroll_area = ui.input(|i| i.force_current_scroll_area);
+        if scrolling_enabled && is_hovering_outer_rect || force_current_scroll_area {
             let always_scroll_enabled_direction = ui.style().always_scroll_the_only_direction
                 && scroll_enabled[0] != scroll_enabled[1];
             for d in 0..2 {
@@ -898,6 +899,7 @@ impl Prepared {
                             } else {
                                 input.smooth_scroll_delta[d] = 0.0;
                             }
+                            input.force_current_scroll_area = false;
                         });
 
                         state.scroll_stuck_to_end[d] = false;

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -782,15 +782,21 @@ impl Prepared {
 
         let content_size = content_ui.min_size();
 
+        let scroll_delta = content_ui
+            .ctx()
+            .frame_state_mut(|state| std::mem::take(&mut state.scroll_delta));
+
         for d in 0..2 {
+            let mut delta = scroll_delta[d];
+
             // We always take both scroll targets regardless of which scroll axes are enabled. This
             // is to avoid them leaking to other scroll areas.
-            let (scroll_target, scroll_delta) = content_ui.ctx().frame_state_mut(|state| {
-                (state.scroll_target[d].take(), state.scroll_delta[d].take())
-            });
+            let scroll_target = content_ui
+                .ctx()
+                .frame_state_mut(|state| state.scroll_target[d].take());
 
             if scroll_enabled[d] {
-                let mut delta = if let Some((target_range, align)) = scroll_target {
+                delta += if let Some((target_range, align)) = scroll_target {
                     let min = content_ui.min_rect().min[d];
                     let clip_rect = content_ui.clip_rect();
                     let visible_range = min..=min + clip_rect.size()[d];
@@ -820,10 +826,6 @@ impl Prepared {
                 } else {
                     0.0
                 };
-
-                if let Some(scroll_delta) = scroll_delta {
-                    delta += scroll_delta;
-                }
 
                 if delta != 0.0 {
                     let target_offset = state.offset[d] + delta;

--- a/crates/egui/src/frame_state.rs
+++ b/crates/egui/src/frame_state.rs
@@ -41,8 +41,8 @@ pub(crate) struct FrameState {
     /// The current scroll area should scroll to this range (horizontal, vertical).
     pub(crate) scroll_target: [Option<(Rangef, Option<Align>)>; 2],
 
-    /// The current scroll area should scroll by this much (horizontal, vertical).
-    pub(crate) scroll_delta: [Option<f32>; 2],
+    /// The current scroll area should scroll by this much.
+    pub(crate) scroll_delta: Vec2,
 
     #[cfg(feature = "accesskit")]
     pub(crate) accesskit_state: Option<AccessKitFrameState>,
@@ -66,7 +66,7 @@ impl Default for FrameState {
             used_by_panels: Rect::NAN,
             tooltip_state: None,
             scroll_target: [None, None],
-            scroll_delta: [None, None],
+            scroll_delta: Vec2::default(),
             #[cfg(feature = "accesskit")]
             accesskit_state: None,
             highlight_this_frame: Default::default(),
@@ -104,7 +104,7 @@ impl FrameState {
         *used_by_panels = Rect::NOTHING;
         *tooltip_state = None;
         *scroll_target = [None, None];
-        *scroll_delta = [None, None];
+        *scroll_delta = Vec2::default();
 
         #[cfg(debug_assertions)]
         {

--- a/crates/egui/src/frame_state.rs
+++ b/crates/egui/src/frame_state.rs
@@ -38,8 +38,11 @@ pub(crate) struct FrameState {
     /// Initialized to `None` at the start of each frame.
     pub(crate) tooltip_state: Option<TooltipFrameState>,
 
-    /// horizontal, vertical
+    /// The current scroll area should scroll to this range (horizontal, vertical).
     pub(crate) scroll_target: [Option<(Rangef, Option<Align>)>; 2],
+
+    /// The current scroll area should scroll by this much (horizontal, vertical).
+    pub(crate) scroll_delta: [Option<f32>; 2],
 
     #[cfg(feature = "accesskit")]
     pub(crate) accesskit_state: Option<AccessKitFrameState>,
@@ -63,6 +66,7 @@ impl Default for FrameState {
             used_by_panels: Rect::NAN,
             tooltip_state: None,
             scroll_target: [None, None],
+            scroll_delta: [None, None],
             #[cfg(feature = "accesskit")]
             accesskit_state: None,
             highlight_this_frame: Default::default(),
@@ -84,6 +88,7 @@ impl FrameState {
             used_by_panels,
             tooltip_state,
             scroll_target,
+            scroll_delta,
             #[cfg(feature = "accesskit")]
             accesskit_state,
             highlight_this_frame,
@@ -99,6 +104,7 @@ impl FrameState {
         *used_by_panels = Rect::NOTHING;
         *tooltip_state = None;
         *scroll_target = [None, None];
+        *scroll_delta = [None, None];
 
         #[cfg(debug_assertions)]
         {

--- a/crates/egui/src/frame_state.rs
+++ b/crates/egui/src/frame_state.rs
@@ -42,6 +42,14 @@ pub(crate) struct FrameState {
     pub(crate) scroll_target: [Option<(Rangef, Option<Align>)>; 2],
 
     /// The current scroll area should scroll by this much.
+    ///
+    /// The delta dictates how the _content_ should move.
+    ///
+    /// A positive X-value indicates the content is being moved right,
+    /// as when swiping right on a touch-screen or track-pad with natural scrolling.
+    ///
+    /// A positive Y-value indicates the content is being moved down,
+    /// as when swiping down on a touch-screen or track-pad with natural scrolling.
     pub(crate) scroll_delta: Vec2,
 
     #[cfg(feature = "accesskit")]

--- a/crates/egui/src/input_state.rs
+++ b/crates/egui/src/input_state.rs
@@ -70,10 +70,6 @@ pub struct InputState {
     /// at the end of the frame this will be zero if a scroll-area consumed the delta.
     pub smooth_scroll_delta: Vec2,
 
-    /// Force the current scroll area to consume the [Self::smooth_scroll_delta], independent of the focus / mouse position.
-    /// This is used when using [crate::Ui::scroll_with_delta] to scroll the current scroll area.
-    pub(crate) force_current_scroll_area: bool,
-
     /// Zoom scale factor this frame (e.g. from ctrl-scroll or pinch gesture).
     ///
     /// * `zoom = 1`: no change.
@@ -158,7 +154,6 @@ impl Default for InputState {
             unprocessed_scroll_delta: Vec2::ZERO,
             raw_scroll_delta: Vec2::ZERO,
             smooth_scroll_delta: Vec2::ZERO,
-            force_current_scroll_area: false,
             zoom_factor_delta: 1.0,
             screen_rect: Rect::from_min_size(Default::default(), vec2(10_000.0, 10_000.0)),
             pixels_per_point: 1.0,
@@ -260,7 +255,6 @@ impl InputState {
             unprocessed_scroll_delta,
             raw_scroll_delta,
             smooth_scroll_delta,
-            force_current_scroll_area: false,
             zoom_factor_delta,
             screen_rect,
             pixels_per_point,
@@ -1119,7 +1113,6 @@ impl InputState {
             unprocessed_scroll_delta,
             raw_scroll_delta,
             smooth_scroll_delta,
-            force_current_scroll_area,
 
             zoom_factor_delta,
             screen_rect,
@@ -1163,9 +1156,6 @@ impl InputState {
         ui.label(format!("raw_scroll_delta: {raw_scroll_delta:?} points"));
         ui.label(format!(
             "smooth_scroll_delta: {smooth_scroll_delta:?} points"
-        ));
-        ui.label(format!(
-            "force_current_scroll_area: {force_current_scroll_area}"
         ));
         ui.label(format!("zoom_factor_delta: {zoom_factor_delta:4.2}x"));
         ui.label(format!("screen_rect: {screen_rect:?} points"));

--- a/crates/egui/src/input_state.rs
+++ b/crates/egui/src/input_state.rs
@@ -70,6 +70,10 @@ pub struct InputState {
     /// at the end of the frame this will be zero if a scroll-area consumed the delta.
     pub smooth_scroll_delta: Vec2,
 
+    /// Force the current scroll area to consume the [Self::smooth_scroll_delta], independent of the focus / mouse position.
+    /// This is used when using [crate::Ui::scroll_with_delta] to scroll the current scroll area.
+    pub(crate) force_current_scroll_area: bool,
+
     /// Zoom scale factor this frame (e.g. from ctrl-scroll or pinch gesture).
     ///
     /// * `zoom = 1`: no change.
@@ -154,6 +158,7 @@ impl Default for InputState {
             unprocessed_scroll_delta: Vec2::ZERO,
             raw_scroll_delta: Vec2::ZERO,
             smooth_scroll_delta: Vec2::ZERO,
+            force_current_scroll_area: false,
             zoom_factor_delta: 1.0,
             screen_rect: Rect::from_min_size(Default::default(), vec2(10_000.0, 10_000.0)),
             pixels_per_point: 1.0,
@@ -255,6 +260,7 @@ impl InputState {
             unprocessed_scroll_delta,
             raw_scroll_delta,
             smooth_scroll_delta,
+            force_current_scroll_area: false,
             zoom_factor_delta,
             screen_rect,
             pixels_per_point,
@@ -1113,6 +1119,7 @@ impl InputState {
             unprocessed_scroll_delta,
             raw_scroll_delta,
             smooth_scroll_delta,
+            force_current_scroll_area,
 
             zoom_factor_delta,
             screen_rect,
@@ -1156,6 +1163,9 @@ impl InputState {
         ui.label(format!("raw_scroll_delta: {raw_scroll_delta:?} points"));
         ui.label(format!(
             "smooth_scroll_delta: {smooth_scroll_delta:?} points"
+        ));
+        ui.label(format!(
+            "force_current_scroll_area: {force_current_scroll_area}"
         ));
         ui.label(format!("zoom_factor_delta: {zoom_factor_delta:4.2}x"));
         ui.label(format!("screen_rect: {screen_rect:?} points"));

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1092,7 +1092,7 @@ impl Ui {
     /// ```
     pub fn scroll_with_delta(&self, delta: Vec2) {
         self.ctx().frame_state_mut(|state| {
-            state.scroll_delta = [Some(delta.x), Some(delta.y)];
+            state.scroll_delta = delta;
         });
     }
 }

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1073,6 +1073,8 @@ impl Ui {
     /// A positive Y-value indicates the content is being moved down,
     /// as when swiping down on a touch-screen or track-pad with natural scrolling.
     ///
+    /// If this is called multiple times per frame for the same ScrollArea, the deltas will be combined.
+    ///
     /// /// See also: [`Response::scroll_to_me`], [`Ui::scroll_to_rect`], [`Ui::scroll_to_cursor`]
     ///
     /// ```
@@ -1092,7 +1094,7 @@ impl Ui {
     /// ```
     pub fn scroll_with_delta(&self, delta: Vec2) {
         self.ctx().frame_state_mut(|state| {
-            state.scroll_delta = delta;
+            state.scroll_delta += delta;
         });
     }
 }

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1073,7 +1073,7 @@ impl Ui {
     /// A positive Y-value indicates the content is being moved down,
     /// as when swiping down on a touch-screen or track-pad with natural scrolling.
     ///
-    /// If this is called multiple times per frame for the same ScrollArea, the deltas will be combined.
+    /// If this is called multiple times per frame for the same [`ScrollArea`], the deltas will be combined.
     ///
     /// /// See also: [`Response::scroll_to_me`], [`Ui::scroll_to_rect`], [`Ui::scroll_to_cursor`]
     ///

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1091,8 +1091,10 @@ impl Ui {
     /// # });
     /// ```
     pub fn scroll_with_delta(&self, delta: Vec2) {
-        self.ctx()
-            .input_mut(|input| input.smooth_scroll_delta += delta);
+        self.ctx().input_mut(|input| {
+            input.smooth_scroll_delta += delta;
+            input.force_current_scroll_area = true;
+        });
     }
 }
 

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1073,7 +1073,7 @@ impl Ui {
     /// A positive Y-value indicates the content is being moved down,
     /// as when swiping down on a touch-screen or track-pad with natural scrolling.
     ///
-    /// If this is called multiple times per frame for the same [`ScrollArea`], the deltas will be combined.
+    /// If this is called multiple times per frame for the same [`ScrollArea`], the deltas will be summed.
     ///
     /// /// See also: [`Response::scroll_to_me`], [`Ui::scroll_to_rect`], [`Ui::scroll_to_cursor`]
     ///

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1091,9 +1091,8 @@ impl Ui {
     /// # });
     /// ```
     pub fn scroll_with_delta(&self, delta: Vec2) {
-        self.ctx().input_mut(|input| {
-            input.smooth_scroll_delta += delta;
-            input.force_current_scroll_area = true;
+        self.ctx().frame_state_mut(|state| {
+            state.scroll_delta = [Some(delta.x), Some(delta.y)];
         });
     }
 }

--- a/crates/egui_demo_lib/src/demo/scrolling.rs
+++ b/crates/egui_demo_lib/src/demo/scrolling.rs
@@ -294,7 +294,7 @@ impl super::View for ScrollTo {
             scroll_top |= ui.button("Scroll to top").clicked();
             scroll_bottom |= ui.button("Scroll to bottom").clicked();
             if ui.button("Scroll down by 64px").clicked() {
-                scroll_delta = Some(Vec2::new(0.0, -64.0));
+                scroll_delta = Some(Vec2::new(0.0, 64.0));
             }
         });
 

--- a/crates/egui_demo_lib/src/demo/scrolling.rs
+++ b/crates/egui_demo_lib/src/demo/scrolling.rs
@@ -294,7 +294,7 @@ impl super::View for ScrollTo {
             scroll_top |= ui.button("Scroll to top").clicked();
             scroll_bottom |= ui.button("Scroll to bottom").clicked();
             if ui.button("Scroll down by 64px").clicked() {
-                scroll_delta = Some(Vec2::new(0.0, 64.0));
+                scroll_delta = Some(Vec2::new(0.0, -64.0));
             }
         });
 

--- a/crates/egui_demo_lib/src/demo/scrolling.rs
+++ b/crates/egui_demo_lib/src/demo/scrolling.rs
@@ -258,6 +258,7 @@ impl super::View for ScrollTo {
         let mut go_to_scroll_offset = false;
         let mut scroll_top = false;
         let mut scroll_bottom = false;
+        let mut scroll_delta = None;
 
         ui.horizontal(|ui| {
             ui.label("Scroll to a specific item index:");
@@ -292,6 +293,9 @@ impl super::View for ScrollTo {
         ui.horizontal(|ui| {
             scroll_top |= ui.button("Scroll to top").clicked();
             scroll_bottom |= ui.button("Scroll to bottom").clicked();
+            if ui.button("Scroll down by 64px").clicked() {
+                scroll_delta = Some(Vec2::new(0.0, -64.0));
+            }
         });
 
         let mut scroll_area = ScrollArea::vertical().max_height(200.0).auto_shrink(false);
@@ -305,6 +309,10 @@ impl super::View for ScrollTo {
                 if scroll_top {
                     ui.scroll_to_cursor(Some(Align::TOP));
                 }
+                if let Some(scroll_delta) = scroll_delta {
+                    ui.scroll_with_delta(scroll_delta);
+                }
+
                 ui.vertical(|ui| {
                     for item in 1..=num_items {
                         if track_item && item == self.track_item {

--- a/crates/egui_demo_lib/src/demo/scrolling.rs
+++ b/crates/egui_demo_lib/src/demo/scrolling.rs
@@ -294,7 +294,7 @@ impl super::View for ScrollTo {
             scroll_top |= ui.button("Scroll to top").clicked();
             scroll_bottom |= ui.button("Scroll to bottom").clicked();
             if ui.button("Scroll down by 64px").clicked() {
-                scroll_delta = Some(Vec2::new(0.0, -64.0));
+                scroll_delta = Some(64.0 * Vec2::UP); // move contents up
             }
         });
 

--- a/crates/egui_demo_lib/src/demo/scrolling.rs
+++ b/crates/egui_demo_lib/src/demo/scrolling.rs
@@ -236,6 +236,7 @@ struct ScrollTo {
     track_item: usize,
     tack_item_align: Option<Align>,
     offset: f32,
+    delta: f32,
 }
 
 impl Default for ScrollTo {
@@ -244,6 +245,7 @@ impl Default for ScrollTo {
             track_item: 25,
             tack_item_align: Some(Align::Center),
             offset: 0.0,
+            delta: 64.0,
         }
     }
 }
@@ -293,8 +295,19 @@ impl super::View for ScrollTo {
         ui.horizontal(|ui| {
             scroll_top |= ui.button("Scroll to top").clicked();
             scroll_bottom |= ui.button("Scroll to bottom").clicked();
-            if ui.button("Scroll down by 64px").clicked() {
-                scroll_delta = Some(64.0 * Vec2::UP); // move contents up
+        });
+
+        ui.horizontal(|ui| {
+            ui.label("Scroll by");
+            DragValue::new(&mut self.delta)
+                .speed(1.0)
+                .suffix("px")
+                .ui(ui);
+            if ui.button("⬇").clicked() {
+                scroll_delta = Some(self.delta * Vec2::UP); // scroll down (move contents up)
+            }
+            if ui.button("⬆").clicked() {
+                scroll_delta = Some(self.delta * Vec2::DOWN); // scroll up (move contents down)
             }
         });
 


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

This introduces the boolean field force_current_scroll_area to InputState which will be set when scroll_with_delta is called, causing the ScrollArea to skip the check whether it is focused and always consume the smooth scroll delta.

* Closes #2783 
* Related to #4295 
