### PR TITLE
egui_plot: Force use of min_auto_bounds if auto_bounds is disabled by default.  Fixes  #3893.

### DIFF
--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -975,10 +975,10 @@ impl<'a> Plot<'a> {
         }
 
         // Reset bounds to initial bounds if they haven't been modified.
-        if mem.auto_bounds.x {
+        if !default_auto_bounds.x || mem.auto_bounds.x {
             bounds.set_x(&min_auto_bounds);
         }
-        if mem.auto_bounds.y {
+        if !default_auto_bounds.y || mem.auto_bounds.y {
             bounds.set_y(&min_auto_bounds);
         }
 


### PR DESCRIPTION
The logic for determining bounds was not using the values supplied by include_x()/include_y() after the initial plot call when auto_bounds() was false. This change forces the use of the manual limits when default_auto_bounds is false.

* Closes <https://github.com/emilk/egui/issues/3893>
