### PR TITLE
Fix `hex_color!` macro by re-exporting `color_hex` crate from `ecolor`

### DIFF
--- a/crates/ecolor/src/hex_color_macro.rs
+++ b/crates/ecolor/src/hex_color_macro.rs
@@ -13,7 +13,7 @@
 #[macro_export]
 macro_rules! hex_color {
     ($s:literal) => {{
-        let array = color_hex::color_from_hex!($s);
+        let array = $crate::color_hex::color_from_hex!($s);
         if array.len() == 3 {
             $crate::Color32::from_rgb(array[0], array[1], array[2])
         } else {

--- a/crates/ecolor/src/lib.rs
+++ b/crates/ecolor/src/lib.rs
@@ -24,6 +24,9 @@ pub use hsva::*;
 
 #[cfg(feature = "color-hex")]
 mod hex_color_macro;
+#[cfg(feature = "color-hex")]
+#[doc(hidden)]
+pub use color_hex;
 
 mod rgba;
 pub use rgba::*;


### PR DESCRIPTION
The `hex_color!` macro currently makes an unqualified reference to the `color_hex` crate, which users may not have in their `Cargo.toml`. This PR re-exports `color_hex` from the root of `ecolor` and changes the macro to use the re-exported path.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes https://github.com/emilk/egui/issues/2644
