### PR TITLE
Add tags to `UiStack`

### DIFF
--- a/crates/egui/src/containers/frame.rs
+++ b/crates/egui/src/containers/frame.rs
@@ -253,10 +253,7 @@ impl Frame {
         let content_ui = ui.child_ui(
             inner_rect,
             *ui.layout(),
-            Some(UiStackInfo {
-                frame: self,
-                kind: Some(UiKind::Frame),
-            }),
+            Some(UiStackInfo::new(UiKind::Frame).with_frame(self)),
         );
 
         // content_ui.set_clip_rect(outer_rect_bounds.shrink(self.stroke.width * 0.5)); // Can't do this since we don't know final size yet

--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -362,10 +362,7 @@ impl SidePanel {
             self.id,
             available_rect,
             clip_rect,
-            UiStackInfo {
-                kind: None, // set by show_inside_dyn
-                frame: Frame::default(),
-            },
+            UiStackInfo::default(),
         );
 
         let inner_response = self.show_inside_dyn(&mut panel_ui, add_contents);
@@ -848,10 +845,7 @@ impl TopBottomPanel {
             self.id,
             available_rect,
             clip_rect,
-            UiStackInfo {
-                kind: None, // set by show_inside_dyn
-                frame: Frame::default(),
-            },
+            UiStackInfo::default(), // set by show_inside_dyn
         );
 
         let inner_response = self.show_inside_dyn(&mut panel_ui, add_contents);
@@ -1120,10 +1114,7 @@ impl CentralPanel {
             id,
             available_rect,
             clip_rect,
-            UiStackInfo {
-                kind: None, // set by show_inside_dyn
-                frame: Frame::default(),
-            },
+            UiStackInfo::default(), // set by show_inside_dyn
         );
 
         let inner_response = self.show_inside_dyn(&mut panel_ui, add_contents);

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -94,8 +94,7 @@ impl Ui {
         let ui_stack = UiStack {
             id,
             layout_direction: layout.main_dir,
-            kind: ui_stack_info.kind,
-            frame: ui_stack_info.frame,
+            info: ui_stack_info,
             parent: None,
             min_rect: placer.min_rect(),
             max_rect: placer.max_rect(),
@@ -130,6 +129,8 @@ impl Ui {
     ///
     /// Note: calling this function twice from the same [`Ui`] will create a conflict of id. Use
     /// [`Self::scope`] if needed.
+    ///
+    /// When in doubt, use `None` for the `UiStackInfo` argument.
     pub fn child_ui(
         &mut self,
         max_rect: Rect,
@@ -140,6 +141,8 @@ impl Ui {
     }
 
     /// Create a new [`Ui`] at a specific region with a specific id.
+    ///
+    /// When in doubt, use `None` for the `UiStackInfo` argument.
     pub fn child_ui_with_id_source(
         &mut self,
         max_rect: Rect,
@@ -162,12 +165,10 @@ impl Ui {
 
         let new_id = self.id.with(id_source);
         let placer = Placer::new(max_rect, layout);
-        let ui_stack_info = ui_stack_info.unwrap_or_default();
         let ui_stack = UiStack {
             id: new_id,
             layout_direction: layout.main_dir,
-            kind: ui_stack_info.kind,
-            frame: ui_stack_info.frame,
+            info: ui_stack_info.unwrap_or_default(),
             parent: Some(self.stack.clone()),
             min_rect: placer.min_rect(),
             max_rect: placer.max_rect(),

--- a/crates/egui/src/ui_stack.rs
+++ b/crates/egui/src/ui_stack.rs
@@ -100,8 +100,7 @@ impl UiStackInfo {
 pub struct UiStack {
     // stuff that `Ui::child_ui` can deal with directly
     pub id: Id,
-    pub kind: Option<UiKind>,
-    pub frame: Frame,
+    pub info: UiStackInfo,
     pub layout_direction: Direction,
     pub min_rect: Rect,
     pub max_rect: Rect,
@@ -110,10 +109,20 @@ pub struct UiStack {
 
 // these methods act on this specific node
 impl UiStack {
+    #[inline]
+    pub fn kind(&self) -> Option<UiKind> {
+        self.info.kind
+    }
+
+    #[inline]
+    pub fn frame(&self) -> &Frame {
+        &self.info.frame
+    }
+
     /// Is this [`crate::Ui`] a panel?
     #[inline]
     pub fn is_panel_ui(&self) -> bool {
-        self.kind.map_or(false, |kind| kind.is_panel())
+        self.kind().map_or(false, |kind| kind.is_panel())
     }
 
     /// Is this a root [`crate::Ui`], i.e. created with [`crate::Ui::new()`]?
@@ -125,7 +134,7 @@ impl UiStack {
     /// This this [`crate::Ui`] a [`crate::Frame`] with a visible stroke?
     #[inline]
     pub fn has_visible_frame(&self) -> bool {
-        !self.frame.stroke.is_empty()
+        !self.info.frame.stroke.is_empty()
     }
 }
 
@@ -139,7 +148,7 @@ impl UiStack {
 
     /// Check if this node is or is contained in a [`crate::Ui`] of a specific kind.
     pub fn contained_in(&self, kind: UiKind) -> bool {
-        self.iter().any(|frame| frame.kind == Some(kind))
+        self.iter().any(|frame| frame.kind() == Some(kind))
     }
 }
 

--- a/crates/egui/src/ui_stack.rs
+++ b/crates/egui/src/ui_stack.rs
@@ -116,7 +116,7 @@ impl UiStackInfo {
 /// User-chosen tags.
 ///
 /// You can use this in any way you want,
-/// i.e. to set some tag on a [`Ui`] and then in your own widget check
+/// i.e. to set some tag on a [`crate::Ui`] and then in your own widget check
 /// for the existence of this tag up the [`UiStack`].
 ///
 /// Note that egui never sets any tags itself, so this is purely for user code.

--- a/crates/egui/src/ui_stack.rs
+++ b/crates/egui/src/ui_stack.rs
@@ -120,6 +120,8 @@ impl UiStackInfo {
 /// for the existence of this tag up the [`UiStack`].
 ///
 /// Note that egui never sets any tags itself, so this is purely for user code.
+///
+/// All tagging is transient, and will only live as long as the parent [`crate::Ui`], i.e. within a single render frame.
 #[derive(Clone, Default, Debug)]
 pub struct UiTags(pub ahash::HashMap<String, Option<Arc<dyn Any + Send + Sync + 'static>>>);
 

--- a/crates/egui/src/ui_stack.rs
+++ b/crates/egui/src/ui_stack.rs
@@ -54,6 +54,7 @@ pub enum UiKind {
 
 impl UiKind {
     /// Is this any kind of panel?
+    #[inline]
     pub fn is_panel(&self) -> bool {
         matches!(
             self,
@@ -63,6 +64,29 @@ impl UiKind {
                 | Self::TopPanel
                 | Self::BottomPanel
         )
+    }
+
+    /// Is this any kind of [`crate::Area`]?
+    #[inline]
+    pub fn is_area(&self) -> bool {
+        match self {
+            Self::CentralPanel
+            | Self::LeftPanel
+            | Self::RightPanel
+            | Self::TopPanel
+            | Self::BottomPanel
+            | Self::Frame
+            | Self::ScrollArea
+            | Self::Resize
+            | Self::TableCell => false,
+
+            Self::Window
+            | Self::Menu
+            | Self::Popup
+            | Self::Tooltip
+            | Self::Picker
+            | Self::GenericArea => true,
+        }
     }
 }
 

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -547,7 +547,7 @@ fn ui_stack_demo(ui: &mut Ui) {
                         });
 
                         row.col(|ui| {
-                            ui.label(if let Some(kind) = node.kind {
+                            ui.label(if let Some(kind) = node.kind() {
                                 format!("{kind:?}")
                             } else {
                                 "-".to_owned()

--- a/tests/test_ui_stack/src/main.rs
+++ b/tests/test_ui_stack/src/main.rs
@@ -209,9 +209,9 @@ fn full_span_horizontal_range(ui_stack: &egui::UiStack) -> Rangef {
         if node.has_visible_frame()
             || node.is_panel_ui()
             || node.is_root_ui()
-            || node.kind == Some(UiKind::TableCell)
+            || node.kind() == Some(UiKind::TableCell)
         {
-            return (node.max_rect + node.frame.inner_margin).x_range();
+            return (node.max_rect + node.frame().inner_margin).x_range();
         }
     }
 
@@ -280,7 +280,7 @@ fn stack_ui_impl(ui: &mut egui::Ui, stack: &egui::UiStack) {
                             }
                         });
                         row.col(|ui| {
-                            let s = if let Some(kind) = node.kind {
+                            let s = if let Some(kind) = node.kind() {
                                 format!("{kind:?}")
                             } else {
                                 "-".to_owned()
@@ -289,7 +289,8 @@ fn stack_ui_impl(ui: &mut egui::Ui, stack: &egui::UiStack) {
                             ui.label(s);
                         });
                         row.col(|ui| {
-                            if node.frame.stroke == egui::Stroke::NONE {
+                            let frame = node.frame();
+                            if frame.stroke == egui::Stroke::NONE {
                                 ui.label("-");
                             } else {
                                 let mut layout_job = egui::text::LayoutJob::default();
@@ -298,11 +299,11 @@ fn stack_ui_impl(ui: &mut egui::Ui, stack: &egui::UiStack) {
                                     0.0,
                                     egui::TextFormat::simple(
                                         egui::TextStyle::Body.resolve(ui.style()),
-                                        node.frame.stroke.color,
+                                        frame.stroke.color,
                                     ),
                                 );
                                 layout_job.append(
-                                    format!("{}px", node.frame.stroke.width).as_str(),
+                                    format!("{}px", frame.stroke.width).as_str(),
                                     0.0,
                                     egui::TextFormat::simple(
                                         egui::TextStyle::Body.resolve(ui.style()),
@@ -314,10 +315,10 @@ fn stack_ui_impl(ui: &mut egui::Ui, stack: &egui::UiStack) {
                             }
                         });
                         row.col(|ui| {
-                            ui.label(print_margin(&node.frame.inner_margin));
+                            ui.label(print_margin(&node.frame().inner_margin));
                         });
                         row.col(|ui| {
-                            ui.label(print_margin(&node.frame.outer_margin));
+                            ui.label(print_margin(&node.frame().outer_margin));
                         });
                         row.col(|ui| {
                             ui.label(format!("{:?}", node.layout_direction));


### PR DESCRIPTION
You can now set custom tags on the `UiStack`. This allows you to write code that is situationally aware at runtime. For instance, you could decide wether or not a label should truncate its text depending on what part of your ui it is in, without having to pass that info down via the callstack.