### PR TITLE
Once you have waited for a tooltip to show, show the next one right away

### DIFF
--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -610,12 +610,15 @@ impl Response {
 
         let tooltip_delay = self.ctx.style().interaction.tooltip_delay;
 
-        let tooltip_was_recently_shown = when_was_a_toolip_last_shown
-            .map_or(false, |time| ((now - time) as f32) < tooltip_delay);
-
         // There is a tooltip_delay before showing the first tooltip,
         // but once one tooltips is show, moving the mouse cursor to
         // another widget should show the tooltip for that widget right away.
+
+        // Let the user quickly move over some dead space to hover the next thing
+        let recent_sec = 0.1;
+        let tooltip_was_recently_shown =
+            when_was_a_toolip_last_shown.map_or(false, |time| ((now - time) as f32) < recent_sec);
+
         if !tooltip_was_recently_shown && !self.is_tooltip_open() {
             if self.ctx.style().interaction.show_tooltips_only_when_still {
                 // We only show the tooltip when the mouse pointer is still.

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -615,7 +615,7 @@ impl Response {
         // another widget should show the tooltip for that widget right away.
 
         // Let the user quickly move over some dead space to hover the next thing
-        let recent_sec = 0.1;
+        let recent_sec = 0.2;
         let tooltip_was_recently_shown =
             when_was_a_toolip_last_shown.map_or(false, |time| ((now - time) as f32) < recent_sec);
 

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -609,15 +609,15 @@ impl Response {
             .data(|d| d.get_temp::<f64>(when_was_a_toolip_last_shown_id));
 
         let tooltip_delay = self.ctx.style().interaction.tooltip_delay;
+        let tooltip_grace_time = self.ctx.style().interaction.tooltip_grace_time;
 
         // There is a tooltip_delay before showing the first tooltip,
         // but once one tooltips is show, moving the mouse cursor to
         // another widget should show the tooltip for that widget right away.
 
         // Let the user quickly move over some dead space to hover the next thing
-        let recent_sec = 0.2;
-        let tooltip_was_recently_shown =
-            when_was_a_toolip_last_shown.map_or(false, |time| ((now - time) as f32) < recent_sec);
+        let tooltip_was_recently_shown = when_was_a_toolip_last_shown
+            .map_or(false, |time| ((now - time) as f32) < tooltip_grace_time);
 
         if !tooltip_was_recently_shown && !self.is_tooltip_open() {
             if self.ctx.style().interaction.show_tooltips_only_when_still {

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -658,6 +658,13 @@ pub struct Interaction {
     /// Delay in seconds before showing tooltips after the mouse stops moving
     pub tooltip_delay: f32,
 
+    /// If you have waited for a tooltip and then hover some other widget within
+    /// this many seconds, then show the new tooltip right away,
+    /// skipping [`Self::tooltip_delay`].
+    ///
+    /// This lets the user quickly move over some dead space to hover the next thing.
+    pub tooltip_grace_time: f32,
+
     /// Can you select the text on a [`crate::Label`] by default?
     pub selectable_labels: bool,
 
@@ -1103,6 +1110,7 @@ impl Default for Interaction {
             interact_radius: 5.0,
             show_tooltips_only_when_still: true,
             tooltip_delay: 0.5,
+            tooltip_grace_time: 0.2,
             selectable_labels: true,
             multi_widget_text_select: true,
         }
@@ -1590,6 +1598,7 @@ impl Interaction {
             resize_grab_radius_corner,
             show_tooltips_only_when_still,
             tooltip_delay,
+            tooltip_grace_time,
             selectable_labels,
             multi_widget_text_select,
         } = self;
@@ -1618,6 +1627,17 @@ impl Interaction {
                 );
                 ui.add(
                     DragValue::new(tooltip_delay)
+                        .clamp_range(0.0..=1.0)
+                        .speed(0.05)
+                        .suffix(" s"),
+                );
+                ui.end_row();
+
+                ui.label("Tooltip grace time").on_hover_text(
+                    "If a tooltip is open and you hover another widget within this grace period, show the next tooltip right away",
+                );
+                ui.add(
+                    DragValue::new(tooltip_grace_time)
                         .clamp_range(0.0..=1.0)
                         .speed(0.05)
                         .suffix(" s"),

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1102,7 +1102,7 @@ impl Default for Interaction {
             resize_grab_radius_corner: 10.0,
             interact_radius: 5.0,
             show_tooltips_only_when_still: true,
-            tooltip_delay: 0.3,
+            tooltip_delay: 0.5,
             selectable_labels: true,
             multi_widget_text_select: true,
         }


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/4582

User-story: there are multiple icons in a row, and the user wants them explained. They hover over one until the tooltips appears. They then move on to the next and don't want to wait for that tooltip again.