### PR TITLE
Add a `Display` impl for `Vec2`, `Pos2`, and `Rect`

### DIFF
--- a/crates/emath/src/pos2.rs
+++ b/crates/emath/src/pos2.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 
 use crate::*;
@@ -316,8 +317,19 @@ impl Div<f32> for Pos2 {
     }
 }
 
-impl std::fmt::Debug for Pos2 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for Pos2 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[{:.1} {:.1}]", self.x, self.y)
+    }
+}
+
+impl fmt::Display for Pos2 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[")?;
+        self.x.fmt(f)?;
+        f.write_str(" ")?;
+        self.y.fmt(f)?;
+        f.write_str("]")?;
+        Ok(())
     }
 }

--- a/crates/emath/src/rect.rs
+++ b/crates/emath/src/rect.rs
@@ -1,4 +1,5 @@
 use std::f32::INFINITY;
+use std::fmt;
 
 use crate::*;
 
@@ -631,9 +632,20 @@ impl Rect {
     }
 }
 
-impl std::fmt::Debug for Rect {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for Rect {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[{:?} - {:?}]", self.min, self.max)
+    }
+}
+
+impl fmt::Display for Rect {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[")?;
+        self.min.fmt(f)?;
+        f.write_str(" - ")?;
+        self.max.fmt(f)?;
+        f.write_str("]")?;
+        Ok(())
     }
 }
 

--- a/crates/emath/src/vec2.rs
+++ b/crates/emath/src/vec2.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::Vec2b;
@@ -464,9 +465,20 @@ impl Div<f32> for Vec2 {
     }
 }
 
-impl std::fmt::Debug for Vec2 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for Vec2 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[{:.1} {:.1}]", self.x, self.y)
+    }
+}
+
+impl fmt::Display for Vec2 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[")?;
+        self.x.fmt(f)?;
+        f.write_str(" ")?;
+        self.y.fmt(f)?;
+        f.write_str("]")?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
These three types currently have a `Debug` implementation that only ever prints one decimal point. Sometimes it is useful to see more of the number, or otherwise have specific formatting.

Add `Display` implementations that pass the format specification to the member `f32`s for an easier way to control what is shown when debugging.

This allows doing e.g. `ui.label(format!("{:.4}", rect * scale))` which currently prints zeroes if scale is small.