### PR TITLE
Consider layer transform when positioning text agent

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -700,11 +700,15 @@ impl<'t> TextEdit<'t> {
                             );
                         }
 
-                        // For IME, so only set it when text is editable and visible!
+                        // Set IME output (in screen coords) when text is editable and visible
+                        let transform = ui
+                            .memory(|m| m.layer_transforms.get(&ui.layer_id()).cloned())
+                            .unwrap_or_default();
+
                         ui.ctx().output_mut(|o| {
                             o.ime = Some(crate::output::IMEOutput {
-                                rect,
-                                cursor_rect: primary_cursor_rect,
+                                rect: transform * rect,
+                                cursor_rect: transform * primary_cursor_rect,
                             });
                         });
                     }


### PR DESCRIPTION
When positioning the text agent, the layer transform was not being considered. This not only caused issues with IME input positioning but also layout shifts if the text agent was off-screen.

Before

![Screenshot 2024-04-04 at 13 33 11@2x](https://github.com/emilk/egui/assets/1410520/5d88a358-67bd-478c-95c9-d76f84d57c39)

After

![Screenshot 2024-04-04 at 13 31 52@2x](https://github.com/emilk/egui/assets/1410520/55f068c7-56fe-4ba4-8455-7d0f613e8a52)
