### PR TITLE
The default constrain rect for `Area/Window` is now `ctx.screen_rect`

### DIFF
--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -220,7 +220,7 @@ impl<'open> Window<'open> {
         self
     }
 
-    /// Constrains this window to the screen bounds.
+    /// Constrains this window to [`Context::screen_rect`].
     ///
     /// To change the area to constrain to, use [`Self::constrain_to`].
     ///
@@ -471,11 +471,10 @@ impl<'open> Window<'open> {
         };
 
         {
-            // Prevent window from becoming larger than the constraint rect and/or screen rect.
-            let screen_rect = ctx.screen_rect();
-            let max_rect = area.constrain_rect().unwrap_or(screen_rect);
-            let max_width = max_rect.width();
-            let max_height = max_rect.height() - title_bar_height;
+            // Prevent window from becoming larger than the constrain rect.
+            let constrain_rect = area.constrain_rect();
+            let max_width = constrain_rect.width();
+            let max_height = constrain_rect.height() - title_bar_height;
             resize.max_size.x = resize.max_size.x.min(max_width);
             resize.max_size.y = resize.max_size.y.min(max_height);
         }

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1776,23 +1776,7 @@ impl Context {
     // ---------------------------------------------------------------------
 
     /// Constrain the position of a window/area so it fits within the provided boundary.
-    ///
-    /// If area is `None`, will constrain to [`Self::available_rect`].
-    pub(crate) fn constrain_window_rect_to_area(&self, window: Rect, area: Option<Rect>) -> Rect {
-        let mut area = area.unwrap_or_else(|| self.available_rect());
-
-        if window.width() > area.width() {
-            // Allow overlapping side bars.
-            // This is important for small screens, e.g. mobiles running the web demo.
-            let screen_rect = self.screen_rect();
-            (area.min.x, area.max.x) = (screen_rect.min.x, screen_rect.max.x);
-        }
-        if window.height() > area.height() {
-            // Allow overlapping top/bottom bars:
-            let screen_rect = self.screen_rect();
-            (area.min.y, area.max.y) = (screen_rect.min.y, screen_rect.max.y);
-        }
-
+    pub(crate) fn constrain_window_rect_to_area(&self, window: Rect, area: Rect) -> Rect {
         let mut pos = window.min;
 
         // Constrain to screen, unless window is too large to fit:


### PR DESCRIPTION
By default, `Windows` can now cover already added panels. For instance: in the egui demo app (egui.rs), windows can now cover the side-panels and top bar.

To get the old behaviour, use `window.constrain_to(ctx.available_rect())`.