### PR TITLE
Move first `request_animation_frame` into resize observer

### DIFF
--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -188,6 +188,7 @@ impl AppRunner {
     /// The result can be painted later with a call to [`Self::run_and_paint`] or [`Self::paint`].
     pub fn logic(&mut self) {
         let canvas_size = super::canvas_size_in_points(self.canvas(), self.egui_ctx());
+        log::info!("LOGIC {canvas_size:?}");
         let raw_input = self.input.new_frame(canvas_size);
 
         let full_output = self.egui_ctx.run(raw_input, |egui_ctx| {

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -188,7 +188,6 @@ impl AppRunner {
     /// The result can be painted later with a call to [`Self::run_and_paint`] or [`Self::paint`].
     pub fn logic(&mut self) {
         let canvas_size = super::canvas_size_in_points(self.canvas(), self.egui_ctx());
-        log::info!("LOGIC {canvas_size:?}");
         let raw_input = self.input.new_frame(canvas_size);
 
         let full_output = self.egui_ctx.run(raw_input, |egui_ctx| {

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -630,11 +630,6 @@ pub(crate) fn install_resize_observer(runner_ref: &WebRunner) -> Result<(), JsVa
                         return;
                     }
                 };
-                log::info!(
-                    "ResizeObserver canvas={:?} to={:?}",
-                    super::canvas_size_in_points(canvas, runner_lock.egui_ctx()),
-                    (width, height),
-                );
                 canvas.set_width(width);
                 canvas.set_height(height);
 

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -608,6 +608,14 @@ pub(crate) fn install_canvas_events(runner_ref: &WebRunner) -> Result<(), JsValu
     Ok(())
 }
 
+/// Install a `ResizeObserver` to observe changes to the size of the canvas.
+///
+/// This is the only way to ensure a canvas size change without an associated window `resize` event
+/// actually results in a resize of the canvas.
+///
+/// The resize observer is called the by the browser at `observe` time, instead of just on the first actual resize.
+/// We use that to trigger the first `request_animation_frame` _after_ updating the size of the canvas to the correct dimensions,
+/// to avoid [#4622](https://github.com/emilk/egui/issues/4622).
 pub(crate) fn install_resize_observer(runner_ref: &WebRunner) -> Result<(), JsValue> {
     let closure = Closure::wrap(Box::new({
         let runner_ref = runner_ref.clone();
@@ -622,12 +630,22 @@ pub(crate) fn install_resize_observer(runner_ref: &WebRunner) -> Result<(), JsVa
                         return;
                     }
                 };
+                log::info!(
+                    "ResizeObserver canvas={:?} to={:?}",
+                    super::canvas_size_in_points(canvas, runner_lock.egui_ctx()),
+                    (width, height),
+                );
                 canvas.set_width(width);
                 canvas.set_height(height);
 
                 // force an immediate repaint
                 runner_lock.needs_repaint.repaint_asap();
                 paint_if_needed(&mut runner_lock);
+                drop(runner_lock);
+                // we rely on the resize observer to trigger the first `request_animation_frame`:
+                if let Err(err) = runner_ref.request_animation_frame() {
+                    log::error!("{}", super::string_from_js_value(&err));
+                };
             }
         }
     }) as Box<dyn FnMut(js_sys::Array)>);

--- a/crates/eframe/src/web/web_runner.rs
+++ b/crates/eframe/src/web/web_runner.rs
@@ -79,9 +79,8 @@ impl WebRunner {
                 events::install_color_scheme_change_event(self)?;
             }
 
+            // The resize observer handles calling `request_animation_frame` to start the render loop.
             events::install_resize_observer(self)?;
-
-            self.request_animation_frame()?;
         }
 
         Ok(())


### PR DESCRIPTION
This PR ensures the first animation frame happens _after_ the resize observer has had a chance to do its job.

* Closes https://github.com/emilk/egui/issues/4622

The first commit contains some `log` calls to observe the changed behavior:

Before:
```
[eframe::web::app_runner] eframe/src/web/app_runner.rs:191: LOGIC [300.0 150.0]
[eframe::web::events] eframe/src/web/events.rs:633: ResizeObserver canvas=[300.0 150.0] to=(1920, 993)
[eframe::web::app_runner] eframe/src/web/app_runner.rs:191: LOGIC [1920.0 993.0]
[eframe::web::app_runner] eframe/src/web/app_runner.rs:191: LOGIC [1920.0 993.0]
```

After:
```
[eframe::web::events] eframe/src/web/events.rs:633: ResizeObserver canvas=[300.0 150.0] to=(1920, 993)
[eframe::web::app_runner] eframe/src/web/app_runner.rs:191: LOGIC [1920.0 993.0]
[eframe::web::app_runner] eframe/src/web/app_runner.rs:191: LOGIC [1920.0 993.0]
```
