### PR TITLE
Round text galley sizes to nearest ui point size

### DIFF
--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -74,6 +74,10 @@ pub struct LayoutJob {
 
     /// Justify text so that word-wrapped rows fill the whole [`TextWrapping::max_width`].
     pub justify: bool,
+
+    /// Rounding to the closest ui point (not pixel!) allows the rest of the
+    /// layout code to run on perfect integers, avoiding rounding errors.
+    pub round_output_size_to_nearest_ui_point: bool,
 }
 
 impl Default for LayoutJob {
@@ -87,6 +91,7 @@ impl Default for LayoutJob {
             break_on_newline: true,
             halign: Align::LEFT,
             justify: false,
+            round_output_size_to_nearest_ui_point: true,
         }
     }
 }
@@ -180,6 +185,7 @@ impl std::hash::Hash for LayoutJob {
             break_on_newline,
             halign,
             justify,
+            round_output_size_to_nearest_ui_point,
         } = self;
 
         text.hash(state);
@@ -189,6 +195,7 @@ impl std::hash::Hash for LayoutJob {
         break_on_newline.hash(state);
         halign.hash(state);
         justify.hash(state);
+        round_output_size_to_nearest_ui_point.hash(state);
     }
 }
 


### PR DESCRIPTION
Previously, many labels had non-integer widths. This lead to rounding errors.

This was most notable for the new `Area` sizing code:

We would run the initial sizing pass, to measure the size of e.g. a tooltip.
Say the tooltip contains text that was 100.123 ui points wide. With a 16pt border, that becomes 116.123, which is stored in the `Area` state as the width. The next frame, we use that stored size as the wrapping width. With perfect precision, we would then tell the label to wrap to 100.123 pts, which the text would _just_ fit in. However, due to rounding errors we might end up asking it to wrap to 100.12**2** pts, meaning the last word would now wrap and end up on the next line.

By rounding label sizes to perfect integers, we avoid such rounding errors, and most ui elements will now end up on perfect integer point coordinates (and `f32` can precisely express and do arithmetic on all integers < 2^24).

Visually this has very little impact. Some labels move by a pixel here and there, mostly for the better.