### PR TITLE
Use PathStroke for the stroke of Frames

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -392,7 +392,7 @@ impl Area {
             // let area_rect =
             //     Rect::from_center_size(area_rect.center(), visibility_factor * area_rect.size());
 
-            let frame = frame.multiply_with_opacity(visibility_factor);
+            let frame = frame.to_owned().multiply_with_opacity(visibility_factor);
             painter.add(frame.paint(area_rect));
         }
     }

--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -260,9 +260,10 @@ impl SidePanel {
         let mut panel_ui = ui.child_ui_with_id_source(panel_rect, Layout::top_down(Align::Min), id);
         panel_ui.expand_to_include_rect(panel_rect);
         let frame = frame.unwrap_or_else(|| Frame::side_top_panel(ui.style()));
+        let inner_margin = frame.inner_margin.sum();
         let inner_response = frame.show(&mut panel_ui, |ui| {
             ui.set_min_height(ui.max_rect().height()); // Make sure the frame fills the full height
-            ui.set_min_width((width_range.min - frame.inner_margin.sum().x).at_least(0.0));
+            ui.set_min_width((width_range.min - inner_margin.x).at_least(0.0));
             add_contents(ui)
         });
 
@@ -726,9 +727,10 @@ impl TopBottomPanel {
         let mut panel_ui = ui.child_ui_with_id_source(panel_rect, Layout::top_down(Align::Min), id);
         panel_ui.expand_to_include_rect(panel_rect);
         let frame = frame.unwrap_or_else(|| Frame::side_top_panel(ui.style()));
+        let inner_margin = frame.inner_margin.sum();
         let inner_response = frame.show(&mut panel_ui, |ui| {
             ui.set_min_width(ui.max_rect().width()); // Make the frame fill full width
-            ui.set_min_height((height_range.min - frame.inner_margin.sum().y).at_least(0.0));
+            ui.set_min_height((height_range.min - inner_margin.y).at_least(0.0));
             add_contents(ui)
         });
 

--- a/crates/egui/src/containers/resize.rs
+++ b/crates/egui/src/containers/resize.rs
@@ -369,7 +369,7 @@ impl Resize {
     }
 }
 
-use epaint::Stroke;
+use epaint::{ColorMode, PathStroke};
 
 pub fn paint_resize_corner(ui: &Ui, response: &Response) {
     let stroke = ui.style().interact(response).fg_stroke;
@@ -379,13 +379,13 @@ pub fn paint_resize_corner(ui: &Ui, response: &Response) {
 pub fn paint_resize_corner_with_style(
     ui: &Ui,
     rect: &Rect,
-    color: impl Into<Color32>,
+    color: impl Into<ColorMode>,
     corner: Align2,
 ) {
     let painter = ui.painter();
     let cp = painter.round_pos_to_pixels(corner.pos_in_rect(rect));
     let mut w = 2.0;
-    let stroke = Stroke {
+    let stroke = PathStroke {
         width: 1.0, // Set width to 1.0 to prevent overlapping
         color: color.into(),
     };
@@ -396,7 +396,7 @@ pub fn paint_resize_corner_with_style(
                 pos2(cp.x - w * corner.x().to_sign(), cp.y),
                 pos2(cp.x, cp.y - w * corner.y().to_sign()),
             ],
-            stroke,
+            stroke.clone(),
         );
         w += 4.0;
     }

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -404,8 +404,9 @@ impl<'open> Window<'open> {
             with_title_bar,
         } = self;
 
-        let header_color =
-            frame.map_or_else(|| ctx.style().visuals.widgets.open.weak_bg_fill, |f| f.fill);
+        let header_color = frame
+            .as_ref()
+            .map_or_else(|| ctx.style().visuals.widgets.open.weak_bg_fill, |f| f.fill);
         let mut window_frame = frame.unwrap_or_else(|| Frame::window(&ctx.style()));
         // Keep the original inner margin for later use
         let window_margin = window_frame.inner_margin;
@@ -480,7 +481,8 @@ impl<'open> Window<'open> {
 
         let content_inner = {
             // BEGIN FRAME --------------------------------
-            let frame_stroke = window_frame.stroke;
+            let frame_stroke = window_frame.stroke.clone();
+            let rounding = window_frame.rounding;
             let mut frame = window_frame.begin(&mut area_content_ui);
 
             let show_close_button = open.is_some();
@@ -530,7 +532,7 @@ impl<'open> Window<'open> {
                 &possible,
                 outer_rect,
                 frame_stroke,
-                window_frame.rounding,
+                rounding,
             );
 
             // END FRAME --------------------------------
@@ -547,7 +549,7 @@ impl<'open> Window<'open> {
                 title_rect = area_content_ui.painter().round_rect_to_pixels(title_rect);
 
                 if on_top && area_content_ui.visuals().window_highlight_topmost {
-                    let mut round = window_frame.rounding;
+                    let mut round = rounding;
 
                     // Eliminate the rounding gap between the title bar and the window frame
                     round -= border_padding;
@@ -599,7 +601,7 @@ fn paint_resize_corner(
     ui: &Ui,
     possible: &PossibleInteractions,
     outer_rect: Rect,
-    stroke: impl Into<Stroke>,
+    stroke: impl Into<PathStroke>,
     rounding: impl Into<Rounding>,
 ) {
     let stroke = stroke.into();

--- a/crates/egui/src/painter.rs
+++ b/crates/egui/src/painter.rs
@@ -340,7 +340,7 @@ impl Painter {
         rect: Rect,
         rounding: impl Into<Rounding>,
         fill_color: impl Into<Color32>,
-        stroke: impl Into<Stroke>,
+        stroke: impl Into<PathStroke>,
     ) -> ShapeIdx {
         self.add(RectShape::new(rect, rounding, fill_color, stroke))
     }
@@ -358,7 +358,7 @@ impl Painter {
         &self,
         rect: Rect,
         rounding: impl Into<Rounding>,
-        stroke: impl Into<Stroke>,
+        stroke: impl Into<PathStroke>,
     ) -> ShapeIdx {
         self.add(RectShape::stroke(rect, rounding, stroke))
     }

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -4,7 +4,7 @@
 
 use std::collections::BTreeMap;
 
-use epaint::{Rounding, Shadow, Stroke};
+use epaint::{ColorMode, PathStroke, Rounding, Shadow, Stroke};
 
 use crate::{
     ecolor::*, emath::*, ComboBox, CursorIcon, FontFamily, FontId, Grid, Margin, Response,
@@ -2264,6 +2264,41 @@ impl Widget for &mut Stroke {
             let left = stroke_rect.left_center();
             let right = stroke_rect.right_center();
             ui.painter().line_segment([left, right], (*width, *color));
+        })
+        .response
+    }
+}
+
+impl Widget for &mut PathStroke {
+    fn ui(self, ui: &mut Ui) -> Response {
+        let PathStroke { width, color } = self;
+
+        ui.horizontal(|ui| {
+            ui.add(
+                DragValue::new(width)
+                    .speed(0.1)
+                    .clamp_range(0.0..=f32::INFINITY),
+            )
+            .on_hover_text("Width");
+
+            match color {
+                ColorMode::Solid(color) => ui.color_edit_button_srgba(color),
+                ColorMode::UV(_) => ui.label("[CALLBACK]").on_hover_text(
+                    "This stroke uses a custom callback function. This isn't editable.",
+                ),
+            };
+
+            let (_id, stroke_rect) = ui.allocate_space(ui.spacing().interact_size);
+            let left = stroke_rect.left_center();
+            let right = stroke_rect.right_center();
+
+            ui.painter().line_segment(
+                [left, right],
+                PathStroke {
+                    width: *width,
+                    color: color.to_owned(),
+                },
+            );
         })
         .response
     }

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2272,7 +2272,7 @@ impl Ui {
         }
 
         frame.frame.fill = fill;
-        frame.frame.stroke = stroke;
+        frame.frame.stroke = stroke.into();
 
         frame.paint(self);
 

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use emath::{Float as _, Rot2};
-use epaint::RectShape;
+use epaint::{PathStroke, RectShape};
 
 use crate::{
     load::{Bytes, SizeHint, SizedTexture, TextureLoadResult, TexturePoll},
@@ -761,7 +761,7 @@ pub fn paint_texture_at(
                 rect,
                 rounding: options.rounding,
                 fill: options.tint,
-                stroke: Stroke::NONE,
+                stroke: PathStroke::NONE,
                 blur_width: 0.0,
                 fill_texture_id: texture.id,
                 uv: options.uv,

--- a/crates/egui_demo_lib/src/demo/frame_demo.rs
+++ b/crates/egui_demo_lib/src/demo/frame_demo.rs
@@ -1,7 +1,10 @@
+use egui::{epaint::PathStroke, lerp, remap_clamp, Color32};
+
 /// Shows off a table with dynamic layout
 #[derive(PartialEq)]
 pub struct FrameDemo {
     frame: egui::Frame,
+    fancy: bool,
 }
 
 impl Default for FrameDemo {
@@ -18,8 +21,9 @@ impl Default for FrameDemo {
                     color: egui::Color32::from_black_alpha(180),
                 },
                 fill: egui::Color32::from_rgba_unmultiplied(97, 0, 255, 128),
-                stroke: egui::Stroke::new(1.0, egui::Color32::GRAY),
+                stroke: egui::Stroke::new(1.0, egui::Color32::GRAY).into(),
             },
+            fancy: false,
         }
     }
 }
@@ -59,7 +63,34 @@ impl super::View for FrameDemo {
                     .stroke(ui.visuals().widgets.noninteractive.bg_stroke)
                     .rounding(ui.visuals().widgets.noninteractive.rounding)
                     .show(ui, |ui| {
-                        self.frame.show(ui, |ui| {
+                        if ui.checkbox(&mut self.fancy, "Fancy Stroke").clicked() {
+                            let width = self.frame.stroke.width;
+                            if self.fancy {
+                                self.frame.stroke = PathStroke::new_uv(width, |rect, pos| {
+                                    let x_t = remap_clamp(pos.x, rect.x_range(), 0.0..=1.0);
+                                    let y_t = remap_clamp(pos.y, rect.y_range(), 0.0..=1.0);
+
+                                    Color32::from_rgb(
+                                        lerp(
+                                            Color32::RED.r() as f32..=Color32::GREEN.r() as f32,
+                                            x_t,
+                                        ) as u8,
+                                        lerp(
+                                            Color32::RED.g() as f32..=Color32::GREEN.g() as f32,
+                                            y_t,
+                                        ) as u8,
+                                        lerp(
+                                            Color32::RED.b() as f32..=Color32::GREEN.b() as f32,
+                                            x_t,
+                                        ) as u8,
+                                    )
+                                });
+                            } else {
+                                self.frame.stroke =
+                                    egui::Stroke::new(width, egui::Color32::GRAY).into();
+                            }
+                        }
+                        self.frame.clone().show(ui, |ui| {
                             ui.style_mut().wrap = Some(false);
                             ui.label(egui::RichText::new("Content").color(egui::Color32::WHITE));
                         });

--- a/crates/egui_plot/src/legend.rs
+++ b/crates/egui_plot/src/legend.rs
@@ -261,7 +261,7 @@ impl Widget for &mut LegendWidget {
                     rounding: ui.style().visuals.window_rounding,
                     shadow: epaint::Shadow::NONE,
                     fill: ui.style().visuals.extreme_bg_color,
-                    stroke: ui.style().visuals.window_stroke(),
+                    stroke: ui.style().visuals.window_stroke().into(),
                     ..Default::default()
                 }
                 .multiply_with_opacity(config.background_alpha);

--- a/crates/epaint/src/color.rs
+++ b/crates/epaint/src/color.rs
@@ -18,6 +18,15 @@ pub enum ColorMode {
     UV(Arc<dyn Fn(Rect, Pos2) -> Color32 + Send + Sync>),
 }
 
+impl<Color> From<Color> for ColorMode
+where
+    Color: Into<Color32>,
+{
+    fn from(value: Color) -> Self {
+        Self::Solid(value.into())
+    }
+}
+
 impl Default for ColorMode {
     fn default() -> Self {
         Self::Solid(Color32::TRANSPARENT)

--- a/crates/epaint/src/shape.rs
+++ b/crates/epaint/src/shape.rs
@@ -266,7 +266,7 @@ impl Shape {
     pub fn rect_stroke(
         rect: Rect,
         rounding: impl Into<Rounding>,
-        stroke: impl Into<Stroke>,
+        stroke: impl Into<PathStroke>,
     ) -> Self {
         Self::Rect(RectShape::stroke(rect, rounding, stroke))
     }
@@ -658,7 +658,7 @@ impl From<PathShape> for Shape {
 // ----------------------------------------------------------------------------
 
 /// How to paint a rectangle.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct RectShape {
     pub rect: Rect,
@@ -670,7 +670,7 @@ pub struct RectShape {
     pub fill: Color32,
 
     /// The thickness and color of the outline.
-    pub stroke: Stroke,
+    pub stroke: PathStroke,
 
     /// If larger than zero, the edges of the rectangle
     /// (for both fill and stroke) will be blurred.
@@ -700,7 +700,7 @@ impl RectShape {
         rect: Rect,
         rounding: impl Into<Rounding>,
         fill_color: impl Into<Color32>,
-        stroke: impl Into<Stroke>,
+        stroke: impl Into<PathStroke>,
     ) -> Self {
         Self {
             rect,
@@ -731,7 +731,11 @@ impl RectShape {
     }
 
     #[inline]
-    pub fn stroke(rect: Rect, rounding: impl Into<Rounding>, stroke: impl Into<Stroke>) -> Self {
+    pub fn stroke(
+        rect: Rect,
+        rounding: impl Into<Rounding>,
+        stroke: impl Into<PathStroke>,
+    ) -> Self {
         Self {
             rect,
             rounding: rounding.into(),

--- a/crates/epaint/src/shape_transform.rs
+++ b/crates/epaint/src/shape_transform.rs
@@ -44,6 +44,15 @@ pub fn adjust_colors(
             closed: _,
             fill,
             stroke,
+        })
+        | Shape::Rect(RectShape {
+            rect: _,
+            rounding: _,
+            fill,
+            stroke,
+            blur_width: _,
+            fill_texture_id: _,
+            uv: _,
         }) => {
             adjust_color(fill);
             match &stroke.color {
@@ -70,15 +79,6 @@ pub fn adjust_colors(
             radius: _,
             fill,
             stroke,
-        })
-        | Shape::Rect(RectShape {
-            rect: _,
-            rounding: _,
-            fill,
-            stroke,
-            blur_width: _,
-            fill_texture_id: _,
-            uv: _,
         }) => {
             adjust_color(fill);
             adjust_color(&mut stroke.color);

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -1582,7 +1582,7 @@ impl Tessellator {
             mut blur_width,
             fill_texture_id,
             uv,
-        } = *rect;
+        } = rect;
 
         if self.options.coarse_tessellation_culling
             && !rect.expand(stroke.width).intersects(self.clip_rect)
@@ -1624,22 +1624,22 @@ impl Tessellator {
         if rect.width() < self.feathering {
             // Very thin - approximate by a vertical line-segment:
             let line = [rect.center_top(), rect.center_bottom()];
-            if fill != Color32::TRANSPARENT {
-                self.tessellate_line(line, Stroke::new(rect.width(), fill), out);
+            if *fill != Color32::TRANSPARENT {
+                self.tessellate_line(line, Stroke::new(rect.width(), *fill), out);
             }
             if !stroke.is_empty() {
-                self.tessellate_line(line, stroke, out); // back…
-                self.tessellate_line(line, stroke, out); // …and forth
+                self.tessellate_line(line, stroke.to_owned(), out); // back…
+                self.tessellate_line(line, stroke.to_owned(), out); // …and forth
             }
         } else if rect.height() < self.feathering {
             // Very thin - approximate by a horizontal line-segment:
             let line = [rect.left_center(), rect.right_center()];
-            if fill != Color32::TRANSPARENT {
-                self.tessellate_line(line, Stroke::new(rect.height(), fill), out);
+            if *fill != Color32::TRANSPARENT {
+                self.tessellate_line(line, Stroke::new(rect.height(), *fill), out);
             }
             if !stroke.is_empty() {
-                self.tessellate_line(line, stroke, out); // back…
-                self.tessellate_line(line, stroke, out); // …and forth
+                self.tessellate_line(line, stroke.to_owned(), out); // back…
+                self.tessellate_line(line, stroke.to_owned(), out); // …and forth
             }
         } else {
             let path = &mut self.scratchpad_path;
@@ -1655,13 +1655,13 @@ impl Tessellator {
                         remap(p.y, rect.y_range(), uv.y_range()),
                     )
                 };
-                path.fill_with_uv(self.feathering, fill, fill_texture_id, uv_from_pos, out);
+                path.fill_with_uv(self.feathering, *fill, *fill_texture_id, uv_from_pos, out);
             } else {
                 // Untextured
-                path.fill(self.feathering, fill, out);
+                path.fill(self.feathering, *fill, out);
             }
 
-            path.stroke_closed(self.feathering, &stroke.into(), out);
+            path.stroke_closed(self.feathering, stroke, out);
         }
 
         self.feathering = old_feathering; // restore

--- a/examples/custom_window_frame/src/main.rs
+++ b/examples/custom_window_frame/src/main.rs
@@ -48,7 +48,7 @@ fn custom_window_frame(ctx: &egui::Context, title: &str, add_contents: impl FnOn
     let panel_frame = egui::Frame {
         fill: ctx.style().visuals.window_fill(),
         rounding: 10.0.into(),
-        stroke: ctx.style().visuals.widgets.noninteractive.fg_stroke,
+        stroke: ctx.style().visuals.widgets.noninteractive.fg_stroke.into(),
         outer_margin: 0.5.into(), // so the stroke is within the bounds
         ..Default::default()
     };


### PR DESCRIPTION
I got bored, so decided to implement PathStroke for frames. I'm a bit worried about some of the stuff I had to do since PathStroke isn't copy, but unless I want to throw generics everywhere there isn't a better option. As a side effect, this also allows for Rect strokes to have UV callbacks too
