### PR TITLE
Fix: Use default features in Image Crate

### DIFF
--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -154,7 +154,7 @@ egui-winit = { workspace = true, default-features = false, features = [
   "clipboard",
   "links",
 ] }
-image = { workspace = true, features = ["png"] } # Needed for app icon
+image = { workspace = true, default-features = true } # Needed for app icon
 winit = { workspace = true, default-features = false, features = ["rwh_06"] }
 
 # optional native:


### PR DESCRIPTION
* Closes #4489 
* Related #4495

Fix: Use default features in Image Crate

Because only `.png` is available after update #4495.

Required to use JPEG, etc.
