### PR TITLE
`egui`: Fix panels panic in debug build

### DIFF
--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -263,7 +263,7 @@ impl SidePanel {
         let inner_response = frame.show(&mut panel_ui, |ui| {
             ui.set_min_height(ui.max_rect().height()); // Make sure the frame fills the full height
             ui.set_min_width(
-                width_range.min - (frame.inner_margin.left + frame.inner_margin.right),
+                (width_range.min - (frame.inner_margin.left + frame.inner_margin.right)).max(0.0),
             );
             add_contents(ui)
         });
@@ -731,7 +731,7 @@ impl TopBottomPanel {
         let inner_response = frame.show(&mut panel_ui, |ui| {
             ui.set_min_width(ui.max_rect().width()); // Make the frame fill full width
             ui.set_min_height(
-                height_range.min - (frame.inner_margin.top + frame.inner_margin.bottom),
+                (height_range.min - (frame.inner_margin.top + frame.inner_margin.bottom)).max(0.0),
             );
             add_contents(ui)
         });

--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -263,7 +263,7 @@ impl SidePanel {
         let inner_response = frame.show(&mut panel_ui, |ui| {
             ui.set_min_height(ui.max_rect().height()); // Make sure the frame fills the full height
             ui.set_min_width(
-                (width_range.min - (frame.inner_margin.left + frame.inner_margin.right)).max(0.0),
+                width_range.min - (frame.inner_margin.left + frame.inner_margin.right),
             );
             add_contents(ui)
         });
@@ -731,7 +731,7 @@ impl TopBottomPanel {
         let inner_response = frame.show(&mut panel_ui, |ui| {
             ui.set_min_width(ui.max_rect().width()); // Make the frame fill full width
             ui.set_min_height(
-                (height_range.min - (frame.inner_margin.top + frame.inner_margin.bottom)).max(0.0),
+                height_range.min - (frame.inner_margin.top + frame.inner_margin.bottom),
             );
             add_contents(ui)
         });

--- a/crates/egui/src/placer.rs
+++ b/crates/egui/src/placer.rs
@@ -218,6 +218,7 @@ impl Placer {
     /// Set the maximum width of the ui.
     /// You won't be able to shrink it below the current minimum size.
     pub(crate) fn set_max_width(&mut self, width: f32) {
+        let width = width.max(0.0);
         let rect = self.next_widget_space_ignore_wrap_justify(vec2(width, 0.0));
         let region = &mut self.region;
         region.max_rect.min.x = rect.min.x;
@@ -233,6 +234,7 @@ impl Placer {
     /// Set the maximum height of the ui.
     /// You won't be able to shrink it below the current minimum size.
     pub(crate) fn set_max_height(&mut self, height: f32) {
+        let height = height.max(0.0);
         let rect = self.next_widget_space_ignore_wrap_justify(vec2(0.0, height));
         let region = &mut self.region;
         region.max_rect.min.y = rect.min.y;
@@ -248,6 +250,7 @@ impl Placer {
     /// Set the minimum width of the ui.
     /// This can't shrink the ui, only make it larger.
     pub(crate) fn set_min_width(&mut self, width: f32) {
+        let width = width.max(0.0);
         let rect = self.next_widget_space_ignore_wrap_justify(vec2(width, 0.0));
         self.region.expand_to_include_x(rect.min.x);
         self.region.expand_to_include_x(rect.max.x);
@@ -256,6 +259,7 @@ impl Placer {
     /// Set the minimum height of the ui.
     /// This can't shrink the ui, only make it larger.
     pub(crate) fn set_min_height(&mut self, height: f32) {
+        let height = height.max(0.0);
         let rect = self.next_widget_space_ignore_wrap_justify(vec2(0.0, height));
         self.region.expand_to_include_y(rect.min.y);
         self.region.expand_to_include_y(rect.max.y);


### PR DESCRIPTION
How to repreproduce:

1. Run the `egui_demo_app` example in debug mode.
2. Click the `Panels` button in the demos panel.
3. You can see the following stack backtrace.

```log
Running `target\debug\egui_demo_app.exe`
thread 'main' panicked at crates\egui\src\layout.rs:600:9:
assertion failed: child_size.x >= 0.0 && child_size.y >= 0.0
stack backtrace:
   0: std::panicking::begin_panic_handler
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library\std\src\panicking.rs:645
   1: core::panicking::panic_fmt
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library\core\src\panicking.rs:72
   2: core::panicking::panic
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library\core\src\panicking.rs:144
   3: egui::layout::Layout::next_frame_ignore_wrap
             at .\crates\egui\src\layout.rs:600
   4: egui::layout::Layout::next_widget_space_ignore_wrap_justify
             at .\crates\egui\src\layout.rs:658
   5: egui::placer::Placer::next_widget_space_ignore_wrap_justify
             at .\crates\egui\src\placer.rs:214
   6: egui::placer::Placer::set_min_height
             at .\crates\egui\src\placer.rs:259
   7: egui::ui::Ui::set_min_height
             at .\crates\egui\src\ui.rs:539
   8: egui::containers::panel::impl$6::show_inside_dyn::closure$2<tuple$<> >
             at .\crates\egui\src\containers\panel.rs:733
   9: core::ops::function::FnOnce::call_once<egui::containers::panel::impl$6::show_inside_dyn::closure_env$2<tuple$<> >,tuple$<ref_mut$<egui::ui::Ui> > >
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\core\src\ops\function.rs:250
  10: alloc::boxed::impl$47::call_once<tuple$<ref_mut$<egui::ui::Ui> >,dyn$<core::ops::function::FnOnce<tuple$<ref_mut$<egui::ui::Ui> >,assoc$<Output,tuple$<> > > >,alloc::alloc::Global>
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\alloc\src\boxed.rs:2015
  11: egui::containers::frame::Frame::show_dyn<tuple$<> >
             at .\crates\egui\src\containers\frame.rs:275
  12: egui::containers::frame::Frame::show<tuple$<>,egui::containers::panel::impl$6::show_inside_dyn::closure_env$2<tuple$<> > >
             at .\crates\egui\src\containers\frame.rs:266
  13: egui::containers::panel::TopBottomPanel::show_inside_dyn<tuple$<> >
             at .\crates\egui\src\containers\panel.rs:731
  14: egui::containers::panel::TopBottomPanel::show_inside<tuple$<>,egui_demo_lib::demo::panels::impl$1::ui::closure_env$3>
             at .\crates\egui\src\containers\panel.rs:674
  15: egui_demo_lib::demo::panels::impl$1::ui
             at .\crates\egui_demo_lib\src\demo\panels.rs:63
  16: egui_demo_lib::demo::panels::impl$0::show::closure$0
             at .\crates\egui_demo_lib\src\demo\panels.rs:17
  17: core::ops::function::FnOnce::call_once<egui_demo_lib::demo::panels::impl$0::show::closure_env$0,tuple$<ref_mut$<egui::ui::Ui> > >
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\core\src\ops\function.rs:250
  18: alloc::boxed::impl$47::call_once<tuple$<ref_mut$<egui::ui::Ui> >,dyn$<core::ops::function::FnOnce<tuple$<ref_mut$<egui::ui::Ui> >,assoc$<Output,tuple$<> > > >,alloc::alloc::Global>
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\alloc\src\boxed.rs:2015
  19: egui::containers::window::impl$1::show_dyn::closure$5::closure$0<tuple$<> >
             at .\crates\egui\src\containers\window.rs:521
  20: egui::containers::resize::Resize::show<tuple$<>,egui::containers::window::impl$1::show_dyn::closure$5::closure_env$0<tuple$<> > >
             at .\crates\egui\src\containers\resize.rs:286
  21: egui::containers::window::impl$1::show_dyn::closure$5<tuple$<> >
             at .\crates\egui\src\containers\window.rs:517
  22: core::ops::function::FnOnce::call_once<egui::containers::window::impl$1::show_dyn::closure_env$5<tuple$<> >,tuple$<ref_mut$<egui::ui::Ui> > >
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\core\src\ops\function.rs:250
  23: alloc::boxed::impl$47::call_once<tuple$<ref_mut$<egui::ui::Ui> >,dyn$<core::ops::function::FnOnce<tuple$<ref_mut$<egui::ui::Ui> >,assoc$<Output,tuple$<> > > >,alloc::alloc::Global>
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\alloc\src\boxed.rs:2015
  24: egui::ui::Ui::scope_dyn<tuple$<> >
             at .\crates\egui\src\ui.rs:1791
  25: egui::ui::Ui::scope<tuple$<>,egui::containers::window::impl$1::show_dyn::closure_env$5<tuple$<> > >
             at .\crates\egui\src\ui.rs:1779
  26: egui::containers::collapsing_header::CollapsingState::show_body_unindented<tuple$<>,egui::containers::window::impl$1::show_dyn::closure_env$5<tuple$<> > >
             at .\crates\egui\src\containers\collapsing_header.rs:225
  27: egui::containers::window::Window::show_dyn<tuple$<> >
             at .\crates\egui\src\containers\window.rs:512
  28: egui::containers::window::Window::show<tuple$<>,egui_demo_lib::demo::panels::impl$0::show::closure_env$0>
             at .\crates\egui\src\containers\window.rs:387
  29: egui_demo_lib::demo::panels::impl$0::show
             at .\crates\egui_demo_lib\src\demo\panels.rs:17
  30: egui_demo_lib::demo::demo_app_windows::Demos::windows
             at .\crates\egui_demo_lib\src\demo\demo_app_windows.rs:88
  31: egui_demo_lib::demo::demo_app_windows::DemoWindows::show_windows
             at .\crates\egui_demo_lib\src\demo\demo_app_windows.rs:294
  32: egui_demo_lib::demo::demo_app_windows::DemoWindows::desktop_ui
             at .\crates\egui_demo_lib\src\demo\demo_app_windows.rs:288
  33: egui_demo_lib::demo::demo_app_windows::DemoWindows::ui
             at .\crates\egui_demo_lib\src\demo\demo_app_windows.rs:191
  34: egui_demo_app::wrap_app::impl$1::update
             at .\crates\egui_demo_app\src\wrap_app.rs:31
  35: egui_demo_app::wrap_app::WrapApp::show_selected_app
             at .\crates\egui_demo_app\src\wrap_app.rs:379
  36: egui_demo_app::wrap_app::impl$9::update
             at .\crates\egui_demo_app\src\wrap_app.rs:293
  37: eframe::native::epi_integration::impl$0::update::closure$0
             at .\crates\eframe\src\native\epi_integration.rs:302
  38: egui::context::Context::run<eframe::native::epi_integration::impl$0::update::closure_env$0>
             at .\crates\egui\src\context.rs:748
  39: eframe::native::epi_integration::EpiIntegration::update
             at .\crates\eframe\src\native\epi_integration.rs:295
  40: eframe::native::glow_integration::GlowWinitRunning::run_ui_and_paint
             at .\crates\eframe\src\native\glow_integration.rs:610
  41: eframe::native::glow_integration::impl$1::run_ui_and_paint
             at .\crates\eframe\src\native\glow_integration.rs:399
  42: eframe::native::run::run_and_return::closure$0<eframe::native::glow_integration::GlowWinitApp>
             at .\crates\eframe\src\native\run.rs:99
  43: winit::platform_impl::platform::event_loop::impl$3::run_on_demand::closure$0<enum2$<eframe::native::winit_integration::UserEvent>,eframe::native::run::run_and_return::closure_env$0<eframe::native::glow_integration::GlowWinitApp> >
             at C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.10\src\platform_impl\windows\event_loop.rs:236
  44: alloc::boxed::impl$48::call_mut<tuple$<enum2$<winit::event::Event<enum2$<eframe::native::winit_integration::UserEvent> > > >,dyn$<core::ops::function::FnMut<tuple$<enum2$<winit::event::Event<enum2$<eframe::native::winit_integration::UserEvent> > > >,assoc
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\alloc\src\boxed.rs:2022
  45: winit::platform_impl::platform::event_loop::runner::impl$3::call_event_handler::closure$0<enum2$<eframe::native::winit_integration::UserEvent> >
             at C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.10\src\platform_impl\windows\event_loop\runner.rs:250
  46: core::panic::unwind_safe::impl$23::call_once<tuple$<>,winit::platform_impl::platform::event_loop::runner::impl$3::call_event_handler::closure_env$0<enum2$<eframe::native::winit_integration::UserEvent> > >
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\core\src\panic\unwind_safe.rs:272
  47: std::panicking::try::do_call<core::panic::unwind_safe::AssertUnwindSafe<winit::platform_impl::platform::event_loop::runner::impl$3::call_event_handler::closure_env$0<enum2$<eframe::native::winit_integration::UserEvent> > >,tuple$<> >
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\std\src\panicking.rs:552
  48: std::panicking::try<tuple$<>,core::panic::unwind_safe::AssertUnwindSafe<winit::platform_impl::platform::event_loop::runner::impl$3::call_event_handler::closure_env$0<enum2$<eframe::native::winit_integration::UserEvent> > > >
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\std\src\panicking.rs:516
  49: std::panic::catch_unwind
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\std\src\panic.rs:142
  50: winit::platform_impl::platform::event_loop::runner::EventLoopRunner<enum2$<eframe::native::winit_integration::UserEvent> >::catch_unwind<enum2$<eframe::native::winit_integration::UserEvent>,tuple$<>,winit::platform_impl::platform::event_loop::runner::impl
             at C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.10\src\platform_impl\windows\event_loop\runner.rs:183
  51: winit::platform_impl::platform::event_loop::runner::EventLoopRunner<enum2$<eframe::native::winit_integration::UserEvent> >::call_event_handler
             at C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.10\src\platform_impl\windows\event_loop\runner.rs:246
  52: winit::platform_impl::platform::event_loop::runner::EventLoopRunner<enum2$<eframe::native::winit_integration::UserEvent> >::send_event<enum2$<eframe::native::winit_integration::UserEvent> >
             at C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.10\src\platform_impl\windows\event_loop\runner.rs:224
  53: winit::platform_impl::platform::event_loop::WindowData<enum2$<eframe::native::winit_integration::UserEvent> >::send_event<enum2$<eframe::native::winit_integration::UserEvent> >
             at C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.10\src\platform_impl\windows\event_loop.rs:112
  54: winit::platform_impl::platform::event_loop::public_window_callback_inner::closure$4<enum2$<eframe::native::winit_integration::UserEvent> >
             at C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.10\src\platform_impl\windows\event_loop.rs:1145
  55: core::ops::function::FnOnce::call_once<winit::platform_impl::platform::event_loop::public_window_callback_inner::closure_env$4<enum2$<eframe::native::winit_integration::UserEvent> >,tuple$<> >
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\core\src\ops\function.rs:250
  56: core::panic::unwind_safe::impl$23::call_once<tuple$<>,winit::platform_impl::platform::event_loop::public_window_callback_inner::closure_env$4<enum2$<eframe::native::winit_integration::UserEvent> > >
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\core\src\panic\unwind_safe.rs:272
  57: std::panicking::try::do_call<core::panic::unwind_safe::AssertUnwindSafe<winit::platform_impl::platform::event_loop::public_window_callback_inner::closure_env$4<enum2$<eframe::native::winit_integration::UserEvent> > >,tuple$<> >
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\std\src\panicking.rs:552
  58: std::panicking::try<tuple$<>,core::panic::unwind_safe::AssertUnwindSafe<winit::platform_impl::platform::event_loop::public_window_callback_inner::closure_env$4<enum2$<eframe::native::winit_integration::UserEvent> > > >
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\std\src\panicking.rs:516
  59: std::panic::catch_unwind
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\std\src\panic.rs:142
  60: winit::platform_impl::platform::event_loop::runner::EventLoopRunner<enum2$<eframe::native::winit_integration::UserEvent> >::catch_unwind<enum2$<eframe::native::winit_integration::UserEvent>,tuple$<>,winit::platform_impl::platform::event_loop::public_windo
             at C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.10\src\platform_impl\windows\event_loop\runner.rs:183
  61: winit::platform_impl::platform::event_loop::public_window_callback_inner<enum2$<eframe::native::winit_integration::UserEvent> >
             at C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.10\src\platform_impl\windows\event_loop.rs:2286
  62: winit::platform_impl::platform::event_loop::public_window_callback<enum2$<eframe::native::winit_integration::UserEvent> >
             at C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.10\src\platform_impl\windows\event_loop.rs:984
  63: DispatchMessageW
  64: CallWindowProcW
  65: wglSwapBuffers
  66: DispatchMessageW
  67: DispatchMessageW
  68: GetClassLongW
  69: KiUserCallbackDispatcher
  70: NtUserDispatchMessage
  71: DispatchMessageW
  72: winit::platform_impl::platform::event_loop::EventLoop<enum2$<eframe::native::winit_integration::UserEvent> >::dispatch_peeked_messages<enum2$<eframe::native::winit_integration::UserEvent> >
             at C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.10\src\platform_impl\windows\event_loop.rs:449
  73: winit::platform_impl::platform::event_loop::EventLoop<enum2$<eframe::native::winit_integration::UserEvent> >::run_on_demand<enum2$<eframe::native::winit_integration::UserEvent>,eframe::native::run::run_and_return::closure_env$0<eframe::native::glow_integr
             at C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.10\src\platform_impl\windows\event_loop.rs:247
  74: winit::platform::run_on_demand::impl$0::run_on_demand<enum2$<eframe::native::winit_integration::UserEvent>,eframe::native::run::run_and_return::closure_env$0<eframe::native::glow_integration::GlowWinitApp> >
             at C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.10\src\platform\run_on_demand.rs:80
  75: eframe::native::run::run_and_return<eframe::native::glow_integration::GlowWinitApp>
             at .\crates\eframe\src\native\run.rs:76
  76: eframe::native::run::run_glow::closure$0
             at .\crates\eframe\src\native\run.rs:402
  77: eframe::native::run::with_event_loop::closure$0<enum2$<core::result::Result<tuple$<>,enum2$<eframe::Error> > >,eframe::native::run::run_glow::closure_env$0>
             at .\crates\eframe\src\native\run.rs:58
  78: std::thread::local::LocalKey<core::cell::RefCell<enum2$<core::option::Option<winit::event_loop::EventLoop<enum2$<eframe::native::winit_integration::UserEvent> > > > > >::try_with<core::cell::RefCell<enum2$<core::option::Option<winit::event_loop::EventLoop
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\std\src\thread\local.rs:270
  79: std::thread::local::LocalKey<core::cell::RefCell<enum2$<core::option::Option<winit::event_loop::EventLoop<enum2$<eframe::native::winit_integration::UserEvent> > > > > >::with<core::cell::RefCell<enum2$<core::option::Option<winit::event_loop::EventLoop<enu
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\std\src\thread\local.rs:246
  80: eframe::native::run::with_event_loop<enum2$<core::result::Result<tuple$<>,enum2$<eframe::Error> > >,eframe::native::run::run_glow::closure_env$0>
             at .\crates\eframe\src\native\run.rs:48
  81: eframe::native::run::run_glow
             at .\crates\eframe\src\native\run.rs:400
  82: eframe::run_native
             at .\crates\eframe\src\lib.rs:262
  83: egui_demo_app::main
             at .\crates\egui_demo_app\src\main.rs:48
  84: core::ops::function::FnOnce::call_once<enum2$<core::result::Result<tuple$<>,enum2$<eframe::Error> > > (*)(),tuple$<> >
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce\library\core\src\ops\function.rs:250
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
error: process didn't exit successfully: `target\debug\egui_demo_app.exe` (exit code: 0xc0000409, STATUS_STACK_BUFFER_OVERRUN)
```