### PR TITLE
egui-winit: emit physical key presses when a non-Latin layout is active

### DIFF
--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -361,10 +361,12 @@ pub enum Event {
 
     /// A key was pressed or released.
     Key {
-        /// The logical key, heeding the users keymap.
+        /// Most of the time, it's the logical key, heeding the active keymap -- for instance, if the user has Dvorak
+        /// keyboard layout, it will be taken into account.
         ///
-        /// For instance, if the user is using Dvorak keyboard layout,
-        /// this will take that into account.
+        /// If it's impossible to determine the logical key on desktop platforms (say, in case of non-Latin letters),
+        /// `key` falls back to the value of the corresponding physical key. This is necessary for proper work of
+        /// standard shortcuts that only respond to Latin-based bindings (such as `Ctrl` + `V`).
         key: Key,
 
         /// The physical key, corresponding to the actual position on the keyboard.


### PR DESCRIPTION
resolves https://github.com/emilk/egui/issues/4081 (see discussion starting from https://github.com/emilk/egui/issues/3653#issuecomment-1962740175 for extra context)

this partly restores event-emitting behaviour to the state before #3649, when shortcuts such as `Ctrl` + `C` used to work regardless of the active layout. the difference is that physical keys are only used in case of the logical ones' absence now among the named keys.

while originally I have only limited this to clipboard shortcuts (Ctrl+C/V/X), honestly it felt like a half-assed solution. as a result, I decided to expand this behaviour to all key events to stick to the original logic, in case there are other workflows and hotkeys people rely on or expect to work out of the box. let me know if this is an issue.