### PR TITLE
`egui_extras`: Make `serde` an optional feature

### DIFF
--- a/crates/egui_demo_app/Cargo.toml
+++ b/crates/egui_demo_app/Cargo.toml
@@ -26,7 +26,7 @@ web_app = ["http", "persistence"]
 
 http = ["ehttp", "image", "poll-promise", "egui_extras/image"]
 image_viewer = ["image", "egui_extras/all_loaders", "rfd"]
-persistence = ["eframe/persistence", "egui/persistence", "serde"]
+persistence = ["eframe/persistence", "egui/persistence", "serde", "egui_extras/serde"]
 puffin = ["eframe/puffin", "dep:puffin", "dep:puffin_http"]
 serde = ["dep:serde", "egui_demo_lib/serde", "egui/serde"]
 syntect = ["egui_demo_lib/syntect"]

--- a/crates/egui_demo_lib/Cargo.toml
+++ b/crates/egui_demo_lib/Cargo.toml
@@ -34,7 +34,7 @@ default = []
 chrono = ["egui_extras/datepicker", "dep:chrono"]
 
 ## Allow serialization using [`serde`](https://docs.rs/serde).
-serde = ["egui/serde", "egui_plot/serde", "dep:serde"]
+serde = ["egui/serde", "egui_plot/serde", "dep:serde", "egui_extras/serde"]
 
 ## Enable better syntax highlighting using [`syntect`](https://docs.rs/syntect).
 syntect = ["egui_extras/syntect"]

--- a/crates/egui_extras/Cargo.toml
+++ b/crates/egui_extras/Cargo.toml
@@ -60,16 +60,21 @@ svg = ["resvg"]
 ## Enable better syntax highlighting using [`syntect`](https://docs.rs/syntect).
 syntect = ["dep:syntect"]
 
+## Derive serde Serialize/Deserialize on stateful structs
+serde = ["egui/serde", "dep:serde"]
+
 
 [dependencies]
-egui = { workspace = true, default-features = false, features = ["serde"] }
+egui = { workspace = true, default-features = false }
 
 ahash.workspace = true
 enum-map = { version = "2", features = ["serde"] }
 log.workspace = true
-serde.workspace = true
 
 #! ### Optional dependencies
+
+# Serde for serializing state
+serde = { workspace = true, optional = true }
 
 # Date operations needed for datepicker widget
 chrono = { version = "0.4", optional = true, default-features = false, features = [

--- a/crates/egui_extras/src/datepicker/button.rs
+++ b/crates/egui_extras/src/datepicker/button.rs
@@ -2,7 +2,8 @@ use super::popup::DatePickerPopup;
 use chrono::NaiveDate;
 use egui::{Area, Button, Frame, InnerResponse, Key, Order, RichText, Ui, Widget};
 
-#[derive(Default, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub(crate) struct DatePickerButtonState {
     pub picker_visible: bool,
 }

--- a/crates/egui_extras/src/datepicker/popup.rs
+++ b/crates/egui_extras/src/datepicker/popup.rs
@@ -6,7 +6,8 @@ use super::{button::DatePickerButtonState, month_data};
 
 use crate::{Column, Size, StripBuilder, TableBuilder};
 
-#[derive(Default, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 struct DatePickerPopupState {
     year: i32,
     month: u32,

--- a/crates/egui_extras/src/syntax_highlighting.rs
+++ b/crates/egui_extras/src/syntax_highlighting.rs
@@ -40,7 +40,8 @@ pub fn highlight(ctx: &egui::Context, theme: &CodeTheme, code: &str, language: &
 // ----------------------------------------------------------------------------
 
 #[cfg(not(feature = "syntect"))]
-#[derive(Clone, Copy, PartialEq, serde::Deserialize, serde::Serialize, enum_map::Enum)]
+#[derive(Clone, Copy, PartialEq, enum_map::Enum)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 enum TokenType {
     Comment,
     Keyword,
@@ -51,7 +52,8 @@ enum TokenType {
 }
 
 #[cfg(feature = "syntect")]
-#[derive(Clone, Copy, Hash, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Copy, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 enum SyntectTheme {
     Base16EightiesDark,
     Base16MochaDark,
@@ -115,8 +117,12 @@ impl SyntectTheme {
 }
 
 /// A selected color theme.
-#[derive(Clone, Hash, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(default)]
+#[derive(Clone, Hash, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(default)
+)]
 pub struct CodeTheme {
     dark_mode: bool,
 

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -528,7 +528,8 @@ impl<'a> TableBuilder<'a> {
 
 // ----------------------------------------------------------------------------
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 struct TableState {
     column_widths: Vec<f32>,
 }

--- a/tests/test_ui_stack/Cargo.toml
+++ b/tests/test_ui_stack/Cargo.toml
@@ -19,7 +19,7 @@ eframe = { workspace = true, features = [
 ] }
 
 # For image support:
-egui_extras = { workspace = true, features = ["default", "image"] }
+egui_extras = { workspace = true, features = ["default", "image", "serde"] }
 
 env_logger = { version = "0.10", default-features = false, features = [
   "auto-color",


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

All the other crates in egui have serde as an optional dependency - which is great! But sadly egui_extras unconditionally includes it, which adds a bunch of code to stuff that may not care for it. This PR gates serde support behind a new `serde` feature.

This is a breaking change; if that's undesirable then we can add it as a default feature instead, though that wouldn't match any of the other crates.