### PR TITLE
Fix bug in ray-rect intersection test

### DIFF
--- a/crates/emath/src/rect.rs
+++ b/crates/emath/src/rect.rs
@@ -628,7 +628,7 @@ impl Rect {
             tmax = tmax.min(ty1.max(ty2));
         }
 
-        tmin <= tmax
+        0.0 <= tmin && tmin <= tmax
     }
 }
 


### PR DESCRIPTION
This made submenu popups stay open when they perhaps shouldn't be
