### PR TITLE
Introduce dithering to reduce banding

### DIFF
--- a/crates/egui-wgpu/src/egui.wgsl
+++ b/crates/egui-wgpu/src/egui.wgsl
@@ -7,12 +7,35 @@ struct VertexOutput {
 };
 
 struct Locals {
-    screen_size: vec2<f32>,
+    screen_size: vec2<f32>, // in points
+    pixels_per_point: f32,
     // Uniform buffers need to be at least 16 bytes in WebGL.
     // See https://github.com/gfx-rs/wgpu/issues/2072
-    _padding: vec2<u32>,
+    _padding: u32,
 };
 @group(0) @binding(0) var<uniform> r_locals: Locals;
+
+
+// -----------------------------------------------
+// Adapted from
+// https://www.shadertoy.com/view/llVGzG
+// Originally presented in:
+// Jimenez 2014, "Next Generation Post-Processing in Call of Duty"
+//
+// A good overview can be found in
+// https://blog.demofox.org/2022/01/01/interleaved-gradient-noise-a-different-kind-of-low-discrepancy-sequence/
+// via https://github.com/rerun-io/rerun/
+fn interleaved_gradient_noise(n: vec2<f32>) -> f32 {
+    let f = 0.06711056 * n.x + 0.00583715 * n.y;
+    return fract(52.9829189 * fract(f));
+}
+
+fn dither_interleaved(rgb: vec3<f32>, levels: f32, frag_coord: vec4<f32>) -> vec3<f32> {
+    var noise = interleaved_gradient_noise(frag_coord.xy);
+    // scale down the noise slightly to ensure flat colors aren't getting dithered
+    noise = (noise - 0.5) * 0.95;
+    return rgb + noise / (levels - 1.0);
+}
 
 // 0-1 linear  from  0-1 sRGB gamma
 fn linear_from_gamma_rgb(srgb: vec3<f32>) -> vec3<f32> {
@@ -78,7 +101,11 @@ fn fs_main_linear_framebuffer(in: VertexOutput) -> @location(0) vec4<f32> {
     let tex_linear = textureSample(r_tex_color, r_tex_sampler, in.tex_coord);
     let tex_gamma = gamma_from_linear_rgba(tex_linear);
     let out_color_gamma = in.color * tex_gamma;
-    return vec4<f32>(linear_from_gamma_rgb(out_color_gamma.rgb), out_color_gamma.a);
+    let out_color_linear = linear_from_gamma_rgb(out_color_gamma.rgb);
+    // Dither the float color down to eight bits to reduce banding.
+    // This step is optional for egui backends.
+    let out_color_dithered = dither_interleaved(out_color_linear, 256.0, in.position);
+    return vec4<f32>(out_color_dithered, out_color_gamma.a);
 }
 
 @fragment
@@ -87,5 +114,6 @@ fn fs_main_gamma_framebuffer(in: VertexOutput) -> @location(0) vec4<f32> {
     let tex_linear = textureSample(r_tex_color, r_tex_sampler, in.tex_coord);
     let tex_gamma = gamma_from_linear_rgba(tex_linear);
     let out_color_gamma = in.color * tex_gamma;
-    return out_color_gamma;
+    let out_color_dithered = vec4<f32>(dither_interleaved(out_color_gamma.rgb, 256.0, in.position * r_locals.pixels_per_point), out_color_gamma.a);
+    return out_color_dithered;
 }

--- a/crates/egui-wgpu/src/renderer.rs
+++ b/crates/egui-wgpu/src/renderer.rs
@@ -132,9 +132,10 @@ impl ScreenDescriptor {
 #[repr(C)]
 struct UniformBuffer {
     screen_size_in_points: [f32; 2],
+    pixels_per_point: f32,
     // Uniform buffers need to be at least 16 bytes in WebGL.
     // See https://github.com/gfx-rs/wgpu/issues/2072
-    _padding: [u32; 2],
+    _padding: u32,
 }
 
 impl PartialEq for UniformBuffer {
@@ -200,6 +201,7 @@ impl Renderer {
             label: Some("egui_uniform_buffer"),
             contents: bytemuck::cast_slice(&[UniformBuffer {
                 screen_size_in_points: [0.0, 0.0],
+                pixels_per_point: 0.,
                 _padding: Default::default(),
             }]),
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
@@ -211,7 +213,7 @@ impl Renderer {
                 label: Some("egui_uniform_bind_group_layout"),
                 entries: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgpu::ShaderStages::VERTEX,
+                    visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Buffer {
                         has_dynamic_offset: false,
                         min_binding_size: NonZeroU64::new(std::mem::size_of::<UniformBuffer>() as _),
@@ -363,7 +365,8 @@ impl Renderer {
             // Buffers on wgpu are zero initialized, so this is indeed its current state!
             previous_uniform_buffer_content: UniformBuffer {
                 screen_size_in_points: [0.0, 0.0],
-                _padding: [0, 0],
+                pixels_per_point: 0.,
+                _padding: 0,
             },
             uniform_bind_group,
             texture_bind_group_layout,
@@ -782,6 +785,7 @@ impl Renderer {
 
         let uniform_buffer_content = UniformBuffer {
             screen_size_in_points,
+            pixels_per_point: screen_descriptor.pixels_per_point,
             _padding: Default::default(),
         };
         if uniform_buffer_content != self.previous_uniform_buffer_content {

--- a/crates/egui_glow/src/shader/fragment.glsl
+++ b/crates/egui_glow/src/shader/fragment.glsl
@@ -16,6 +16,27 @@ uniform sampler2D u_sampler;
     varying vec2 v_tc;
 #endif
 
+// -----------------------------------------------
+// Adapted from
+// https://www.shadertoy.com/view/llVGzG
+// Originally presented in:
+// Jimenez 2014, "Next Generation Post-Processing in Call of Duty"
+//
+// A good overview can be found in
+// https://blog.demofox.org/2022/01/01/interleaved-gradient-noise-a-different-kind-of-low-discrepancy-sequence/
+// via https://github.com/rerun-io/rerun/
+float interleaved_gradient_noise(vec2 n) {
+    float f = 0.06711056 * n.x + 0.00583715 * n.y;
+    return fract(52.9829189 * fract(f));
+}
+
+vec3 dither_interleaved(vec3 rgb, float levels) {
+    float noise = interleaved_gradient_noise(gl_FragCoord.xy);
+    // scale down the noise slightly to ensure flat colors aren't getting dithered
+    noise = (noise - 0.5) * 0.95;
+    return rgb + noise / (levels - 1.0);
+}
+
 // 0-1 sRGB gamma  from  0-1 linear
 vec3 srgb_gamma_from_linear(vec3 rgb) {
     bvec3 cutoff = lessThan(rgb, vec3(0.0031308));
@@ -37,5 +58,9 @@ void main() {
 #endif
 
     // We multiply the colors in gamma space, because that's the only way to get text to look right.
-    gl_FragColor = v_rgba_in_gamma * texture_in_gamma;
+    vec4 frag_color_gamma = v_rgba_in_gamma * texture_in_gamma;
+
+    // Dither the float color down to eight bits to reduce banding.
+    // This step is optional for egui backends.
+    gl_FragColor = vec4(dither_interleaved(frag_color_gamma.rgb, 256.), frag_color_gamma.a);
 }


### PR DESCRIPTION
This PR introduces dithering in the egui_glow and egui_wgpu backends to reduce banding artifacts.

It's based on the approach mentioned in #4493 with the small difference that the amount of noise is scaled down slightly to avoid dithering colors that can be represented exactly. This keeps flat surfaces clean.

Exaggerated dithering to show what is happening:
![Screenshot from 2024-05-14 19-09-48](https://github.com/emilk/egui/assets/293536/75782b83-9023-4cb2-99f7-a24e15fdefcc)

Subtle dithering as commited.
![Screenshot from 2024-05-14 19-13-40](https://github.com/emilk/egui/assets/293536/eb904698-a6ec-494a-952b-447e9a49bfda)

Closes #4493 