### PR TITLE
Fix: Menu not closing when clicking menu button

### DIFF
--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -356,6 +356,7 @@ impl MenuRoot {
         } else if button
             .ctx
             .input(|i| i.pointer.any_pressed() && i.pointer.primary_down())
+            && !button.contains_pointer()
         {
             if let Some(pos) = button.ctx.input(|i| i.pointer.interact_pos()) {
                 if let Some(root) = root.inner.as_mut() {


### PR DESCRIPTION
Fixed an issue where the menu would not close if the menu button was clicked while the menu was already open.

**Behaviour before:**

https://github.com/emilk/egui/assets/55352293/dbd27b26-e7a5-4bde-93de-8cd6cfd08e19

**Behaviour after:**

https://github.com/emilk/egui/assets/55352293/dc8d0c70-5c97-4827-b723-31a86d11e742


The problem was that the logic to close the menu when the user presses outside the menu, closed the menu before the menu button registered the click. This means the following code gets no longer called when clicking on the menu button and instead the menu will be opened again.
```rust
// menu.rs : 326

        if (button.clicked() && root.is_menu_open(id))
            || button.ctx.input(|i| i.key_pressed(Key::Escape))
        {
            // menu open and button clicked or esc pressed
            return MenuResponse::Close;
        }
```

I fixed the problem by checking whether the mouse is currently hovering over the menu button before closing the menu.