### PR TITLE
Allow users to create viewports larger than monitor on Windows & macOS

### DIFF
--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -30,7 +30,7 @@ pub fn viewport_builder<E>(
     let inner_size_points = if let Some(mut window_settings) = window_settings {
         // Restore pos/size from previous session
 
-        if with_constraint {
+        if clamp_size_to_monitor_size {
             window_settings.clamp_size_to_sane_values(largest_monitor_point_size(
                 egui_zoom_factor,
                 event_loop,

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -45,7 +45,7 @@ pub fn viewport_builder<E>(
             viewport_builder = viewport_builder.with_position(pos);
         }
 
-        if with_constraint {
+        if clamp_size_to_monitor_size {
             if let Some(initial_window_size) = viewport_builder.inner_size {
                 let initial_window_size = initial_window_size
                     .at_most(largest_monitor_point_size(egui_zoom_factor, event_loop));

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -22,7 +22,8 @@ pub fn viewport_builder<E>(
 
     let clamp_size_to_monitor_size = viewport_builder.clamp_size_to_monitor_size.unwrap_or(
         // On some Linux systems, a window size larger than the monitor causes crashes
-        cfg!(target_os = "linux"));
+        cfg!(target_os = "linux"),
+    );
 
     // Always use the default window size / position on iOS. Trying to restore the previous position
     // causes the window to be shown too small.

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -20,9 +20,9 @@ pub fn viewport_builder<E>(
 
     let mut viewport_builder = native_options.viewport.clone();
 
-    // Allow users to create windows larger than monitor on windows & macos
-    let with_constraint: bool = !cfg!(any(target_os = "windows", target_os = "macos"))
-        || viewport_builder.clamp_size_to_monitor_size.unwrap_or(true);
+    let clamp_size_to_monitor_size = viewport_builder.clamp_size_to_monitor_size.unwrap_or(
+        // On some Linux systems, a window size larger than the monitor causes crashes
+        cfg!(target_os = "linux"));
 
     // Always use the default window size / position on iOS. Trying to restore the previous position
     // causes the window to be shown too small.

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1563,6 +1563,7 @@ pub fn create_winit_window_builder<T>(
         window_type: _window_type,
 
         mouse_passthrough: _, // handled in `apply_viewport_builder_to_window`
+        ..
     } = viewport_builder;
 
     let mut window_builder = winit::window::WindowBuilder::new()

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1563,7 +1563,7 @@ pub fn create_winit_window_builder<T>(
         window_type: _window_type,
 
         mouse_passthrough: _, // handled in `apply_viewport_builder_to_window`
-        ..
+        clamp_size_to_monitor_size: _, // Handled in `viewport_builder` in `epi_integration.rs`
     } = viewport_builder;
 
     let mut window_builder = winit::window::WindowBuilder::new()

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -275,6 +275,9 @@ pub struct ViewportBuilder {
     pub min_inner_size: Option<Vec2>,
     pub max_inner_size: Option<Vec2>,
 
+    /// Whether clamp the window's size to monitor's size. Default to `true`
+    pub clamp_size_to_monitor_size: Option<bool>,
+
     pub fullscreen: Option<bool>,
     pub maximized: Option<bool>,
     pub resizable: Option<bool>,
@@ -493,6 +496,17 @@ impl ViewportBuilder {
         self
     }
 
+    /// Sets whether clamp the window's size to monitor's size.
+    ///
+    /// This only works on windows & macos, otherwise will be dismissed.
+    ///
+    /// Default to `true`
+    #[inline]
+    pub fn with_clamp_size_to_monitor_size(mut self, value: bool) -> Self {
+        self.clamp_size_to_monitor_size = Some(value);
+        self
+    }
+
     /// Does not work on X11.
     #[inline]
     pub fn with_close_button(mut self, value: bool) -> Self {
@@ -606,6 +620,7 @@ impl ViewportBuilder {
             inner_size: new_inner_size,
             min_inner_size: new_min_inner_size,
             max_inner_size: new_max_inner_size,
+            clamp_size_to_monitor_size: new_clamp_size_to_monitor_size,
             fullscreen: new_fullscreen,
             maximized: new_maximized,
             resizable: new_resizable,
@@ -739,6 +754,16 @@ impl ViewportBuilder {
         // changing them without recreating the window.
 
         let mut recreate_window = false;
+
+        // TODO(lopo12123): Rebuild the window directly?
+        // Or should we get the size of each monitor somewhere
+        // and then compare and adjust the window size(if need)
+        if new_clamp_size_to_monitor_size.is_some()
+            && self.clamp_size_to_monitor_size != new_clamp_size_to_monitor_size
+        {
+            self.clamp_size_to_monitor_size = new_clamp_size_to_monitor_size;
+            recreate_window = true;
+        }
 
         if new_active.is_some() && self.active != new_active {
             self.active = new_active;

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -755,9 +755,6 @@ impl ViewportBuilder {
 
         let mut recreate_window = false;
 
-        // TODO(lopo12123): Rebuild the window directly?
-        // Or should we get the size of each monitor somewhere
-        // and then compare and adjust the window size(if need)
         if new_clamp_size_to_monitor_size.is_some()
             && self.clamp_size_to_monitor_size != new_clamp_size_to_monitor_size
         {

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -275,7 +275,7 @@ pub struct ViewportBuilder {
     pub min_inner_size: Option<Vec2>,
     pub max_inner_size: Option<Vec2>,
 
-    /// Whether clamp the window's size to monitor's size. Default to `true`.
+    /// Whether clamp the window's size to monitor's size. The default is `true` on linux, otherwise it is `false`.
     ///
     /// Note: On some Linux systems, a window size larger than the monitor causes crashes
     pub clamp_size_to_monitor_size: Option<bool>,
@@ -498,7 +498,7 @@ impl ViewportBuilder {
         self
     }
 
-    /// Sets whether clamp the window's size to monitor's size. Default to `true`.
+    /// Sets whether clamp the window's size to monitor's size. The default is `true` on linux, otherwise it is `false`.
     ///
     /// Note: On some Linux systems, a window size larger than the monitor causes crashes
     #[inline]

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -275,7 +275,9 @@ pub struct ViewportBuilder {
     pub min_inner_size: Option<Vec2>,
     pub max_inner_size: Option<Vec2>,
 
-    /// Whether clamp the window's size to monitor's size. Default to `true`
+    /// Whether clamp the window's size to monitor's size. Default to `true`.
+    ///
+    /// Note: On some Linux systems, a window size larger than the monitor causes crashes
     pub clamp_size_to_monitor_size: Option<bool>,
 
     pub fullscreen: Option<bool>,
@@ -496,11 +498,9 @@ impl ViewportBuilder {
         self
     }
 
-    /// Sets whether clamp the window's size to monitor's size.
+    /// Sets whether clamp the window's size to monitor's size. Default to `true`.
     ///
-    /// This only works on windows & macos, otherwise will be dismissed.
-    ///
-    /// Default to `true`
+    /// Note: On some Linux systems, a window size larger than the monitor causes crashes
     #[inline]
     pub fn with_clamp_size_to_monitor_size(mut self, value: bool) -> Self {
         self.clamp_size_to_monitor_size = Some(value);


### PR DESCRIPTION
Added clamp_size_to_monitor_size field on ViewportBuilder, which means whether clamp the window's size to monitor's size. (default to `true`)

* Closes https://github.com/emilk/egui/issues/3389

### simple example

```rust
pub struct MyApp {}

impl MyApp {
    pub fn new() -> MyApp {
        MyApp {}
    }
}

impl eframe::App for MyApp {
    fn update(&mut self, ctx: &Context, frame: &mut eframe::Frame) {
        egui::CentralPanel::default()
            .frame(Frame::none().fill(Color32::DARK_GRAY))
            .show(ctx, |ui| {
                if ctx.input(|i| i.key_pressed(Key::Escape)) {
                    ctx.send_viewport_cmd(ViewportCommand::Close);
                }
            });
    }
}

pub fn main() {
    let option = eframe::NativeOptions {
        viewport: ViewportBuilder::default()
            .with_position([10.0, 10.0])
            .with_inner_size([3000.0, 2000.0])
            .with_clamp_size_to_monitor_size(false),
        ..Default::default()
    };

    eframe::run_native(
        "a large window app",
        option,
        Box::new(|ctx| Box::new(MyApp::new())),
    ).unwrap();
}
```

It works on my windows (with 3 monitors), but I don't have a test environment for macos

