### PR TITLE
Enable egui_glow's winit feature on wasm (#4420)

### DIFF
--- a/crates/egui_glow/Cargo.toml
+++ b/crates/egui_glow/Cargo.toml
@@ -54,6 +54,7 @@ x11 = ["winit?/x11"]
 
 [dependencies]
 egui = { workspace = true, default-features = false, features = ["bytemuck"] }
+egui-winit = { workspace = true, optional = true, default-features = false }
 
 bytemuck = "1.7"
 glow.workspace = true
@@ -66,7 +67,6 @@ document-features = { workspace = true, optional = true }
 
 # Native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-egui-winit = { workspace = true, optional = true, default-features = false }
 puffin = { workspace = true, optional = true }
 winit = { workspace = true, optional = true, default-features = false, features = [
   "rwh_06", # for compatibility with egui-winit

--- a/crates/egui_glow/src/lib.rs
+++ b/crates/egui_glow/src/lib.rs
@@ -21,9 +21,9 @@ mod vao;
 
 pub use shader_version::ShaderVersion;
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "winit"))]
+#[cfg(feature = "winit")]
 pub mod winit;
-#[cfg(all(not(target_arch = "wasm32"), feature = "winit"))]
+#[cfg(feature = "winit")]
 pub use winit::*;
 
 /// Check for OpenGL error and report it using `log::error`.


### PR DESCRIPTION
Reverts change in #1303, enabling the egui_glow::winit module when using wasm.

* Closes <https://github.com/emilk/egui/issues/4420>
