### PR TITLE
eframe: Add `NativeOptions::persistence_path`

### DIFF
--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -362,6 +362,10 @@ pub struct NativeOptions {
     /// Controls whether or not the native window position and size will be
     /// persisted (only if the "persistence" feature is enabled).
     pub persist_window: bool,
+
+    /// The folder where `eframe` will store the app state. If not set, eframe will get the paths
+    /// from [directories_next].
+    pub persistence_path: Option<std::path::PathBuf>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -378,6 +382,8 @@ impl Clone for NativeOptions {
 
             #[cfg(feature = "wgpu")]
             wgpu_options: self.wgpu_options.clone(),
+
+            persistence_path: self.persistence_path.clone(),
 
             ..*self
         }
@@ -418,6 +424,8 @@ impl Default for NativeOptions {
             wgpu_options: egui_wgpu::WgpuConfiguration::default(),
 
             persist_window: true,
+
+            persistence_path: None,
         }
     }
 }

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -150,6 +150,7 @@ pub trait App {
     /// On web the state is stored to "Local Storage".
     ///
     /// On native the path is picked using [`crate::storage_dir`].
+    /// The path can be customized via [`NativeOptions::persistence_path`].
     fn save(&mut self, _storage: &mut dyn Storage) {}
 
     /// Called once on shutdown, after [`Self::save`].

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -131,10 +131,10 @@ pub fn create_storage(_app_name: &str) -> Option<Box<dyn epi::Storage>> {
     None
 }
 
-pub fn create_storage_with_file(file: impl Into<PathBuf>) -> Option<Box<dyn epi::Storage>> {
+pub fn create_storage_with_file(_file: impl Into<PathBuf>) -> Option<Box<dyn epi::Storage>> {
     #[cfg(feature = "persistence")]
     return Some(Box::new(
-        super::file_storage::FileStorage::from_ron_filepath(file),
+        super::file_storage::FileStorage::from_ron_filepath(_file),
     ));
     #[cfg(not(feature = "persistence"))]
     None

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -131,6 +131,7 @@ pub fn create_storage(_app_name: &str) -> Option<Box<dyn epi::Storage>> {
     None
 }
 
+#[allow(clippy::unnecessary_wraps)]
 pub fn create_storage_with_file(_file: impl Into<PathBuf>) -> Option<Box<dyn epi::Storage>> {
     #[cfg(feature = "persistence")]
     return Some(Box::new(

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -1,6 +1,8 @@
 //! Common tools used by [`super::glow_integration`] and [`super::wgpu_integration`].
 
 use web_time::Instant;
+
+use std::path::PathBuf;
 use winit::event_loop::EventLoopWindowTarget;
 
 use raw_window_handle::{HasDisplayHandle as _, HasWindowHandle as _};
@@ -126,6 +128,15 @@ pub fn create_storage(_app_name: &str) -> Option<Box<dyn epi::Storage>> {
     if let Some(storage) = super::file_storage::FileStorage::from_app_id(_app_name) {
         return Some(Box::new(storage));
     }
+    None
+}
+
+pub fn create_storage_with_file(file: impl Into<PathBuf>) -> Option<Box<dyn epi::Storage>> {
+    #[cfg(feature = "persistence")]
+    return Some(Box::new(
+        super::file_storage::FileStorage::from_ron_filepath(file),
+    ));
+    #[cfg(not(feature = "persistence"))]
     None
 }
 

--- a/crates/eframe/src/native/file_storage.rs
+++ b/crates/eframe/src/native/file_storage.rs
@@ -41,7 +41,7 @@ impl Drop for FileStorage {
 
 impl FileStorage {
     /// Store the state in this .ron file.
-    fn from_ron_filepath(ron_filepath: impl Into<PathBuf>) -> Self {
+    pub(crate) fn from_ron_filepath(ron_filepath: impl Into<PathBuf>) -> Self {
         crate::profile_function!();
         let ron_filepath: PathBuf = ron_filepath.into();
         log::debug!("Loading app state from {:?}…", ron_filepath);

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -195,13 +195,17 @@ impl GlowWinitApp {
     ) -> Result<&mut GlowWinitRunning> {
         crate::profile_function!();
 
-        let storage = epi_integration::create_storage(
-            self.native_options
-                .viewport
-                .app_id
-                .as_ref()
-                .unwrap_or(&self.app_name),
-        );
+        let storage = if let Some(file) = &self.native_options.persistence_path {
+            epi_integration::create_storage_with_file(file)
+        } else {
+            epi_integration::create_storage(
+                self.native_options
+                    .viewport
+                    .app_id
+                    .as_ref()
+                    .unwrap_or(&self.app_name),
+            )
+        };
 
         let egui_ctx = create_egui_context(storage.as_deref());
 

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -420,13 +420,17 @@ impl WinitApp for WgpuWinitApp {
                     self.recreate_window(event_loop, running);
                     running
                 } else {
-                    let storage = epi_integration::create_storage(
-                        self.native_options
-                            .viewport
-                            .app_id
-                            .as_ref()
-                            .unwrap_or(&self.app_name),
-                    );
+                    let storage = if let Some(file) = &self.native_options.persistence_path {
+                        epi_integration::create_storage_with_file(file)
+                    } else {
+                        epi_integration::create_storage(
+                            self.native_options
+                                .viewport
+                                .app_id
+                                .as_ref()
+                                .unwrap_or(&self.app_name),
+                        )
+                    };
                     let egui_ctx = winit_integration::create_egui_context(storage.as_deref());
                     let (window, builder) = create_window(
                         &egui_ctx,


### PR DESCRIPTION
This allows customizing the persistence path in NativeOptions. Previously, persistence wouldn't work with android because directories-next doesn't support android so eframe would just fail to find a place where it could store its config. 

* Closes #4098 (android users can now specify a path that works with android, by e.g. using app_dirs2, which supports android)
