### PR TITLE
Add support for text truncation to `egui::Style`

### DIFF
--- a/crates/egui/src/containers/collapsing_header.rs
+++ b/crates/egui/src/containers/collapsing_header.rs
@@ -506,8 +506,12 @@ impl CollapsingHeader {
         let available = ui.available_rect_before_wrap();
         let text_pos = available.min + vec2(ui.spacing().indent, 0.0);
         let wrap_width = available.right() - text_pos.x;
-        let wrap = Some(false);
-        let galley = text.into_galley(ui, wrap, wrap_width, TextStyle::Button);
+        let galley = text.into_galley(
+            ui,
+            Some(text::TextWrapMode::Extend),
+            wrap_width,
+            TextStyle::Button,
+        );
         let text_max_x = text_pos.x + galley.size().x;
 
         let mut desired_width = text_max_x + button_padding.x - available.left();

--- a/crates/egui/src/containers/collapsing_header.rs
+++ b/crates/egui/src/containers/collapsing_header.rs
@@ -508,7 +508,7 @@ impl CollapsingHeader {
         let wrap_width = available.right() - text_pos.x;
         let galley = text.into_galley(
             ui,
-            Some(text::TextWrapMode::Extend),
+            Some(TextWrapMode::Extend),
             wrap_width,
             TextStyle::Button,
         );

--- a/crates/egui/src/containers/combo_box.rs
+++ b/crates/egui/src/containers/combo_box.rs
@@ -148,14 +148,6 @@ impl ComboBox {
         self
     }
 
-    /// Controls whether text wrap is used for the selected text.
-    #[deprecated = "Use `wrap_mode` instead"]
-    #[inline]
-    pub fn wrap(mut self, wrap: bool) -> Self {
-        self.wrap_mode = if wrap { Some(TextWrapMode::Wrap) } else { None };
-        self
-    }
-
     /// Controls the wrap mode used for the selected text.
     ///
     /// By default, [`Ui::wrap_mode`] will be used, which can be overridden with [`Style::wrap_mode`].
@@ -164,6 +156,21 @@ impl ComboBox {
     #[inline]
     pub fn wrap_mode(mut self, wrap_mode: TextWrapMode) -> Self {
         self.wrap_mode = Some(wrap_mode);
+        self
+    }
+
+    /// Set [`Self::wrap_mode`] to [`TextWrapMode::Wrap`].
+    #[inline]
+    pub fn wrap(mut self) -> Self {
+        self.wrap_mode = Some(TextWrapMode::Wrap);
+
+        self
+    }
+
+    /// Set [`Self::wrap_mode`] to [`TextWrapMode::Truncate`].
+    #[inline]
+    pub fn truncate(mut self) -> Self {
+        self.wrap_mode = Some(TextWrapMode::Truncate);
         self
     }
 

--- a/crates/egui/src/containers/combo_box.rs
+++ b/crates/egui/src/containers/combo_box.rs
@@ -158,7 +158,7 @@ impl ComboBox {
 
     /// Controls the wrap mode used for the selected text.
     ///
-    /// By default, the text will extend the [`Ui`] boundary. This default behavior can be
+    /// By default, [`Ui::wrap_mode`] will be used, which can be
     /// overridden with [`Style::wrap_mode`].
     ///
     /// Note that any `\n` in the text will always produce a new line.

--- a/crates/egui/src/containers/combo_box.rs
+++ b/crates/egui/src/containers/combo_box.rs
@@ -373,9 +373,7 @@ fn combo_box_dyn<'c, R>(
                     // result in labels that wrap very early.
                     // Instead, we turn it off by default so that the labels
                     // expand the width of the menu.
-                    if ui.style().wrap_mode == Some(TextWrapMode::Wrap) {
-                        ui.style_mut().wrap_mode = None;
-                    }
+                    ui.style_mut().wrap_mode = Some(TextWrapMode::Extend);
                     menu_contents(ui)
                 })
                 .inner

--- a/crates/egui/src/containers/combo_box.rs
+++ b/crates/egui/src/containers/combo_box.rs
@@ -1,3 +1,4 @@
+use epaint::text::TextWrapMode;
 use epaint::Shape;
 
 use crate::{style::WidgetVisuals, *};
@@ -5,7 +6,7 @@ use crate::{style::WidgetVisuals, *};
 #[allow(unused_imports)] // Documentation
 use crate::style::Spacing;
 
-/// Indicate whether or not a popup will be shown above or below the box.
+/// Indicate whether a popup will be shown above or below the box.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum AboveOrBelow {
     Above,
@@ -40,7 +41,7 @@ pub struct ComboBox {
     width: Option<f32>,
     height: Option<f32>,
     icon: Option<IconPainter>,
-    wrap_enabled: bool,
+    wrap_mode: Option<TextWrapMode>,
 }
 
 impl ComboBox {
@@ -53,7 +54,7 @@ impl ComboBox {
             width: None,
             height: None,
             icon: None,
-            wrap_enabled: false,
+            wrap_mode: None,
         }
     }
 
@@ -67,7 +68,7 @@ impl ComboBox {
             width: None,
             height: None,
             icon: None,
-            wrap_enabled: false,
+            wrap_mode: None,
         }
     }
 
@@ -80,7 +81,7 @@ impl ComboBox {
             width: None,
             height: None,
             icon: None,
-            wrap_enabled: false,
+            wrap_mode: None,
         }
     }
 
@@ -148,10 +149,23 @@ impl ComboBox {
         self
     }
 
-    /// Controls whether text wrap is used for the selected text
+    /// Controls whether text wrap is used for the selected text.
+    #[deprecated = "Use `wrap_mode` instead"]
     #[inline]
     pub fn wrap(mut self, wrap: bool) -> Self {
-        self.wrap_enabled = wrap;
+        self.wrap_mode = if wrap { Some(TextWrapMode::Wrap) } else { None };
+        self
+    }
+
+    /// Controls the wrap mode used for the selected text.
+    ///
+    /// By default, the text will extend the [`Ui`] boundary. This default behavior can be
+    /// overridden with [`Style::wrap_mode`].
+    ///
+    /// Note that any `\n` in the text will always produce a new line.
+    #[inline]
+    pub fn wrap_mode(mut self, wrap_mode: TextWrapMode) -> Self {
+        self.wrap_mode = Some(wrap_mode);
         self
     }
 
@@ -178,7 +192,7 @@ impl ComboBox {
             width,
             height,
             icon,
-            wrap_enabled,
+            wrap_mode,
         } = self;
 
         let button_id = ui.make_persistent_id(id_source);
@@ -190,7 +204,7 @@ impl ComboBox {
                 selected_text,
                 menu_contents,
                 icon,
-                wrap_enabled,
+                wrap_mode,
                 (width, height),
             );
             if let Some(label) = label {
@@ -253,13 +267,14 @@ impl ComboBox {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn combo_box_dyn<'c, R>(
     ui: &mut Ui,
     button_id: Id,
     selected_text: WidgetText,
     menu_contents: Box<dyn FnOnce(&mut Ui) -> R + 'c>,
     icon: Option<IconPainter>,
-    wrap_enabled: bool,
+    wrap_mode: Option<TextWrapMode>,
     (width, height): (Option<f32>, Option<f32>),
 ) -> InnerResponse<Option<R>> {
     let popup_id = button_id.with("popup");
@@ -277,45 +292,33 @@ fn combo_box_dyn<'c, R>(
             AboveOrBelow::Above
         };
 
+    let wrap_mode = wrap_mode.unwrap_or_else(|| ui.wrap_mode());
+
     let margin = ui.spacing().button_padding;
     let button_response = button_frame(ui, button_id, is_popup_open, Sense::click(), |ui| {
         let icon_spacing = ui.spacing().icon_spacing;
-        // We don't want to change width when user selects something new
-        let full_minimum_width = if wrap_enabled {
-            // Currently selected value's text will be wrapped if needed, so occupy the available width.
-            ui.available_width()
-        } else {
-            // Occupy at least the minimum width assigned to ComboBox.
-            let width = width.unwrap_or_else(|| ui.spacing().combo_width);
-            width - 2.0 * margin.x
-        };
         let icon_size = Vec2::splat(ui.spacing().icon_width);
-        let wrap_width = if wrap_enabled {
-            // Use the available width, currently selected value's text will be wrapped if exceeds this value.
-            ui.available_width() - icon_spacing - icon_size.x
-        } else {
+
+        // The combo box selected text will always have this minimum width.
+        // Note: the `ComboBox::width()` if set or `Spacing::combo_width` are considered as the
+        // minimum overall width, regardless of the wrap mode.
+        let minimum_width = width.unwrap_or_else(|| ui.spacing().combo_width) - 2.0 * margin.x;
+
+        // width against which to lay out the selected text
+        let wrap_width = if wrap_mode == TextWrapMode::Extend {
             // Use all the width necessary to display the currently selected value's text.
             f32::INFINITY
-        };
-
-        let galley =
-            selected_text.into_galley(ui, Some(wrap_enabled), wrap_width, TextStyle::Button);
-
-        // The width necessary to contain the whole widget with the currently selected value's text.
-        let width = if wrap_enabled {
-            full_minimum_width
         } else {
-            // Occupy at least the minimum width needed to contain the widget with the currently selected value's text.
-            galley.size().x + icon_spacing + icon_size.x
+            // Use the available width, currently selected value's text will be wrapped if exceeds this value.
+            ui.available_width() - icon_spacing - icon_size.x
         };
 
-        // Case : wrap_enabled : occupy all the available width.
-        // Case : !wrap_enabled : occupy at least the minimum width assigned to Slider and ComboBox,
-        // increase if the currently selected value needs additional horizontal space to fully display its text (up to wrap_width (f32::INFINITY)).
-        let width = width.at_least(full_minimum_width);
-        let height = galley.size().y.max(icon_size.y);
+        let galley = selected_text.into_galley(ui, Some(wrap_mode), wrap_width, TextStyle::Button);
 
-        let (_, rect) = ui.allocate_space(Vec2::new(width, height));
+        let actual_width = (galley.size().x + icon_spacing + icon_size.x).at_least(minimum_width);
+        let actual_height = galley.size().y.max(icon_size.y);
+
+        let (_, rect) = ui.allocate_space(Vec2::new(actual_width, actual_height));
         let button_rect = ui.min_rect().expand2(ui.spacing().button_padding);
         let response = ui.interact(button_rect, button_id, Sense::click());
         // response.active |= is_popup_open;
@@ -371,7 +374,9 @@ fn combo_box_dyn<'c, R>(
                     // result in labels that wrap very early.
                     // Instead, we turn it off by default so that the labels
                     // expand the width of the menu.
-                    ui.style_mut().wrap = Some(false);
+                    if ui.style().wrap_mode == Some(TextWrapMode::Wrap) {
+                        ui.style_mut().wrap_mode = None;
+                    }
                     menu_contents(ui)
                 })
                 .inner

--- a/crates/egui/src/containers/combo_box.rs
+++ b/crates/egui/src/containers/combo_box.rs
@@ -158,8 +158,7 @@ impl ComboBox {
 
     /// Controls the wrap mode used for the selected text.
     ///
-    /// By default, [`Ui::wrap_mode`] will be used, which can be
-    /// overridden with [`Style::wrap_mode`].
+    /// By default, [`Ui::wrap_mode`] will be used, which can be overridden with [`Style::wrap_mode`].
     ///
     /// Note that any `\n` in the text will always produce a new line.
     #[inline]

--- a/crates/egui/src/containers/combo_box.rs
+++ b/crates/egui/src/containers/combo_box.rs
@@ -1,4 +1,3 @@
-use epaint::text::TextWrapMode;
 use epaint::Shape;
 
 use crate::{style::WidgetVisuals, *};

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -1028,7 +1028,12 @@ fn show_title_bar(
             collapsing.show_default_button_with_size(ui, button_size);
         }
 
-        let title_galley = title.into_galley(ui, Some(false), f32::INFINITY, TextStyle::Heading);
+        let title_galley = title.into_galley(
+            ui,
+            Some(crate::text::TextWrapMode::Extend),
+            f32::INFINITY,
+            TextStyle::Heading,
+        );
 
         let minimum_width = if collapsible || show_close_button {
             // If at least one button is shown we make room for both buttons (since title is centered):

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -1030,7 +1030,7 @@ fn show_title_bar(
 
         let title_galley = title.into_galley(
             ui,
-            Some(crate::text::TextWrapMode::Extend),
+            Some(crate::TextWrapMode::Extend),
             f32::INFINITY,
             TextStyle::Heading,
         );

--- a/crates/egui/src/debug_text.rs
+++ b/crates/egui/src/debug_text.rs
@@ -12,7 +12,7 @@ use crate::*;
 ///
 /// This is a built-in plugin in egui,
 /// meaning [`Context`] calls this from its `Default` implementation,
-/// so this i marked as `pub(crate)`.
+/// so this is marked as `pub(crate)`.
 pub(crate) fn register(ctx: &Context) {
     ctx.on_end_frame("debug_text", std::sync::Arc::new(State::end_frame));
 }
@@ -105,13 +105,11 @@ impl State {
 
             {
                 // Paint `text` to right of `pos`:
-                let wrap = true;
                 let available_width = ctx.screen_rect().max.x - pos.x;
                 let galley = text.into_galley_impl(
                     ctx,
                     &ctx.style(),
-                    wrap,
-                    available_width,
+                    text::TextWrapping::wrap_at_width(available_width),
                     font_id.clone().into(),
                     Align::TOP,
                 );

--- a/crates/egui/src/introspection.rs
+++ b/crates/egui/src/introspection.rs
@@ -129,7 +129,7 @@ impl Widget for &epaint::stats::PaintStats {
 }
 
 fn label(ui: &mut Ui, alloc_info: &epaint::stats::AllocInfo, what: &str) -> Response {
-    ui.add(Label::new(alloc_info.format(what)).wrap(false))
+    ui.add(Label::new(alloc_info.format(what)).wrap_mode(text::TextWrapMode::Extend))
 }
 
 impl Widget for &mut epaint::TessellationOptions {

--- a/crates/egui/src/introspection.rs
+++ b/crates/egui/src/introspection.rs
@@ -129,7 +129,7 @@ impl Widget for &epaint::stats::PaintStats {
 }
 
 fn label(ui: &mut Ui, alloc_info: &epaint::stats::AllocInfo, what: &str) -> Response {
-    ui.add(Label::new(alloc_info.format(what)).wrap_mode(text::TextWrapMode::Extend))
+    ui.add(Label::new(alloc_info.format(what)).wrap_mode(TextWrapMode::Extend))
 }
 
 impl Widget for &mut epaint::TessellationOptions {

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -338,7 +338,7 @@
 //! ## Code snippets
 //!
 //! ```
-//! # use egui::text::TextWrapMode;
+//! # use egui::TextWrapMode;
 //! # egui::__run_test_ui(|ui| {
 //! # let mut some_bool = true;
 //! // Miscellaneous tips and tricks
@@ -437,7 +437,7 @@ pub mod text {
     pub use crate::text_selection::{CCursorRange, CursorRange};
     pub use epaint::text::{
         cursor::CCursor, FontData, FontDefinitions, FontFamily, Fonts, Galley, LayoutJob,
-        LayoutSection, TextFormat, TextWrapMode, TextWrapping, TAB_SIZE,
+        LayoutSection, TextFormat, TextWrapping, TAB_SIZE,
     };
 }
 
@@ -452,6 +452,7 @@ pub use {
         Key,
     },
     drag_and_drop::DragAndDrop,
+    epaint::text::TextWrapMode,
     grid::Grid,
     id::{Id, IdMap},
     input_state::{InputState, MultiTouchInfo, PointerState},

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -338,6 +338,7 @@
 //! ## Code snippets
 //!
 //! ```
+//! # use egui::text::TextWrapMode;
 //! # egui::__run_test_ui(|ui| {
 //! # let mut some_bool = true;
 //! // Miscellaneous tips and tricks
@@ -358,7 +359,7 @@
 //! ui.scope(|ui| {
 //!     ui.visuals_mut().override_text_color = Some(egui::Color32::RED);
 //!     ui.style_mut().override_text_style = Some(egui::TextStyle::Monospace);
-//!     ui.style_mut().wrap = Some(false);
+//!     ui.style_mut().wrap_mode = Some(TextWrapMode::Truncate);
 //!
 //!     ui.label("This text will be red, monospace, and won't wrap to a new line");
 //! }); // the temporary settings are reverted here
@@ -436,7 +437,7 @@ pub mod text {
     pub use crate::text_selection::{CCursorRange, CursorRange};
     pub use epaint::text::{
         cursor::CCursor, FontData, FontDefinitions, FontFamily, Fonts, Galley, LayoutJob,
-        LayoutSection, TextFormat, TextWrapping, TAB_SIZE,
+        LayoutSection, TextFormat, TextWrapMode, TextWrapping, TAB_SIZE,
     };
 }
 

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -481,7 +481,7 @@ impl SubMenuButton {
         let text_available_width = ui.available_width() - total_extra.x;
         let text_galley = text.into_galley(
             ui,
-            Some(text::TextWrapMode::Wrap),
+            Some(TextWrapMode::Wrap),
             text_available_width,
             text_style.clone(),
         );
@@ -489,7 +489,7 @@ impl SubMenuButton {
         let icon_available_width = text_available_width - text_galley.size().x;
         let icon_galley = icon.into_galley(
             ui,
-            Some(text::TextWrapMode::Wrap),
+            Some(TextWrapMode::Wrap),
             icon_available_width,
             text_style,
         );

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -479,11 +479,20 @@ impl SubMenuButton {
         let button_padding = ui.spacing().button_padding;
         let total_extra = button_padding + button_padding;
         let text_available_width = ui.available_width() - total_extra.x;
-        let text_galley =
-            text.into_galley(ui, Some(true), text_available_width, text_style.clone());
+        let text_galley = text.into_galley(
+            ui,
+            Some(text::TextWrapMode::Wrap),
+            text_available_width,
+            text_style.clone(),
+        );
 
         let icon_available_width = text_available_width - text_galley.size().x;
-        let icon_galley = icon.into_galley(ui, Some(true), icon_available_width, text_style);
+        let icon_galley = icon.into_galley(
+            ui,
+            Some(text::TextWrapMode::Wrap),
+            icon_available_width,
+            text_style,
+        );
         let text_and_icon_size = Vec2::new(
             text_galley.size().x + icon_galley.size().x,
             text_galley.size().y.max(icon_galley.size().y),

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -188,8 +188,8 @@ pub struct Style {
     /// **Note**: this API is deprecated, use `wrap_mode` instead.
     ///
     /// * `None`: use `wrap_mode` instead
-    /// * `Some(true)`: wrap mode defaults to [`TextWrapMode::Wrap`]
-    /// * `Some(false)`: wrap mode defaults to [`TextWrapMode::Extend`]
+    /// * `Some(true)`: wrap mode defaults to [`crate::text::TextWrapMode::Wrap`]
+    /// * `Some(false)`: wrap mode defaults to [`crate::text::TextWrapMode::Extend`]
     #[deprecated = "Use wrap_mode instead"]
     pub wrap: Option<bool>,
 

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -188,8 +188,8 @@ pub struct Style {
     /// **Note**: this API is deprecated, use `wrap_mode` instead.
     ///
     /// * `None`: use `wrap_mode` instead
-    /// * `Some(true)`: wrap mode defaults to [`crate::text::TextWrapMode::Wrap`]
-    /// * `Some(false)`: wrap mode defaults to [`crate::text::TextWrapMode::Extend`]
+    /// * `Some(true)`: wrap mode defaults to [`crate::TextWrapMode::Wrap`]
+    /// * `Some(false)`: wrap mode defaults to [`crate::TextWrapMode::Extend`]
     #[deprecated = "Use wrap_mode instead"]
     pub wrap: Option<bool>,
 
@@ -199,7 +199,7 @@ pub struct Style {
     ///
     /// * `None`: follow layout (with may wrap)
     /// * `Some(mode)`: use the specified mode as default
-    pub wrap_mode: Option<crate::text::TextWrapMode>,
+    pub wrap_mode: Option<crate::TextWrapMode>,
 
     /// Sizes and distances between widgets
     pub spacing: Spacing,

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -182,14 +182,24 @@ pub struct Style {
     /// The style to use for [`DragValue`] text.
     pub drag_value_text_style: TextStyle,
 
-    /// If set, labels buttons wtc will use this to determine whether or not
-    /// to wrap the text at the right edge of the [`Ui`] they are in.
-    /// By default this is `None`.
+    /// If set, labels, buttons, etc. will use this to determine whether to wrap the text at the
+    /// right edge of the [`Ui`] they are in. By default, this is `None`.
     ///
-    /// * `None`: follow layout
-    /// * `Some(true)`: default on
-    /// * `Some(false)`: default off
+    /// **Note**: this API is deprecated, use `wrap_mode` instead.
+    ///
+    /// * `None`: use `wrap_mode` instead
+    /// * `Some(true)`: wrap mode defaults to [`TextWrapMode::Wrap`]
+    /// * `Some(false)`: wrap mode defaults to [`TextWrapMode::Extend`]
+    #[deprecated = "Use wrap_mode instead"]
     pub wrap: Option<bool>,
+
+    /// If set, labels, buttons, etc. will use this to determine whether to wrap or truncate the
+    /// text at the right edge of the [`Ui`] they are in, or to extend it. By default, this is
+    /// `None`.
+    ///
+    /// * `None`: follow layout (with may wrap)
+    /// * `Some(mode)`: use the specified mode as default
+    pub wrap_mode: Option<crate::text::TextWrapMode>,
 
     /// Sizes and distances between widgets
     pub spacing: Spacing,
@@ -1026,12 +1036,14 @@ pub fn default_text_styles() -> BTreeMap<TextStyle, FontId> {
 
 impl Default for Style {
     fn default() -> Self {
+        #[allow(deprecated)]
         Self {
             override_font_id: None,
             override_text_style: None,
             text_styles: default_text_styles(),
             drag_value_text_style: TextStyle::Button,
             wrap: None,
+            wrap_mode: None,
             spacing: Spacing::default(),
             interaction: Interaction::default(),
             visuals: Visuals::default(),
@@ -1317,12 +1329,14 @@ use crate::{widgets::*, Ui};
 
 impl Style {
     pub fn ui(&mut self, ui: &mut crate::Ui) {
+        #[allow(deprecated)]
         let Self {
             override_font_id,
             override_text_style,
             text_styles,
             drag_value_text_style,
             wrap: _,
+            wrap_mode: _,
             spacing,
             interaction,
             visuals,

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -333,16 +333,17 @@ impl Ui {
     ///
     /// This is determined first by [`Style::wrap_mode`], and then by the layout of this [`Ui`].
     pub fn wrap_mode(&self) -> TextWrapMode {
-        // `wrap` handling for backward compatibility
         #[allow(deprecated)]
-        if let Some(wrap) = self.style.wrap {
+        if let Some(wrap_mode) = self.style.wrap_mode {
+            wrap_mode
+        }
+        // `wrap` handling for backward compatibility
+        else if let Some(wrap) = self.style.wrap {
             if wrap {
                 TextWrapMode::Wrap
             } else {
                 TextWrapMode::Extend
             }
-        } else if let Some(wrap_mode) = self.style.wrap_mode {
-            wrap_mode
         } else if let Some(grid) = self.placer.grid() {
             if grid.wrap_text() {
                 TextWrapMode::Wrap

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -4,7 +4,6 @@
 use std::{any::Any, hash::Hash, sync::Arc};
 
 use epaint::mutex::RwLock;
-use epaint::text::TextWrapMode;
 
 use crate::{
     containers::*, ecolor::*, epaint::text::Fonts, layout::*, menu::MenuState, placer::Placer,

--- a/crates/egui/src/widget_text.rs
+++ b/crates/egui/src/widget_text.rs
@@ -1,8 +1,8 @@
 use std::{borrow::Cow, sync::Arc};
 
 use crate::{
-    text::LayoutJob, Align, Color32, FontFamily, FontSelection, Galley, Style, TextStyle, Ui,
-    Visuals,
+    text::{LayoutJob, TextWrapMode, TextWrapping},
+    Align, Color32, FontFamily, FontSelection, Galley, Style, TextStyle, Ui, Visuals,
 };
 
 /// Text and optional style choices for it.
@@ -640,47 +640,39 @@ impl WidgetText {
 
     /// Layout with wrap mode based on the containing [`Ui`].
     ///
-    /// wrap: override for [`Ui::wrap_text`].
+    /// `wrap_mode`: override for [`Ui::wrap_mode`]
     pub fn into_galley(
         self,
         ui: &Ui,
-        wrap: Option<bool>,
+        wrap_mode: Option<TextWrapMode>,
         available_width: f32,
         fallback_font: impl Into<FontSelection>,
     ) -> Arc<Galley> {
-        let wrap = wrap.unwrap_or_else(|| ui.wrap_text());
         let valign = ui.layout().vertical_align();
         let style = ui.style();
 
-        self.into_galley_impl(
-            ui.ctx(),
-            style,
-            wrap,
-            available_width,
-            fallback_font.into(),
-            valign,
-        )
+        let wrap_mode = wrap_mode.unwrap_or_else(|| ui.wrap_mode());
+        let text_wrapping = TextWrapping::from_wrap_mode_and_width(wrap_mode, available_width);
+
+        self.into_galley_impl(ui.ctx(), style, text_wrapping, fallback_font.into(), valign)
     }
 
     pub fn into_galley_impl(
         self,
         ctx: &crate::Context,
         style: &Style,
-        wrap: bool,
-        available_width: f32,
+        text_wrapping: TextWrapping,
         fallback_font: FontSelection,
         default_valign: Align,
     ) -> Arc<Galley> {
-        let wrap_width = if wrap { available_width } else { f32::INFINITY };
-
         match self {
             Self::RichText(text) => {
                 let mut layout_job = text.into_layout_job(style, fallback_font, default_valign);
-                layout_job.wrap.max_width = wrap_width;
+                layout_job.wrap = text_wrapping;
                 ctx.fonts(|f| f.layout_job(layout_job))
             }
             Self::LayoutJob(mut job) => {
-                job.wrap.max_width = wrap_width;
+                job.wrap = text_wrapping;
                 ctx.fonts(|f| f.layout_job(job))
             }
             Self::Galley(galley) => galley,

--- a/crates/egui/src/widget_text.rs
+++ b/crates/egui/src/widget_text.rs
@@ -1,8 +1,8 @@
 use std::{borrow::Cow, sync::Arc};
 
 use crate::{
-    text::{LayoutJob, TextWrapMode, TextWrapping},
-    Align, Color32, FontFamily, FontSelection, Galley, Style, TextStyle, Ui, Visuals,
+    text::{LayoutJob, TextWrapping},
+    Align, Color32, FontFamily, FontSelection, Galley, Style, TextStyle, TextWrapMode, Ui, Visuals,
 };
 
 /// Text and optional style choices for it.

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -86,9 +86,7 @@ impl<'a> Button<'a> {
 
     /// Set the wrap mode for the text.
     ///
-    /// By default, the text will wrap at the [`Ui`] boundary in vertical layouts and wrapping
-    /// horizontal layouts, or extend the [`Ui`] otherwise. This default behavior can be overridden
-    /// with [`Style::wrap_mode`].
+    /// By default, [`Ui::wrap_mode`] will be used, which can be overridden with [`Style::wrap_mode`].
     ///
     /// Note that any `\n` in the text will always produce a new line.
     #[inline]

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -23,7 +23,7 @@ pub struct Button<'a> {
     image: Option<Image<'a>>,
     text: Option<WidgetText>,
     shortcut_text: WidgetText,
-    wrap_mode: Option<text::TextWrapMode>,
+    wrap_mode: Option<TextWrapMode>,
 
     /// None means default for interact
     fill: Option<Color32>,
@@ -77,9 +77,9 @@ impl<'a> Button<'a> {
     #[inline]
     pub fn wrap(mut self, wrap: bool) -> Self {
         if wrap {
-            self.wrap_mode = Some(text::TextWrapMode::Wrap);
+            self.wrap_mode = Some(TextWrapMode::Wrap);
         } else {
-            self.wrap_mode = Some(text::TextWrapMode::Extend);
+            self.wrap_mode = Some(TextWrapMode::Extend);
         }
         self
     }
@@ -92,7 +92,7 @@ impl<'a> Button<'a> {
     ///
     /// Note that any `\n` in the text will always produce a new line.
     #[inline]
-    pub fn wrap_mode(mut self, wrap_mode: text::TextWrapMode) -> Self {
+    pub fn wrap_mode(mut self, wrap_mode: TextWrapMode) -> Self {
         self.wrap_mode = Some(wrap_mode);
         self
     }
@@ -229,7 +229,7 @@ impl Widget for Button<'_> {
         let shortcut_galley = (!shortcut_text.is_empty()).then(|| {
             shortcut_text.into_galley(
                 ui,
-                Some(text::TextWrapMode::Extend),
+                Some(TextWrapMode::Extend),
                 f32::INFINITY,
                 TextStyle::Button,
             )

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -72,7 +72,7 @@ impl<'a> Button<'a> {
 
     /// If `true`, the text will wrap to stay within the max width of the [`Ui`].
     ///
-    /// Deprecated. Use [`wrap_mode`] instead.
+    /// Deprecated. Use [`Self::wrap_mode`] instead.
     #[deprecated = "Use `wrap_mode` instead"]
     #[inline]
     pub fn wrap(mut self, wrap: bool) -> Self {

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -70,20 +70,6 @@ impl<'a> Button<'a> {
         }
     }
 
-    /// If `true`, the text will wrap to stay within the max width of the [`Ui`].
-    ///
-    /// Deprecated. Use [`Self::wrap_mode`] instead.
-    #[deprecated = "Use `wrap_mode` instead"]
-    #[inline]
-    pub fn wrap(mut self, wrap: bool) -> Self {
-        if wrap {
-            self.wrap_mode = Some(TextWrapMode::Wrap);
-        } else {
-            self.wrap_mode = Some(TextWrapMode::Extend);
-        }
-        self
-    }
-
     /// Set the wrap mode for the text.
     ///
     /// By default, [`Ui::wrap_mode`] will be used, which can be overridden with [`Style::wrap_mode`].
@@ -92,6 +78,21 @@ impl<'a> Button<'a> {
     #[inline]
     pub fn wrap_mode(mut self, wrap_mode: TextWrapMode) -> Self {
         self.wrap_mode = Some(wrap_mode);
+        self
+    }
+
+    /// Set [`Self::wrap_mode`] to [`TextWrapMode::Wrap`].
+    #[inline]
+    pub fn wrap(mut self) -> Self {
+        self.wrap_mode = Some(TextWrapMode::Wrap);
+
+        self
+    }
+
+    /// Set [`Self::wrap_mode`] to [`TextWrapMode::Truncate`].
+    #[inline]
+    pub fn truncate(mut self) -> Self {
+        self.wrap_mode = Some(TextWrapMode::Truncate);
         self
     }
 

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -521,7 +521,7 @@ impl<'a> Widget for DragValue<'a> {
                 RichText::new(format!("{}{}{}", prefix, value_text.clone(), suffix))
                     .text_style(text_style),
             )
-            .wrap_mode(text::TextWrapMode::Extend)
+            .wrap_mode(TextWrapMode::Extend)
             .sense(Sense::click_and_drag())
             .min_size(ui.spacing().interact_size); // TODO(emilk): find some more generic solution to `min_size`
 

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -521,7 +521,7 @@ impl<'a> Widget for DragValue<'a> {
                 RichText::new(format!("{}{}{}", prefix, value_text.clone(), suffix))
                     .text_style(text_style),
             )
-            .wrap(false)
+            .wrap_mode(text::TextWrapMode::Extend)
             .sense(Sense::click_and_drag())
             .min_size(ui.spacing().interact_size); // TODO(emilk): find some more generic solution to `min_size`
 

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -9,7 +9,7 @@ use self::text_selection::LabelSelectionState;
 /// Usually it is more convenient to use [`Ui::label`].
 ///
 /// ```
-/// # use egui::text::TextWrapMode;
+/// # use egui::TextWrapMode;
 /// # egui::__run_test_ui(|ui| {
 /// ui.label("Equivalent");
 /// ui.add(egui::Label::new("Equivalent"));
@@ -23,7 +23,7 @@ use self::text_selection::LabelSelectionState;
 #[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
 pub struct Label {
     text: WidgetText,
-    wrap_mode: Option<text::TextWrapMode>,
+    wrap_mode: Option<TextWrapMode>,
     sense: Option<Sense>,
     selectable: Option<bool>,
 }
@@ -49,9 +49,9 @@ impl Label {
     #[inline]
     pub fn wrap(mut self, wrap: bool) -> Self {
         if wrap {
-            self.wrap_mode = Some(text::TextWrapMode::Wrap);
+            self.wrap_mode = Some(TextWrapMode::Wrap);
         } else {
-            self.wrap_mode = Some(text::TextWrapMode::Extend);
+            self.wrap_mode = Some(TextWrapMode::Extend);
         }
         self
     }
@@ -65,9 +65,9 @@ impl Label {
     #[inline]
     pub fn truncate(mut self, truncate: bool) -> Self {
         if truncate {
-            self.wrap_mode = Some(text::TextWrapMode::Truncate);
+            self.wrap_mode = Some(TextWrapMode::Truncate);
         } else {
-            self.wrap_mode = Some(text::TextWrapMode::Extend);
+            self.wrap_mode = Some(TextWrapMode::Extend);
         }
         self
     }
@@ -80,7 +80,7 @@ impl Label {
     ///
     /// Note that any `\n` in the text will always produce a new line.
     #[inline]
-    pub fn wrap_mode(mut self, wrap_mode: text::TextWrapMode) -> Self {
+    pub fn wrap_mode(mut self, wrap_mode: TextWrapMode) -> Self {
         self.wrap_mode = Some(wrap_mode);
         self
     }
@@ -167,7 +167,7 @@ impl Label {
         let available_width = ui.available_width();
 
         let wrap_mode = self.wrap_mode.unwrap_or_else(|| ui.wrap_mode());
-        if wrap_mode == text::TextWrapMode::Wrap
+        if wrap_mode == TextWrapMode::Wrap
             && ui.layout().main_dir() == Direction::LeftToRight
             && ui.layout().main_wrap()
             && available_width.is_finite()

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -44,7 +44,7 @@ impl Label {
 
     /// If `true`, the text will wrap to stay within the max width of the [`Ui`].
     ///
-    /// Deprecated. Use [`wrap_mode`] instead.
+    /// Deprecated. Use [`Self::wrap_mode`] instead.
     #[deprecated = "Use `wrap_mode(TextWrapMode::Wrap)` instead"]
     #[inline]
     pub fn wrap(mut self, wrap: bool) -> Self {
@@ -59,6 +59,7 @@ impl Label {
     /// If `true`, the text will stop at the max width of the [`Ui`],
     /// and what doesn't fit will be elided, replaced with `…`.
     ///
+    /// [`Self::wrap_mode`] instead.
     /// If the text is truncated, the full text will be shown on hover as a tool-tip.
     #[deprecated = "Use `wrap_mode(TextWrapMode::Truncate)` instead"]
     #[inline]

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -74,9 +74,7 @@ impl Label {
 
     /// Set the wrap mode for the text.
     ///
-    /// By default, the text will wrap at the [`Ui`] boundary in vertical layouts and wrapping
-    /// horizontal layouts, or extend the [`Ui`] otherwise. This default behavior can be overridden
-    /// with [`Style::wrap_mode`].
+    /// By default, [`Ui::wrap_mode`] will be used, which can be overridden with [`Style::wrap_mode`].
     ///
     /// Note that any `\n` in the text will always produce a new line.
     #[inline]

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -13,7 +13,7 @@ use self::text_selection::LabelSelectionState;
 /// # egui::__run_test_ui(|ui| {
 /// ui.label("Equivalent");
 /// ui.add(egui::Label::new("Equivalent"));
-/// ui.add(egui::Label::new("With Options").wrap_mode(TextWrapMode::Truncate));
+/// ui.add(egui::Label::new("With Options").truncate());
 /// ui.label(egui::RichText::new("With formatting").underline());
 /// # });
 /// ```
@@ -42,36 +42,6 @@ impl Label {
         self.text.text()
     }
 
-    /// If `true`, the text will wrap to stay within the max width of the [`Ui`].
-    ///
-    /// Deprecated. Use [`Self::wrap_mode`] instead.
-    #[deprecated = "Use `wrap_mode(TextWrapMode::Wrap)` instead"]
-    #[inline]
-    pub fn wrap(mut self, wrap: bool) -> Self {
-        if wrap {
-            self.wrap_mode = Some(TextWrapMode::Wrap);
-        } else {
-            self.wrap_mode = Some(TextWrapMode::Extend);
-        }
-        self
-    }
-
-    /// If `true`, the text will stop at the max width of the [`Ui`],
-    /// and what doesn't fit will be elided, replaced with `…`.
-    ///
-    /// [`Self::wrap_mode`] instead.
-    /// If the text is truncated, the full text will be shown on hover as a tool-tip.
-    #[deprecated = "Use `wrap_mode(TextWrapMode::Truncate)` instead"]
-    #[inline]
-    pub fn truncate(mut self, truncate: bool) -> Self {
-        if truncate {
-            self.wrap_mode = Some(TextWrapMode::Truncate);
-        } else {
-            self.wrap_mode = Some(TextWrapMode::Extend);
-        }
-        self
-    }
-
     /// Set the wrap mode for the text.
     ///
     /// By default, [`Ui::wrap_mode`] will be used, which can be overridden with [`Style::wrap_mode`].
@@ -80,6 +50,21 @@ impl Label {
     #[inline]
     pub fn wrap_mode(mut self, wrap_mode: TextWrapMode) -> Self {
         self.wrap_mode = Some(wrap_mode);
+        self
+    }
+
+    /// Set [`Self::wrap_mode`] to [`TextWrapMode::Wrap`].
+    #[inline]
+    pub fn wrap(mut self) -> Self {
+        self.wrap_mode = Some(TextWrapMode::Wrap);
+
+        self
+    }
+
+    /// Set [`Self::wrap_mode`] to [`TextWrapMode::Truncate`].
+    #[inline]
+    pub fn truncate(mut self) -> Self {
+        self.wrap_mode = Some(TextWrapMode::Truncate);
         self
     }
 

--- a/crates/egui/src/widgets/progress_bar.rs
+++ b/crates/egui/src/widgets/progress_bar.rs
@@ -185,7 +185,7 @@ impl Widget for ProgressBar {
                 };
                 let galley = text.into_galley(
                     ui,
-                    Some(text::TextWrapMode::Extend),
+                    Some(TextWrapMode::Extend),
                     f32::INFINITY,
                     TextStyle::Button,
                 );

--- a/crates/egui/src/widgets/progress_bar.rs
+++ b/crates/egui/src/widgets/progress_bar.rs
@@ -183,7 +183,12 @@ impl Widget for ProgressBar {
                         format!("{}%", (progress * 100.0) as usize).into()
                     }
                 };
-                let galley = text.into_galley(ui, Some(false), f32::INFINITY, TextStyle::Button);
+                let galley = text.into_galley(
+                    ui,
+                    Some(text::TextWrapMode::Extend),
+                    f32::INFINITY,
+                    TextStyle::Button,
+                );
                 let text_pos = outer_rect.left_center() - Vec2::new(0.0, galley.size().y / 2.0)
                     + vec2(ui.spacing().item_spacing.x, 0.0);
                 let text_color = visuals

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -904,7 +904,8 @@ impl<'a> Slider<'a> {
         };
 
         if !self.text.is_empty() {
-            let label_response = ui.add(Label::new(self.text.clone()).wrap(false));
+            let label_response =
+                ui.add(Label::new(self.text.clone()).wrap_mode(text::TextWrapMode::Extend));
             // The slider already has an accessibility label via widget info,
             // but sometimes it's useful for a screen reader to know
             // that a piece of text is a label for another widget,

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -905,7 +905,7 @@ impl<'a> Slider<'a> {
 
         if !self.text.is_empty() {
             let label_response =
-                ui.add(Label::new(self.text.clone()).wrap_mode(text::TextWrapMode::Extend));
+                ui.add(Label::new(self.text.clone()).wrap_mode(TextWrapMode::Extend));
             // The slider already has an accessibility label via widget info,
             // but sometimes it's useful for a screen reader to know
             // that a piece of text is a label for another widget,

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -667,14 +667,14 @@ impl<'t> TextEdit<'t> {
                 let galley = if multiline {
                     hint_text.into_galley(
                         ui,
-                        Some(text::TextWrapMode::Wrap),
+                        Some(TextWrapMode::Wrap),
                         desired_inner_size.x,
                         hint_text_font_id,
                     )
                 } else {
                     hint_text.into_galley(
                         ui,
-                        Some(text::TextWrapMode::Extend),
+                        Some(TextWrapMode::Extend),
                         f32::INFINITY,
                         hint_text_font_id,
                     )

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -665,9 +665,19 @@ impl<'t> TextEdit<'t> {
                 let hint_text_color = ui.visuals().weak_text_color();
                 let hint_text_font_id = hint_text_font.unwrap_or(font_id.into());
                 let galley = if multiline {
-                    hint_text.into_galley(ui, Some(true), desired_inner_size.x, hint_text_font_id)
+                    hint_text.into_galley(
+                        ui,
+                        Some(text::TextWrapMode::Wrap),
+                        desired_inner_size.x,
+                        hint_text_font_id,
+                    )
                 } else {
-                    hint_text.into_galley(ui, Some(false), f32::INFINITY, hint_text_font_id)
+                    hint_text.into_galley(
+                        ui,
+                        Some(text::TextWrapMode::Extend),
+                        f32::INFINITY,
+                        hint_text_font_id,
+                    )
                 };
                 painter.galley(rect.min, galley, hint_text_color);
             }

--- a/crates/egui_demo_app/src/backend_panel.rs
+++ b/crates/egui_demo_app/src/backend_panel.rs
@@ -180,7 +180,7 @@ fn integration_ui(ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
 
     #[cfg(target_arch = "wasm32")]
     ui.collapsing("Web info (location)", |ui| {
-        ui.style_mut().wrap_mode = Some(egui::text::TextWrapMode::Extend);
+        ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
         ui.monospace(format!("{:#?}", _frame.info().web_info.location));
     });
 

--- a/crates/egui_demo_app/src/backend_panel.rs
+++ b/crates/egui_demo_app/src/backend_panel.rs
@@ -180,7 +180,7 @@ fn integration_ui(ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
 
     #[cfg(target_arch = "wasm32")]
     ui.collapsing("Web info (location)", |ui| {
-        ui.style_mut().wrap = Some(false);
+        ui.style_mut().wrap_mode = Some(egui::text::TextWrapMode::Extend);
         ui.monospace(format!("{:#?}", _frame.info().web_info.location));
     });
 

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -335,7 +335,7 @@ fn file_menu_button(ui: &mut Ui) {
 
     ui.menu_button("File", |ui| {
         ui.set_min_width(220.0);
-        ui.style_mut().wrap_mode = Some(egui::text::TextWrapMode::Extend);
+        ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
 
         // On the web the browser controls the zoom
         #[cfg(not(target_arch = "wasm32"))]

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -335,7 +335,7 @@ fn file_menu_button(ui: &mut Ui) {
 
     ui.menu_button("File", |ui| {
         ui.set_min_width(220.0);
-        ui.style_mut().wrap = Some(false);
+        ui.style_mut().wrap_mode = Some(egui::text::TextWrapMode::Extend);
 
         // On the web the browser controls the zoom
         #[cfg(not(target_arch = "wasm32"))]

--- a/crates/egui_demo_lib/src/demo/frame_demo.rs
+++ b/crates/egui_demo_lib/src/demo/frame_demo.rs
@@ -60,7 +60,7 @@ impl super::View for FrameDemo {
                     .rounding(ui.visuals().widgets.noninteractive.rounding)
                     .show(ui, |ui| {
                         self.frame.show(ui, |ui| {
-                            ui.style_mut().wrap = Some(false);
+                            ui.style_mut().wrap_mode = Some(egui::text::TextWrapMode::Extend);
                             ui.label(egui::RichText::new("Content").color(egui::Color32::WHITE));
                         });
                     });

--- a/crates/egui_demo_lib/src/demo/frame_demo.rs
+++ b/crates/egui_demo_lib/src/demo/frame_demo.rs
@@ -60,7 +60,7 @@ impl super::View for FrameDemo {
                     .rounding(ui.visuals().widgets.noninteractive.rounding)
                     .show(ui, |ui| {
                         self.frame.show(ui, |ui| {
-                            ui.style_mut().wrap_mode = Some(egui::text::TextWrapMode::Extend);
+                            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
                             ui.label(egui::RichText::new("Content").color(egui::Color32::WHITE));
                         });
                     });

--- a/crates/egui_demo_lib/src/demo/layout_test.rs
+++ b/crates/egui_demo_lib/src/demo/layout_test.rs
@@ -178,7 +178,7 @@ impl LayoutTest {
 fn demo_ui(ui: &mut Ui) {
     ui.add(
         egui::Label::new("Wrapping text followed by example widgets:")
-            .wrap_mode(text::TextWrapMode::Wrap),
+            .wrap_mode(TextWrapMode::Wrap),
     );
     let mut dummy = false;
     ui.checkbox(&mut dummy, "checkbox");

--- a/crates/egui_demo_lib/src/demo/layout_test.rs
+++ b/crates/egui_demo_lib/src/demo/layout_test.rs
@@ -176,7 +176,10 @@ impl LayoutTest {
 }
 
 fn demo_ui(ui: &mut Ui) {
-    ui.add(egui::Label::new("Wrapping text followed by example widgets:").wrap(true));
+    ui.add(
+        egui::Label::new("Wrapping text followed by example widgets:")
+            .wrap_mode(text::TextWrapMode::Wrap),
+    );
     let mut dummy = false;
     ui.checkbox(&mut dummy, "checkbox");
     ui.radio_value(&mut dummy, false, "radio");

--- a/crates/egui_demo_lib/src/demo/layout_test.rs
+++ b/crates/egui_demo_lib/src/demo/layout_test.rs
@@ -176,10 +176,7 @@ impl LayoutTest {
 }
 
 fn demo_ui(ui: &mut Ui) {
-    ui.add(
-        egui::Label::new("Wrapping text followed by example widgets:")
-            .wrap_mode(TextWrapMode::Wrap),
-    );
+    ui.add(egui::Label::new("Wrapping text followed by example widgets:").wrap());
     let mut dummy = false;
     ui.checkbox(&mut dummy, "checkbox");
     ui.radio_value(&mut dummy, false, "radio");

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -223,7 +223,7 @@ fn label_ui(ui: &mut egui::Ui) {
         egui::Label::new(
             "Labels containing long text can be set to elide the text that doesn't fit on a single line using `Label::elide`. When hovered, the label will show the full text.",
         )
-        .truncate(true),
+        .wrap_mode(text::TextWrapMode::Truncate),
     );
 }
 

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -223,7 +223,7 @@ fn label_ui(ui: &mut egui::Ui) {
         egui::Label::new(
             "Labels containing long text can be set to elide the text that doesn't fit on a single line using `Label::elide`. When hovered, the label will show the full text.",
         )
-        .wrap_mode(TextWrapMode::Truncate),
+        .truncate(),
     );
 }
 

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -223,7 +223,7 @@ fn label_ui(ui: &mut egui::Ui) {
         egui::Label::new(
             "Labels containing long text can be set to elide the text that doesn't fit on a single line using `Label::elide`. When hovered, the label will show the full text.",
         )
-        .wrap_mode(text::TextWrapMode::Truncate),
+        .wrap_mode(TextWrapMode::Truncate),
     );
 }
 

--- a/crates/egui_demo_lib/src/demo/pan_zoom.rs
+++ b/crates/egui_demo_lib/src/demo/pan_zoom.rs
@@ -1,4 +1,5 @@
 use egui::emath::TSTransform;
+use egui::text;
 
 #[derive(Clone, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -122,7 +123,7 @@ impl super::View for PanZoom {
                         .stroke(ui.ctx().style().visuals.window_stroke)
                         .fill(ui.style().visuals.panel_fill)
                         .show(ui, |ui| {
-                            ui.style_mut().wrap = Some(false);
+                            ui.style_mut().wrap_mode = Some(text::TextWrapMode::Extend);
                             callback(ui, self)
                         });
                 })

--- a/crates/egui_demo_lib/src/demo/pan_zoom.rs
+++ b/crates/egui_demo_lib/src/demo/pan_zoom.rs
@@ -1,5 +1,5 @@
 use egui::emath::TSTransform;
-use egui::text;
+use egui::TextWrapMode;
 
 #[derive(Clone, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -123,7 +123,7 @@ impl super::View for PanZoom {
                         .stroke(ui.ctx().style().visuals.window_stroke)
                         .fill(ui.style().visuals.panel_fill)
                         .show(ui, |ui| {
-                            ui.style_mut().wrap_mode = Some(text::TextWrapMode::Extend);
+                            ui.style_mut().wrap_mode = Some(TextWrapMode::Extend);
                             callback(ui, self)
                         });
                 })

--- a/crates/egui_demo_lib/src/demo/plot_demo.rs
+++ b/crates/egui_demo_lib/src/demo/plot_demo.rs
@@ -200,7 +200,7 @@ impl LineDemo {
             });
 
             ui.vertical(|ui| {
-                ui.style_mut().wrap_mode = Some(text::TextWrapMode::Extend);
+                ui.style_mut().wrap_mode = Some(TextWrapMode::Extend);
                 ui.checkbox(animate, "Animate");
                 ui.checkbox(square, "Square view")
                     .on_hover_text("Always keep the viewport square.");

--- a/crates/egui_demo_lib/src/demo/plot_demo.rs
+++ b/crates/egui_demo_lib/src/demo/plot_demo.rs
@@ -200,7 +200,7 @@ impl LineDemo {
             });
 
             ui.vertical(|ui| {
-                ui.style_mut().wrap = Some(false);
+                ui.style_mut().wrap_mode = Some(text::TextWrapMode::Extend);
                 ui.checkbox(animate, "Animate");
                 ui.checkbox(square, "Square view")
                     .on_hover_text("Always keep the viewport square.");

--- a/crates/egui_demo_lib/src/demo/scrolling.rs
+++ b/crates/egui_demo_lib/src/demo/scrolling.rs
@@ -82,7 +82,7 @@ impl super::View for Scrolling {
             }
             ScrollDemo::Bidirectional => {
                 egui::ScrollArea::both().show(ui, |ui| {
-                    ui.style_mut().wrap_mode = Some(text::TextWrapMode::Extend);
+                    ui.style_mut().wrap_mode = Some(TextWrapMode::Extend);
                     for _ in 0..100 {
                         ui.label(crate::LOREM_IPSUM);
                     }

--- a/crates/egui_demo_lib/src/demo/scrolling.rs
+++ b/crates/egui_demo_lib/src/demo/scrolling.rs
@@ -82,7 +82,7 @@ impl super::View for Scrolling {
             }
             ScrollDemo::Bidirectional => {
                 egui::ScrollArea::both().show(ui, |ui| {
-                    ui.style_mut().wrap = Some(false);
+                    ui.style_mut().wrap_mode = Some(text::TextWrapMode::Extend);
                     for _ in 0..100 {
                         ui.label(crate::LOREM_IPSUM);
                     }

--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -1,4 +1,4 @@
-use egui::TextStyle;
+use egui::{text, TextStyle};
 
 #[derive(PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -196,7 +196,7 @@ impl TableDemo {
                                 ui.label(long_text(row_index));
                             });
                             row.col(|ui| {
-                                ui.style_mut().wrap = Some(false);
+                                ui.style_mut().wrap_mode = Some(egui::text::TextWrapMode::Extend);
                                 if is_thick {
                                     ui.heading("Extra thick row");
                                 } else {
@@ -227,7 +227,8 @@ impl TableDemo {
                         });
                         row.col(|ui| {
                             ui.add(
-                                egui::Label::new("Thousands of rows of even height").wrap(false),
+                                egui::Label::new("Thousands of rows of even height")
+                                    .wrap_mode(text::TextWrapMode::Extend),
                             );
                         });
 
@@ -253,7 +254,7 @@ impl TableDemo {
                             ui.label(long_text(row_index));
                         });
                         row.col(|ui| {
-                            ui.style_mut().wrap = Some(false);
+                            ui.style_mut().wrap_mode = Some(egui::text::TextWrapMode::Extend);
                             if thick_row(row_index) {
                                 ui.heading("Extra thick row");
                             } else {

--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -1,4 +1,4 @@
-use egui::{text, TextStyle};
+use egui::{TextStyle, TextWrapMode};
 
 #[derive(PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -196,7 +196,7 @@ impl TableDemo {
                                 ui.label(long_text(row_index));
                             });
                             row.col(|ui| {
-                                ui.style_mut().wrap_mode = Some(egui::text::TextWrapMode::Extend);
+                                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
                                 if is_thick {
                                     ui.heading("Extra thick row");
                                 } else {
@@ -228,7 +228,7 @@ impl TableDemo {
                         row.col(|ui| {
                             ui.add(
                                 egui::Label::new("Thousands of rows of even height")
-                                    .wrap_mode(text::TextWrapMode::Extend),
+                                    .wrap_mode(TextWrapMode::Extend),
                             );
                         });
 
@@ -254,7 +254,7 @@ impl TableDemo {
                             ui.label(long_text(row_index));
                         });
                         row.col(|ui| {
-                            ui.style_mut().wrap_mode = Some(egui::text::TextWrapMode::Extend);
+                            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
                             if thick_row(row_index) {
                                 ui.heading("Extra thick row");
                             } else {

--- a/crates/egui_demo_lib/src/demo/widget_gallery.rs
+++ b/crates/egui_demo_lib/src/demo/widget_gallery.rs
@@ -172,7 +172,7 @@ impl WidgetGallery {
         egui::ComboBox::from_label("Take your pick")
             .selected_text(format!("{radio:?}"))
             .show_ui(ui, |ui| {
-                ui.style_mut().wrap = Some(false);
+                ui.style_mut().wrap_mode = Some(egui::text::TextWrapMode::Extend);
                 ui.set_min_width(60.0);
                 ui.selectable_value(radio, Enum::First, "First");
                 ui.selectable_value(radio, Enum::Second, "Second");

--- a/crates/egui_demo_lib/src/demo/widget_gallery.rs
+++ b/crates/egui_demo_lib/src/demo/widget_gallery.rs
@@ -172,7 +172,7 @@ impl WidgetGallery {
         egui::ComboBox::from_label("Take your pick")
             .selected_text(format!("{radio:?}"))
             .show_ui(ui, |ui| {
-                ui.style_mut().wrap_mode = Some(egui::text::TextWrapMode::Extend);
+                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
                 ui.set_min_width(60.0);
                 ui.selectable_value(radio, Enum::First, "First");
                 ui.selectable_value(radio, Enum::Second, "Second");

--- a/crates/egui_plot/src/axis.rs
+++ b/crates/egui_plot/src/axis.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, ops::RangeInclusive, sync::Arc};
 use egui::{
     emath::{remap_clamp, round_to_decimals, Rot2},
     epaint::TextShape,
-    Pos2, Rangef, Rect, Response, Sense, TextStyle, Ui, Vec2, WidgetText,
+    text, Pos2, Rangef, Rect, Response, Sense, TextStyle, Ui, Vec2, WidgetText,
 };
 
 use super::{transform::PlotTransform, GridMark};
@@ -264,7 +264,12 @@ impl<'a> AxisWidget<'a> {
 
         {
             let text = self.hints.label;
-            let galley = text.into_galley(ui, Some(false), f32::INFINITY, TextStyle::Body);
+            let galley = text.into_galley(
+                ui,
+                Some(text::TextWrapMode::Extend),
+                f32::INFINITY,
+                TextStyle::Body,
+            );
             let text_color = visuals
                 .override_text_color
                 .unwrap_or_else(|| ui.visuals().text_color());

--- a/crates/egui_plot/src/axis.rs
+++ b/crates/egui_plot/src/axis.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, ops::RangeInclusive, sync::Arc};
 use egui::{
     emath::{remap_clamp, round_to_decimals, Rot2},
     epaint::TextShape,
-    text, Pos2, Rangef, Rect, Response, Sense, TextStyle, Ui, Vec2, WidgetText,
+    Pos2, Rangef, Rect, Response, Sense, TextStyle, TextWrapMode, Ui, Vec2, WidgetText,
 };
 
 use super::{transform::PlotTransform, GridMark};
@@ -266,7 +266,7 @@ impl<'a> AxisWidget<'a> {
             let text = self.hints.label;
             let galley = text.into_galley(
                 ui,
-                Some(text::TextWrapMode::Extend),
+                Some(TextWrapMode::Extend),
                 f32::INFINITY,
                 TextStyle::Body,
             );

--- a/crates/egui_plot/src/items/mod.rs
+++ b/crates/egui_plot/src/items/mod.rs
@@ -852,7 +852,7 @@ impl PlotItem for Text {
 
         let galley = self.text.clone().into_galley(
             ui,
-            Some(egui::text::TextWrapMode::Extend),
+            Some(egui::TextWrapMode::Extend),
             f32::INFINITY,
             TextStyle::Small,
         );

--- a/crates/egui_plot/src/items/mod.rs
+++ b/crates/egui_plot/src/items/mod.rs
@@ -850,10 +850,12 @@ impl PlotItem for Text {
             self.color
         };
 
-        let galley =
-            self.text
-                .clone()
-                .into_galley(ui, Some(false), f32::INFINITY, TextStyle::Small);
+        let galley = self.text.clone().into_galley(
+            ui,
+            Some(egui::text::TextWrapMode::Extend),
+            f32::INFINITY,
+            TextStyle::Small,
+        );
 
         let pos = transform.position_from_point(&self.position);
         let rect = self.anchor.anchor_size(pos, galley.size());

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -325,8 +325,13 @@ impl TextFormat {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum TextWrapMode {
+    /// The text should expand the `Ui` size when reaching its boundary.
     Extend,
+    /// The text should wrap to the next line when reaching the `Ui` boundary.
     Wrap,
+    /// The text should elided using "…" when reaching the `Ui` boundary.
+    ///
+    /// Note that using [`TextWrapping`] and [`LayoutJob`] offers more control over the elision.
     Truncate,
 }
 
@@ -346,7 +351,7 @@ pub struct TextWrapping {
 
     /// Maximum amount of rows the text galley should have.
     ///
-    /// If this limit is reached, text will be truncated and
+    /// If this limit is reached, text will be truncated
     /// and [`Self::overflow_character`] appended to the final row.
     /// You can detect this by checking [`Galley::elided`].
     ///

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -327,8 +327,10 @@ impl TextFormat {
 pub enum TextWrapMode {
     /// The text should expand the `Ui` size when reaching its boundary.
     Extend,
+
     /// The text should wrap to the next line when reaching the `Ui` boundary.
     Wrap,
+
     /// The text should be elided using "…" when reaching the `Ui` boundary.
     ///
     /// Note that using [`TextWrapping`] and [`LayoutJob`] offers more control over the elision.

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -319,6 +319,17 @@ impl TextFormat {
 
 // ----------------------------------------------------------------------------
 
+/// How to wrap and elide text.
+///
+/// This enum is used in high-level APIs where providing a [`TextWrapping`] is too verbose.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum TextWrapMode {
+    Extend,
+    Wrap,
+    Truncate,
+}
+
 /// Controls the text wrapping and elision of a [`LayoutJob`].
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -394,10 +405,27 @@ impl Default for TextWrapping {
 }
 
 impl TextWrapping {
+    /// Create a [`TextWrapping`] from a [`TextWrapMode`] and an available width.
+    pub fn from_wrap_mode_and_width(mode: TextWrapMode, max_width: f32) -> Self {
+        match mode {
+            TextWrapMode::Extend => Self::no_max_width(),
+            TextWrapMode::Wrap => Self::wrap_at_width(max_width),
+            TextWrapMode::Truncate => Self::truncate_at_width(max_width),
+        }
+    }
+
     /// A row can be as long as it need to be.
     pub fn no_max_width() -> Self {
         Self {
             max_width: f32::INFINITY,
+            ..Default::default()
+        }
+    }
+
+    /// A row can be at most `max_width` wide but can wrap in any number of lines.
+    pub fn wrap_at_width(max_width: f32) -> Self {
+        Self {
+            max_width,
             ..Default::default()
         }
     }

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -329,7 +329,7 @@ pub enum TextWrapMode {
     Extend,
     /// The text should wrap to the next line when reaching the `Ui` boundary.
     Wrap,
-    /// The text should elided using "…" when reaching the `Ui` boundary.
+    /// The text should be elided using "…" when reaching the `Ui` boundary.
     ///
     /// Note that using [`TextWrapping`] and [`LayoutJob`] offers more control over the elision.
     Truncate,


### PR DESCRIPTION
* Closes #4473

This PR introduce `Style::wrap_mode`, which adds support for text truncation in addition to text wrapping. This PR also update some width calculation of the ComboBox.

#### Core

- Add `egui::TextWrapMode` (pure enum with `Extend`, `Wrap`, `Truncate`)
- Add `Style::wrap_mode: Option<tTextWrapMode>`
- **DEPRECATED**: `Style::wrap`, use `Style::wrap_mode` instead.
- Add `Ui::wrap_mode()` to return the wrap mode to use in the current ui. If specified in `Style`, return it. Otherwise, return `TextWrapMode::Wrap` for vertical layout and wrapping horizontal layout, and `TextWrapMode::Extend` otherwise.
- **DEPRECATED**: `Ui::wrap_text()`, use `Ui::wrap_mode` instead.

#### Widget

- Update the width calculation of the `ComboBox` button (_not_ its popup menu).
  - Now, `ComboBox::width()` (defaulting to `Spacing::combo_width`) is always considered a minimum width and will extend the `Ui`, regardless of the selected text width and wrap mode.
  - Introduce `ComboBox::wrap_mode`, which overrides `Ui::wrap_mode` for the selected text layout.
    - Note: since `ComboBox` uses `ui.horizontal` internally, the default wrap mode is always `TextWrapMode::Extend`, regardless of the caller's `Ui`'s layout.
  - The `ComboBox` button no longer extend to `ui.available_width()` with wrapping is enabled.
  - **BREAKING**: `ComboBox::wrap()` no longer has a `bool` argument and is now a short-hand for `ComboBox::wrap_mode(TextWrapMode::Wrap)`.
  - Added `ComboBox::truncate()` as short-hand for `ComboBox::wrap_mode(TextWrapMode::Truncate)`.
- Update `Label`
  - Add `Label::wrap_mode()` to specify the text wrap mode.
  - **BREAKING**:  `Label::wrap()` no longer has a `bool` argument and is now a short-hand for `Label::wrap_mode(TextWrapMode::Wrap)`.
  - **BREAKING**:  `Label::truncate()` no longer has a `bool` argument and is now a short-hand for `Label::wrap_mode(TextWrapMode::Truncate)`.
- Update `Button`
  - Add `Button::wrap_mode()` to specify the text wrap mode.
  - **BREAKING**:  `Button::wrap()` no longer has a `bool` argument and is now a short-hand for `Button::wrap_mode(TextWrapMode::Wrap)`.
  - Added `Button::truncate()` as short-hand for `Button::wrap_mode(TextWrapMode::Truncate)`.

#### Low-level

- **BREAKING**: `WidgetText::into_galley()` now takes an `Option<TextWrapMode>` instead of a `Option<bool>` argument.
- **BREAKING**: `WidgetText::into_galley_impl(()` now takes a `TextWrapping` argument instead of `wrap: bool` and `availalbe_width: f32` arguments.

