### PR TITLE
Fixes Drag and Dropping multiple layered Widget Trees

### DIFF
--- a/crates/egui/src/widget_rect.rs
+++ b/crates/egui/src/widget_rect.rs
@@ -139,11 +139,6 @@ impl WidgetRects {
                 // e.g. calling `response.interact(…)` to add more interaction.
                 let (idx_in_layer, existing) = entry.get_mut();
 
-                debug_assert!(
-                    existing.layer_id == widget_rect.layer_id,
-                    "Widget changed layer_id during the frame"
-                );
-
                 // Update it:
                 existing.rect = widget_rect.rect; // last wins
                 existing.interact_rect = widget_rect.interact_rect; // last wins


### PR DESCRIPTION
I'm removing the debug assertion from the widget_rect.insert function, as it's causing problems now. If there is a change to the layer_id it's resolved later in the function, so it's unnecessary.  

* Closes <https://github.com/emilk/egui/issues/4604>
