### PR TITLE
Add a way to specify Undoer settings and construct Undoers more easily

### DIFF
--- a/crates/egui/src/util/undoer.rs
+++ b/crates/egui/src/util/undoer.rs
@@ -47,7 +47,7 @@ impl Default for Settings {
 ///
 /// Rule 1) will make sure an undo point is not created until you _stop_ dragging that slider.
 /// Rule 2) will make sure that you will get some undo points even if you are constantly changing the state.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Undoer<State> {
     settings: Settings,
@@ -77,6 +77,21 @@ impl<State> std::fmt::Debug for Undoer<State> {
     }
 }
 
+impl<State> Default for Undoer<State>
+where
+    State: Clone + PartialEq,
+{
+    #[inline]
+    fn default() -> Self {
+        Self {
+            settings: Settings::default(),
+            undos: VecDeque::new(),
+            redos: Vec::new(),
+            flux: None,
+        }
+    }
+}
+
 /// Represents how the current state is changing
 #[derive(Clone)]
 struct Flux<State> {
@@ -89,20 +104,11 @@ impl<State> Undoer<State>
 where
     State: Clone + PartialEq,
 {
-    pub fn new() -> Self {
-        Self {
-            settings: Settings::default(),
-            undos: VecDeque::new(),
-            redos: Vec::new(),
-            flux: None,
-        }
-    }
-
     /// Create a new [`Undoer`] with the given [`Settings`].
     pub fn with_settings(settings: Settings) -> Self {
         Self {
             settings,
-            ..Self::new()
+            ..Default::default()
         }
     }
 

--- a/crates/egui/src/util/undoer.rs
+++ b/crates/egui/src/util/undoer.rs
@@ -89,6 +89,23 @@ impl<State> Undoer<State>
 where
     State: Clone + PartialEq,
 {
+    pub fn new() -> Self {
+        Self {
+            settings: Settings::default(),
+            undos: VecDeque::new(),
+            redos: Vec::new(),
+            flux: None,
+        }
+    }
+
+    /// Create a new [`Undoer`] with the given [`Settings`].
+    pub fn with_settings(settings: Settings) -> Self {
+        Self {
+            settings,
+            ..Self::new()
+        }
+    }
+
     /// Do we have an undo point different from the given state?
     pub fn has_undo(&self, current_state: &State) -> bool {
         match self.undos.len() {


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes https://github.com/emilk/egui/issues/4356

- Add `Undoer::new()`
  - This is necessary to construct an `Undoer` whose `State` parameter doesn't implement `Default`.
- Add `Undoer::with_settings(...)`
  - This is necessary to actually pass settings into the `Undoer`. Without this, API consumers could construct their own `Settings` but not actually do anything with it.

I've refrained from adding any kind of builder API for `Settings` because there are only three options and I don't want to duplicate or move all the documentation onto the builder methods.