### PR TITLE
Import directly from correct crates rather than the re-exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,8 +1340,12 @@ dependencies = [
 name = "egui_plot"
 version = "0.27.2"
 dependencies = [
+ "ahash",
  "document-features",
+ "ecolor",
  "egui",
+ "emath",
+ "epaint",
  "serde",
 ]
 

--- a/crates/egui_plot/Cargo.toml
+++ b/crates/egui_plot/Cargo.toml
@@ -35,7 +35,11 @@ serde = ["dep:serde", "egui/serde"]
 
 
 [dependencies]
+ahash.workspace = true
+ecolor.workspace = true
 egui = { workspace = true, default-features = false }
+emath.workspace = true
+epaint.workspace = true
 
 
 #! ### Optional dependencies

--- a/crates/egui_plot/src/axis.rs
+++ b/crates/egui_plot/src/axis.rs
@@ -1,10 +1,8 @@
 use std::{fmt::Debug, ops::RangeInclusive, sync::Arc};
 
-use egui::{
-    emath::{remap_clamp, round_to_decimals, Rot2},
-    epaint::TextShape,
-    Pos2, Rangef, Rect, Response, Sense, TextStyle, Ui, Vec2, WidgetText,
-};
+use egui::{Rangef, Response, Sense, TextStyle, Ui, WidgetText};
+use emath::{remap_clamp, round_to_decimals, Pos2, Rect, Rot2, Vec2};
+use epaint::TextShape;
 
 use super::{transform::PlotTransform, GridMark};
 

--- a/crates/egui_plot/src/items/bar.rs
+++ b/crates/egui_plot/src/items/bar.rs
@@ -1,5 +1,5 @@
-use egui::emath::NumExt;
-use egui::epaint::{Color32, RectShape, Rounding, Shape, Stroke};
+use emath::NumExt;
+use epaint::{Color32, RectShape, Rounding, Shape, Stroke};
 
 use super::{add_rulers_and_text, highlighted_color, Orientation, PlotConfig, RectElement};
 use crate::{BarChart, Cursor, PlotPoint, PlotTransform};

--- a/crates/egui_plot/src/items/box_elem.rs
+++ b/crates/egui_plot/src/items/box_elem.rs
@@ -1,5 +1,5 @@
-use egui::emath::NumExt as _;
-use egui::epaint::{Color32, RectShape, Rounding, Shape, Stroke};
+use emath::NumExt as _;
+use epaint::{Color32, RectShape, Rounding, Shape, Stroke};
 
 use crate::{BoxPlot, Cursor, PlotPoint, PlotTransform};
 

--- a/crates/egui_plot/src/items/mod.rs
+++ b/crates/egui_plot/src/items/mod.rs
@@ -3,12 +3,13 @@
 
 use std::ops::RangeInclusive;
 
-use epaint::{emath::Rot2, Mesh};
-
-use crate::*;
+use ecolor::{Color32, Rgba};
+use egui::{Id, ImageOptions, NumExt as _, TextStyle, Ui, WidgetText};
+use emath::{pos2, vec2, Align2, Float as _, Pos2, Rect, Rot2, Vec2};
+use epaint::{Mesh, Rounding, Shape, Stroke, TextureId};
 
 use super::{Cursor, LabelFormatter, PlotBounds, PlotTransform};
-use rect_elem::*;
+use rect_elem::{highlighted_color, RectElement};
 
 pub use bar::Bar;
 pub use box_elem::{BoxElem, BoxSpread};

--- a/crates/egui_plot/src/items/rect_elem.rs
+++ b/crates/egui_plot/src/items/rect_elem.rs
@@ -1,5 +1,6 @@
-use egui::emath::NumExt as _;
-use egui::epaint::{Color32, Rgba, Stroke};
+use ecolor::{Color32, Rgba};
+use emath::NumExt as _;
+use epaint::Stroke;
 
 use crate::transform::{PlotBounds, PlotTransform};
 

--- a/crates/egui_plot/src/items/values.rs
+++ b/crates/egui_plot/src/items/values.rs
@@ -1,6 +1,7 @@
 use std::ops::{Bound, RangeBounds, RangeInclusive};
 
-use egui::{Pos2, Shape, Stroke, Vec2};
+use emath::{Pos2, Vec2};
+use epaint::{Shape, Stroke};
 
 use crate::transform::PlotBounds;
 

--- a/crates/egui_plot/src/legend.rs
+++ b/crates/egui_plot/src/legend.rs
@@ -1,6 +1,11 @@
 use std::{collections::BTreeMap, string::String};
 
-use crate::*;
+use ecolor::Color32;
+use egui::{
+    Direction, Frame, Layout, PointerButton, Response, Sense, TextStyle, Ui, Widget, WidgetInfo,
+    WidgetType,
+};
+use emath::{pos2, vec2, Align, Rect};
 
 use super::items::PlotItem;
 

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -15,10 +15,9 @@ mod transform;
 
 use std::{cmp::Ordering, ops::RangeInclusive, sync::Arc};
 
-use egui::ahash::HashMap;
+use ahash::HashMap;
 use egui::*;
 use emath::Float as _;
-use epaint::Hsva;
 
 pub use crate::{
     axis::{Axis, AxisHints, HPlacement, Placement, VPlacement},

--- a/crates/egui_plot/src/memory.rs
+++ b/crates/egui_plot/src/memory.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use egui::{ahash, Context, Id, Pos2, Vec2b};
+use egui::{Context, Id, Pos2, Vec2b};
 
 use crate::{PlotBounds, PlotTransform};
 

--- a/crates/egui_plot/src/plot_ui.rs
+++ b/crates/egui_plot/src/plot_ui.rs
@@ -1,4 +1,10 @@
-use crate::*;
+use crate::{
+    Arrows, BarChart, BoundsModification, BoxPlot, HLine, Line, PlotBounds, PlotImage, PlotItem,
+    PlotPoint, PlotTransform, Points, Polygon, Text, VLine,
+};
+use ecolor::{Color32, Hsva};
+use egui::{Context, Response};
+use emath::{Pos2, Vec2, Vec2b};
 
 /// Provides methods to interact with a plot while building it. It is the single argument of the closure
 /// provided to [`Plot::show`]. See [`Plot`] for an example of how to use it.

--- a/crates/egui_plot/src/transform.rs
+++ b/crates/egui_plot/src/transform.rs
@@ -1,7 +1,7 @@
 use std::ops::RangeInclusive;
 
-use super::PlotPoint;
-use crate::*;
+use super::{Axis, PlotPoint};
+use emath::{pos2, remap, Pos2, Rect, Vec2};
 
 /// 2D bounding box of f64 precision.
 ///


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

Slightly related to #4504 and by noting that there are quite a lot of *-imports in egui. So I decided to get rid of the *-imports which then naturally opens the question: where should things be imported from? As an example, Pos2 is defined in emath, but re-exported from egui, epaint, egui::emath, egui::epaint, etc...

Not claiming to be 100% correct, but this should at least be a step in the right direction when it comes to imports. If one would like to go in that direction...