### PR TITLE
In Progress : Fix: Troubleshooting winit

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1578,7 +1578,7 @@ pub fn create_winit_window_builder<T>(
         decorations,
         icon,
         active,
-        visible,
+        visible: _,
         close_button,
         minimize_button,
         maximize_button,
@@ -1609,7 +1609,6 @@ pub fn create_winit_window_builder<T>(
         .with_transparent(transparent.unwrap_or(false))
         .with_decorations(decorations.unwrap_or(true))
         .with_resizable(resizable.unwrap_or(true))
-        .with_visible(visible.unwrap_or(true))
         .with_maximized(maximized.unwrap_or(false))
         .with_window_level(match window_level.unwrap_or_default() {
             egui::viewport::WindowLevel::AlwaysOnBottom => WindowLevel::AlwaysOnBottom,

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -530,13 +530,13 @@ impl Ui {
     /// Set the minimum width of the ui.
     /// This can't shrink the ui, only make it larger.
     pub fn set_min_width(&mut self, width: f32) {
-        self.placer.set_min_width(width);
+        self.placer.set_min_width((width).max(0.0));
     }
 
     /// Set the minimum height of the ui.
     /// This can't shrink the ui, only make it larger.
     pub fn set_min_height(&mut self, height: f32) {
-        self.placer.set_min_height(height);
+        self.placer.set_min_height((height).max(0.0));
     }
 
     // ------------------------------------------------------------------------
@@ -607,7 +607,7 @@ impl Ui {
     /// A small size should be interpreted as "as little as possible".
     /// An infinite size should be interpreted as "as much as you want".
     pub fn available_size(&self) -> Vec2 {
-        self.placer.available_size()
+        self.placer.available_size().max(vec2(0.0, 0.0))
     }
 
     /// The available width at the moment, given the current cursor.

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -530,13 +530,13 @@ impl Ui {
     /// Set the minimum width of the ui.
     /// This can't shrink the ui, only make it larger.
     pub fn set_min_width(&mut self, width: f32) {
-        self.placer.set_min_width((width).max(0.0));
+        self.placer.set_min_width(width);
     }
 
     /// Set the minimum height of the ui.
     /// This can't shrink the ui, only make it larger.
     pub fn set_min_height(&mut self, height: f32) {
-        self.placer.set_min_height((height).max(0.0));
+        self.placer.set_min_height(height);
     }
 
     // ------------------------------------------------------------------------
@@ -607,7 +607,7 @@ impl Ui {
     /// A small size should be interpreted as "as little as possible".
     /// An infinite size should be interpreted as "as much as you want".
     pub fn available_size(&self) -> Vec2 {
-        self.placer.available_size().max(vec2(0.0, 0.0))
+        self.placer.available_size()
     }
 
     /// The available width at the moment, given the current cursor.


### PR DESCRIPTION
In Progress : Not Completed.

* Related #4091
* Related #4451 
* Related #4453
* Related #4458

Fix: Troubleshooting winit

To resolve the Winit issue, temporarily removed '.with_visible()'.
(TODO:) To re-enable the `.with_visible()` function, you need to write `visible` to all viewports.
