### PR TITLE
Release 0.27.2 - bug fixes

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -3,7 +3,9 @@
 # run:      typos
 
 [default.extend-words]
+ime = "ime"       # Input Method Editor
 nknown = "nknown" # part of @55nknown username
+ro = "ro"         # read-only, also part of the username @Phen-Ro
 
 [files]
 extend-exclude = ["web_demo/egui_demo_app.js"] # auto-generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.2 - 2024-04-02
+### 🐛 Fixed
+* Fix tooltips for non-interactive widgets [#4291](https://github.com/emilk/egui/pull/4291)
+* Fix problem clicking the edge of a `TextEdit` [#4272](https://github.com/emilk/egui/pull/4272)
+* Fix: `Response::clicked_elsewhere` takes clip rect into account [#4274](https://github.com/emilk/egui/pull/4274)
+* Fix incorrect `Response::interact_rect` for `Area/Window` [#4273](https://github.com/emilk/egui/pull/4273)
+
+### ⭐ Added
+* Allow disabling animations on a `ScrollArea` [#4309](https://github.com/emilk/egui/pull/4309) (thanks [@lucasmerlin](https://github.com/lucasmerlin)!)
+
+
 ## 0.27.1 - 2024-03-29
 ### 🐛 Fixed
 * Fix visual glitch on the right side of highly rounded rectangles [#4244](https://github.com/emilk/egui/pull/4244)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.1 - 2024-03-29
+### 🐛 Fixed
+* Fix visual glitch on the right side of highly rounded rectangles [#4244](https://github.com/emilk/egui/pull/4244)
+* Prevent visual glitch when shadow blur width is very high [#4245](https://github.com/emilk/egui/pull/4245)
+* Fix `InputState::any_touches` and add `InputState::has_touch_screen` [#4247](https://github.com/emilk/egui/pull/4247)
+* Fix `Context::repaint_causes` returning no causes [#4248](https://github.com/emilk/egui/pull/4248)
+* Fix touch-and-hold to open context menu [#4249](https://github.com/emilk/egui/pull/4249)
+* Hide shortcut text on zoom buttons if `zoom_with_keyboard` is false [#4262](https://github.com/emilk/egui/pull/4262)
+
+### 🔧 Changed
+* Don't apply a clip rect to the contents of an `Area` or `Window` [#4258](https://github.com/emilk/egui/pull/4258)
+
+
 ## 0.27.0 - 2024-03-26 - Nicer menus and new hit test logic
 The hit test logic (what is the user clicking on?) has been completely rewritten, and should now be much more accurate and helpful.
 The hit test and interaction logic is run at the start of the frame, using the widgets rects from the previous frame, but the latest mouse coordinates.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,7 +1187,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "ecolor"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "bytemuck",
  "cint",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "egui_demo_app"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "bytemuck",
  "chrono",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "egui_demo_lib"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "chrono",
  "criterion",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "chrono",
  "document-features",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "egui_plot"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "document-features",
  "egui",
@@ -1394,7 +1394,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "emath"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,7 +1187,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "ecolor"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bytemuck",
  "cint",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "egui_demo_app"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bytemuck",
  "chrono",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "egui_demo_lib"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "chrono",
  "criterion",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "chrono",
  "document-features",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "egui_plot"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "document-features",
  "egui",
@@ -1394,7 +1394,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "emath"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.72"
-version = "0.27.1"
+version = "0.27.2"
 
 
 [profile.release]
@@ -48,17 +48,17 @@ opt-level = 2
 
 
 [workspace.dependencies]
-emath = { version = "0.27.1", path = "crates/emath", default-features = false }
-ecolor = { version = "0.27.1", path = "crates/ecolor", default-features = false }
-epaint = { version = "0.27.1", path = "crates/epaint", default-features = false }
-egui = { version = "0.27.1", path = "crates/egui", default-features = false }
-egui_plot = { version = "0.27.1", path = "crates/egui_plot", default-features = false }
-egui-winit = { version = "0.27.1", path = "crates/egui-winit", default-features = false }
-egui_extras = { version = "0.27.1", path = "crates/egui_extras", default-features = false }
-egui-wgpu = { version = "0.27.1", path = "crates/egui-wgpu", default-features = false }
-egui_demo_lib = { version = "0.27.1", path = "crates/egui_demo_lib", default-features = false }
-egui_glow = { version = "0.27.1", path = "crates/egui_glow", default-features = false }
-eframe = { version = "0.27.1", path = "crates/eframe", default-features = false }
+emath = { version = "0.27.2", path = "crates/emath", default-features = false }
+ecolor = { version = "0.27.2", path = "crates/ecolor", default-features = false }
+epaint = { version = "0.27.2", path = "crates/epaint", default-features = false }
+egui = { version = "0.27.2", path = "crates/egui", default-features = false }
+egui_plot = { version = "0.27.2", path = "crates/egui_plot", default-features = false }
+egui-winit = { version = "0.27.2", path = "crates/egui-winit", default-features = false }
+egui_extras = { version = "0.27.2", path = "crates/egui_extras", default-features = false }
+egui-wgpu = { version = "0.27.2", path = "crates/egui-wgpu", default-features = false }
+egui_demo_lib = { version = "0.27.2", path = "crates/egui_demo_lib", default-features = false }
+egui_glow = { version = "0.27.2", path = "crates/egui_glow", default-features = false }
+eframe = { version = "0.27.2", path = "crates/eframe", default-features = false }
 
 #TODO(emilk): make more things workspace dependencies
 ahash = { version = "0.8.6", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.72"
-version = "0.27.0"
+version = "0.27.1"
 
 
 [profile.release]
@@ -48,17 +48,17 @@ opt-level = 2
 
 
 [workspace.dependencies]
-emath = { version = "0.27.0", path = "crates/emath", default-features = false }
-ecolor = { version = "0.27.0", path = "crates/ecolor", default-features = false }
-epaint = { version = "0.27.0", path = "crates/epaint", default-features = false }
-egui = { version = "0.27.0", path = "crates/egui", default-features = false }
-egui_plot = { version = "0.27.0", path = "crates/egui_plot", default-features = false }
-egui-winit = { version = "0.27.0", path = "crates/egui-winit", default-features = false }
-egui_extras = { version = "0.27.0", path = "crates/egui_extras", default-features = false }
-egui-wgpu = { version = "0.27.0", path = "crates/egui-wgpu", default-features = false }
-egui_demo_lib = { version = "0.27.0", path = "crates/egui_demo_lib", default-features = false }
-egui_glow = { version = "0.27.0", path = "crates/egui_glow", default-features = false }
-eframe = { version = "0.27.0", path = "crates/eframe", default-features = false }
+emath = { version = "0.27.1", path = "crates/emath", default-features = false }
+ecolor = { version = "0.27.1", path = "crates/ecolor", default-features = false }
+epaint = { version = "0.27.1", path = "crates/epaint", default-features = false }
+egui = { version = "0.27.1", path = "crates/egui", default-features = false }
+egui_plot = { version = "0.27.1", path = "crates/egui_plot", default-features = false }
+egui-winit = { version = "0.27.1", path = "crates/egui-winit", default-features = false }
+egui_extras = { version = "0.27.1", path = "crates/egui_extras", default-features = false }
+egui-wgpu = { version = "0.27.1", path = "crates/egui-wgpu", default-features = false }
+egui_demo_lib = { version = "0.27.1", path = "crates/egui_demo_lib", default-features = false }
+egui_glow = { version = "0.27.1", path = "crates/egui_glow", default-features = false }
+eframe = { version = "0.27.1", path = "crates/eframe", default-features = false }
 
 #TODO(emilk): make more things workspace dependencies
 ahash = { version = "0.8.6", default-features = false, features = [

--- a/crates/ecolor/CHANGELOG.md
+++ b/crates/ecolor/CHANGELOG.md
@@ -6,6 +6,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.2 - 2024-04-02
+* Nothing new
+
+
 ## 0.27.1 - 2024-03-29
 * Nothing new
 

--- a/crates/ecolor/CHANGELOG.md
+++ b/crates/ecolor/CHANGELOG.md
@@ -6,6 +6,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.1 - 2024-03-29
+* Nothing new
+
+
 ## 0.27.0 - 2024-03-26
 * Nothing new
 

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -7,6 +7,16 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.2 - 2024-04-02
+#### Desktop/Native
+* Fix continuous repaint on Wayland when TextEdit is focused or IME output is set [#4269](https://github.com/emilk/egui/pull/4269) (thanks [@white-axe](https://github.com/white-axe)!)
+* Remove a bunch of `unwrap()` [#4285](https://github.com/emilk/egui/pull/4285)
+
+#### Web
+* Fix blurry rendering in some browsers [#4299](https://github.com/emilk/egui/pull/4299)
+* Correctly identify if the browser tab has focus [#4280](https://github.com/emilk/egui/pull/4280)
+
+
 ## 0.27.1 - 2024-03-29
 * Web: repaint if the `#hash` in the URL changes [#4261](https://github.com/emilk/egui/pull/4261)
 * Add web support for `zoom_factor` [#4260](https://github.com/emilk/egui/pull/4260) (thanks [@justusdieckmann](https://github.com/justusdieckmann)!)

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -7,6 +7,11 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.1 - 2024-03-29
+* Web: repaint if the `#hash` in the URL changes [#4261](https://github.com/emilk/egui/pull/4261)
+* Add web support for `zoom_factor` [#4260](https://github.com/emilk/egui/pull/4260) (thanks [@justusdieckmann](https://github.com/justusdieckmann)!)
+
+
 ## 0.27.0 - 2024-03-26
 * Update to document-features 0.2.8 [#4003](https://github.com/emilk/egui/pull/4003)
 * Added `App::raw_input_hook` allows for the manipulation or filtering of raw input events [#4008](https://github.com/emilk/egui/pull/4008) (thanks [@varphone](https://github.com/varphone)!)

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -7,7 +7,7 @@
 
 #![allow(clippy::arc_with_non_send_sync)] // glow::Context was accidentally non-Sync in glow 0.13, but that will be fixed in future releases of glow: https://github.com/grovesNL/glow/commit/c4a5f7151b9b4bbb380faa06ec27415235d1bf7e
 
-use std::{cell::RefCell, rc::Rc, sync::Arc, time::Instant};
+use std::{cell::RefCell, num::NonZeroU32, rc::Rc, sync::Arc, time::Instant};
 
 use glutin::{
     config::GlConfig,
@@ -22,9 +22,9 @@ use winit::{
 };
 
 use egui::{
-    epaint::ahash::HashMap, DeferredViewportUiCallback, ImmediateViewport, NumExt as _,
-    ViewportBuilder, ViewportClass, ViewportId, ViewportIdMap, ViewportIdPair, ViewportIdSet,
-    ViewportInfo, ViewportOutput,
+    epaint::ahash::HashMap, DeferredViewportUiCallback, ImmediateViewport, ViewportBuilder,
+    ViewportClass, ViewportId, ViewportIdMap, ViewportIdPair, ViewportIdSet, ViewportInfo,
+    ViewportOutput,
 };
 #[cfg(feature = "accesskit")]
 use egui_winit::accesskit_winit;
@@ -252,7 +252,7 @@ impl GlowWinitApp {
         #[cfg(feature = "accesskit")]
         {
             let event_loop_proxy = self.repaint_proxy.lock().clone();
-            let viewport = glutin.viewports.get_mut(&ViewportId::ROOT).unwrap();
+            let viewport = glutin.viewports.get_mut(&ViewportId::ROOT).unwrap(); // we always have a root
             if let Viewport {
                 window: Some(window),
                 egui_winit: Some(egui_winit),
@@ -544,13 +544,17 @@ impl GlowWinitRunning {
         let (raw_input, viewport_ui_cb) = {
             let mut glutin = self.glutin.borrow_mut();
             let egui_ctx = glutin.egui_ctx.clone();
-            let viewport = glutin.viewports.get_mut(&viewport_id).unwrap();
+            let Some(viewport) = glutin.viewports.get_mut(&viewport_id) else {
+                return EventResult::Wait;
+            };
             let Some(window) = viewport.window.as_ref() else {
                 return EventResult::Wait;
             };
             egui_winit::update_viewport_info(&mut viewport.info, &egui_ctx, window);
 
-            let egui_winit = viewport.egui_winit.as_mut().unwrap();
+            let Some(egui_winit) = viewport.egui_winit.as_mut() else {
+                return EventResult::Wait;
+            };
             let mut raw_input = egui_winit.take_egui_input(window);
             let viewport_ui_cb = viewport.viewport_ui_cb.clone();
 
@@ -583,8 +587,12 @@ impl GlowWinitRunning {
                 ..
             } = &mut *glutin;
             let viewport = &viewports[&viewport_id];
-            let window = viewport.window.as_ref().unwrap();
-            let gl_surface = viewport.gl_surface.as_ref().unwrap();
+            let Some(window) = viewport.window.as_ref() else {
+                return EventResult::Wait;
+            };
+            let Some(gl_surface) = viewport.gl_surface.as_ref() else {
+                return EventResult::Wait;
+            };
 
             let screen_size_in_pixels: [u32; 2] = window.inner_size().into();
 
@@ -634,7 +642,9 @@ impl GlowWinitRunning {
             ..
         } = &mut *glutin;
 
-        let viewport = viewports.get_mut(&viewport_id).unwrap();
+        let Some(viewport) = viewports.get_mut(&viewport_id) else {
+            return EventResult::Wait;
+        };
         viewport.info.events.clear(); // they should have been processed
         let window = viewport.window.clone().unwrap();
         let gl_surface = viewport.gl_surface.as_ref().unwrap();
@@ -865,7 +875,7 @@ impl GlutinWindowContext {
             crate::HardwareAcceleration::Off => Some(false),
         };
         let swap_interval = if native_options.vsync {
-            glutin::surface::SwapInterval::Wait(std::num::NonZeroU32::new(1).unwrap())
+            glutin::surface::SwapInterval::Wait(NonZeroU32::MIN)
         } else {
             glutin::surface::SwapInterval::DontWait
         };
@@ -1089,8 +1099,8 @@ impl GlutinWindowContext {
 
             // surface attributes
             let (width_px, height_px): (u32, u32) = window.inner_size().into();
-            let width_px = std::num::NonZeroU32::new(width_px.at_least(1)).unwrap();
-            let height_px = std::num::NonZeroU32::new(height_px.at_least(1)).unwrap();
+            let width_px = NonZeroU32::new(width_px).unwrap_or(NonZeroU32::MIN);
+            let height_px = NonZeroU32::new(height_px).unwrap_or(NonZeroU32::MIN);
             let surface_attributes = {
                 use rwh_05::HasRawWindowHandle as _; // glutin stuck on old version of raw-window-handle
                 glutin::surface::SurfaceAttributesBuilder::<glutin::surface::WindowSurface>::new()
@@ -1169,8 +1179,8 @@ impl GlutinWindowContext {
     }
 
     fn resize(&mut self, viewport_id: ViewportId, physical_size: winit::dpi::PhysicalSize<u32>) {
-        let width_px = std::num::NonZeroU32::new(physical_size.width.at_least(1)).unwrap();
-        let height_px = std::num::NonZeroU32::new(physical_size.height.at_least(1)).unwrap();
+        let width_px = NonZeroU32::new(physical_size.width).unwrap_or(NonZeroU32::MIN);
+        let height_px = NonZeroU32::new(physical_size.height).unwrap_or(NonZeroU32::MIN);
 
         if let Some(viewport) = self.viewports.get(&viewport_id) {
             if let Some(gl_surface) = &viewport.gl_surface {

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -707,7 +707,7 @@ impl GlowWinitRunning {
         #[cfg(feature = "__screenshot")]
         if integration.egui_ctx.frame_nr() == 2 {
             if let Ok(path) = std::env::var("EFRAME_SCREENSHOT_TO") {
-                save_screeshot_and_exit(&path, &painter, screen_size_in_pixels);
+                save_screenshot_and_exit(&path, &painter, screen_size_in_pixels);
             }
         }
 
@@ -1491,7 +1491,7 @@ fn render_immediate_viewport(
 }
 
 #[cfg(feature = "__screenshot")]
-fn save_screeshot_and_exit(
+fn save_screenshot_and_exit(
     path: &str,
     painter: &egui_glow::Painter,
     screen_size_in_pixels: [u32; 2],

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -5,7 +5,7 @@
 //! There is a bunch of improvements we could do,
 //! like removing a bunch of `unwraps`.
 
-use std::{cell::RefCell, rc::Rc, sync::Arc, time::Instant};
+use std::{cell::RefCell, num::NonZeroU32, rc::Rc, sync::Arc, time::Instant};
 
 use parking_lot::Mutex;
 use raw_window_handle::{HasDisplayHandle as _, HasWindowHandle as _};
@@ -435,13 +435,12 @@ impl WinitApp for WgpuWinitApp {
                     self.init_run_state(egui_ctx, event_loop, storage, window, builder)?
                 };
 
-                EventResult::RepaintNow(
-                    running.shared.borrow().viewports[&ViewportId::ROOT]
-                        .window
-                        .as_ref()
-                        .unwrap()
-                        .id(),
-                )
+                let viewport = &running.shared.borrow().viewports[&ViewportId::ROOT];
+                if let Some(window) = &viewport.window {
+                    EventResult::RepaintNow(window.id())
+                } else {
+                    EventResult::Wait
+                }
             }
 
             winit::event::Event::Suspended => {
@@ -613,7 +612,9 @@ impl WgpuWinitRunning {
                 }
             }
 
-            let egui_winit = egui_winit.as_mut().unwrap();
+            let Some(egui_winit) = egui_winit.as_mut() else {
+                return EventResult::Wait;
+            };
             let mut raw_input = egui_winit.take_egui_input(window);
 
             integration.pre_update();
@@ -773,7 +774,6 @@ impl WgpuWinitRunning {
                 // See: https://github.com/rust-windowing/winit/issues/208
                 // This solves an issue where the app would panic when minimizing on Windows.
                 if let Some(viewport_id) = viewport_id {
-                    use std::num::NonZeroU32;
                     if let (Some(width), Some(height)) = (
                         NonZeroU32::new(physical_size.width),
                         NonZeroU32::new(physical_size.height),

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -60,7 +60,9 @@ impl AppRunner {
         super::storage::load_memory(&egui_ctx);
 
         egui_ctx.options_mut(|o| {
-            // On web, the browser controls the zoom factor:
+            // On web by default egui follows the zoom factor of the browser,
+            // and lets the browser handle the zoom shortscuts.
+            // A user can still zoom egui separately by calling [`egui::Context::set_zoom_factor`].
             o.zoom_with_keyboard = false;
             o.zoom_factor = 1.0;
         });
@@ -183,7 +185,7 @@ impl AppRunner {
     /// The result can be painted later with a call to [`Self::run_and_paint`] or [`Self::paint`].
     pub fn logic(&mut self) {
         super::resize_canvas_to_screen_size(self.canvas(), self.web_options.max_size_points);
-        let canvas_size = super::canvas_size_in_points(self.canvas());
+        let canvas_size = super::canvas_size_in_points(self.canvas(), self.egui_ctx());
         let raw_input = self.input.new_frame(canvas_size);
 
         let full_output = self.egui_ctx.run(raw_input, |egui_ctx| {

--- a/crates/eframe/src/web/backend.rs
+++ b/crates/eframe/src/web/backend.rs
@@ -36,8 +36,10 @@ impl WebInput {
         raw_input
     }
 
+    /// On alt-tab and similar.
     pub fn on_web_page_focus_change(&mut self, focused: bool) {
-        self.raw.modifiers = egui::Modifiers::default();
+        // log::debug!("on_web_page_focus_change: {focused}");
+        self.raw.modifiers = egui::Modifiers::default(); // Avoid sticky modifier keys on alt-tab:
         self.raw.focused = focused;
         self.raw.events.push(egui::Event::WindowFocused(focused));
         self.latest_touch_pos = None;

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -242,6 +242,7 @@ pub(crate) fn install_window_events(runner_ref: &WebRunner) -> Result<(), JsValu
     runner_ref.add_event_listener(&window, "hashchange", |_: web_sys::Event, runner| {
         // `epi::Frame::info(&self)` clones `epi::IntegrationInfo`, but we need to modify the original here
         runner.frame.info.web_info.location.hash = location_hash();
+        runner.needs_repaint.repaint_asap(); // tell the user about the new hash
     })?;
 
     Ok(())

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -116,8 +116,8 @@ fn canvas_origin(canvas: &web_sys::HtmlCanvasElement) -> egui::Pos2 {
     egui::pos2(rect.left() as f32, rect.top() as f32)
 }
 
-fn canvas_size_in_points(canvas: &web_sys::HtmlCanvasElement) -> egui::Vec2 {
-    let pixels_per_point = native_pixels_per_point();
+fn canvas_size_in_points(canvas: &web_sys::HtmlCanvasElement, ctx: &egui::Context) -> egui::Vec2 {
+    let pixels_per_point = ctx.pixels_per_point();
     egui::vec2(
         canvas.width() as f32 / pixels_per_point,
         canvas.height() as f32 / pixels_per_point,

--- a/crates/egui-wgpu/CHANGELOG.md
+++ b/crates/egui-wgpu/CHANGELOG.md
@@ -6,6 +6,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.2 - 2024-04-02
+* Nothing new
+
+
 ## 0.27.1 - 2024-03-29
 * Nothing new
 

--- a/crates/egui-wgpu/CHANGELOG.md
+++ b/crates/egui-wgpu/CHANGELOG.md
@@ -6,6 +6,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.1 - 2024-03-29
+* Nothing new
+
+
 ## 0.27.0 - 2024-03-26
 * Improve panic message in egui-wgpu when failing to create buffers [#3986](https://github.com/emilk/egui/pull/3986)
 

--- a/crates/egui-winit/CHANGELOG.md
+++ b/crates/egui-winit/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.2 - 2024-04-02
+* Fix continuous repaint on Wayland when TextEdit is focused or IME output is set [#4269](https://github.com/emilk/egui/pull/4269) (thanks [@white-axe](https://github.com/white-axe)!)
+
+
 ## 0.27.1 - 2024-03-29
 * Nothing new
 

--- a/crates/egui-winit/CHANGELOG.md
+++ b/crates/egui-winit/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.1 - 2024-03-29
+* Nothing new
+
+
 ## 0.27.0 - 2024-03-26
 * Update memoffset to 0.9.0, arboard to 3.3.1, and remove egui_glow's needless dependency on pure_glow's deps  [#4036](https://github.com/emilk/egui/pull/4036) (thanks [@Nopey](https://github.com/Nopey)!)
 * Don't clear modifier state on focus change [#4157](https://github.com/emilk/egui/pull/4157) (thanks [@ming08108](https://github.com/ming08108)!)

--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -355,7 +355,8 @@ impl Area {
         state.set_left_top_pos(ctx.round_pos_to_pixels(state.left_top_pos()));
 
         // Update responsbe with posisbly moved/constrained rect:
-        move_response = move_response.with_new_rect(state.rect());
+        move_response.rect = state.rect();
+        move_response.interact_rect = state.rect();
 
         Prepared {
             layer_id,

--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -384,7 +384,7 @@ impl Area {
         let layer_id = LayerId::new(self.order, self.id);
         let area_rect = ctx.memory(|mem| mem.areas().get(self.id).map(|area| area.rect()));
         if let Some(area_rect) = area_rect {
-            let clip_rect = ctx.available_rect();
+            let clip_rect = Rect::EVERYTHING;
             let painter = Painter::new(ctx.clone(), layer_id, clip_rect);
 
             // shrinkage: looks kinda a bad on its own
@@ -437,12 +437,7 @@ impl Prepared {
                 .at_least(self.state.left_top_pos() + Vec2::splat(32.0)),
         );
 
-        let shadow_radius = ctx.style().visuals.window_shadow.margin().sum().max_elem(); // hacky
-        let clip_rect_margin = ctx.style().visuals.clip_rect_margin.max(shadow_radius);
-
-        let clip_rect = Rect::from_min_max(self.state.left_top_pos(), constrain_rect.max)
-            .expand(clip_rect_margin)
-            .intersect(constrain_rect);
+        let clip_rect = constrain_rect; // Don't paint outside our bounds
 
         let mut ui = Ui::new(
             ctx.clone(),

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -176,6 +176,9 @@ pub struct ScrollArea {
     /// end position until user manually changes position. It will become true
     /// again once scroll handle makes contact with end.
     stick_to_end: Vec2b,
+
+    /// If false, `scroll_to_*` functions will not be animated
+    animated: bool,
 }
 
 impl ScrollArea {
@@ -219,6 +222,7 @@ impl ScrollArea {
             scrolling_enabled: true,
             drag_to_scroll: true,
             stick_to_end: Vec2b::FALSE,
+            animated: true,
         }
     }
 
@@ -383,6 +387,15 @@ impl ScrollArea {
         self
     }
 
+    /// Should the scroll area animate `scroll_to_*` functions?
+    ///
+    /// Default: `true`.
+    #[inline]
+    pub fn animated(mut self, animated: bool) -> Self {
+        self.animated = animated;
+        self
+    }
+
     /// Is any scrolling enabled?
     pub(crate) fn is_any_scroll_enabled(&self) -> bool {
         self.scroll_enabled[0] || self.scroll_enabled[1]
@@ -449,6 +462,7 @@ struct Prepared {
 
     scrolling_enabled: bool,
     stick_to_end: Vec2b,
+    animated: bool,
 }
 
 impl ScrollArea {
@@ -465,6 +479,7 @@ impl ScrollArea {
             scrolling_enabled,
             drag_to_scroll,
             stick_to_end,
+            animated,
         } = self;
 
         let ctx = ui.ctx().clone();
@@ -640,6 +655,7 @@ impl ScrollArea {
             viewport,
             scrolling_enabled,
             stick_to_end,
+            animated,
         }
     }
 
@@ -751,6 +767,7 @@ impl Prepared {
             viewport: _,
             scrolling_enabled,
             stick_to_end,
+            animated,
         } = self;
 
         let content_size = content_ui.min_size();
@@ -794,7 +811,9 @@ impl Prepared {
                     if delta != 0.0 {
                         let target_offset = state.offset[d] + delta;
 
-                        if let Some(animation) = &mut state.offset_target[d] {
+                        if !animated {
+                            state.offset[d] = target_offset;
+                        } else if let Some(animation) = &mut state.offset_target[d] {
                             // For instance: the user is continuously calling `ui.scroll_to_cursor`,
                             // so we don't want to reset the animation, but perhaps update the target:
                             animation.target_offset = target_offset;

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1113,8 +1113,6 @@ impl Context {
             changed: false,
         };
 
-        let clicked_elsewhere = res.clicked_elsewhere();
-
         self.write(|ctx| {
             let viewport = ctx.viewports.entry(ctx.viewport_id()).or_default();
 
@@ -1157,15 +1155,22 @@ impl Context {
             }
 
             let clicked = Some(id) == viewport.interact_widgets.clicked;
+            let mut any_press = false;
 
             for pointer_event in &input.pointer.pointer_events {
-                if let PointerEvent::Released { click, .. } = pointer_event {
-                    if enabled && sense.click && clicked && click.is_some() {
-                        res.clicked = true;
+                match pointer_event {
+                    PointerEvent::Moved(_) => {}
+                    PointerEvent::Pressed { .. } => {
+                        any_press = true;
                     }
+                    PointerEvent::Released { click, .. } => {
+                        if enabled && sense.click && clicked && click.is_some() {
+                            res.clicked = true;
+                        }
 
-                    res.is_pointer_button_down_on = false;
-                    res.dragged = false;
+                        res.is_pointer_button_down_on = false;
+                        res.dragged = false;
+                    }
                 }
             }
 
@@ -1188,13 +1193,9 @@ impl Context {
                 res.hovered = false;
             }
 
-            if clicked_elsewhere && memory.has_focus(id) {
+            let pointer_pressed_elsewhere = any_press && !res.hovered;
+            if pointer_pressed_elsewhere && memory.has_focus(id) {
                 memory.surrender_focus(id);
-            }
-
-            if res.dragged() && !memory.has_focus(id) {
-                // e.g.: remove focus from a widget when you drag something else
-                memory.stop_text_input();
             }
         });
 

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2777,7 +2777,7 @@ impl Context {
     /// The `Context` lock is held while the given closure is called!
     ///
     /// Returns `None` if acesskit is off.
-    // TODO(emilk): consider making both RO and RW versions
+    // TODO(emilk): consider making both read-only and read-write versions
     #[cfg(feature = "accesskit")]
     pub fn accesskit_node_builder<R>(
         &self,

--- a/crates/egui/src/gui_zoom.rs
+++ b/crates/egui/src/gui_zoom.rs
@@ -70,10 +70,20 @@ pub fn zoom_out(ctx: &Context) {
 ///
 /// This is meant to be called from within a menu (See [`Ui::menu_button`]).
 pub fn zoom_menu_buttons(ui: &mut Ui) {
+    fn button(ctx: &Context, text: &str, shortcut: &KeyboardShortcut) -> Button<'static> {
+        let btn = Button::new(text);
+        let zoom_with_keyboard = ctx.options(|o| o.zoom_with_keyboard);
+        if zoom_with_keyboard {
+            btn.shortcut_text(ctx.format_shortcut(shortcut))
+        } else {
+            btn
+        }
+    }
+
     if ui
         .add_enabled(
             ui.ctx().zoom_factor() < MAX_ZOOM_FACTOR,
-            Button::new("Zoom In").shortcut_text(ui.ctx().format_shortcut(&kb_shortcuts::ZOOM_IN)),
+            button(ui.ctx(), "Zoom In", &kb_shortcuts::ZOOM_IN),
         )
         .clicked()
     {
@@ -84,8 +94,7 @@ pub fn zoom_menu_buttons(ui: &mut Ui) {
     if ui
         .add_enabled(
             ui.ctx().zoom_factor() > MIN_ZOOM_FACTOR,
-            Button::new("Zoom Out")
-                .shortcut_text(ui.ctx().format_shortcut(&kb_shortcuts::ZOOM_OUT)),
+            button(ui.ctx(), "Zoom Out", &kb_shortcuts::ZOOM_OUT),
         )
         .clicked()
     {
@@ -96,8 +105,7 @@ pub fn zoom_menu_buttons(ui: &mut Ui) {
     if ui
         .add_enabled(
             ui.ctx().zoom_factor() != 1.0,
-            Button::new("Reset Zoom")
-                .shortcut_text(ui.ctx().format_shortcut(&kb_shortcuts::ZOOM_RESET)),
+            button(ui.ctx(), "Reset Zoom", &kb_shortcuts::ZOOM_RESET),
         )
         .clicked()
     {

--- a/crates/egui/src/input_state.rs
+++ b/crates/egui/src/input_state.rs
@@ -326,6 +326,10 @@ impl InputState {
         self.pointer.wants_repaint()
             || self.unprocessed_scroll_delta.abs().max_elem() > 0.2
             || !self.events.is_empty()
+
+        // We need to wake up and check for press-and-hold for the context menu.
+        // TODO(emilk): wake up after `MAX_CLICK_DURATION` instead of every frame.
+        || (self.any_touches() && !self.pointer.is_decidedly_dragging())
     }
 
     /// Count presses of a key. If non-zero, the presses are consumed, so that this will only return non-zero once.

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -185,6 +185,12 @@ pub struct Options {
     /// presses Cmd+Plus, Cmd+Minus or Cmd+0, just like in a browser.
     ///
     /// This is `true` by default.
+    ///
+    /// On the web-backend of `eframe` this is set to false by default,
+    /// so that the zoom shortcuts are handled exclusively by the browser,
+    /// which will change the `native_pixels_per_point` (`devicePixelRatio`).
+    /// You can still zoom egui independently by calling [`crate::Context::set_zoom_factor`],
+    /// which will be applied on top of the browsers global zoom.
     #[cfg_attr(feature = "serde", serde(skip))]
     pub zoom_with_keyboard: bool,
 

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -38,9 +38,6 @@ pub struct Response {
     ///
     /// This is sometimes smaller than [`Self::rect`] because of clipping
     /// (e.g. when inside a scroll area).
-    ///
-    /// The interact rect may also be slightly larger than the widget rect,
-    /// because egui adds half if the item spacing to make the interact rect easier to hit.
     pub interact_rect: Rect,
 
     /// The senses (click and/or drag) that the widget was interested in (if any).
@@ -59,7 +56,7 @@ pub struct Response {
     pub enabled: bool,
 
     // OUT:
-    /// The pointer is hovering above this widget.
+    /// The pointer is above this widget with no other blocking it.
     #[doc(hidden)]
     pub contains_pointer: bool,
 
@@ -200,7 +197,10 @@ impl Response {
         self.clicked && self.ctx.input(|i| i.pointer.button_triple_clicked(button))
     }
 
-    /// `true` if there was a click *outside* this widget this frame.
+    /// `true` if there was a click *outside* the rect of this widget.
+    ///
+    /// Clicks on widgets contained in this one counts as clicks inside this widget,
+    /// so that clicking a button in an area will not be considered as clicking "elsewhere" from the area.
     pub fn clicked_elsewhere(&self) -> bool {
         // We do not use self.clicked(), because we want to catch all clicks within our frame,
         // even if we aren't clickable (or even enabled).
@@ -243,14 +243,13 @@ impl Response {
         self.hovered
     }
 
-    /// Returns true if the pointer is contained by the response rect.
+    /// Returns true if the pointer is contained by the response rect, and no other widget is covering it.
     ///
     /// In contrast to [`Self::hovered`], this can be `true` even if some other widget is being dragged.
     /// This means it is useful for styling things like drag-and-drop targets.
     /// `contains_pointer` can also be `true` for disabled widgets.
     ///
-    /// This is slightly different from [`Ui::rect_contains_pointer`] and [`Context::rect_contains_pointer`],
-    /// The rectangle used here is slightly larger, by half of the current item spacing.
+    /// This is slightly different from [`Ui::rect_contains_pointer`] and [`Context::rect_contains_pointer`], in that
     /// [`Self::contains_pointer`] also checks that no other widget is covering this response rectangle.
     #[inline(always)]
     pub fn contains_pointer(&self) -> bool {

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -209,14 +209,10 @@ impl Response {
             let pointer = &i.pointer;
 
             if pointer.any_click() {
-                // We detect clicks/hover on a "interact_rect" that is slightly larger than
-                // self.rect. See Context::interact.
-                // This means we can be hovered and clicked even though `!self.rect.contains(pos)` is true,
-                // hence the extra complexity here.
-                if self.contains_pointer() {
+                if self.contains_pointer || self.hovered {
                     false
                 } else if let Some(pos) = pointer.interact_pos() {
-                    !self.rect.contains(pos)
+                    !self.interact_rect.contains(pos)
                 } else {
                     false // clicked without a pointer, weird
                 }

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1806,6 +1806,9 @@ impl Ui {
     }
 
     /// A [`CollapsingHeader`] that starts out collapsed.
+    ///
+    /// The name must be unique within the current parent,
+    /// or you need to use [`CollapsingHeader::id_source`].
     pub fn collapsing<R>(
         &mut self,
         heading: impl Into<WidgetText>,

--- a/crates/egui/src/widget_rect.rs
+++ b/crates/egui/src/widget_rect.rs
@@ -72,6 +72,11 @@ impl WidgetRects {
         self.by_id.get(&id).map(|(_, w)| w)
     }
 
+    /// In which layer, and in which order in that layer?
+    pub fn order(&self, id: Id) -> Option<(LayerId, usize)> {
+        self.by_id.get(&id).map(|(idx, w)| (w.layer_id, *idx))
+    }
+
     #[inline]
     pub fn contains(&self, id: Id) -> bool {
         self.by_id.contains_key(&id)

--- a/crates/egui_extras/CHANGELOG.md
+++ b/crates/egui_extras/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.2 - 2024-04-02
+* Nothing new
+
+
 ## 0.27.1 - 2024-03-29
 * Nothing new
 

--- a/crates/egui_extras/CHANGELOG.md
+++ b/crates/egui_extras/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.1 - 2024-03-29
+* Nothing new
+
+
 ## 0.27.0 - 2024-03-26
 * Add scroll bar visibility option to `Table` widget [#3981](https://github.com/emilk/egui/pull/3981) (thanks [@richardhozak](https://github.com/richardhozak)!)
 * Update `ehttp` to 0.5 [#4055](https://github.com/emilk/egui/pull/4055)

--- a/crates/egui_glow/CHANGELOG.md
+++ b/crates/egui_glow/CHANGELOG.md
@@ -6,6 +6,10 @@ Changes since the last release can be found at <https://github.com/emilk/egui/co
 
 
 
+## 0.27.2 - 2024-04-02
+* Nothing new
+
+
 ## 0.27.1 - 2024-03-29
 * Nothing new
 

--- a/crates/egui_glow/CHANGELOG.md
+++ b/crates/egui_glow/CHANGELOG.md
@@ -6,6 +6,10 @@ Changes since the last release can be found at <https://github.com/emilk/egui/co
 
 
 
+## 0.27.1 - 2024-03-29
+* Nothing new
+
+
 ## 0.27.0 - 2024-03-26
 * Only disable sRGB framebuffer on supported platforms [#3994](https://github.com/emilk/egui/pull/3994) (thanks [@Nopey](https://github.com/Nopey)!)
 * Update memoffset to 0.9.0, arboard to 3.3.1, and remove egui_glow's needless dependency on pure_glow's deps  [#4036](https://github.com/emilk/egui/pull/4036) (thanks [@Nopey](https://github.com/Nopey)!)

--- a/crates/egui_glow/examples/pure_glow.rs
+++ b/crates/egui_glow/examples/pure_glow.rs
@@ -4,6 +4,8 @@
 #![allow(unsafe_code)]
 #![allow(clippy::arc_with_non_send_sync)] // glow::Context was accidentally non-Sync in glow 0.13, but that will be fixed in future releases of glow: https://github.com/grovesNL/glow/commit/c4a5f7151b9b4bbb380faa06ec27415235d1bf7e
 
+use std::num::NonZeroU32;
+
 use egui_winit::winit;
 
 /// The majority of `GlutinWindowContext` is taken from `eframe`
@@ -19,7 +21,6 @@ impl GlutinWindowContext {
     // preferably add android support at the same time.
     #[allow(unsafe_code)]
     unsafe fn new(event_loop: &winit::event_loop::EventLoopWindowTarget<UserEvent>) -> Self {
-        use egui::NumExt;
         use glutin::context::NotCurrentGlContext;
         use glutin::display::GetGlDisplay;
         use glutin::display::GlDisplay;
@@ -87,8 +88,8 @@ impl GlutinWindowContext {
                 .expect("failed to finalize glutin window")
         });
         let (width, height): (u32, u32) = window.inner_size().into();
-        let width = std::num::NonZeroU32::new(width.at_least(1)).unwrap();
-        let height = std::num::NonZeroU32::new(height.at_least(1)).unwrap();
+        let width = NonZeroU32::new(width).unwrap_or(NonZeroU32::MIN);
+        let height = NonZeroU32::new(height).unwrap_or(NonZeroU32::MIN);
         let surface_attributes =
             glutin::surface::SurfaceAttributesBuilder::<glutin::surface::WindowSurface>::new()
                 .build(window.raw_window_handle(), width, height);
@@ -107,7 +108,7 @@ impl GlutinWindowContext {
         gl_surface
             .set_swap_interval(
                 &gl_context,
-                glutin::surface::SwapInterval::Wait(std::num::NonZeroU32::new(1).unwrap()),
+                glutin::surface::SwapInterval::Wait(NonZeroU32::MIN),
             )
             .unwrap();
 

--- a/crates/egui_plot/CHANGELOG.md
+++ b/crates/egui_plot/CHANGELOG.md
@@ -5,6 +5,12 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.2 - 2024-04-02
+* Allow zoom/pan a plot as long as it contains the mouse cursor [#4292](https://github.com/emilk/egui/pull/4292)
+* Prevent plot from resetting one axis while zooming/dragging the other [#4252](https://github.com/emilk/egui/pull/4252) (thanks [@YgorSouza](https://github.com/YgorSouza)!)
+* egui_plot: Fix the same plot tick label being painted multiple times [#4307](https://github.com/emilk/egui/pull/4307)
+
+
 ## 0.27.1 - 2024-03-29
 * Nothing new
 

--- a/crates/egui_plot/CHANGELOG.md
+++ b/crates/egui_plot/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.1 - 2024-03-29
+* Nothing new
+
+
 ## 0.27.0 - 2024-03-26
 * Add `sense` option to `Plot` [#4052](https://github.com/emilk/egui/pull/4052) (thanks [@AmesingFlank](https://github.com/AmesingFlank)!)
 * Plot widget - allow disabling scroll for x and y separately [#4051](https://github.com/emilk/egui/pull/4051) (thanks [@YgorSouza](https://github.com/YgorSouza)!)

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -13,7 +13,7 @@ mod memory;
 mod plot_ui;
 mod transform;
 
-use std::{ops::RangeInclusive, sync::Arc};
+use std::{cmp::Ordering, ops::RangeInclusive, sync::Arc};
 
 use egui::ahash::HashMap;
 use egui::*;
@@ -1714,7 +1714,29 @@ fn generate_marks(step_sizes: [f64; 3], bounds: (f64, f64)) -> Vec<GridMark> {
     fill_marks_between(&mut steps, step_sizes[0], bounds);
     fill_marks_between(&mut steps, step_sizes[1], bounds);
     fill_marks_between(&mut steps, step_sizes[2], bounds);
+
+    // Remove duplicates:
+    // This can happen because we have overlapping steps, e.g.:
+    // step_size[0] =   10  =>  [-10, 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]
+    // step_size[1] =  100  =>  [     0,                                     100          ]
+    // step_size[2] = 1000  =>  [     0                                                   ]
+
+    steps.sort_by(|a, b| match cmp_f64(a.value, b.value) {
+        // Keep the largest step size when we dedup later
+        Ordering::Equal => cmp_f64(b.step_size, a.step_size),
+
+        ord => ord,
+    });
+    steps.dedup_by(|a, b| a.value == b.value);
+
     steps
+}
+
+fn cmp_f64(a: f64, b: f64) -> Ordering {
+    match a.partial_cmp(&b) {
+        Some(ord) => ord,
+        None => a.is_nan().cmp(&b.is_nan()),
+    }
 }
 
 /// Fill in all values between [min, max] which are a multiple of `step_size`

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -1076,8 +1076,13 @@ impl Plot {
             }
         }
 
-        let hover_pos = response.hover_pos();
-        if let Some(hover_pos) = hover_pos {
+        // Note: we catch zoom/pan if the response contains the pointer, even if it isn't hovered.
+        // For instance: The user is painting another interactive widget on top of the plot
+        // but they still want to be able to pan/zoom the plot.
+        if let (true, Some(hover_pos)) = (
+            response.contains_pointer,
+            ui.input(|i| i.pointer.hover_pos()),
+        ) {
             if allow_zoom.any() {
                 let mut zoom_factor = if data_aspect.is_some() {
                     Vec2::splat(ui.input(|i| i.zoom_delta()))

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -1021,7 +1021,7 @@ impl Plot {
                 delta.y = 0.0;
             }
             mem.transform.translate_bounds(delta);
-            mem.auto_bounds = !allow_drag;
+            mem.auto_bounds = mem.auto_bounds.and(!allow_drag);
         }
 
         // Zooming
@@ -1097,7 +1097,7 @@ impl Plot {
                 }
                 if zoom_factor != Vec2::splat(1.0) {
                     mem.transform.zoom(zoom_factor, hover_pos);
-                    mem.auto_bounds = !allow_zoom;
+                    mem.auto_bounds = mem.auto_bounds.and(!allow_zoom);
                 }
             }
             if allow_scroll.any() {

--- a/crates/epaint/CHANGELOG.md
+++ b/crates/epaint/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.2 - 2024-04-02
+* Nothing new
+
+
 ## 0.27.1 - 2024-03-29
 * Fix visual glitch on the right side of highly rounded rectangles [#4244](https://github.com/emilk/egui/pull/4244)
 * Prevent visual glitch when shadow blur width is very high [#4245](https://github.com/emilk/egui/pull/4245)

--- a/crates/epaint/CHANGELOG.md
+++ b/crates/epaint/CHANGELOG.md
@@ -5,6 +5,11 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.1 - 2024-03-29
+* Fix visual glitch on the right side of highly rounded rectangles [#4244](https://github.com/emilk/egui/pull/4244)
+* Prevent visual glitch when shadow blur width is very high [#4245](https://github.com/emilk/egui/pull/4245)
+
+
 ## 0.27.0 - 2024-03-26
 * Add `ColorImage::from_gray_iter` [#3536](https://github.com/emilk/egui/pull/3536) (thanks [@wangxiaochuTHU](https://github.com/wangxiaochuTHU)!)
 * Convenience const fn for `Margin`, `Rounding` and `Shadow` [#4080](https://github.com/emilk/egui/pull/4080) (thanks [@0Qwel](https://github.com/0Qwel)!)

--- a/web_demo/index.html
+++ b/web_demo/index.html
@@ -37,7 +37,12 @@
             width: 100%;
         }
 
-        /* Position canvas in center-top: */
+        /* Position canvas in center-top.
+        This is rather arbitrarily chosen.
+        In particular, it seems like both Chromium and Firefox will still align
+        the canvas on the physical pixel grid, which is required to get
+        pixel-perfect (non-blurry) rendering in egui.
+        See https://github.com/emilk/egui/issues/4241 for more */
         canvas {
             margin-right: auto;
             margin-left: auto;


### PR DESCRIPTION
# Changelogs
#### egui
* Fix tooltips for non-interactive widgets [#4291](https://github.com/emilk/egui/pull/4291)
* Fix problem clicking the edge of a `TextEdit` [#4272](https://github.com/emilk/egui/pull/4272)
* Fix incorrect `Response::interact_rect` for `Area/Window` [#4273](https://github.com/emilk/egui/pull/4273)
* Fix: `Response::clicked_elsewhere` takes clip rect into account [#4274](https://github.com/emilk/egui/pull/4274)
* Allow disabling animations on a `ScrollArea` [#4309](https://github.com/emilk/egui/pull/4309) (thanks [@lucasmerlin](https://github.com/lucasmerlin)!)

#### eframe
* Fix blurry rendering in some browsers [#4299](https://github.com/emilk/egui/pull/4299)
* Correctly identify if browser tab has focus [#4280](https://github.com/emilk/egui/pull/4280)
* Fix continuous repaint on Wayland when TextEdit is focused or IME output is set [#4269](https://github.com/emilk/egui/pull/4269) (thanks [@white-axe](https://github.com/white-axe)!)
* Remove a bunch of `unwrap()` [#4285](https://github.com/emilk/egui/pull/4285)

#### egui_plot
* Allow zoom/pan a plot as long as it contains the mouse cursor [#4292](https://github.com/emilk/egui/pull/4292)
* Prevent plot from resetting one axis while zooming/dragging the other [#4252](https://github.com/emilk/egui/pull/4252) (thanks [@YgorSouza](https://github.com/YgorSouza)!)
* Fix the same plot tick label being painted multiple times [#4307](https://github.com/emilk/egui/pull/4307)

#### egui-winit
* Fix continuous repaint on Wayland when TextEdit is focused or IME output is set [#4269](https://github.com/emilk/egui/pull/4269) (thanks [@white-axe](https://github.com/white-axe)!)
