### PR TITLE
Fix incorrect line breaks

### DIFF
--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -296,7 +296,7 @@ fn line_break(paragraph: &Paragraph, job: &LayoutJob, out_rows: &mut Vec<Row>, e
                 // Start a new row:
                 row_start_idx = last_kept_index + 1;
                 row_start_x = paragraph.glyphs[row_start_idx].pos.x;
-                row_break_candidates.forget_candiates_before_idx(row_start_idx);
+                row_break_candidates.forget_before_idx(row_start_idx);
             } else {
                 // Found no place to break, so we have to overrun wrap_width.
             }
@@ -944,7 +944,7 @@ impl RowBreakCandidates {
         }
     }
 
-    fn forget_candiates_before_idx(&mut self, index: usize) {
+    fn forget_before_idx(&mut self, index: usize) {
         if self.space.map(|s| s < index).unwrap_or_default() {
             self.space = None;
         }

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -945,23 +945,31 @@ impl RowBreakCandidates {
     }
 
     fn forget_before_idx(&mut self, index: usize) {
-        if self.space.map(|s| s < index).unwrap_or_default() {
-            self.space = None;
+        let Self {
+            space,
+            cjk,
+            pre_cjk,
+            dash,
+            punctuation,
+            any,
+        } = self;
+        if space.map_or(false, |s| s < index) {
+            *space = None;
         }
-        if self.cjk.map(|s| s < index).unwrap_or_default() {
-            self.cjk = None;
+        if cjk.map_or(false, |s| s < index) {
+            *cjk = None;
         }
-        if self.pre_cjk.map(|s| s < index).unwrap_or_default() {
-            self.pre_cjk = None;
+        if pre_cjk.map_or(false, |s| s < index) {
+            *pre_cjk = None;
         }
-        if self.dash.map(|s| s < index).unwrap_or_default() {
-            self.dash = None;
+        if dash.map_or(false, |s| s < index) {
+            *dash = None;
         }
-        if self.punctuation.map(|s| s < index).unwrap_or_default() {
-            self.punctuation = None;
+        if punctuation.map_or(false, |s| s < index) {
+            *punctuation = None;
         }
-        if self.any.map(|s| s < index).unwrap_or_default() {
-            self.any = None;
+        if any.map_or(false, |s| s < index) {
+            *any = None;
         }
     }
 }

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -296,7 +296,7 @@ fn line_break(paragraph: &Paragraph, job: &LayoutJob, out_rows: &mut Vec<Row>, e
                 // Start a new row:
                 row_start_idx = last_kept_index + 1;
                 row_start_x = paragraph.glyphs[row_start_idx].pos.x;
-                row_break_candidates = Default::default();
+                row_break_candidates.forget_candiates_before_idx(row_start_idx);
             } else {
                 // Found no place to break, so we have to overrun wrap_width.
             }
@@ -941,6 +941,27 @@ impl RowBreakCandidates {
                 .or(self.dash)
                 .or(self.punctuation)
                 .or(self.any)
+        }
+    }
+
+    fn forget_candiates_before_idx(&mut self, index: usize) {
+        if self.space.map(|s| s < index).unwrap_or_default() {
+            self.space = None;
+        }
+        if self.cjk.map(|s| s < index).unwrap_or_default() {
+            self.cjk = None;
+        }
+        if self.pre_cjk.map(|s| s < index).unwrap_or_default() {
+            self.pre_cjk = None;
+        }
+        if self.dash.map(|s| s < index).unwrap_or_default() {
+            self.dash = None;
+        }
+        if self.punctuation.map(|s| s < index).unwrap_or_default() {
+            self.punctuation = None;
+        }
+        if self.any.map(|s| s < index).unwrap_or_default() {
+            self.any = None;
         }
     }
 }


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo cranky`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

While breaking a paragraph, it was possible to lose line break candidates that could've been used on the next line, causing egui to unnecessarily overrun `wrap.max_width`.

This PR fixes it so that we don't forget about those candidates.


Before:
Note that the window can't resize to the requested width because the text is not wrapping.

https://github.com/emilk/egui/assets/1410520/6430a334-2995-4b40-bc34-8f01923f9f95

After:

https://github.com/emilk/egui/assets/1410520/225fa4cd-cbbb-4a7e-9580-7f1814c05ee7

