### PR TITLE
Fade in windows, tooltips, popups, etc

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -496,6 +496,7 @@ impl ContextImpl {
                 pivot: Align2::LEFT_TOP,
                 size: screen_rect.size(),
                 interactable: true,
+                last_became_visible_at: f64::NEG_INFINITY,
             },
         );
 

--- a/crates/egui_demo_lib/src/demo/widget_gallery.rs
+++ b/crates/egui_demo_lib/src/demo/widget_gallery.rs
@@ -63,7 +63,7 @@ impl super::View for WidgetGallery {
     fn ui(&mut self, ui: &mut egui::Ui) {
         ui.add_enabled_ui(self.enabled, |ui| {
             ui.set_visible(self.visible);
-            ui.set_opacity(self.opacity);
+            ui.multiply_opacity(self.opacity);
 
             egui::Grid::new("my_grid")
                 .num_columns(2)


### PR DESCRIPTION
All `Area`s now have a quick fade-in animation. You can turn it off with `Area::fade_in` or `Window::fade_in` .

The `Window` fade-out animation is now nicer: it fades all elements of the window, not just the frame.
It can be controlled with `Window::fade_out`.