### PR TITLE
Do no use the ahash reimport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,6 +1172,7 @@ dependencies = [
 name = "eframe"
 version = "0.27.2"
 dependencies = [
+ "ahash",
  "bytemuck",
  "directories-next",
  "document-features",
@@ -1227,6 +1228,7 @@ dependencies = [
 name = "egui-wgpu"
 version = "0.27.2"
 dependencies = [
+ "ahash",
  "bytemuck",
  "document-features",
  "egui",
@@ -1245,6 +1247,7 @@ name = "egui-winit"
 version = "0.27.2"
 dependencies = [
  "accesskit_winit",
+ "ahash",
  "arboard",
  "document-features",
  "egui",
@@ -1302,6 +1305,7 @@ dependencies = [
 name = "egui_extras"
 version = "0.27.2"
 dependencies = [
+ "ahash",
  "chrono",
  "document-features",
  "egui",
@@ -1320,6 +1324,7 @@ dependencies = [
 name = "egui_glow"
 version = "0.27.2"
 dependencies = [
+ "ahash",
  "bytemuck",
  "document-features",
  "egui",
@@ -1340,6 +1345,7 @@ dependencies = [
 name = "egui_plot"
 version = "0.27.2"
 dependencies = [
+ "ahash",
  "document-features",
  "egui",
  "serde",

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -129,6 +129,7 @@ egui = { workspace = true, default-features = false, features = [
   "log",
 ] }
 
+ahash.workspace = true
 document-features.workspace = true
 log.workspace = true
 parking_lot.workspace = true

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -26,10 +26,10 @@ use winit::{
     window::{Window, WindowId},
 };
 
+use ahash::{HashMap, HashSet};
 use egui::{
-    ahash::HashSet, epaint::ahash::HashMap, DeferredViewportUiCallback, ImmediateViewport,
-    ViewportBuilder, ViewportClass, ViewportId, ViewportIdMap, ViewportIdPair, ViewportInfo,
-    ViewportOutput,
+    DeferredViewportUiCallback, ImmediateViewport, ViewportBuilder, ViewportClass, ViewportId,
+    ViewportIdMap, ViewportIdPair, ViewportInfo, ViewportOutput,
 };
 #[cfg(feature = "accesskit")]
 use egui_winit::accesskit_winit;

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, time::Instant};
 
 use winit::event_loop::{EventLoop, EventLoopBuilder};
 
-use egui::epaint::ahash::HashMap;
+use ahash::HashMap;
 
 use crate::{
     epi,

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -15,8 +15,8 @@ use winit::{
     window::{Window, WindowId},
 };
 
+use ahash::{HashMap, HashSet, HashSetExt};
 use egui::{
-    ahash::{HashMap, HashSet, HashSetExt},
     DeferredViewportUiCallback, FullOutput, ImmediateViewport, ViewportBuilder, ViewportClass,
     ViewportId, ViewportIdMap, ViewportIdPair, ViewportIdSet, ViewportInfo, ViewportOutput,
 };

--- a/crates/egui-wgpu/Cargo.toml
+++ b/crates/egui-wgpu/Cargo.toml
@@ -50,6 +50,7 @@ x11 = ["winit?/x11"]
 egui = { workspace = true, default-features = false }
 epaint = { workspace = true, default-features = false, features = ["bytemuck"] }
 
+ahash.workspace = true
 bytemuck.workspace = true
 document-features.workspace = true
 log.workspace = true

--- a/crates/egui-wgpu/src/renderer.rs
+++ b/crates/egui-wgpu/src/renderer.rs
@@ -2,7 +2,8 @@
 
 use std::{borrow::Cow, num::NonZeroU64, ops::Range};
 
-use epaint::{ahash::HashMap, emath::NumExt, PaintCallbackInfo, Primitive, Vertex};
+use ahash::HashMap;
+use epaint::{emath::NumExt, PaintCallbackInfo, Primitive, Vertex};
 
 use wgpu::util::DeviceExt as _;
 

--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -59,6 +59,8 @@ x11 = ["winit/x11", "bytemuck"]
 
 [dependencies]
 egui = { workspace = true, default-features = false, features = ["log"] }
+
+ahash.workspace = true
 log.workspace = true
 raw-window-handle.workspace = true
 web-time.workspace = true

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -14,9 +14,7 @@ pub use accesskit_winit;
 pub use egui;
 #[cfg(feature = "accesskit")]
 use egui::accesskit;
-use egui::{
-    ahash::HashSet, Pos2, Rect, Vec2, ViewportBuilder, ViewportCommand, ViewportId, ViewportInfo,
-};
+use egui::{Pos2, Rect, Vec2, ViewportBuilder, ViewportCommand, ViewportId, ViewportInfo};
 pub use winit;
 
 pub mod clipboard;
@@ -24,6 +22,7 @@ mod window_settings;
 
 pub use window_settings::WindowSettings;
 
+use ahash::HashSet;
 use raw_window_handle::HasDisplayHandle;
 
 #[allow(unused_imports)]

--- a/crates/egui/src/id.rs
+++ b/crates/egui/src/id.rs
@@ -52,13 +52,13 @@ impl Id {
 
     /// Generate a new [`Id`] by hashing some source (e.g. a string or integer).
     pub fn new(source: impl std::hash::Hash) -> Self {
-        Self::from_hash(epaint::ahash::RandomState::with_seeds(1, 2, 3, 4).hash_one(source))
+        Self::from_hash(ahash::RandomState::with_seeds(1, 2, 3, 4).hash_one(source))
     }
 
     /// Generate a new [`Id`] by hashing the parent [`Id`] and the given argument.
     pub fn with(self, child: impl std::hash::Hash) -> Self {
         use std::hash::{BuildHasher, Hasher};
-        let mut hasher = epaint::ahash::RandomState::with_seeds(1, 2, 3, 4).build_hasher();
+        let mut hasher = ahash::RandomState::with_seeds(1, 2, 3, 4).build_hasher();
         hasher.write_u64(self.0.get());
         child.hash(&mut hasher);
         Self::from_hash(hasher.finish())

--- a/crates/egui_extras/Cargo.toml
+++ b/crates/egui_extras/Cargo.toml
@@ -64,6 +64,7 @@ syntect = ["dep:syntect"]
 [dependencies]
 egui = { workspace = true, default-features = false, features = ["serde"] }
 
+ahash.workspace = true
 enum-map = { version = "2", features = ["serde"] }
 log.workspace = true
 serde.workspace = true

--- a/crates/egui_extras/src/loaders/ehttp_loader.rs
+++ b/crates/egui_extras/src/loaders/ehttp_loader.rs
@@ -1,5 +1,5 @@
+use ahash::HashMap;
 use egui::{
-    ahash::HashMap,
     load::{Bytes, BytesLoadResult, BytesLoader, BytesPoll, LoadError},
     mutex::Mutex,
 };

--- a/crates/egui_extras/src/loaders/file_loader.rs
+++ b/crates/egui_extras/src/loaders/file_loader.rs
@@ -1,5 +1,5 @@
+use ahash::HashMap;
 use egui::{
-    ahash::HashMap,
     load::{Bytes, BytesLoadResult, BytesLoader, BytesPoll, LoadError},
     mutex::Mutex,
 };

--- a/crates/egui_extras/src/loaders/image_loader.rs
+++ b/crates/egui_extras/src/loaders/image_loader.rs
@@ -1,5 +1,5 @@
+use ahash::HashMap;
 use egui::{
-    ahash::HashMap,
     load::{BytesPoll, ImageLoadResult, ImageLoader, ImagePoll, LoadError, SizeHint},
     mutex::Mutex,
     ColorImage,

--- a/crates/egui_extras/src/loaders/svg_loader.rs
+++ b/crates/egui_extras/src/loaders/svg_loader.rs
@@ -1,7 +1,8 @@
 use std::{mem::size_of, path::Path, sync::Arc};
 
+use ahash::HashMap;
+
 use egui::{
-    ahash::HashMap,
     load::{BytesPoll, ImageLoadResult, ImageLoader, ImagePoll, LoadError, SizeHint},
     mutex::Mutex,
     ColorImage,

--- a/crates/egui_glow/Cargo.toml
+++ b/crates/egui_glow/Cargo.toml
@@ -56,6 +56,7 @@ x11 = ["winit?/x11"]
 egui = { workspace = true, default-features = false, features = ["bytemuck"] }
 egui-winit = { workspace = true, optional = true, default-features = false }
 
+ahash.workspace = true
 bytemuck.workspace = true
 glow.workspace = true
 log.workspace = true

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -1,8 +1,8 @@
+use ahash::HashSet;
+use egui::{ViewportId, ViewportOutput};
 pub use egui_winit;
-pub use egui_winit::EventResponse;
-
-use egui::{ahash::HashSet, ViewportId, ViewportOutput};
 use egui_winit::winit;
+pub use egui_winit::EventResponse;
 
 use crate::shader_version::ShaderVersion;
 

--- a/crates/egui_plot/Cargo.toml
+++ b/crates/egui_plot/Cargo.toml
@@ -37,6 +37,7 @@ serde = ["dep:serde", "egui/serde"]
 [dependencies]
 egui = { workspace = true, default-features = false }
 
+ahash.workspace = true
 
 #! ### Optional dependencies
 ## Enable this when generating docs.

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -15,7 +15,7 @@ mod transform;
 
 use std::{cmp::Ordering, ops::RangeInclusive, sync::Arc};
 
-use egui::ahash::HashMap;
+use ahash::HashMap;
 use egui::*;
 use emath::Float as _;
 use epaint::Hsva;

--- a/crates/egui_plot/src/memory.rs
+++ b/crates/egui_plot/src/memory.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use egui::{ahash, Context, Id, Pos2, Vec2b};
+use egui::{Context, Id, Pos2, Vec2b};
 
 use crate::{PlotBounds, PlotTransform};
 


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

Related to #3482 

Not sure what the "best practice" is, to me it seems like one should import from "the original location" if possible, but now it should at least be possible to not re-export ahash without any breakage in the egui code base (but possibly in projects using egui, so one should probably deprecate it if one would like to go that path). It also seems like epaint re-exports ahash.
