### PR TITLE
Don't persist `Area` state

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -8,8 +8,12 @@ use crate::*;
 ///
 /// Areas back [`crate::Window`]s and other floating containers,
 /// like tooltips and the popups of [`crate::ComboBox`].
+///
+/// Area state is intentionally NOT persisted between sessions,
+/// so that a bad tooltip or menu size won't be remembered forever.
+/// A resizable [`Window`] remembers the size the user picked using
+/// the state in the [`Resize`] container.
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct AreaState {
     /// Last known position of the pivot.
     pub pivot_pos: Pos2,

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -934,6 +934,9 @@ impl Memory {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct Areas {
+    /// Area state is intentionally NOT persisted between sessions,
+    /// so that a bad tooltip or menu size won't be remembered forever.
+    #[cfg_attr(feature = "serde", serde(skip))]
     areas: IdMap<area::AreaState>,
 
     /// Back-to-front. Top is last.


### PR DESCRIPTION
If you change your code for what is contained in a menu, tooltips, combobox etc, it is helpful if egui will recompute the size of that Area next frame. Now it will!

The user-chosen size of a `Window` is still persisted via other means.