### PR TITLE
`Grid`: set the `sizing_pass` flag during the initial sizing pass

### DIFF
--- a/crates/egui/src/grid.rs
+++ b/crates/egui/src/grid.rs
@@ -426,7 +426,10 @@ impl Grid {
         // which we do here:
         let max_rect = ui.cursor().intersect(ui.max_rect());
         ui.allocate_ui_at_rect(max_rect, |ui| {
-            ui.set_visible(prev_state.is_some()); // Avoid visible first-frame jitter
+            if prev_state.is_none() {
+                // Hide the ui this frame, and make things as narrow as possible.
+                ui.set_sizing_pass();
+            }
             ui.horizontal(|ui| {
                 let is_color = color_picker.is_some();
                 let mut grid = GridLayout {


### PR DESCRIPTION
* Part of https://github.com/emilk/egui/issues/4535

This should improve the auto-sizing of columns when nesting expanding widgets (e.g. `Separator`), or centered or justified layouts.