### PR TITLE
Constrain `Area`s to screen by default

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -108,7 +108,7 @@ impl Area {
             sense: None,
             movable: true,
             interactable: true,
-            constrain: false,
+            constrain: true,
             constrain_rect: None,
             enabled: true,
             order: Order::Middle,
@@ -229,6 +229,8 @@ impl Area {
     }
 
     /// Constrains this area to [`Context::screen_rect`]?
+    ///
+    /// Default: `true`.
     #[inline]
     pub fn constrain(mut self, constrain: bool) -> Self {
         self.constrain = constrain;

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -128,7 +128,6 @@ fn show_tooltip_at_avoid_dyn<'c, R>(
         .pivot(pivot)
         .fixed_pos(anchor)
         .default_width(ctx.style().spacing.tooltip_width)
-        .constrain_to(screen_rect)
         .interactable(false)
         .show(ctx, |ui| {
             Frame::popup(&ctx.style()).show_dyn(ui, add_contents).inner
@@ -288,7 +287,6 @@ pub fn popup_above_or_below_widget<R>(
 
         let inner = Area::new(popup_id)
             .order(Order::Foreground)
-            .constrain(true)
             .fixed_pos(pos)
             .default_width(inner_width)
             .pivot(pivot)

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -49,7 +49,7 @@ impl<'open> Window<'open> {
     /// If you need a changing title, you must call `window.id(…)` with a fixed id.
     pub fn new(title: impl Into<WidgetText>) -> Self {
         let title = title.into().fallback_text_style(TextStyle::Heading);
-        let area = Area::new(Id::new(title.text())).constrain(true);
+        let area = Area::new(Id::new(title.text()));
         Self {
             title,
             open: None,

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -148,7 +148,6 @@ fn menu_popup<'c, R>(
     let area = Area::new(menu_id.with("__menu"))
         .order(Order::Foreground)
         .fixed_pos(pos)
-        .constrain_to(ctx.screen_rect())
         .interactable(true)
         .default_width(ctx.style().spacing.menu_width)
         .sense(Sense::hover());

--- a/crates/egui/src/widgets/color_picker.rs
+++ b/crates/egui/src/widgets/color_picker.rs
@@ -491,7 +491,6 @@ pub fn color_edit_button_hsva(ui: &mut Ui, hsva: &mut Hsva, alpha: Alpha) -> Res
         let area_response = Area::new(popup_id)
             .order(Order::Foreground)
             .fixed_pos(button_response.rect.max)
-            .constrain(true)
             .show(ui.ctx(), |ui| {
                 ui.spacing_mut().slider_width = COLOR_SLIDER_WIDTH;
                 Frame::popup(ui.style()).show(ui, |ui| {

--- a/crates/egui_extras/src/datepicker/button.rs
+++ b/crates/egui_extras/src/datepicker/button.rs
@@ -142,7 +142,6 @@ impl<'a> Widget for DatePickerButton<'a> {
             } = Area::new(ui.make_persistent_id(self.id_source))
                 .order(Order::Foreground)
                 .fixed_pos(pos)
-                .constrain_to(ui.ctx().screen_rect())
                 .show(ui.ctx(), |ui| {
                     let frame = Frame::popup(ui.style());
                     frame


### PR DESCRIPTION
Call `area.constrain(false)` if you want your areas to extend outside the screen rect.
