### PR TITLE
Add easy way to draw circle arcs

### DIFF
--- a/crates/egui/src/util/angle_iter.rs
+++ b/crates/egui/src/util/angle_iter.rs
@@ -1,0 +1,43 @@
+use std::f32::consts::PI;
+
+const PI_OVER_2: f32 = PI / 2.0;
+
+pub(crate) struct AngleIter {
+    start: Option<f32>,
+    end: f32,
+}
+
+impl AngleIter {
+    pub(crate) const fn new(start_angle: f32, end_angle: f32) -> Self {
+        Self {
+            start: Some(start_angle),
+            end: end_angle,
+        }
+    }
+}
+
+impl Iterator for AngleIter {
+    type Item = (f32, f32);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.start.map(|start| {
+            let diff = self.end - start;
+            if diff.abs() < PI_OVER_2 {
+                self.start = None;
+                (start, self.end)
+            } else {
+                let new_start = start + (PI_OVER_2 * diff.signum());
+                self.start = Some(new_start);
+                (start, new_start)
+            }
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (
+            0,
+            self.start
+                .map(|start| ((self.end - start).abs() / PI_OVER_2).ceil() as usize),
+        )
+    }
+}

--- a/crates/egui/src/util/mod.rs
+++ b/crates/egui/src/util/mod.rs
@@ -1,5 +1,6 @@
 //! Miscellaneous tools used by the rest of egui.
 
+pub(crate) mod angle_iter;
 pub mod cache;
 pub(crate) mod fixed_cache;
 pub mod id_type_map;


### PR DESCRIPTION
This PR is related to the discussion in #4188, however it doesn't resolve the issue. It does, however, add a way to draw arcs on a circle. A couple things which need discussion:

* AngleIter can, in it's current state, loop infinitely. I'm not sure what the best way to handle this is.
* Using this method, it can sometimes be difficult to get the arc to behave the way you want. For example, drawing a track for a dial requires you to rather unintuitively provide a start and end angle of 225 and -45.
* The documentation could use some better wording, but I'm not sure how best to communicate its quirks.