### PR TITLE
Expose `ClosestElem` and `PlotConfig`

### DIFF
--- a/crates/egui_plot/src/items/mod.rs
+++ b/crates/egui_plot/src/items/mod.rs
@@ -9,11 +9,12 @@ use crate::*;
 
 use super::{Cursor, LabelFormatter, PlotBounds, PlotTransform};
 use rect_elem::*;
-use values::ClosestElem;
 
 pub use bar::Bar;
 pub use box_elem::{BoxElem, BoxSpread};
-pub use values::{LineStyle, MarkerShape, Orientation, PlotGeometry, PlotPoint, PlotPoints};
+pub use values::{
+    ClosestElem, LineStyle, MarkerShape, Orientation, PlotGeometry, PlotPoint, PlotPoints,
+};
 
 mod bar;
 mod box_elem;
@@ -45,7 +46,7 @@ pub trait PlotItem {
 
     fn highlighted(&self) -> bool;
 
-    /// Can the user hover this is item?
+    /// Can the user hover this item?
     fn allow_hover(&self) -> bool;
 
     fn geometry(&self) -> PlotGeometry<'_>;

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -22,9 +22,9 @@ use epaint::{util::FloatOrd, Hsva};
 pub use crate::{
     axis::{Axis, AxisHints, HPlacement, Placement, VPlacement},
     items::{
-        Arrows, Bar, BarChart, BoxElem, BoxPlot, BoxSpread, HLine, Line, LineStyle, MarkerShape,
-        Orientation, PlotGeometry, PlotImage, PlotItem, PlotPoint, PlotPoints, Points, Polygon,
-        Text, VLine,
+        Arrows, Bar, BarChart, BoxElem, BoxPlot, BoxSpread, ClosestElem, HLine, Line, LineStyle,
+        MarkerShape, Orientation, PlotConfig, PlotGeometry, PlotImage, PlotItem, PlotPoint,
+        PlotPoints, Points, Polygon, Text, VLine,
     },
     legend::{Corner, Legend},
     memory::PlotMemory,


### PR DESCRIPTION
These two items are needed to implement the `PlotItem` trait (which is already public) when using `PlotGeometry::Rects`.
Specifically, they are used in the return type of `PlotItem::find_closest` and as arguments to `PlotItem::on_hover`, which need to be implemented when using `PlotGeometry::Rects`.