### PR TITLE
TextEdit hint text styling

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -662,9 +662,19 @@ impl<'t> TextEdit<'t> {
             if text.as_str().is_empty() && !hint_text.is_empty() {
                 let hint_text_color = ui.visuals().weak_text_color();
                 let galley = if multiline {
-                    hint_text.into_galley(ui, Some(true), desired_inner_size.x, hint_text_font.unwrap_or(font_id.into()))
+                    hint_text.into_galley(
+                        ui,
+                        Some(true),
+                        desired_inner_size.x,
+                        hint_text_font.unwrap_or(font_id.into()),
+                    )
                 } else {
-                    hint_text.into_galley(ui, Some(false), f32::INFINITY, hint_text_font.unwrap_or(font_id.into()))
+                    hint_text.into_galley(
+                        ui,
+                        Some(false),
+                        f32::INFINITY,
+                        hint_text_font.unwrap_or(font_id.into()),
+                    )
                 };
                 painter.galley(rect.min, galley, hint_text_color);
             }

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -191,7 +191,7 @@ impl<'t> TextEdit<'t> {
         self
     }
 
-    /// Forces a specific style for the hint text.
+    /// Set a specific style for the hint text.
     #[inline]
     pub fn hint_text_font(mut self, hint_text_font: impl Into<FontSelection>) -> Self {
         self.hint_text_font = Some(hint_text_font.into());
@@ -661,20 +661,11 @@ impl<'t> TextEdit<'t> {
 
             if text.as_str().is_empty() && !hint_text.is_empty() {
                 let hint_text_color = ui.visuals().weak_text_color();
+                let hint_text_font_id = hint_text_font.unwrap_or(font_id.into());
                 let galley = if multiline {
-                    hint_text.into_galley(
-                        ui,
-                        Some(true),
-                        desired_inner_size.x,
-                        hint_text_font.unwrap_or(font_id.into()),
-                    )
+                    hint_text.into_galley(ui, Some(true), desired_inner_size.x, hint_text_font_id)
                 } else {
-                    hint_text.into_galley(
-                        ui,
-                        Some(false),
-                        f32::INFINITY,
-                        hint_text_font.unwrap_or(font_id.into()),
-                    )
+                    hint_text.into_galley(ui, Some(false), f32::INFINITY, hint_text_font_id)
                 };
                 painter.galley(rect.min, galley, hint_text_color);
             }

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -60,6 +60,7 @@ use super::{TextEditOutput, TextEditState};
 pub struct TextEdit<'t> {
     text: &'t mut dyn TextBuffer,
     hint_text: WidgetText,
+    hint_text_font: Option<FontSelection>,
     id: Option<Id>,
     id_source: Option<Id>,
     font_selection: FontSelection,
@@ -111,6 +112,7 @@ impl<'t> TextEdit<'t> {
         Self {
             text,
             hint_text: Default::default(),
+            hint_text_font: None,
             id: None,
             id_source: None,
             font_selection: Default::default(),
@@ -186,6 +188,13 @@ impl<'t> TextEdit<'t> {
     #[inline]
     pub fn hint_text(mut self, hint_text: impl Into<WidgetText>) -> Self {
         self.hint_text = hint_text.into();
+        self
+    }
+
+    /// Forces a specific style for the hint text.
+    #[inline]
+    pub fn hint_text_font(mut self, hint_text_font: impl Into<FontSelection>) -> Self {
+        self.hint_text_font = Some(hint_text_font.into());
         self
     }
 
@@ -436,6 +445,7 @@ impl<'t> TextEdit<'t> {
         let TextEdit {
             text,
             hint_text,
+            hint_text_font,
             id,
             id_source,
             font_selection,
@@ -652,9 +662,9 @@ impl<'t> TextEdit<'t> {
             if text.as_str().is_empty() && !hint_text.is_empty() {
                 let hint_text_color = ui.visuals().weak_text_color();
                 let galley = if multiline {
-                    hint_text.into_galley(ui, Some(true), desired_inner_size.x, font_id)
+                    hint_text.into_galley(ui, Some(true), desired_inner_size.x, hint_text_font.unwrap_or(font_id.into()))
                 } else {
-                    hint_text.into_galley(ui, Some(false), f32::INFINITY, font_id)
+                    hint_text.into_galley(ui, Some(false), f32::INFINITY, hint_text_font.unwrap_or(font_id.into()))
                 };
                 painter.galley(rect.min, galley, hint_text_color);
             }


### PR DESCRIPTION
Simply adds a `hint_text_font` (any suggestions for a better name? hint_text_style seemed misleading as it doesn't only accept `TextStyle`) method to the TextEdit builder that allows to set the styling (specifically, a `FontSelection`) for the hint text.

My personal use-case for this was having body-sized hint text in a heading-sized TextEdit, but I'm sure there's more out there.

The PR shouldn't break compatibility, as it's stored as an `Option` that defaults to the `font_id` (which was the only behaviour prior to this) when empty.

It looked too trivial to add something to the actual demo, but I have it locally, so let me know if I should commit that.

Ran the check script locally, had no complaints.