### PR TITLE
Remove `extra_asserts` and `extra_debug_asserts` feature flags

### DIFF
--- a/crates/ecolor/Cargo.toml
+++ b/crates/ecolor/Cargo.toml
@@ -28,10 +28,6 @@ all-features = true
 [features]
 default = []
 
-## Enable additional checks if debug assertions are enabled (debug builds).
-extra_debug_asserts = []
-## Always enable additional checks.
-extra_asserts = []
 
 [dependencies]
 #! ### Optional dependencies

--- a/crates/ecolor/src/color32.rs
+++ b/crates/ecolor/src/color32.rs
@@ -199,7 +199,7 @@ impl Color32 {
     /// This is perceptually even, and faster that [`Self::linear_multiply`].
     #[inline]
     pub fn gamma_multiply(self, factor: f32) -> Self {
-        crate::ecolor_assert!(0.0 <= factor && factor <= 1.0);
+        debug_assert!(0.0 <= factor && factor <= 1.0);
         let Self([r, g, b, a]) = self;
         Self([
             (r as f32 * factor + 0.5) as u8,
@@ -215,7 +215,7 @@ impl Color32 {
     /// You likely want to use [`Self::gamma_multiply`] instead.
     #[inline]
     pub fn linear_multiply(self, factor: f32) -> Self {
-        crate::ecolor_assert!(0.0 <= factor && factor <= 1.0);
+        debug_assert!(0.0 <= factor && factor <= 1.0);
         // As an unfortunate side-effect of using premultiplied alpha
         // we need a somewhat expensive conversion to linear space and back.
         Rgba::from(self).multiply(factor).into()

--- a/crates/ecolor/src/lib.rs
+++ b/crates/ecolor/src/lib.rs
@@ -135,22 +135,6 @@ pub fn gamma_from_linear(linear: f32) -> f32 {
 
 // ----------------------------------------------------------------------------
 
-/// An assert that is only active when `epaint` is compiled with the `extra_asserts` feature
-/// or with the `extra_debug_asserts` feature in debug builds.
-#[macro_export]
-macro_rules! ecolor_assert {
-    ($($arg: tt)*) => {
-        if cfg!(any(
-            feature = "extra_asserts",
-            all(feature = "extra_debug_asserts", debug_assertions),
-        )) {
-            assert!($($arg)*);
-        }
-    }
-}
-
-// ----------------------------------------------------------------------------
-
 /// Cheap and ugly.
 /// Made for graying out disabled `Ui`s.
 pub fn tint_color_towards(color: Color32, target: Color32) -> Color32 {

--- a/crates/ecolor/src/rgba.rs
+++ b/crates/ecolor/src/rgba.rs
@@ -98,22 +98,22 @@ impl Rgba {
 
     #[inline]
     pub fn from_luminance_alpha(l: f32, a: f32) -> Self {
-        crate::ecolor_assert!(0.0 <= l && l <= 1.0);
-        crate::ecolor_assert!(0.0 <= a && a <= 1.0);
+        debug_assert!(0.0 <= l && l <= 1.0);
+        debug_assert!(0.0 <= a && a <= 1.0);
         Self([l * a, l * a, l * a, a])
     }
 
     /// Transparent black
     #[inline]
     pub fn from_black_alpha(a: f32) -> Self {
-        crate::ecolor_assert!(0.0 <= a && a <= 1.0);
+        debug_assert!(0.0 <= a && a <= 1.0);
         Self([0.0, 0.0, 0.0, a])
     }
 
     /// Transparent white
     #[inline]
     pub fn from_white_alpha(a: f32) -> Self {
-        crate::ecolor_assert!(0.0 <= a && a <= 1.0, "a: {}", a);
+        debug_assert!(0.0 <= a && a <= 1.0, "a: {a}");
         Self([a, a, a, a])
     }
 

--- a/crates/egui/Cargo.toml
+++ b/crates/egui/Cargo.toml
@@ -52,11 +52,6 @@ deadlock_detection = ["epaint/deadlock_detection"]
 ## If you plan on specifying your own fonts you may disable this feature.
 default_fonts = ["epaint/default_fonts"]
 
-## Enable additional checks if debug assertions are enabled (debug builds).
-extra_debug_asserts = ["epaint/extra_debug_asserts"]
-## Always enable additional checks.
-extra_asserts = ["epaint/extra_asserts"]
-
 ## Turn on the `log` feature, that makes egui log some errors using the [`log`](https://docs.rs/log) crate.
 log = ["dep:log", "epaint/log"]
 

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1748,7 +1748,7 @@ impl Context {
         let name = name.into();
         let image = image.into();
         let max_texture_side = self.input(|i| i.max_texture_side);
-        crate::egui_assert!(
+        debug_assert!(
             image.width() <= max_texture_side && image.height() <= max_texture_side,
             "Texture {:?} has size {}x{}, but the maximum texture side is {}",
             name,

--- a/crates/egui/src/frame_state.rs
+++ b/crates/egui/src/frame_state.rs
@@ -117,7 +117,7 @@ impl FrameState {
     /// This is the "background" area, what egui doesn't cover with panels (but may cover with windows).
     /// This is also the area to which windows are constrained.
     pub(crate) fn available_rect(&self) -> Rect {
-        crate::egui_assert!(
+        debug_assert!(
             self.available_rect.is_finite(),
             "Called `available_rect()` before `Context::run()`"
         );
@@ -126,7 +126,7 @@ impl FrameState {
 
     /// Shrink `available_rect`.
     pub(crate) fn allocate_left_panel(&mut self, panel_rect: Rect) {
-        crate::egui_assert!(
+        debug_assert!(
             panel_rect.min.distance(self.available_rect.min) < 0.1,
             "Mismatching left panel. You must not create a panel from within another panel."
         );
@@ -137,7 +137,7 @@ impl FrameState {
 
     /// Shrink `available_rect`.
     pub(crate) fn allocate_right_panel(&mut self, panel_rect: Rect) {
-        crate::egui_assert!(
+        debug_assert!(
             panel_rect.max.distance(self.available_rect.max) < 0.1,
             "Mismatching right panel. You must not create a panel from within another panel."
         );
@@ -148,7 +148,7 @@ impl FrameState {
 
     /// Shrink `available_rect`.
     pub(crate) fn allocate_top_panel(&mut self, panel_rect: Rect) {
-        crate::egui_assert!(
+        debug_assert!(
             panel_rect.min.distance(self.available_rect.min) < 0.1,
             "Mismatching top panel. You must not create a panel from within another panel."
         );
@@ -159,7 +159,7 @@ impl FrameState {
 
     /// Shrink `available_rect`.
     pub(crate) fn allocate_bottom_panel(&mut self, panel_rect: Rect) {
-        crate::egui_assert!(
+        debug_assert!(
             panel_rect.max.distance(self.available_rect.max) < 0.1,
             "Mismatching bottom panel. You must not create a panel from within another panel."
         );

--- a/crates/egui/src/grid.rs
+++ b/crates/egui/src/grid.rs
@@ -85,7 +85,7 @@ impl GridLayout {
         // TODO(emilk): respect current layout
 
         let initial_available = ui.placer().max_rect().intersect(ui.cursor());
-        crate::egui_assert!(
+        debug_assert!(
             initial_available.min.x.is_finite(),
             "Grid not yet available for right-to-left layouts"
         );

--- a/crates/egui/src/layout.rs
+++ b/crates/egui/src/layout.rs
@@ -1,4 +1,4 @@
-use crate::{egui_assert, emath::*, Align};
+use crate::{emath::*, Align};
 use std::f32::INFINITY;
 
 // ----------------------------------------------------------------------------
@@ -66,9 +66,9 @@ impl Region {
     }
 
     pub fn sanity_check(&self) {
-        egui_assert!(!self.min_rect.any_nan());
-        egui_assert!(!self.max_rect.any_nan());
-        egui_assert!(!self.cursor.any_nan());
+        debug_assert!(!self.min_rect.any_nan());
+        debug_assert!(!self.max_rect.any_nan());
+        debug_assert!(!self.cursor.any_nan());
     }
 }
 
@@ -389,8 +389,8 @@ impl Layout {
 /// ## Doing layout
 impl Layout {
     pub fn align_size_within_rect(&self, size: Vec2, outer: Rect) -> Rect {
-        egui_assert!(size.x >= 0.0 && size.y >= 0.0);
-        egui_assert!(!outer.is_negative());
+        debug_assert!(size.x >= 0.0 && size.y >= 0.0);
+        debug_assert!(!outer.is_negative());
         self.align2().align_size_within_rect(size, outer)
     }
 
@@ -416,8 +416,8 @@ impl Layout {
     }
 
     pub(crate) fn region_from_max_rect(&self, max_rect: Rect) -> Region {
-        egui_assert!(!max_rect.any_nan());
-        egui_assert!(max_rect.is_finite());
+        debug_assert!(!max_rect.any_nan());
+        debug_assert!(max_rect.is_finite());
         let mut region = Region {
             min_rect: Rect::NOTHING, // temporary
             max_rect,
@@ -450,9 +450,9 @@ impl Layout {
     /// Given the cursor in the region, how much space is available
     /// for the next widget?
     fn available_from_cursor_max_rect(&self, cursor: Rect, max_rect: Rect) -> Rect {
-        egui_assert!(!cursor.any_nan());
-        egui_assert!(!max_rect.any_nan());
-        egui_assert!(max_rect.is_finite());
+        debug_assert!(!cursor.any_nan());
+        debug_assert!(!max_rect.any_nan());
+        debug_assert!(max_rect.is_finite());
 
         // NOTE: in normal top-down layout the cursor has moved below the current max_rect,
         // but the available shouldn't be negative.
@@ -506,7 +506,7 @@ impl Layout {
             avail.max.y = y;
         }
 
-        egui_assert!(!avail.any_nan());
+        debug_assert!(!avail.any_nan());
 
         avail
     }
@@ -517,7 +517,7 @@ impl Layout {
     /// Use `justify_and_align` to get the inner `widget_rect`.
     pub(crate) fn next_frame(&self, region: &Region, child_size: Vec2, spacing: Vec2) -> Rect {
         region.sanity_check();
-        egui_assert!(child_size.x >= 0.0 && child_size.y >= 0.0);
+        debug_assert!(child_size.x >= 0.0 && child_size.y >= 0.0);
 
         if self.main_wrap {
             let available_size = self.available_rect_before_wrap(region).size();
@@ -597,7 +597,7 @@ impl Layout {
 
     fn next_frame_ignore_wrap(&self, region: &Region, child_size: Vec2) -> Rect {
         region.sanity_check();
-        egui_assert!(child_size.x >= 0.0 && child_size.y >= 0.0);
+        debug_assert!(child_size.x >= 0.0 && child_size.y >= 0.0);
 
         let available_rect = self.available_rect_before_wrap(region);
 
@@ -630,16 +630,16 @@ impl Layout {
             frame_rect = frame_rect.translate(Vec2::Y * (region.cursor.top() - frame_rect.top()));
         }
 
-        egui_assert!(!frame_rect.any_nan());
-        egui_assert!(!frame_rect.is_negative());
+        debug_assert!(!frame_rect.any_nan());
+        debug_assert!(!frame_rect.is_negative());
 
         frame_rect
     }
 
     /// Apply justify (fill width/height) and/or alignment after calling `next_space`.
     pub(crate) fn justify_and_align(&self, frame: Rect, mut child_size: Vec2) -> Rect {
-        egui_assert!(child_size.x >= 0.0 && child_size.y >= 0.0);
-        egui_assert!(!frame.is_negative());
+        debug_assert!(child_size.x >= 0.0 && child_size.y >= 0.0);
+        debug_assert!(!frame.is_negative());
 
         if self.horizontal_justify() {
             child_size.x = child_size.x.at_least(frame.width()); // fill full width
@@ -657,10 +657,10 @@ impl Layout {
     ) -> Rect {
         let frame = self.next_frame_ignore_wrap(region, size);
         let rect = self.align_size_within_rect(size, frame);
-        egui_assert!(!rect.any_nan());
-        egui_assert!(!rect.is_negative());
-        egui_assert!((rect.width() - size.x).abs() < 1.0 || size.x == f32::INFINITY);
-        egui_assert!((rect.height() - size.y).abs() < 1.0 || size.y == f32::INFINITY);
+        debug_assert!(!rect.any_nan());
+        debug_assert!(!rect.is_negative());
+        debug_assert!((rect.width() - size.x).abs() < 1.0 || size.x == f32::INFINITY);
+        debug_assert!((rect.height() - size.y).abs() < 1.0 || size.y == f32::INFINITY);
         rect
     }
 
@@ -703,7 +703,7 @@ impl Layout {
         widget_rect: Rect,
         item_spacing: Vec2,
     ) {
-        egui_assert!(!cursor.any_nan());
+        debug_assert!(!cursor.any_nan());
         if self.main_wrap {
             if cursor.intersects(frame_rect.shrink(1.0)) {
                 // make row/column larger if necessary

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -549,22 +549,6 @@ macro_rules! github_link_file {
 
 // ----------------------------------------------------------------------------
 
-/// An assert that is only active when `egui` is compiled with the `extra_asserts` feature
-/// or with the `extra_debug_asserts` feature in debug builds.
-#[macro_export]
-macro_rules! egui_assert {
-    ($($arg: tt)*) => {
-        if cfg!(any(
-            feature = "extra_asserts",
-            all(feature = "extra_debug_asserts", debug_assertions),
-        )) {
-            assert!($($arg)*);
-        }
-    }
-}
-
-// ----------------------------------------------------------------------------
-
 /// The minus character: <https://www.compart.com/en/unicode/U+2212>
 pub(crate) const MINUS_CHAR_STR: &str = "−";
 

--- a/crates/egui/src/placer.rs
+++ b/crates/egui/src/placer.rs
@@ -106,7 +106,7 @@ impl Placer {
     /// This is what you then pass to `advance_after_rects`.
     /// Use `justify_and_align` to get the inner `widget_rect`.
     pub(crate) fn next_space(&self, child_size: Vec2, item_spacing: Vec2) -> Rect {
-        egui_assert!(child_size.is_finite() && child_size.x >= 0.0 && child_size.y >= 0.0);
+        debug_assert!(child_size.is_finite() && child_size.x >= 0.0 && child_size.y >= 0.0);
         self.region.sanity_check();
         if let Some(grid) = &self.grid {
             grid.next_cell(self.region.cursor, child_size)
@@ -127,8 +127,8 @@ impl Placer {
 
     /// Apply justify or alignment after calling `next_space`.
     pub(crate) fn justify_and_align(&self, rect: Rect, child_size: Vec2) -> Rect {
-        crate::egui_assert!(!rect.any_nan());
-        crate::egui_assert!(!child_size.any_nan());
+        debug_assert!(!rect.any_nan());
+        debug_assert!(!child_size.any_nan());
 
         if let Some(grid) = &self.grid {
             grid.justify_and_align(rect, child_size)
@@ -140,7 +140,7 @@ impl Placer {
     /// Advance the cursor by this many points.
     /// [`Self::min_rect`] will expand to contain the cursor.
     pub(crate) fn advance_cursor(&mut self, amount: f32) {
-        crate::egui_assert!(
+        debug_assert!(
             self.grid.is_none(),
             "You cannot advance the cursor when in a grid layout"
         );
@@ -158,8 +158,8 @@ impl Placer {
         widget_rect: Rect,
         item_spacing: Vec2,
     ) {
-        egui_assert!(!frame_rect.any_nan());
-        egui_assert!(!widget_rect.any_nan());
+        debug_assert!(!frame_rect.any_nan());
+        debug_assert!(!widget_rect.any_nan());
         self.region.sanity_check();
 
         if let Some(grid) = &mut self.grid {

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -936,7 +936,7 @@ impl Response {
     /// You may not call [`Self::interact`] on the resulting `Response`.
     pub fn union(&self, other: Self) -> Self {
         assert!(self.ctx == other.ctx);
-        crate::egui_assert!(
+        debug_assert!(
             self.layer_id == other.layer_id,
             "It makes no sense to combine Responses from two different layers"
         );

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -111,7 +111,7 @@ impl Ui {
         layout: Layout,
         id_source: impl Hash,
     ) -> Self {
-        crate::egui_assert!(!max_rect.any_nan());
+        debug_assert!(!max_rect.any_nan());
         let next_auto_id_source = Id::new(self.next_auto_id_source).with("child").value();
         self.next_auto_id_source = self.next_auto_id_source.wrapping_add(1);
         let child_ui = Ui {
@@ -530,14 +530,14 @@ impl Ui {
     /// Set the minimum width of the ui.
     /// This can't shrink the ui, only make it larger.
     pub fn set_min_width(&mut self, width: f32) {
-        egui_assert!(0.0 <= width);
+        debug_assert!(0.0 <= width);
         self.placer.set_min_width(width);
     }
 
     /// Set the minimum height of the ui.
     /// This can't shrink the ui, only make it larger.
     pub fn set_min_height(&mut self, height: f32) {
-        egui_assert!(0.0 <= height);
+        debug_assert!(0.0 <= height);
         self.placer.set_min_height(height);
     }
 
@@ -847,7 +847,7 @@ impl Ui {
     fn allocate_space_impl(&mut self, desired_size: Vec2) -> Rect {
         let item_spacing = self.spacing().item_spacing;
         let frame_rect = self.placer.next_space(desired_size, item_spacing);
-        egui_assert!(!frame_rect.any_nan());
+        debug_assert!(!frame_rect.any_nan());
         let widget_rect = self.placer.justify_and_align(frame_rect, desired_size);
 
         self.placer
@@ -870,7 +870,7 @@ impl Ui {
 
     /// Allocate a rect without interacting with it.
     pub fn advance_cursor_after_rect(&mut self, rect: Rect) -> Id {
-        egui_assert!(!rect.any_nan());
+        debug_assert!(!rect.any_nan());
         let item_spacing = self.spacing().item_spacing;
         self.placer.advance_after_rects(rect, rect, item_spacing);
 
@@ -939,7 +939,7 @@ impl Ui {
         layout: Layout,
         add_contents: Box<dyn FnOnce(&mut Self) -> R + 'c>,
     ) -> InnerResponse<R> {
-        crate::egui_assert!(desired_size.x >= 0.0 && desired_size.y >= 0.0);
+        debug_assert!(desired_size.x >= 0.0 && desired_size.y >= 0.0);
         let item_spacing = self.spacing().item_spacing;
         let frame_rect = self.placer.next_space(desired_size, item_spacing);
         let child_rect = self.placer.justify_and_align(frame_rect, desired_size);
@@ -964,7 +964,7 @@ impl Ui {
         max_rect: Rect,
         add_contents: impl FnOnce(&mut Self) -> R,
     ) -> InnerResponse<R> {
-        egui_assert!(max_rect.is_finite());
+        debug_assert!(max_rect.is_finite());
         let mut child_ui = self.child_ui(max_rect, *self.layout());
         let ret = add_contents(&mut child_ui);
         let final_child_rect = child_ui.min_rect();

--- a/crates/egui/src/widget_rect.rs
+++ b/crates/egui/src/widget_rect.rs
@@ -139,7 +139,7 @@ impl WidgetRects {
                 // e.g. calling `response.interact(…)` to add more interaction.
                 let (idx_in_layer, existing) = entry.get_mut();
 
-                egui_assert!(
+                debug_assert!(
                     existing.layer_id == widget_rect.layer_id,
                     "Widget changed layer_id during the frame"
                 );

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -746,7 +746,7 @@ pub fn paint_texture_at(
         Some((rot, origin)) => {
             // TODO(emilk): implement this using `PathShape` (add texture support to it).
             // This will also give us anti-aliasing of rotated images.
-            egui_assert!(
+            debug_assert!(
                 options.rounding == Rounding::ZERO,
                 "Image had both rounding and rotation. Please pick only one"
             );

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -170,7 +170,7 @@ impl Label {
 
             let cursor = ui.cursor();
             let first_row_indentation = available_width - ui.available_size_before_wrap().x;
-            egui_assert!(first_row_indentation.is_finite());
+            debug_assert!(first_row_indentation.is_finite());
 
             layout_job.wrap.max_width = available_width;
             layout_job.first_row_min_height = cursor.height();

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -983,7 +983,7 @@ fn value_from_normalized(normalized: f64, range: RangeInclusive<f64>, spec: &Sli
             }
         }
     } else {
-        crate::egui_assert!(
+        debug_assert!(
             min.is_finite() && max.is_finite(),
             "You should use a logarithmic range"
         );
@@ -1032,7 +1032,7 @@ fn normalized_from_value(value: f64, range: RangeInclusive<f64>, spec: &SliderSp
             }
         }
     } else {
-        crate::egui_assert!(
+        debug_assert!(
             min.is_finite() && max.is_finite(),
             "You should use a logarithmic range"
         );
@@ -1080,6 +1080,6 @@ fn logarithmic_zero_cutoff(min: f64, max: f64) -> f64 {
     };
 
     let cutoff = min_magnitude / (min_magnitude + max_magnitude);
-    crate::egui_assert!(0.0 <= cutoff && cutoff <= 1.0);
+    debug_assert!(0.0 <= cutoff && cutoff <= 1.0);
     cutoff
 }

--- a/crates/egui_demo_app/Cargo.toml
+++ b/crates/egui_demo_app/Cargo.toml
@@ -44,12 +44,7 @@ chrono = { version = "0.4", default-features = false, features = [
 eframe = { workspace = true, default-features = false, features = [
   "web_screen_reader",
 ] }
-egui = { workspace = true, features = [
-  "callstack",
-  "default",
-  "extra_debug_asserts",
-  "log",
-] }
+egui = { workspace = true, features = ["callstack", "default", "log"] }
 egui_demo_lib = { workspace = true, features = ["default", "chrono"] }
 egui_extras = { workspace = true, features = ["default", "image"] }
 log.workspace = true

--- a/crates/egui_extras/src/sizing.rs
+++ b/crates/egui_extras/src/sizing.rs
@@ -32,7 +32,7 @@ impl Size {
 
     /// Relative size relative to all available space. Values must be in range `0.0..=1.0`.
     pub fn relative(fraction: f32) -> Self {
-        egui::egui_assert!(0.0 <= fraction && fraction <= 1.0);
+        debug_assert!(0.0 <= fraction && fraction <= 1.0);
         Self::Relative {
             fraction,
             range: Rangef::new(0.0, f32::INFINITY),

--- a/crates/emath/Cargo.toml
+++ b/crates/emath/Cargo.toml
@@ -25,12 +25,6 @@ all-features = true
 [features]
 default = []
 
-## Enable additional checks if debug assertions are enabled (debug builds).
-extra_debug_asserts = []
-
-## Always enable additional checks.
-extra_asserts = []
-
 
 [dependencies]
 #! ### Optional dependencies

--- a/crates/emath/src/history.rs
+++ b/crates/emath/src/history.rs
@@ -126,7 +126,7 @@ where
     /// Values must be added with a monotonically increasing time, or at least not decreasing.
     pub fn add(&mut self, now: f64, value: T) {
         if let Some((last_time, _)) = self.values.back() {
-            crate::emath_assert!(now >= *last_time, "Time shouldn't move backwards");
+            debug_assert!(*last_time <= now, "Time shouldn't move backwards");
         }
         self.total_count += 1;
         self.values.push_back((now, value));

--- a/crates/emath/src/lib.rs
+++ b/crates/emath/src/lib.rs
@@ -146,7 +146,7 @@ where
 {
     let from = from.into();
     let to = to.into();
-    crate::emath_assert!(from.start() != from.end());
+    debug_assert!(from.start() != from.end());
     let t = (x - *from.start()) / (*from.end() - *from.start());
     lerp(to, t)
 }
@@ -170,7 +170,7 @@ where
     } else if *from.end() <= x {
         *to.end()
     } else {
-        crate::emath_assert!(from.start() != from.end());
+        debug_assert!(from.start() != from.end());
         let t = (x - *from.start()) / (*from.end() - *from.start());
         // Ensure no numerical inaccuracies sneak in:
         if T::ONE <= t {
@@ -194,8 +194,8 @@ pub fn format_with_minimum_decimals(value: f64, decimals: usize) -> String {
 pub fn format_with_decimals_in_range(value: f64, decimal_range: RangeInclusive<usize>) -> String {
     let min_decimals = *decimal_range.start();
     let max_decimals = *decimal_range.end();
-    crate::emath_assert!(min_decimals <= max_decimals);
-    crate::emath_assert!(max_decimals < 100);
+    debug_assert!(min_decimals <= max_decimals);
+    debug_assert!(max_decimals < 100);
     let max_decimals = max_decimals.min(16);
     let min_decimals = min_decimals.min(max_decimals);
 
@@ -429,20 +429,4 @@ pub fn interpolation_factor(
 pub fn ease_in_ease_out(t: f32) -> f32 {
     let t = t.clamp(0.0, 1.0);
     (3.0 * t * t - 2.0 * t * t * t).clamp(0.0, 1.0)
-}
-
-// ----------------------------------------------------------------------------
-
-/// An assert that is only active when `emath` is compiled with the `extra_asserts` feature
-/// or with the `extra_debug_asserts` feature in debug builds.
-#[macro_export]
-macro_rules! emath_assert {
-    ($($arg: tt)*) => {
-        if cfg!(any(
-            feature = "extra_asserts",
-            all(feature = "extra_debug_asserts", debug_assertions),
-        )) {
-            assert!($($arg)*);
-        }
-    }
 }

--- a/crates/emath/src/rot2.rs
+++ b/crates/emath/src/rot2.rs
@@ -84,7 +84,7 @@ impl Rot2 {
             c: self.c / l,
             s: self.s / l,
         };
-        crate::emath_assert!(ret.is_finite());
+        debug_assert!(ret.is_finite());
         ret
     }
 }

--- a/crates/emath/src/smart_aim.rs
+++ b/crates/emath/src/smart_aim.rs
@@ -33,7 +33,7 @@ pub fn best_in_range_f64(min: f64, max: f64) -> f64 {
     if !max.is_finite() {
         return min;
     }
-    crate::emath_assert!(min.is_finite() && max.is_finite());
+    debug_assert!(min.is_finite() && max.is_finite());
 
     let min_exponent = min.log10();
     let max_exponent = max.log10();
@@ -82,7 +82,7 @@ fn is_integer(f: f64) -> bool {
 }
 
 fn to_decimal_string(v: f64) -> [i32; NUM_DECIMALS] {
-    crate::emath_assert!(v < 10.0, "{:?}", v);
+    debug_assert!(v < 10.0, "{v:?}");
     let mut digits = [0; NUM_DECIMALS];
     let mut v = v.abs();
     for r in &mut digits {
@@ -104,7 +104,7 @@ fn from_decimal_string(s: &[i32]) -> f64 {
 
 /// Find the simplest integer in the range [min, max]
 fn simplest_digit_closed_range(min: i32, max: i32) -> i32 {
-    crate::emath_assert!(1 <= min && min <= max && max <= 9);
+    debug_assert!(1 <= min && min <= max && max <= 9);
     if min <= 5 && 5 <= max {
         5
     } else {

--- a/crates/epaint/Cargo.toml
+++ b/crates/epaint/Cargo.toml
@@ -52,14 +52,6 @@ deadlock_detection = ["dep:backtrace"]
 ## If you plan on specifying your own fonts you may disable this feature.
 default_fonts = []
 
-## Enable additional checks if debug assertions are enabled (debug builds).
-extra_debug_asserts = [
-  "emath/extra_debug_asserts",
-  "ecolor/extra_debug_asserts",
-]
-## Always enable additional checks.
-extra_asserts = ["emath/extra_asserts", "ecolor/extra_asserts"]
-
 ## Turn on the `log` feature, that makes egui log some errors using the [`log`](https://docs.rs/log) crate.
 log = ["dep:log"]
 

--- a/crates/epaint/src/bezier.rs
+++ b/crates/epaint/src/bezier.rs
@@ -141,8 +141,8 @@ impl CubicBezierShape {
 
     /// split the original cubic curve into a new one within a range.
     pub fn split_range(&self, t_range: Range<f32>) -> Self {
-        crate::epaint_assert!(
-            t_range.start >= 0.0 && t_range.end <= 1.0 && t_range.start <= t_range.end,
+        debug_assert!(
+            0.0 <= t_range.start && t_range.end <= 1.0 && t_range.start <= t_range.end,
             "range should be in [0.0,1.0]"
         );
 
@@ -178,7 +178,7 @@ impl CubicBezierShape {
     // https://scholarsarchive.byu.edu/cgi/viewcontent.cgi?article=1000&context=facpub#section.10.6
     // and the error metric from the caffein owl blog post http://caffeineowl.com/graphics/2d/vectorial/cubic2quad01.html
     pub fn num_quadratics(&self, tolerance: f32) -> u32 {
-        crate::epaint_assert!(tolerance > 0.0, "the tolerance should be positive");
+        debug_assert!(tolerance > 0.0, "the tolerance should be positive");
 
         let x =
             self.points[0].x - 3.0 * self.points[1].x + 3.0 * self.points[2].x - self.points[3].x;
@@ -273,7 +273,7 @@ impl CubicBezierShape {
     /// [Bézier Curve](https://en.wikipedia.org/wiki/B%C3%A9zier_curve#Cubic_B.C3.A9zier_curves)
     ///
     pub fn sample(&self, t: f32) -> Pos2 {
-        crate::epaint_assert!(
+        debug_assert!(
             t >= 0.0 && t <= 1.0,
             "the sample value should be in [0.0,1.0]"
         );
@@ -496,7 +496,7 @@ impl QuadraticBezierShape {
     /// [Bézier Curve](https://en.wikipedia.org/wiki/B%C3%A9zier_curve#Quadratic_B.C3.A9zier_curves)
     ///
     pub fn sample(&self, t: f32) -> Pos2 {
-        crate::epaint_assert!(
+        debug_assert!(
             t >= 0.0 && t <= 1.0,
             "the sample value should be in [0.0,1.0]"
         );

--- a/crates/epaint/src/lib.rs
+++ b/crates/epaint/src/lib.rs
@@ -138,22 +138,6 @@ pub enum Primitive {
     Callback(PaintCallback),
 }
 
-// ----------------------------------------------------------------------------
-
-/// An assert that is only active when `epaint` is compiled with the `extra_asserts` feature
-/// or with the `extra_debug_asserts` feature in debug builds.
-#[macro_export]
-macro_rules! epaint_assert {
-    ($($arg: tt)*) => {
-        if cfg!(any(
-            feature = "extra_asserts",
-            all(feature = "extra_debug_asserts", debug_assertions),
-        )) {
-            assert!($($arg)*);
-        }
-    }
-}
-
 // ---------------------------------------------------------------------------
 
 /// Was epaint compiled with the `rayon` feature?

--- a/crates/epaint/src/mesh.rs
+++ b/crates/epaint/src/mesh.rs
@@ -109,7 +109,7 @@ impl Mesh {
     /// Append all the indices and vertices of `other` to `self`.
     pub fn append(&mut self, other: Self) {
         crate::profile_function!();
-        crate::epaint_assert!(other.is_valid());
+        debug_assert!(other.is_valid());
 
         if self.is_empty() {
             *self = other;
@@ -121,7 +121,7 @@ impl Mesh {
     /// Append all the indices and vertices of `other` to `self` without
     /// taking ownership.
     pub fn append_ref(&mut self, other: &Self) {
-        crate::epaint_assert!(other.is_valid());
+        debug_assert!(other.is_valid());
 
         if self.is_empty() {
             self.texture_id = other.texture_id;
@@ -140,7 +140,7 @@ impl Mesh {
 
     #[inline(always)]
     pub fn colored_vertex(&mut self, pos: Pos2, color: Color32) {
-        crate::epaint_assert!(self.texture_id == TextureId::default());
+        debug_assert!(self.texture_id == TextureId::default());
         self.vertices.push(Vertex {
             pos,
             uv: WHITE_UV,
@@ -203,7 +203,7 @@ impl Mesh {
     /// Uniformly colored rectangle.
     #[inline(always)]
     pub fn add_colored_rect(&mut self, rect: Rect, color: Color32) {
-        crate::epaint_assert!(self.texture_id == TextureId::default());
+        debug_assert!(self.texture_id == TextureId::default());
         self.add_rect_with_uv(rect, [WHITE_UV, WHITE_UV].into(), color);
     }
 
@@ -212,7 +212,7 @@ impl Mesh {
     /// Splits this mesh into many smaller meshes (if needed)
     /// where the smaller meshes have 16-bit indices.
     pub fn split_to_u16(self) -> Vec<Mesh16> {
-        crate::epaint_assert!(self.is_valid());
+        debug_assert!(self.is_valid());
 
         const MAX_SIZE: u32 = std::u16::MAX as u32;
 
@@ -265,7 +265,7 @@ impl Mesh {
                 vertices: self.vertices[(min_vindex as usize)..=(max_vindex as usize)].to_vec(),
                 texture_id: self.texture_id,
             };
-            crate::epaint_assert!(mesh.is_valid());
+            debug_assert!(mesh.is_valid());
             output.push(mesh);
         }
         output

--- a/crates/epaint/src/shape.rs
+++ b/crates/epaint/src/shape.rs
@@ -313,7 +313,7 @@ impl Shape {
 
     #[inline]
     pub fn mesh(mesh: Mesh) -> Self {
-        crate::epaint_assert!(mesh.is_valid());
+        debug_assert!(mesh.is_valid());
         Self::Mesh(mesh)
     }
 

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -1311,7 +1311,7 @@ impl Tessellator {
                 crate::profile_scope!("mesh");
 
                 if self.options.validate_meshes && !mesh.is_valid() {
-                    crate::epaint_assert!(false, "Invalid Mesh in Shape::Mesh");
+                    debug_assert!(false, "Invalid Mesh in Shape::Mesh");
                     return;
                 }
                 // note: `append` still checks if the mesh is valid if extra asserts are enabled.
@@ -1480,7 +1480,7 @@ impl Tessellator {
     /// * `out`: triangles are appended to this.
     pub fn tessellate_mesh(&mut self, mesh: &Mesh, out: &mut Mesh) {
         if !mesh.is_valid() {
-            crate::epaint_assert!(false, "Invalid Mesh in Shape::Mesh");
+            debug_assert!(false, "Invalid Mesh in Shape::Mesh");
             return;
         }
 
@@ -1554,7 +1554,7 @@ impl Tessellator {
         }
 
         if *fill != Color32::TRANSPARENT {
-            crate::epaint_assert!(
+            debug_assert!(
                 closed,
                 "You asked to fill a path that is not closed. That makes no sense."
             );
@@ -1760,7 +1760,7 @@ impl Tessellator {
                             color = color.gamma_multiply(*opacity_factor);
                         }
 
-                        crate::epaint_assert!(color != Color32::PLACEHOLDER, "A placeholder color made it to the tessellator. You forgot to set a fallback color.");
+                        debug_assert!(color != Color32::PLACEHOLDER, "A placeholder color made it to the tessellator. You forgot to set a fallback color.");
 
                         let offset = if *angle == 0.0 {
                             pos.to_vec2()
@@ -1864,7 +1864,7 @@ impl Tessellator {
             self.scratchpad_path.add_open_points(points);
         }
         if fill != Color32::TRANSPARENT {
-            crate::epaint_assert!(
+            debug_assert!(
                 closed,
                 "You asked to fill a path that is not closed. That makes no sense."
             );
@@ -1946,7 +1946,7 @@ impl Tessellator {
 
         for clipped_primitive in &clipped_primitives {
             if let Primitive::Mesh(mesh) = &clipped_primitive.primitive {
-                crate::epaint_assert!(mesh.is_valid(), "Tessellator generated invalid Mesh");
+                debug_assert!(mesh.is_valid(), "Tessellator generated invalid Mesh");
             }
         }
 

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -890,7 +890,7 @@ impl Galley {
                 pcursor_it.offset += row.char_count_including_newline();
             }
         }
-        crate::epaint_assert!(ccursor_it == self.end().ccursor);
+        debug_assert!(ccursor_it == self.end().ccursor);
         Cursor {
             ccursor: ccursor_it, // clamp
             rcursor: self.end_rcursor(),

--- a/crates/epaint/src/textures.rs
+++ b/crates/epaint/src/textures.rs
@@ -49,7 +49,7 @@ impl TextureManager {
     pub fn set(&mut self, id: TextureId, delta: ImageDelta) {
         if let Some(meta) = self.metas.get_mut(&id) {
             if let Some(pos) = delta.pos {
-                crate::epaint_assert!(
+                debug_assert!(
                     pos[0] + delta.image.width() <= meta.size[0]
                         && pos[1] + delta.image.height() <= meta.size[1],
                     "Partial texture update is outside the bounds of texture {id:?}",
@@ -63,7 +63,7 @@ impl TextureManager {
             }
             self.delta.set.push((id, delta));
         } else {
-            crate::epaint_assert!(false, "Tried setting texture {id:?} which is not allocated");
+            debug_assert!(false, "Tried setting texture {id:?} which is not allocated");
         }
     }
 
@@ -77,7 +77,7 @@ impl TextureManager {
                 self.delta.free.push(id);
             }
         } else {
-            crate::epaint_assert!(false, "Tried freeing texture {id:?} which is not allocated");
+            debug_assert!(false, "Tried freeing texture {id:?} which is not allocated");
         }
     }
 
@@ -88,7 +88,7 @@ impl TextureManager {
         if let Some(meta) = self.metas.get_mut(&id) {
             meta.retain_count += 1;
         } else {
-            crate::epaint_assert!(
+            debug_assert!(
                 false,
                 "Tried retaining texture {id:?} which is not allocated",
             );


### PR DESCRIPTION
Removes `egui_assert` etc and replaces it with normal `debug_assert` calls.

Previously you could opt-in to more runtime checks using feature flags.
Now these extra runtime checks are always enabled for debug builds.

You are most likely to encounter them if you use negative sizes or NaNs or other similar bugs.
These usually indicate bugs in user space.