### PR TITLE
Set the `sizing_pass` flag in first frame of `egui_extras::Table`

### DIFF
--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -437,8 +437,11 @@ impl<'a> TableBuilder<'a> {
 
         let table_top = ui.cursor().top();
 
-        // Hide first-frame-jitters when auto-sizing.
-        ui.add_visible_ui(!first_frame_auto_size_columns, |ui| {
+        ui.scope(|ui| {
+            if first_frame_auto_size_columns {
+                // Hide first-frame-jitters when auto-sizing.
+                ui.set_sizing_pass();
+            }
             let mut layout = StripLayout::new(ui, CellDirection::Horizontal, cell_layout, sense);
             let mut response: Option<Response> = None;
             add_header_row(TableRow {
@@ -648,7 +651,11 @@ impl<'a> Table<'a> {
             let clip_rect = ui.clip_rect();
 
             // Hide first-frame-jitters when auto-sizing.
-            ui.add_visible_ui(!first_frame_auto_size_columns, |ui| {
+            ui.scope(|ui| {
+                if first_frame_auto_size_columns {
+                    ui.set_sizing_pass();
+                }
+
                 let hovered_row_index_id = self.state_id.with("__table_hovered_row");
                 let hovered_row_index =
                     ui.data_mut(|data| data.remove_temp::<usize>(hovered_row_index_id));


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/4535

This should improve the auto-sizing of columns when nesting expanding widgets (e.g. `Separator`), or centered or justified layouts.