### PR TITLE
Add Arc and Pie Drawing and Plotting Features

### DIFF
--- a/crates/egui/src/painter.rs
+++ b/crates/egui/src/painter.rs
@@ -304,7 +304,7 @@ impl Painter {
         radius: f32,
         start_angle: f32,
         end_angle: f32,
-        stroke: impl Into<Stroke>,
+        stroke: impl Into<PathStroke>,
     ) -> ShapeIdx {
         self.add(Shape::arc(center, radius, start_angle, end_angle, stroke))
     }
@@ -317,7 +317,7 @@ impl Painter {
         start_angle: f32,
         end_angle: f32,
         fill: impl Into<Color32>,
-        stroke: impl Into<Stroke>,
+        stroke: impl Into<PathStroke>,
     ) -> ShapeIdx {
         self.add(Shape::pie(
             center,

--- a/crates/egui/src/painter.rs
+++ b/crates/egui/src/painter.rs
@@ -297,6 +297,38 @@ impl Painter {
         self.add(Shape::vline(x, y, stroke.into()))
     }
 
+    /// Paints an arc line.
+    pub fn arc(
+        &self,
+        center: Pos2,
+        radius: f32,
+        start_angle: f32,
+        end_angle: f32,
+        stroke: impl Into<Stroke>,
+    ) -> ShapeIdx {
+        self.add(Shape::arc(center, radius, start_angle, end_angle, stroke))
+    }
+
+    /// Paints a pie slice.
+    pub fn pie(
+        &self,
+        center: Pos2,
+        radius: f32,
+        start_angle: f32,
+        end_angle: f32,
+        fill: impl Into<Color32>,
+        stroke: impl Into<Stroke>,
+    ) -> ShapeIdx {
+        self.add(Shape::pie(
+            center,
+            radius,
+            start_angle,
+            end_angle,
+            fill,
+            stroke,
+        ))
+    }
+
     pub fn circle(
         &self,
         center: Pos2,

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -16,6 +16,12 @@ pub struct MiscDemoWindow {
     dummy_bool: bool,
     dummy_usize: usize,
     checklist: [bool; 3],
+
+    start_angle: f32,
+    end_angle: f32,
+    radius: f32,
+    fill: Color32,
+    stroke: Stroke,
 }
 
 impl Default for MiscDemoWindow {
@@ -32,6 +38,12 @@ impl Default for MiscDemoWindow {
             dummy_bool: false,
             dummy_usize: 0,
             checklist: std::array::from_fn(|i| i == 0),
+
+            start_angle: 0.0,
+            end_angle: std::f32::consts::FRAC_PI_2,
+            radius: 20.0,
+            fill: Color32::GREEN,
+            stroke: Stroke::new(1.0, Color32::RED),
         }
     }
 }
@@ -185,6 +197,49 @@ impl View for MiscDemoWindow {
                         ui.painter()
                             .circle_filled(rect.center(), r, ui.visuals().text_color());
                     }
+                });
+            });
+
+        CollapsingHeader::new("Arc and Pie")
+            .default_open(false)
+            .show(ui, |ui| {
+                ui.vertical(|ui| {
+                    ui.horizontal_wrapped(|ui| {
+                        ui.label("Start angle:");
+                        ui.drag_angle(&mut self.start_angle);
+                        ui.label("End angle:");
+                        ui.drag_angle(&mut self.end_angle);
+                        ui.label("Radius:");
+                        ui.add(egui::Slider::new(&mut self.radius, 0.0..=100.0));
+                        ui.end_row();
+                        ui.label("Fill:");
+                        ui.color_edit_button_srgba(&mut self.fill);
+                        ui.label("Stroke:");
+                        ui.add(&mut self.stroke);
+                    });
+                    ui.separator();
+                    ui.horizontal_wrapped(|ui| {
+                        let r = self.radius;
+                        let size = Vec2::splat(2.0 * r + self.stroke.width + 5.0);
+                        let (rect, _response) = ui.allocate_at_least(size, Sense::hover());
+                        ui.painter().arc(
+                            rect.center(),
+                            r,
+                            self.start_angle,
+                            self.end_angle,
+                            self.stroke,
+                        );
+                        let (rect, _response) = ui.allocate_at_least(size, Sense::hover());
+                        ui.painter().pie(
+                            rect.center(),
+                            r,
+                            self.start_angle,
+                            self.end_angle,
+                            self.fill,
+                            self.stroke,
+                        );
+                    });
+                    ui.separator();
                 });
             });
     }

--- a/crates/egui_demo_lib/src/demo/plot_demo.rs
+++ b/crates/egui_demo_lib/src/demo/plot_demo.rs
@@ -4,9 +4,9 @@ use std::ops::RangeInclusive;
 use egui::*;
 
 use egui_plot::{
-    Arrows, AxisHints, Bar, BarChart, BoxElem, BoxPlot, BoxSpread, CoordinatesFormatter, Corner,
-    GridInput, GridMark, HLine, Legend, Line, LineStyle, MarkerShape, Plot, PlotImage, PlotPoint,
-    PlotPoints, PlotResponse, Points, Polygon, Text, VLine,
+    ArcLine, Arrows, AxisHints, Bar, BarChart, BoxElem, BoxPlot, BoxSpread, CoordinatesFormatter,
+    Corner, GridInput, GridMark, HLine, Legend, Line, LineStyle, MarkerShape, Pie, PieChart, Plot,
+    PlotImage, PlotPoint, PlotPoints, PlotResponse, Points, Polygon, Text, VLine,
 };
 
 // ----------------------------------------------------------------------------
@@ -741,6 +741,20 @@ impl ItemsDemo {
             5.0 * vec2(texture.aspect_ratio(), 1.0),
         );
 
+        let arc_line = ArcLine::new(
+            PlotPoint::new(0.0, -10.0),
+            3.0,
+            225.0f32.to_radians(),
+            135.0f32.to_radians(),
+        );
+
+        let pie = Pie::new(
+            PlotPoint::new(0.0, -10.0),
+            3.0,
+            -45.0f32.to_radians(),
+            45.0f32.to_radians(),
+        );
+
         let plot = Plot::new("items_demo")
             .legend(Legend::default().position(Corner::RightBottom))
             .show_x(false)
@@ -760,6 +774,8 @@ impl ItemsDemo {
             plot_ui.text(Text::new(PlotPoint::new(2.5, -2.0), "such plot").name("Text"));
             plot_ui.image(image.name("Image"));
             plot_ui.arrows(arrows.name("Arrows"));
+            plot_ui.arc_line(arc_line.name("Arc line"));
+            plot_ui.pie(pie.name("Pie"));
         })
         .response
     }
@@ -864,6 +880,7 @@ enum Chart {
     GaussBars,
     StackedBars,
     BoxPlot,
+    Pies,
 }
 
 impl Default for Chart {
@@ -902,6 +919,7 @@ impl ChartsDemo {
                     ui.selectable_value(&mut self.chart, Chart::GaussBars, "Histogram");
                     ui.selectable_value(&mut self.chart, Chart::StackedBars, "Stacked Bar Chart");
                     ui.selectable_value(&mut self.chart, Chart::BoxPlot, "Box Plot");
+                    ui.selectable_value(&mut self.chart, Chart::Pies, "Pie Chart");
                 });
                 ui.label("Orientation:");
                 ui.horizontal(|ui| {
@@ -935,6 +953,7 @@ impl ChartsDemo {
             Chart::GaussBars => self.bar_gauss(ui),
             Chart::StackedBars => self.bar_stacked(ui),
             Chart::BoxPlot => self.box_plot(ui),
+            Chart::Pies => self.pies(ui),
         }
     }
 
@@ -1074,6 +1093,43 @@ impl ChartsDemo {
                 plot_ui.box_plot(box1);
                 plot_ui.box_plot(box2);
                 plot_ui.box_plot(box3);
+            })
+            .response
+    }
+
+    fn pies(&self, ui: &mut Ui) -> Response {
+        let data: Vec<f64> = vec![
+            16.41, 10.21, 9.76, 8.94, 6.77, 2.89, 1.85, 1.70, 1.61, 1.47, 38.39,
+        ];
+        let labels = vec![
+            "Python".to_owned(),
+            "C".to_owned(),
+            "C++".to_owned(),
+            "Java".to_owned(),
+            "C#".to_owned(),
+            "JavaScript".to_owned(),
+            "Go".to_owned(),
+            "Visual Basic".to_owned(),
+            "Fortran".to_owned(),
+            "SQL".to_owned(),
+            "Others".to_owned(),
+        ];
+        let pie_chart1 = PieChart::new([-6.0, 0.0], 5.0, data.clone())
+            .name("TIOBE - April 2024")
+            .labels(labels.clone());
+        let pie_chart2 = PieChart::new([6.0, 0.0], 5.0, data).labels(labels);
+
+        Plot::new("Pie Chart Demo")
+            .legend(Legend::default())
+            .auto_bounds(Vec2b::TRUE)
+            .allow_zoom(self.allow_zoom)
+            .allow_drag(self.allow_drag)
+            .data_aspect(1.0)
+            .show(ui, |plot_ui| {
+                plot_ui.pie_chart(pie_chart1);
+                for pie in pie_chart2.to_pies() {
+                    plot_ui.pie(pie);
+                }
             })
             .response
     }

--- a/crates/egui_plot/src/items/arc_pie.rs
+++ b/crates/egui_plot/src/items/arc_pie.rs
@@ -266,6 +266,7 @@ impl Pie {
     }
 
     /// Set the highlight state of the pie.
+    #[inline]
     pub fn highlight(mut self, highlight: bool) -> Self {
         self.highlight = highlight;
         self
@@ -721,7 +722,6 @@ impl PlotItem for PieChart {
 }
 
 /// Calculate the fill color of the pie chart.
-#[inline]
 fn auto_color(start_angle: f64, end_angle: f64) -> Color32 {
     let mid_angle = (start_angle + end_angle) / 2.0;
     let h = mid_angle.abs() / std::f64::consts::TAU;
@@ -729,12 +729,12 @@ fn auto_color(start_angle: f64, end_angle: f64) -> Color32 {
 }
 
 /// Calculate the inverted fill color of the pie chart.
-#[inline]
 fn auto_color_inverted(start_angle: f64, end_angle: f64) -> Color32 {
     let mid_angle = (start_angle + end_angle) / 2.0;
     let h = (mid_angle.abs() / std::f64::consts::TAU + 0.5) % 1.0;
     Hsva::new(h as f32, 0.95, 0.85, 0.95).into()
 }
+
 /// Calculate the bounds of a arc.
 fn calculate_arc_bounds(
     center: PlotPoint,

--- a/crates/egui_plot/src/items/arc_pie.rs
+++ b/crates/egui_plot/src/items/arc_pie.rs
@@ -1,0 +1,826 @@
+use super::{Id, PlotBounds, PlotGeometry, PlotItem, PlotPoint, PlotTransform};
+use crate::items::{ClosestElem, PlotConfig};
+use crate::{
+    Align2, Color32, Cursor, Hsva, LabelFormatter, LineStyle, Pos2, Shape, Stroke, TextStyle, Ui,
+};
+use std::ops::RangeInclusive;
+
+/// A arc line in a plot.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ArcLine {
+    pub(crate) center: PlotPoint,
+    pub(crate) radius: f64,
+    pub(crate) start_angle: f32,
+    pub(crate) end_angle: f32,
+    pub(crate) name: String,
+    pub(crate) highlight: bool,
+    pub(crate) allow_hover: bool,
+    pub(crate) stroke: Stroke,
+    pub(crate) style: LineStyle,
+    id: Option<Id>,
+}
+
+impl ArcLine {
+    /// Create a new arc line.
+    ///
+    /// # Arguments
+    ///
+    /// * `center` - The center of the arc line.
+    /// * `radius` - The radius of the arc line in plot coordinates.
+    /// * `start_angle` - The start angle of the arc line in radians.
+    /// * `end_angle` - The end angle of the arc line in radians.
+    pub fn new(
+        center: impl Into<PlotPoint>,
+        radius: f64,
+        start_angle: f32,
+        end_angle: f32,
+    ) -> Self {
+        Self {
+            center: center.into(),
+            radius,
+            start_angle,
+            end_angle,
+            name: Default::default(),
+            highlight: false,
+            allow_hover: true,
+            stroke: Stroke::new(1.0, Color32::TRANSPARENT),
+            style: LineStyle::Solid,
+            id: None,
+        }
+    }
+
+    /// Set the center of the arc line.
+    #[inline]
+    pub fn center(mut self, center: PlotPoint) -> Self {
+        self.center = center;
+        self
+    }
+
+    /// Set the radius of the arc line.
+    #[inline]
+    pub fn radius(mut self, radius: f64) -> Self {
+        self.radius = radius;
+        self
+    }
+
+    /// Set the start angle of the arc line.
+    #[inline]
+    pub fn start_angle(mut self, start_angle: f32) -> Self {
+        self.start_angle = start_angle;
+        self
+    }
+
+    /// Set the end angle of the arc line.
+    #[inline]
+    pub fn end_angle(mut self, end_angle: f32) -> Self {
+        self.end_angle = end_angle;
+        self
+    }
+
+    /// Set the name of the arc line.
+    #[inline]
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Set the highlight state of the arc line.
+    #[inline]
+    pub fn highlight(mut self, highlight: bool) -> Self {
+        self.highlight = highlight;
+        self
+    }
+
+    /// Set the hover state of the arc line.
+    #[inline]
+    pub fn allow_hover(mut self, allow_hover: bool) -> Self {
+        self.allow_hover = allow_hover;
+        self
+    }
+
+    /// Set the stroke of the arc line.
+    #[inline]
+    pub fn stroke(mut self, stroke: Stroke) -> Self {
+        self.stroke = stroke;
+        self
+    }
+
+    /// Set the color of the arc line.
+    ///
+    /// This will override the color set in the stroke.
+    #[inline]
+    pub fn color(mut self, color: Color32) -> Self {
+        self.stroke.color = color;
+        self
+    }
+
+    /// Set the style of the arc line.
+    #[inline]
+    pub fn style(mut self, style: LineStyle) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Set the id of the arc line.
+    #[inline]
+    pub fn id(mut self, id: Id) -> Self {
+        self.id = Some(id);
+        self
+    }
+}
+
+impl PlotItem for ArcLine {
+    fn shapes(&self, _ui: &Ui, transform: &PlotTransform, shapes: &mut Vec<Shape>) {
+        let center = transform.position_from_point(&self.center);
+        let max_x_pos = transform
+            .position_from_point(&PlotPoint::new(self.center.x + self.radius, self.center.y));
+        let radius = max_x_pos.x - center.x;
+        let start_angle = self.start_angle;
+        let end_angle = self.end_angle;
+        let mut stroke = self.stroke;
+
+        // Expand the radius with stroke width if the item is highlighted
+        if self.highlight {
+            stroke.width *= 2.0;
+        }
+
+        shapes.push(Shape::arc(center, radius, start_angle, end_angle, stroke));
+    }
+
+    fn initialize(&mut self, _x_range: RangeInclusive<f64>) {}
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn color(&self) -> Color32 {
+        self.stroke.color
+    }
+
+    fn highlight(&mut self) {
+        self.highlight = true;
+    }
+
+    fn highlighted(&self) -> bool {
+        self.highlight
+    }
+
+    fn allow_hover(&self) -> bool {
+        self.allow_hover
+    }
+
+    fn geometry(&self) -> PlotGeometry<'_> {
+        PlotGeometry::None
+    }
+
+    fn bounds(&self) -> PlotBounds {
+        calculate_arc_bounds(self.center, self.radius, self.start_angle, self.end_angle)
+    }
+
+    fn id(&self) -> Option<Id> {
+        self.id
+    }
+}
+
+/// A pie in a plot.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Pie {
+    pub(crate) center: PlotPoint,
+    pub(crate) radius: f64,
+    pub(crate) start_angle: f32,
+    pub(crate) end_angle: f32,
+    pub(crate) name: String,
+    pub(crate) highlight: bool,
+    pub(crate) allow_hover: bool,
+    pub(crate) fill: Color32,
+    pub(crate) stroke: Stroke,
+    pub(crate) style: LineStyle,
+    shrink_or_expand: Option<f32>,
+    id: Option<Id>,
+}
+
+impl Pie {
+    /// Create a new pie.
+    ///
+    /// # Arguments
+    ///
+    /// * `center` - The center of the pie.
+    /// * `radius` - The radius of the pie in plot coordinates.
+    /// * `start_angle` - The start angle of the pie in radians.
+    /// * `end_angle` - The end angle of the pie in radians.
+    pub fn new(
+        center: impl Into<PlotPoint>,
+        radius: f64,
+        start_angle: f32,
+        end_angle: f32,
+    ) -> Self {
+        Self {
+            center: center.into(),
+            radius,
+            start_angle,
+            end_angle,
+            name: Default::default(),
+            highlight: false,
+            allow_hover: true,
+            fill: Color32::TRANSPARENT,
+            stroke: Stroke::new(1.0, Color32::TRANSPARENT),
+            style: LineStyle::Solid,
+            shrink_or_expand: None,
+            id: None,
+        }
+    }
+
+    /// Set the center of the pie.
+    #[inline]
+    pub fn center(mut self, center: PlotPoint) -> Self {
+        self.center = center;
+        self
+    }
+
+    /// Set the radius of the pie.
+    #[inline]
+    pub fn radius(mut self, radius: f64) -> Self {
+        self.radius = radius;
+        self
+    }
+
+    /// Set the start angle of the pie.
+    #[inline]
+    pub fn start_angle(mut self, start_angle: f32) -> Self {
+        self.start_angle = start_angle;
+        self
+    }
+
+    /// Set the end angle of the pie.
+    #[inline]
+    pub fn end_angle(mut self, end_angle: f32) -> Self {
+        self.end_angle = end_angle;
+        self
+    }
+
+    /// Set the name of the pie.
+    #[inline]
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Set the highlight state of the pie.
+    pub fn highlight(mut self, highlight: bool) -> Self {
+        self.highlight = highlight;
+        self
+    }
+
+    /// Set the hover state of the pie.
+    #[inline]
+    pub fn allow_hover(mut self, allow_hover: bool) -> Self {
+        self.allow_hover = allow_hover;
+        self
+    }
+
+    /// Set the fill color of the pie.
+    #[inline]
+    pub fn fill(mut self, fill: Color32) -> Self {
+        self.fill = fill;
+        self
+    }
+
+    /// Set the stroke of the pie.
+    #[inline]
+    pub fn stroke(mut self, stroke: Stroke) -> Self {
+        self.stroke = stroke;
+        self
+    }
+
+    /// Set the style of the pie.
+    #[inline]
+    pub fn style(mut self, style: LineStyle) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Shrink the pie by a amount of pixels in screen coordinates.
+    #[inline]
+    pub fn shrink(mut self, amount: f32) -> Self {
+        self.shrink_or_expand = Some(-amount);
+        self
+    }
+
+    /// Expand the pie by a amount of pixels in screen coordinates.
+    #[inline]
+    pub fn expand(mut self, amount: f32) -> Self {
+        self.shrink_or_expand = Some(amount);
+        self
+    }
+
+    /// Set the id of the pie.
+    #[inline]
+    pub fn id(mut self, id: Id) -> Self {
+        self.id = Some(id);
+        self
+    }
+}
+
+impl PlotItem for Pie {
+    fn shapes(&self, _ui: &Ui, transform: &PlotTransform, shapes: &mut Vec<Shape>) {
+        let mut center = transform.position_from_point(&self.center);
+        let max_x_pos = transform
+            .position_from_point(&PlotPoint::new(self.center.x + self.radius, self.center.y));
+        let mut radius = max_x_pos.x - center.x;
+        let mut start_angle = self.start_angle;
+        let mut end_angle = self.end_angle;
+        let fill = self.fill;
+        let stroke = self.stroke;
+
+        // Shrink or expand the pie
+        if let Some(mut amount) = self.shrink_or_expand {
+            // Adjust the amount to fit within a smaller radius.
+            if radius < 64.0 {
+                amount *= radius / 64.0;
+            }
+            let (new_center, new_radius, new_start_angle, new_end_angle) =
+                shrink_or_expand_pie(center, radius, start_angle, end_angle, amount);
+            center = new_center;
+            radius = new_radius;
+            start_angle = new_start_angle;
+            end_angle = new_end_angle;
+        }
+
+        // Expand the radius with stroke width if the item is highlighted
+        if self.highlight {
+            radius += (stroke.width * 2.0).clamp(2.0, 10.0);
+        }
+
+        shapes.push(Shape::pie(
+            center,
+            radius,
+            start_angle,
+            end_angle,
+            fill,
+            stroke,
+        ));
+    }
+
+    fn initialize(&mut self, _x_range: RangeInclusive<f64>) {}
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn color(&self) -> Color32 {
+        self.fill
+    }
+
+    fn highlight(&mut self) {
+        self.highlight = true;
+    }
+
+    fn highlighted(&self) -> bool {
+        self.highlight
+    }
+
+    fn allow_hover(&self) -> bool {
+        self.allow_hover
+    }
+
+    fn geometry(&self) -> PlotGeometry<'_> {
+        PlotGeometry::None
+    }
+
+    fn bounds(&self) -> PlotBounds {
+        calculate_arc_bounds(self.center, self.radius, self.start_angle, self.end_angle)
+    }
+
+    fn id(&self) -> Option<Id> {
+        self.id
+    }
+
+    fn find_closest(&self, point: Pos2, transform: &PlotTransform) -> Option<ClosestElem> {
+        let center = transform.position_from_point(&self.center);
+        let radius = transform.position_from_point_x(self.center.x + self.radius) - center.x;
+        // let angle_pairs = self.to_angle_pairs();
+        // for (i, (start, end)) in angle_pairs.into_iter().enumerate() {
+        if contains_in_pie(center, radius, self.start_angle, self.end_angle, point) {
+            return Some(ClosestElem {
+                index: 0,
+                dist_sq: 0.0,
+            });
+        }
+        // }
+
+        None
+    }
+
+    fn on_hover(
+        &self,
+        _elem: ClosestElem,
+        shapes: &mut Vec<Shape>,
+        _cursors: &mut Vec<Cursor>,
+        plot: &PlotConfig<'_>,
+        _label_formatter: &LabelFormatter,
+    ) {
+        // let text = format!("{}", self.name);
+        let font_id = TextStyle::Body.resolve(plot.ui.style());
+        plot.ui.fonts(|f| {
+            let center = center_of_pie(
+                self.center.to_pos2(),
+                self.radius as f32,
+                self.start_angle,
+                self.end_angle,
+            );
+            let color = auto_color_inverted(self.start_angle as f64, self.end_angle as f64);
+            shapes.push(Shape::text(
+                f,
+                plot.transform
+                    .position_from_point(&PlotPoint::new(center.x, center.y)),
+                Align2::CENTER_CENTER,
+                &self.name,
+                font_id,
+                color,
+            ));
+        });
+    }
+}
+
+pub struct PieChart {
+    pub(crate) center: PlotPoint,
+    pub(crate) radius: f64,
+    pub(crate) name: String,
+    pub(crate) highlight: bool,
+    pub(crate) allow_hover: bool,
+    pub(crate) stroke: Stroke,
+    pub(crate) data: Vec<f64>,
+    pub(crate) colors: Vec<Color32>,
+    pub(crate) labels: Vec<String>,
+    pub(crate) style: LineStyle,
+    pub(crate) shrink_or_expand: Option<f32>,
+    id: Option<Id>,
+}
+
+impl PieChart {
+    /// Create a new pie chart.
+    ///
+    /// # Arguments
+    ///
+    /// * `center` - The center of the pie chart.
+    /// * `radius` - The radius of the pie chart in plot coordinates.
+    /// * `data` - The data of the pie chart.
+    pub fn new(center: impl Into<PlotPoint>, radius: f64, data: Vec<f64>) -> Self {
+        Self {
+            center: center.into(),
+            radius,
+            name: Default::default(),
+            highlight: false,
+            allow_hover: true,
+            stroke: Stroke::new(1.0, Color32::TRANSPARENT),
+            data,
+            colors: vec![],
+            labels: vec![],
+            style: LineStyle::Solid,
+            shrink_or_expand: None,
+            id: None,
+        }
+    }
+
+    /// Set the center of the pie chart.
+    #[inline]
+    pub fn center(mut self, center: PlotPoint) -> Self {
+        self.center = center;
+        self
+    }
+
+    /// Set the radius of the pie chart.
+    #[inline]
+    pub fn radius(mut self, radius: f64) -> Self {
+        self.radius = radius;
+        self
+    }
+
+    /// Set the name of the pie chart.
+    #[inline]
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Set the highlight state of the pie chart.
+    #[inline]
+    pub fn highlight(mut self, highlight: bool) -> Self {
+        self.highlight = highlight;
+        self
+    }
+
+    /// Set the hover state of the pie chart.
+    #[inline]
+    pub fn allow_hover(mut self, allow_hover: bool) -> Self {
+        self.allow_hover = allow_hover;
+        self
+    }
+
+    /// Set the stroke of the pie chart.
+    #[inline]
+    pub fn stroke(mut self, stroke: Stroke) -> Self {
+        self.stroke = stroke;
+        self
+    }
+
+    /// Set the data of the pie chart.
+    #[inline]
+    pub fn data(mut self, data: Vec<f64>) -> Self {
+        self.data = data;
+        self
+    }
+
+    /// Set the fill colors of the pie chart.
+    #[inline]
+    pub fn colors(mut self, colors: Vec<Color32>) -> Self {
+        self.colors = colors;
+        self
+    }
+
+    #[inline]
+    pub fn label(mut self, label: impl Into<String>) -> Self {
+        self.labels.push(label.into());
+        self
+    }
+
+    /// Set the labels of the pie chart.
+    #[inline]
+    pub fn labels(mut self, labels: Vec<String>) -> Self {
+        self.labels = labels;
+        self
+    }
+
+    /// Set the style of the pie chart
+    #[inline]
+    pub fn style(mut self, style: LineStyle) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Shrink the pie chart by a amount of pixels in screen coordinates.
+    #[inline]
+    pub fn shrink(mut self, amount: f32) -> Self {
+        self.shrink_or_expand = Some(-amount);
+        self
+    }
+
+    /// Expand the pie chart by a amount of pixels in screen coordinates.
+    #[inline]
+    pub fn expand(mut self, amount: f32) -> Self {
+        self.shrink_or_expand = Some(amount);
+        self
+    }
+
+    /// Set the id of the pie chart.
+    #[inline]
+    pub fn id(mut self, id: Id) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    /// Convert the pie chart to a list of pies.
+    pub fn to_pies(&self) -> Vec<Pie> {
+        use std::f64::consts::TAU;
+
+        let sum: f64 = self.data.iter().sum();
+        let mut start_angle = 0.0;
+        let mut pies = vec![];
+        for (i, v) in self.data.iter().enumerate() {
+            let end_angle = start_angle + (v / sum) * TAU;
+            let default_color = auto_color(start_angle, end_angle);
+            let name = self.labels.get(i).map_or(Default::default(), |s| s.clone());
+            let fill = self.colors.get(i).map_or(default_color, |v| *v);
+            let pie = Pie::new(
+                self.center,
+                self.radius,
+                start_angle as f32,
+                end_angle as f32,
+            )
+            .name(name)
+            .fill(fill)
+            .stroke(self.stroke)
+            .style(self.style);
+            pies.push(pie);
+            start_angle = end_angle;
+        }
+        pies
+    }
+
+    pub fn to_angle_pairs(&self) -> Vec<(f32, f32)> {
+        use std::f64::consts::TAU;
+
+        let sum: f64 = self.data.iter().sum();
+        let mut start_angle = 0.0;
+        let mut pies = vec![];
+        for v in &self.data {
+            let end_angle = start_angle + (v / sum) * TAU;
+            pies.push((start_angle as f32, end_angle as f32));
+            start_angle = end_angle;
+        }
+        pies
+    }
+}
+
+impl PlotItem for PieChart {
+    fn shapes(&self, ui: &Ui, transform: &PlotTransform, shapes: &mut Vec<Shape>) {
+        let pies = self.to_pies();
+        for pie in pies {
+            pie.highlight(self.highlight).shapes(ui, transform, shapes);
+        }
+    }
+
+    fn initialize(&mut self, _x_range: RangeInclusive<f64>) {}
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn color(&self) -> Color32 {
+        Color32::TRANSPARENT
+    }
+
+    fn highlight(&mut self) {
+        self.highlight = true;
+    }
+
+    fn highlighted(&self) -> bool {
+        self.highlight
+    }
+
+    fn allow_hover(&self) -> bool {
+        self.allow_hover
+    }
+
+    fn geometry(&self) -> PlotGeometry<'_> {
+        PlotGeometry::None
+    }
+
+    fn bounds(&self) -> PlotBounds {
+        let min_point = [self.center.x - self.radius, self.center.y - self.radius];
+        let max_point = [self.center.x + self.radius, self.center.y + self.radius];
+        PlotBounds::from_min_max(min_point, max_point)
+    }
+
+    fn id(&self) -> Option<Id> {
+        self.id
+    }
+
+    fn find_closest(&self, point: Pos2, transform: &PlotTransform) -> Option<ClosestElem> {
+        let center = transform.position_from_point(&self.center);
+        let radius = transform.position_from_point_x(self.center.x + self.radius) - center.x;
+        let angle_pairs = self.to_angle_pairs();
+        for (i, (start, end)) in angle_pairs.into_iter().enumerate() {
+            if contains_in_pie(center, radius, start, end, point) {
+                return Some(ClosestElem {
+                    index: i,
+                    dist_sq: 0.0,
+                });
+            }
+        }
+
+        None
+    }
+
+    fn on_hover(
+        &self,
+        elem: ClosestElem,
+        shapes: &mut Vec<Shape>,
+        _cursors: &mut Vec<Cursor>,
+        plot: &PlotConfig<'_>,
+        _label_formatter: &LabelFormatter,
+    ) {
+        let angles = self.to_angle_pairs();
+        let value = self.data[elem.index];
+        let text = if let Some(label) = self.labels.get(elem.index) {
+            format!("{value}\n{label}")
+        } else {
+            format!("{value}")
+        };
+        let font_id = TextStyle::Body.resolve(plot.ui.style());
+        plot.ui.fonts(|f| {
+            let (start_angle, end_angle) = angles[elem.index];
+            let center = center_of_pie(
+                self.center.to_pos2(),
+                self.radius as f32,
+                start_angle,
+                end_angle,
+            );
+            let color = auto_color_inverted(start_angle as f64, end_angle as f64);
+            shapes.push(Shape::text(
+                f,
+                plot.transform
+                    .position_from_point(&PlotPoint::new(center.x, center.y)),
+                Align2::CENTER_CENTER,
+                text,
+                font_id,
+                color,
+            ));
+        });
+    }
+}
+
+/// Calculate the fill color of the pie chart.
+#[inline]
+fn auto_color(start_angle: f64, end_angle: f64) -> Color32 {
+    let mid_angle = (start_angle + end_angle) / 2.0;
+    let h = mid_angle.abs() / std::f64::consts::TAU;
+    Hsva::new(h as f32, 0.95, 0.85, 0.95).into()
+}
+
+/// Calculate the inverted fill color of the pie chart.
+#[inline]
+fn auto_color_inverted(start_angle: f64, end_angle: f64) -> Color32 {
+    let mid_angle = (start_angle + end_angle) / 2.0;
+    let h = (mid_angle.abs() / std::f64::consts::TAU + 0.5) % 1.0;
+    Hsva::new(h as f32, 0.95, 0.85, 0.95).into()
+}
+/// Calculate the bounds of a arc.
+fn calculate_arc_bounds(
+    center: PlotPoint,
+    radius: f64,
+    start_angle: f32,
+    end_angle: f32,
+) -> PlotBounds {
+    let x = center.x;
+    let y = center.y;
+    let r = radius;
+    let start_angle = start_angle as f64;
+    let end_angle = end_angle as f64;
+    let min_point = [x - r, y - r];
+    let max_point = [x + r, y + r];
+    let start_point = [x + r * start_angle.cos(), y + r * start_angle.sin()];
+    let end_point = [x + r * end_angle.cos(), y + r * end_angle.sin()];
+    let min_x = min_point[0].min(start_point[0]).min(end_point[0]);
+    let max_x = max_point[0].max(start_point[0]).max(end_point[0]);
+    let min_y = min_point[1].min(start_point[1]).min(end_point[1]);
+    let max_y = max_point[1].max(start_point[1]).max(end_point[1]);
+    PlotBounds::from_min_max([min_x, min_y], [max_x, max_y])
+}
+
+/// Shrink or expand a pie by a amount of pixels in screen coordinates.
+fn shrink_or_expand_pie(
+    center: Pos2,
+    radius: f32,
+    start_angle: f32,
+    end_angle: f32,
+    amount: f32,
+) -> (Pos2, f32, f32, f32) {
+    let move_distance = amount * 2.0;
+    let new_radius = radius + move_distance;
+
+    // Calculate the direction of the midline
+    let mid_angle = (start_angle + end_angle) / 2.0;
+    let direction = Pos2 {
+        x: mid_angle.cos(),
+        y: mid_angle.sin(),
+    };
+
+    // Move the center along the midline
+    let center = Pos2 {
+        x: center.x - direction.x * move_distance,
+        y: center.y - direction.y * move_distance,
+    };
+
+    (center, new_radius, start_angle, end_angle)
+}
+
+/// Check if a point is within a pie.
+fn contains_in_pie(
+    center: Pos2,
+    radius: f32,
+    start_angle: f32,
+    end_angle: f32,
+    point: Pos2,
+) -> bool {
+    use std::f32::consts::PI;
+
+    // Calculate the distance between the point and the center
+    let dx = point.x - center.x;
+    let dy = point.y - center.y;
+    let distance = dx.hypot(dy);
+
+    // Check if the point is within the radius
+    if distance > radius {
+        return false;
+    }
+
+    // Calculate the angle of the point
+    let angle = dy.atan2(dx);
+    let angle = if angle < 0.0 { angle + 2.0 * PI } else { angle };
+
+    // Check if the angle is within the start and end angles
+    start_angle <= angle && angle <= end_angle
+}
+
+fn center_of_pie(center: Pos2, radius: f32, start_angle: f32, end_angle: f32) -> Pos2 {
+    let mid_angle = (start_angle + end_angle) / 2.0;
+    let direction = Pos2 {
+        x: mid_angle.cos(),
+        y: mid_angle.sin(),
+    };
+    Pos2 {
+        x: center.x + direction.x * radius / 2.0,
+        y: center.y - direction.y * radius / 2.0,
+    }
+}

--- a/crates/egui_plot/src/items/mod.rs
+++ b/crates/egui_plot/src/items/mod.rs
@@ -10,12 +10,14 @@ use crate::*;
 use super::{Cursor, LabelFormatter, PlotBounds, PlotTransform};
 use rect_elem::*;
 
+pub use arc_pie::{ArcLine, Pie, PieChart};
 pub use bar::Bar;
 pub use box_elem::{BoxElem, BoxSpread};
 pub use values::{
     ClosestElem, LineStyle, MarkerShape, Orientation, PlotGeometry, PlotPoint, PlotPoints,
 };
 
+mod arc_pie;
 mod bar;
 mod box_elem;
 mod rect_elem;

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -23,9 +23,9 @@ use epaint::Hsva;
 pub use crate::{
     axis::{Axis, AxisHints, HPlacement, Placement, VPlacement},
     items::{
-        Arrows, Bar, BarChart, BoxElem, BoxPlot, BoxSpread, ClosestElem, HLine, Line, LineStyle,
-        MarkerShape, Orientation, PlotConfig, PlotGeometry, PlotImage, PlotItem, PlotPoint,
-        PlotPoints, Points, Polygon, Text, VLine,
+        ArcLine, Arrows, Bar, BarChart, BoxElem, BoxPlot, BoxSpread, ClosestElem, HLine, Line,
+        LineStyle, MarkerShape, Orientation, Pie, PieChart, PlotConfig, PlotGeometry, PlotImage,
+        PlotItem, PlotPoint, PlotPoints, Points, Polygon, Text, VLine,
     },
     legend::{Corner, Legend},
     memory::PlotMemory,

--- a/crates/egui_plot/src/plot_ui.rs
+++ b/crates/egui_plot/src/plot_ui.rs
@@ -232,4 +232,28 @@ impl PlotUi {
         }
         self.items.push(Box::new(chart));
     }
+
+    /// Add an arc line.
+    pub fn arc_line(&mut self, mut arc_line: ArcLine) {
+        if arc_line.stroke.color == Color32::TRANSPARENT {
+            arc_line.stroke.color = self.auto_color();
+        }
+        self.items.push(Box::new(arc_line));
+    }
+
+    /// Add a pie.
+    pub fn pie(&mut self, mut pie: Pie) {
+        if pie.fill == Color32::TRANSPARENT {
+            pie.fill = self.auto_color();
+        }
+        self.items.push(Box::new(pie));
+    }
+
+    /// Add a pie chart.
+    pub fn pie_chart(&mut self, pie_chart: PieChart) {
+        if pie_chart.data.is_empty() {
+            return;
+        }
+        self.items.push(Box::new(pie_chart));
+    }
 }

--- a/crates/epaint/src/lib.rs
+++ b/crates/epaint/src/lib.rs
@@ -51,8 +51,8 @@ pub use self::{
     mesh::{Mesh, Mesh16, Vertex},
     shadow::Shadow,
     shape::{
-        CircleShape, EllipseShape, PaintCallback, PaintCallbackInfo, PathShape, RectShape,
-        Rounding, Shape, TextShape,
+        ArcPieShape, CircleShape, EllipseShape, PaintCallback, PaintCallbackInfo, PathShape,
+        RectShape, Rounding, Shape, TextShape,
     },
     stats::PaintStats,
     stroke::{PathStroke, Stroke},

--- a/crates/epaint/src/shape.rs
+++ b/crates/epaint/src/shape.rs
@@ -261,7 +261,7 @@ impl Shape {
         radius: f32,
         start_angle: f32,
         end_angle: f32,
-        stroke: impl Into<Stroke>,
+        stroke: impl Into<PathStroke>,
     ) -> Self {
         Self::ArcPie(ArcPieShape::arc(
             center,
@@ -298,7 +298,7 @@ impl Shape {
         start_angle: f32,
         end_angle: f32,
         fill: impl Into<Color32>,
-        stroke: impl Into<Stroke>,
+        stroke: impl Into<PathStroke>,
     ) -> Self {
         Self::ArcPie(ArcPieShape::pie(
             center,
@@ -559,7 +559,7 @@ pub struct ArcPieShape {
     pub end_angle: f32,
     pub closed: bool,
     pub fill: Color32,
-    pub stroke: Stroke,
+    pub stroke: PathStroke,
 }
 
 impl ArcPieShape {
@@ -581,7 +581,7 @@ impl ArcPieShape {
         end_angle: f32,
         closed: bool,
         fill: impl Into<Color32>,
-        stroke: impl Into<Stroke>,
+        stroke: impl Into<PathStroke>,
     ) -> Self {
         Self {
             center,
@@ -608,7 +608,7 @@ impl ArcPieShape {
         radius: f32,
         start_angle: f32,
         end_angle: f32,
-        stroke: impl Into<Stroke>,
+        stroke: impl Into<PathStroke>,
     ) -> Self {
         Self::new(
             center,
@@ -637,7 +637,7 @@ impl ArcPieShape {
         start_angle: f32,
         end_angle: f32,
         fill: impl Into<Color32>,
-        stroke: impl Into<Stroke>,
+        stroke: impl Into<PathStroke>,
     ) -> Self {
         Self::new(center, radius, start_angle, end_angle, true, fill, stroke)
     }

--- a/crates/epaint/src/shape.rs
+++ b/crates/epaint/src/shape.rs
@@ -28,6 +28,9 @@ pub enum Shape {
     /// For performance reasons it is better to avoid it.
     Vec(Vec<Shape>),
 
+    /// An arc or pie with a given start and end angle.
+    ArcPie(ArcPieShape),
+
     /// Circle with optional outline and fill.
     Circle(CircleShape),
 
@@ -233,6 +236,80 @@ impl Shape {
         Self::Path(PathShape::convex_polygon(points, fill, stroke))
     }
 
+    /// Generates an arc with a given start and end angle.
+    ///
+    /// This function creates an arc centered at a specified point, with a specified radius.
+    /// The arc starts at the `start_angle` and ends at the `end_angle`.
+    /// Angles are specified in radians, with positive angles indicating clockwise rotation and negative angles indicating counterclockwise rotation.
+    ///
+    /// # Arguments
+    ///
+    /// * `center` - The center point of the arc.
+    /// * `radius` - The radius of the arc.
+    /// * `start_angle` - The start angle of the arc, in radians.
+    /// * `end_angle` - The end angle of the arc, in radians.
+    /// * `stroke` - The stroke of the arc.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use epaint::{pos2, Color32, Shape, Stroke};
+    /// let arc = Shape::arc(pos2(100.0, 100.0), 50.0, 0.0, std::f32::consts::PI, Stroke::new(3.0, Color32::RED));
+    /// ```
+    pub fn arc(
+        center: Pos2,
+        radius: f32,
+        start_angle: f32,
+        end_angle: f32,
+        stroke: impl Into<Stroke>,
+    ) -> Self {
+        Self::ArcPie(ArcPieShape::arc(
+            center,
+            radius,
+            start_angle,
+            end_angle,
+            stroke,
+        ))
+    }
+
+    /// Generates an pie with a given start and end angle.
+    ///
+    /// This function creates an arc centered at a specified point, with a specified radius.
+    /// The pie starts at the `start_angle` and ends at the `end_angle`.
+    /// Angles are specified in radians, with positive angles indicating clockwise rotation and negative angles indicating counterclockwise rotation.
+    ///
+    /// # Arguments
+    ///
+    /// * `center` - The center point of the pie.
+    /// * `radius` - The radius of the pie.
+    /// * `start_angle` - The start angle of the pie, in radians.
+    /// * `end_angle` - The end angle of the pie, in radians.
+    /// * `stroke` - The stroke of the pie.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use epaint::{pos2, Color32, Shape, Stroke};
+    /// let pie = Shape::pie(pos2(100.0, 100.0), 50.0, 0.0, std::f32::consts::PI, Color32::BLUE, Stroke::new(3.0, Color32::RED));
+    /// ```
+    pub fn pie(
+        center: Pos2,
+        radius: f32,
+        start_angle: f32,
+        end_angle: f32,
+        fill: impl Into<Color32>,
+        stroke: impl Into<Stroke>,
+    ) -> Self {
+        Self::ArcPie(ArcPieShape::pie(
+            center,
+            radius,
+            start_angle,
+            end_angle,
+            fill,
+            stroke,
+        ))
+    }
+
     #[inline]
     pub fn circle_filled(center: Pos2, radius: f32, fill_color: impl Into<Color32>) -> Self {
         Self::Circle(CircleShape::filled(center, radius, fill_color))
@@ -340,6 +417,7 @@ impl Shape {
                 }
                 rect
             }
+            Self::ArcPie(arc_pie_shape) => arc_pie_shape.visual_bounding_rect(),
             Self::Circle(circle_shape) => circle_shape.visual_bounding_rect(),
             Self::Ellipse(ellipse_shape) => ellipse_shape.visual_bounding_rect(),
             Self::LineSegment { points, stroke } => {
@@ -428,6 +506,11 @@ impl Shape {
                 rect_shape.stroke.width *= transform.scaling;
                 rect_shape.rounding *= transform.scaling;
             }
+            Self::ArcPie(arc_pie_shape) => {
+                arc_pie_shape.center = transform * arc_pie_shape.center;
+                arc_pie_shape.radius *= transform.scaling;
+                arc_pie_shape.stroke.width *= transform.scaling;
+            }
             Self::Text(text_shape) => {
                 text_shape.pos = transform * text_shape.pos;
 
@@ -461,6 +544,114 @@ impl Shape {
             Self::Callback(shape) => {
                 shape.rect = transform * shape.rect;
             }
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+/// A arc or pie slice with a given start and end angle.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ArcPieShape {
+    pub center: Pos2,
+    pub radius: f32,
+    pub start_angle: f32,
+    pub end_angle: f32,
+    pub closed: bool,
+    pub fill: Color32,
+    pub stroke: Stroke,
+}
+
+impl ArcPieShape {
+    /// Create a new arc or pie shape.
+    ///
+    /// # Arguments
+    ///
+    /// * `center` - The center of the arc or pie.
+    /// * `radius` - The radius of the arc or pie.
+    /// * `start_angle` - The start angle of the arc or pie, in radians.
+    /// * `end_angle` - The end angle of the arc or pie, in radians.
+    /// * `closed` - If true, connect the center with the start and end points.
+    /// * `fill` - The fill color of the arc or pie.
+    /// * `stroke` - The stroke of the arc or pie.
+    pub fn new(
+        center: Pos2,
+        radius: f32,
+        start_angle: f32,
+        end_angle: f32,
+        closed: bool,
+        fill: impl Into<Color32>,
+        stroke: impl Into<Stroke>,
+    ) -> Self {
+        Self {
+            center,
+            radius,
+            start_angle,
+            end_angle,
+            closed,
+            fill: fill.into(),
+            stroke: stroke.into(),
+        }
+    }
+
+    /// Create a new arc shape.
+    ///
+    /// # Arguments
+    ///
+    /// * `center` - The center of the arc.
+    /// * `radius` - The radius of the arc.
+    /// * `start_angle` - The start angle of the arc, in radians.
+    /// * `end_angle` - The end angle of the arc, in radians.
+    /// * `stroke` - The stroke of the arc.
+    pub fn arc(
+        center: Pos2,
+        radius: f32,
+        start_angle: f32,
+        end_angle: f32,
+        stroke: impl Into<Stroke>,
+    ) -> Self {
+        Self::new(
+            center,
+            radius,
+            start_angle,
+            end_angle,
+            false,
+            Color32::TRANSPARENT,
+            stroke,
+        )
+    }
+
+    /// Create a new pie shape.
+    ///
+    /// # Arguments
+    ///
+    /// * `center` - The center of the pie.
+    /// * `radius` - The radius of the pie.
+    /// * `start_angle` - The start angle of the pie, in radians.
+    /// * `end_angle` - The end angle of the pie, in radians.
+    /// * `fill` - The fill color of the pie.
+    /// * `stroke` - The stroke of the pie.
+    pub fn pie(
+        center: Pos2,
+        radius: f32,
+        start_angle: f32,
+        end_angle: f32,
+        fill: impl Into<Color32>,
+        stroke: impl Into<Stroke>,
+    ) -> Self {
+        Self::new(center, radius, start_angle, end_angle, true, fill, stroke)
+    }
+
+    /// The visual bounding rectangle (includes stroke width)
+    pub fn visual_bounding_rect(&self) -> Rect {
+        if self.fill == Color32::TRANSPARENT && self.stroke.is_empty() {
+            Rect::NOTHING
+        } else {
+            let rect = Rect::from_center_size(self.center, vec2(self.radius, self.radius));
+            let start =
+                self.center + vec2(self.start_angle.cos(), self.start_angle.sin()) * self.radius;
+            let end = self.center + vec2(self.end_angle.cos(), self.end_angle.sin()) * self.radius;
+            rect.union(Rect::from_two_pos(start, end))
         }
     }
 }

--- a/crates/epaint/src/shape_transform.rs
+++ b/crates/epaint/src/shape_transform.rs
@@ -70,8 +70,17 @@ pub fn adjust_colors(
         }) => {
             if *closed {
                 adjust_color(fill);
-            } else {
-                adjust_color(&mut stroke.color);
+            }
+            match &stroke.color {
+                color::ColorMode::Solid(mut col) => adjust_color(&mut col),
+                color::ColorMode::UV(callback) => {
+                    let callback = callback.clone();
+                    stroke.color = color::ColorMode::UV(Arc::new(Box::new(move |rect, pos| {
+                        let mut col = callback(rect, pos);
+                        adjust_color(&mut col);
+                        col
+                    })));
+                }
             }
         }
 

--- a/crates/epaint/src/shape_transform.rs
+++ b/crates/epaint/src/shape_transform.rs
@@ -59,6 +59,22 @@ pub fn adjust_colors(
             }
         }
 
+        Shape::ArcPie(ArcPieShape {
+            center: _,
+            radius: _,
+            start_angle: _,
+            end_angle: _,
+            closed,
+            fill,
+            stroke,
+        }) => {
+            if *closed {
+                adjust_color(fill);
+            } else {
+                adjust_color(&mut stroke.color);
+            }
+        }
+
         Shape::Circle(CircleShape {
             center: _,
             radius: _,

--- a/crates/epaint/src/stats.rs
+++ b/crates/epaint/src/stats.rs
@@ -200,6 +200,7 @@ impl PaintStats {
                 }
             }
             Shape::Noop
+            | Shape::ArcPie { .. }
             | Shape::Circle { .. }
             | Shape::Ellipse { .. }
             | Shape::LineSegment { .. }

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -2088,6 +2088,7 @@ impl Tessellator {
 
                 Shape::Noop
                 | Shape::Text(_)
+                | Shape::ArcPie(_)
                 | Shape::Circle(_)
                 | Shape::Mesh(_)
                 | Shape::LineSegment { .. }

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -473,6 +473,59 @@ impl Path {
         }
     }
 
+    fn add_arc_pie(
+        &mut self,
+        center: Pos2,
+        radius: f32,
+        start_angle: f32,
+        end_angle: f32,
+        closed: bool,
+    ) {
+        use std::f32::consts::TAU;
+
+        let num_segs = if radius <= 2.0 {
+            8
+        } else if radius <= 5.0 {
+            16
+        } else if radius < 18.0 {
+            32
+        } else if radius < 50.0 {
+            64
+        } else {
+            128
+        };
+
+        let angle = (end_angle - start_angle).clamp(-TAU + f32::EPSILON, TAU - f32::EPSILON);
+        let mut points = Vec::with_capacity(num_segs + 3);
+        let step = angle / num_segs as f32;
+        if closed {
+            points.push(center);
+        }
+        for i in 0..=num_segs {
+            let a = start_angle + step * i as f32;
+            points.push(pos2(
+                center.x + radius * a.cos(),
+                center.y + radius * a.sin(),
+            ));
+        }
+        if closed {
+            points.push(center);
+            self.add_line_loop(&points[..]);
+        } else {
+            self.add_open_points(&points[..]);
+        }
+    }
+
+    /// Add an arc line.
+    pub fn add_arc(&mut self, center: Pos2, radius: f32, start_angle: f32, end_angle: f32) {
+        self.add_arc_pie(center, radius, start_angle, end_angle, false);
+    }
+
+    /// Add a pie slice.
+    pub fn add_pie(&mut self, center: Pos2, radius: f32, start_angle: f32, end_angle: f32) {
+        self.add_arc_pie(center, radius, start_angle, end_angle, true);
+    }
+
     /// Open-ended.
     pub fn stroke_open(&self, feathering: f32, stroke: &PathStroke, out: &mut Mesh) {
         stroke_path(feathering, &self.0, PathType::Open, stroke, out);
@@ -1301,6 +1354,9 @@ impl Tessellator {
                     self.tessellate_shape(shape, out);
                 }
             }
+            Shape::ArcPie(arc_pie_shape) => {
+                self.tessellate_arc_pie(&arc_pie_shape, out);
+            }
             Shape::Circle(circle) => {
                 self.tessellate_circle(circle, out);
             }
@@ -1348,6 +1404,64 @@ impl Tessellator {
             Shape::Callback(_) => {
                 panic!("Shape::Callback passed to Tessellator");
             }
+        }
+    }
+
+    /// Tessellate a single [`ArcPieShape`] into a [`Mesh`].
+    ///
+    /// * `arc_pie_shape`: the arc or pie to tessellate.
+    /// * `out`: triangles are appended to this.
+    pub fn tessellate_arc_pie(&mut self, arc_pie_shape: &ArcPieShape, out: &mut Mesh) {
+        let ArcPieShape {
+            center,
+            radius,
+            start_angle,
+            end_angle,
+            closed,
+            fill,
+            stroke,
+        } = *arc_pie_shape;
+
+        if radius <= 0.0
+            || start_angle == end_angle
+            || stroke.width <= 0.0 && (!closed || fill == Color32::TRANSPARENT)
+        {
+            return;
+        }
+
+        if self.options.coarse_tessellation_culling
+            && !self
+                .clip_rect
+                .expand(radius + stroke.width)
+                .contains(center)
+        {
+            return;
+        }
+
+        // If the arc is a full circle, we can just use the circle function.
+        if (end_angle - start_angle).abs() >= std::f32::consts::TAU {
+            let circle = CircleShape {
+                center,
+                radius,
+                fill,
+                stroke,
+            };
+            return self.tessellate_circle(circle, out);
+        }
+
+        self.scratchpad_path.clear();
+
+        if closed {
+            self.scratchpad_path
+                .add_pie(center, radius, start_angle, end_angle);
+            self.scratchpad_path.fill(self.feathering, fill, out);
+            self.scratchpad_path
+                .stroke_closed(self.feathering, &PathStroke::from(stroke), out);
+        } else {
+            self.scratchpad_path
+                .add_arc(center, radius, start_angle, end_angle);
+            self.scratchpad_path
+                .stroke_open(self.feathering, &PathStroke::from(stroke), out);
         }
     }
 


### PR DESCRIPTION
## Summary

This PR introduces several new features related to drawing and plotting arcs and pies in the `egui` ecosystem.

## Changes

- `epaint`: Introduced `ArcPieShape`, a new shape that represents an arc or a pie slice with specified radius, angle, fill, and stroke properties.
- `egui`: Added `Painter::{arc, pie}` methods, which simplify the process of drawing arcs and pies.
- `egui_plot`: Introduced three new plot types: `ArcLine`, `Pie`, and `PieChart`. `ArcLine` renders a simple arc line, `Pie` renders a single pie slice, and `PieChart` renders a pie chart with data and labels.
- `egui_demo_lib`: Added demonstrations for `ArcPieShape`, `ArcLine`, `Pie`, and `PieChart`. These demos showcase how to use these new features in a variety of contexts.

## Impact

These changes enhance the capabilities of the `egui` ecosystem by providing users with more options for drawing and plotting.
The new demos also serve as valuable examples for users to learn from.

[screencast-egui_demo_app-2024-04-27.webm](https://github.com/emilk/egui/assets/1274171/f91e9600-aff5-4bba-9c79-f5d2596d1b0e)
