### PR TITLE
Remove `Event::Scroll` and handle it in egui

### DIFF
--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -503,36 +503,6 @@ pub(crate) fn install_canvas_events(runner_ref: &WebRunner) -> Result<(), JsValu
             modifiers,
         });
 
-        let scroll_multiplier = match unit {
-            egui::MouseWheelUnit::Page => {
-                canvas_size_in_points(runner.canvas(), runner.egui_ctx()).y
-            }
-            egui::MouseWheelUnit::Line => {
-                #[allow(clippy::let_and_return)]
-                let points_per_scroll_line = 8.0; // Note that this is intentionally different from what we use in winit.
-                points_per_scroll_line
-            }
-            egui::MouseWheelUnit::Point => 1.0,
-        };
-
-        let mut delta = scroll_multiplier * delta;
-
-        // Report a zoom event in case CTRL (on Windows or Linux) or CMD (on Mac) is pressed.
-        // This if-statement is equivalent to how `Modifiers.command` is determined in
-        // `modifiers_from_kb_event()`, but we cannot directly use that fn for a [`WheelEvent`].
-        if event.ctrl_key() || event.meta_key() {
-            let factor = (delta.y / 200.0).exp();
-            runner.input.raw.events.push(egui::Event::Zoom(factor));
-        } else {
-            if event.shift_key() {
-                // Treat as horizontal scrolling.
-                // Note: one Mac we already get horizontal scroll events when shift is down.
-                delta = egui::vec2(delta.x + delta.y, 0.0);
-            }
-
-            runner.input.raw.events.push(egui::Event::Scroll(delta));
-        }
-
         runner.needs_repaint.repaint_asap();
         event.stop_propagation();
         event.prevent_default();

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -694,29 +694,6 @@ impl State {
                 modifiers,
             });
         }
-        let delta = match delta {
-            winit::event::MouseScrollDelta::LineDelta(x, y) => {
-                let points_per_scroll_line = 50.0; // Scroll speed decided by consensus: https://github.com/emilk/egui/issues/461
-                egui::vec2(x, y) * points_per_scroll_line
-            }
-            winit::event::MouseScrollDelta::PixelDelta(delta) => {
-                egui::vec2(delta.x as f32, delta.y as f32) / pixels_per_point
-            }
-        };
-
-        if self.egui_input.modifiers.ctrl || self.egui_input.modifiers.command {
-            // Treat as zoom instead:
-            let factor = (delta.y / 200.0).exp();
-            self.egui_input.events.push(egui::Event::Zoom(factor));
-        } else if self.egui_input.modifiers.shift {
-            // Treat as horizontal scrolling.
-            // Note: one Mac we already get horizontal scroll events when shift is down.
-            self.egui_input
-                .events
-                .push(egui::Event::Scroll(egui::vec2(delta.x + delta.y, 0.0)));
-        } else {
-            self.egui_input.events.push(egui::Event::Scroll(delta));
-        }
     }
 
     fn on_keyboard_input(&mut self, event: &winit::event::KeyEvent) {

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -426,21 +426,6 @@ pub enum Event {
     /// On touch-up first send `PointerButton{pressed: false, …}` followed by `PointerLeft`.
     PointerGone,
 
-    /// How many points (logical pixels) the user scrolled.
-    ///
-    /// The direction of the vector indicates how to move the _content_ that is being viewed.
-    /// So if you get positive values, the content being viewed should move to the right and down,
-    /// revealing new things to the left and up.
-    ///
-    /// A positive X-value indicates the content is being moved right,
-    /// as when swiping right on a touch-screen or track-pad with natural scrolling.
-    ///
-    /// A positive Y-value indicates the content is being moved down,
-    /// as when swiping down on a touch-screen or track-pad with natural scrolling.
-    ///
-    /// Shift-scroll should result in horizontal scrolling (it is up to the integrations to do this).
-    Scroll(Vec2),
-
     /// Zoom scale factor this frame (e.g. from ctrl-scroll or pinch gesture).
     /// * `zoom = 1`: no change.
     /// * `zoom < 1`: pinch together
@@ -473,16 +458,22 @@ pub enum Event {
         force: Option<f32>,
     },
 
-    /// A raw mouse wheel event as sent by the backend (minus the z coordinate),
-    /// for implementing alternative custom controls.
-    /// Note that the same event can also trigger [`Self::Zoom`] and [`Self::Scroll`],
-    /// so you probably want to handle only one of them.
+    /// A raw mouse wheel event as sent by the backend.
+    ///
+    /// Used for scrolling.
     MouseWheel {
-        /// The unit of scrolling: points, lines, or pages.
+        /// The unit of `delta`: points, lines, or pages.
         unit: MouseWheelUnit,
 
-        /// The amount scrolled horizontally and vertically. The amount and direction corresponding
-        /// to one step of the wheel depends on the platform.
+        /// The direction of the vector indicates how to move the _content_ that is being viewed.
+        /// So if you get positive values, the content being viewed should move to the right and down,
+        /// revealing new things to the left and up.
+        ///
+        /// A positive X-value indicates the content is being moved right,
+        /// as when swiping right on a touch-screen or track-pad with natural scrolling.
+        ///
+        /// A positive Y-value indicates the content is being moved down,
+        /// as when swiping down on a touch-screen or track-pad with natural scrolling.
         delta: Vec2,
 
         /// The state of the modifier keys at the time of the event.


### PR DESCRIPTION
For integrations: just emit `egui::Event::MouseWheel` (like before). egui will interpret that as zoom or pan.

On the way towards https://github.com/emilk/egui/issues/4401