### PR TITLE
`egui-winit`: Update `webbrowser` to `v1.0.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4205,9 +4205,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "0.8.11"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c79b77f525a2d670cb40619d7d9c673d09e0666f72c591ebd7861f84a87e57"
+checksum = "60b6f804e41d0852e16d2eaee61c7e4f7d3e8ffdb7b8ed85886aeb0791fe9fcd"
 dependencies = [
  "core-foundation",
  "home",

--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -71,7 +71,7 @@ document-features = { workspace = true, optional = true }
 
 puffin = { workspace = true, optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
-webbrowser = { version = "0.8.3", optional = true }
+webbrowser = { version = "1.0.0", optional = true }
 
 [target.'cfg(any(target_os="linux", target_os="dragonfly", target_os="freebsd", target_os="netbsd", target_os="openbsd"))'.dependencies]
 smithay-clipboard = { version = "0.7.0", optional = true }


### PR DESCRIPTION
No significant changes, mostly marks API stability: https://github.com/amodm/webbrowser-rs/releases/tag/v1.0.0