### PR TITLE
report super/meta key for win/linux/web

### DIFF
--- a/crates/eframe/src/web/input.rs
+++ b/crates/eframe/src/web/input.rs
@@ -130,6 +130,7 @@ pub fn modifiers_from_kb_event(event: &web_sys::KeyboardEvent) -> egui::Modifier
         alt: event.alt_key(),
         ctrl: event.ctrl_key(),
         shift: event.shift_key(),
+        meta: event.meta_key(),
 
         // Ideally we should know if we are running or mac or not,
         // but this works good enough for now.
@@ -146,6 +147,7 @@ pub fn modifiers_from_mouse_event(event: &web_sys::MouseEvent) -> egui::Modifier
         alt: event.alt_key(),
         ctrl: event.ctrl_key(),
         shift: event.shift_key(),
+        meta: event.meta_key(),
 
         // Ideally we should know if we are running or mac or not,
         // but this works good enough for now.

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -426,7 +426,7 @@ impl State {
                 self.egui_input.modifiers.ctrl = ctrl;
                 self.egui_input.modifiers.shift = shift;
                 self.egui_input.modifiers.mac_cmd = cfg!(target_os = "macos") && super_;
-                self.egui_input.modifiers.super_ = if cfg!(target_os = "macos") {
+                self.egui_input.modifiers.meta = if cfg!(target_os = "macos") {
                     false
                 } else {
                     super_

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -426,6 +426,11 @@ impl State {
                 self.egui_input.modifiers.ctrl = ctrl;
                 self.egui_input.modifiers.shift = shift;
                 self.egui_input.modifiers.mac_cmd = cfg!(target_os = "macos") && super_;
+                self.egui_input.modifiers.super_ = if cfg!(target_os = "macos") {
+                    false
+                } else {
+                    super_
+                };
                 self.egui_input.modifiers.command = if cfg!(target_os = "macos") {
                     super_
                 } else {

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -562,7 +562,7 @@ pub struct Modifiers {
 
     /// On Windows, the Windows key. On Linux, the super key (often.. the Windows key)
     /// On Mac will always be false
-    pub super_: bool,
+    pub meta: bool,
 }
 
 impl Modifiers {
@@ -572,7 +572,7 @@ impl Modifiers {
         shift: false,
         mac_cmd: false,
         command: false,
-        super_: false,
+        meta: false,
     };
 
     pub const ALT: Self = Self {
@@ -581,7 +581,7 @@ impl Modifiers {
         shift: false,
         mac_cmd: false,
         command: false,
-        super_: false,
+        meta: false,
     };
     pub const CTRL: Self = Self {
         alt: false,
@@ -589,7 +589,7 @@ impl Modifiers {
         shift: false,
         mac_cmd: false,
         command: false,
-        super_: false,
+        meta: false,
     };
     pub const SHIFT: Self = Self {
         alt: false,
@@ -597,7 +597,7 @@ impl Modifiers {
         shift: true,
         mac_cmd: false,
         command: false,
-        super_: false,
+        meta: false,
     };
 
     /// The Mac ⌘ Command key
@@ -607,7 +607,7 @@ impl Modifiers {
         shift: false,
         mac_cmd: true,
         command: false,
-        super_: false,
+        meta: false,
     };
 
     /// On Mac: ⌘ Command key, elsewhere: Ctrl key
@@ -617,16 +617,17 @@ impl Modifiers {
         shift: false,
         mac_cmd: false,
         command: true,
-        super_: false,
+        meta: false,
     };
 
-    pub const SUPER: Self = Self {
+    /// On Windows: the Windows key, On Linux: Super
+    pub const META: Self = Self {
         alt: false,
         ctrl: false,
         shift: false,
         mac_cmd: false,
         command: false,
-        super_: true,
+        meta: true,
     };
 
     /// ```
@@ -652,7 +653,7 @@ impl Modifiers {
             shift: self.shift | rhs.shift,
             mac_cmd: self.mac_cmd | rhs.mac_cmd,
             command: self.command | rhs.command,
-            super_: self.super_ | rhs.super_,
+            meta: self.meta | rhs.meta,
         }
     }
 
@@ -837,7 +838,7 @@ impl Modifiers {
             shift,
             mac_cmd,
             command,
-            super_,
+            meta,
         } = *self;
 
         if alt && query.alt {
@@ -846,6 +847,7 @@ impl Modifiers {
                 ..query
             });
         }
+
         if shift && query.shift {
             return self.contains(Self {
                 shift: false,
@@ -860,6 +862,7 @@ impl Modifiers {
                 ..query
             });
         }
+
         if (mac_cmd || command) && (query.mac_cmd || query.command) {
             return self.contains(Self {
                 mac_cmd: false,
@@ -867,9 +870,10 @@ impl Modifiers {
                 ..query
             });
         }
-        if super_ && query.super_ {
+
+        if meta && query.meta {
             return self.contains(Self {
-                super_: false,
+                meta: false,
                 ..query
             });
         }
@@ -901,13 +905,14 @@ pub struct ModifierNames<'a> {
     pub shift: &'a str,
     pub mac_cmd: &'a str,
     pub mac_alt: &'a str,
+    pub meta: &'a str,
 
     /// What goes between the names
     pub concat: &'a str,
 }
 
 impl ModifierNames<'static> {
-    /// ⌥ ⌃ ⇧ ⌘ - NOTE: not supported by the default egui font.
+    /// ⌥ ⌃ ⇧ ⌘ ⊞ - NOTE: not supported by the default egui font.
     pub const SYMBOLS: Self = Self {
         is_short: true,
         alt: "⌥",
@@ -915,10 +920,11 @@ impl ModifierNames<'static> {
         shift: "⇧",
         mac_cmd: "⌘",
         mac_alt: "⌥",
+        meta: "⊞",
         concat: "",
     };
 
-    /// Alt, Ctrl, Shift, Cmd
+    /// Alt, Ctrl, Shift, Cmd, Win
     pub const NAMES: Self = Self {
         is_short: false,
         alt: "Alt",
@@ -926,6 +932,7 @@ impl ModifierNames<'static> {
         shift: "Shift",
         mac_cmd: "Cmd",
         mac_alt: "Option",
+        meta: "Win",
         concat: "+",
     };
 }
@@ -952,6 +959,7 @@ impl<'a> ModifierNames<'a> {
             append_if(modifiers.ctrl || modifiers.command, self.ctrl);
             append_if(modifiers.alt, self.alt);
             append_if(modifiers.shift, self.shift);
+            append_if(modifiers.meta, self.meta);
         }
 
         s

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -559,6 +559,10 @@ pub struct Modifiers {
     /// This is so that egui can, for instance, select all text by checking for `command + A`
     /// and it will work on both Mac and Windows.
     pub command: bool,
+
+    /// On Windows, the Windows key. On Linux, the super key (often.. the Windows key)
+    /// On Mac will always be false
+    pub super_: bool,
 }
 
 impl Modifiers {
@@ -568,6 +572,7 @@ impl Modifiers {
         shift: false,
         mac_cmd: false,
         command: false,
+        super_: false,
     };
 
     pub const ALT: Self = Self {
@@ -576,6 +581,7 @@ impl Modifiers {
         shift: false,
         mac_cmd: false,
         command: false,
+        super_: false,
     };
     pub const CTRL: Self = Self {
         alt: false,
@@ -583,6 +589,7 @@ impl Modifiers {
         shift: false,
         mac_cmd: false,
         command: false,
+        super_: false,
     };
     pub const SHIFT: Self = Self {
         alt: false,
@@ -590,6 +597,7 @@ impl Modifiers {
         shift: true,
         mac_cmd: false,
         command: false,
+        super_: false,
     };
 
     /// The Mac ⌘ Command key
@@ -599,6 +607,7 @@ impl Modifiers {
         shift: false,
         mac_cmd: true,
         command: false,
+        super_: false,
     };
 
     /// On Mac: ⌘ Command key, elsewhere: Ctrl key
@@ -608,6 +617,16 @@ impl Modifiers {
         shift: false,
         mac_cmd: false,
         command: true,
+        super_: false,
+    };
+
+    pub const SUPER: Self = Self {
+        alt: false,
+        ctrl: false,
+        shift: false,
+        mac_cmd: false,
+        command: false,
+        super_: true,
     };
 
     /// ```
@@ -633,6 +652,7 @@ impl Modifiers {
             shift: self.shift | rhs.shift,
             mac_cmd: self.mac_cmd | rhs.mac_cmd,
             command: self.command | rhs.command,
+            super_: self.super_ | rhs.super_,
         }
     }
 
@@ -817,6 +837,7 @@ impl Modifiers {
             shift,
             mac_cmd,
             command,
+            super_,
         } = *self;
 
         if alt && query.alt {
@@ -843,6 +864,12 @@ impl Modifiers {
             return self.contains(Self {
                 mac_cmd: false,
                 command: false,
+                ..query
+            });
+        }
+        if super_ && query.super_ {
+            return self.contains(Self {
+                super_: false,
                 ..query
             });
         }


### PR DESCRIPTION
 Re: #3653

Tested on linux (x11).  I'm sort of trusting that winit/(other backends) handle the other platforms correctly.

this is a non-breaking change, I believe. 

Alternatively (breaking) We _could_ send meta on Mac, too? And then deprecate and eventually remove mac_cmd?