### PR TITLE
eframe: update ViewportBuilder.with_icon() documentation

### DIFF
--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -389,7 +389,7 @@ impl ViewportBuilder {
     /// The application icon, e.g. in the Windows task bar or the alt-tab menu.
     ///
     /// The default icon is a white `e` on a black background (for "egui" or "eframe").
-    /// If you prefer the OS default, set this to `None`.
+    /// If you prefer the OS default, set this to `IconData::default()`.
     #[inline]
     pub fn with_icon(mut self, icon: impl Into<Arc<IconData>>) -> Self {
         self.icon = Some(icon.into());


### PR DESCRIPTION
`None` is no longer correct. To disable the egui icon one has to pass `IconData::default()` now.