### PR TITLE
Disable interaction for `ScrollArea` and `Plot` when UI is disabled

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -493,6 +493,7 @@ impl ScrollArea {
         } = self;
 
         let ctx = ui.ctx().clone();
+        let scrolling_enabled = scrolling_enabled && ui.is_enabled();
 
         let id_source = id_source.unwrap_or_else(|| Id::new("scroll_area"));
         let id = ui.make_persistent_id(id_source);

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -766,6 +766,11 @@ impl Plot {
             sense,
         } = self;
 
+        // Disable interaction if ui is disabled.
+        let allow_zoom = allow_zoom.and(ui.is_enabled());
+        let allow_drag = allow_drag.and(ui.is_enabled());
+        let allow_scroll = allow_scroll.and(ui.is_enabled());
+
         // Determine position of widget.
         let pos = ui.available_rect_before_wrap().min;
         // Determine size of widget.


### PR DESCRIPTION
## Summary

This PR modifies `ScrollArea` and `Plot` to disable their interactions when the UI is disabled.

## Changes

- Interaction with `ScrollArea` in `egui` is disabled when the UI is disabled.
- Interaction with `Plot` in `egui_plot` is disabled when the UI is disabled.
- These changes ensure that `ScrollArea` and `Plot` behave consistently with the rest of the UI, preventing them from responding to user input when the UI is in a disabled state.

## Impact

This PR enhances the consistency of `egui`'s UI behavior by ensuring that all elements, including `ScrollArea` and `Plot`, respect the UI's disabled state. This prevents unexpected interactions when the UI is disabled.

Closes #4341 
