### PR TITLE
Fix dead link to mycomarkup in easy_mark sample

### DIFF
--- a/crates/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/crates/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -277,5 +277,5 @@ The style characters are chosen to be similar to what they are representing:
   - `<url>` and `[url](url)` do the same thing yet look completely different.
   - let's keep similarity with images
 - Tables
-- Inspiration: <https://mycorrhiza.lesarbr.es/page/mycomarkup>
+- Inspiration: <https://mycorrhiza.wiki/help/en/mycomarkup>
 "#;


### PR DESCRIPTION
This is a very minor fix, but I noticed the link in the default text was dead, so I found a link to the same project which works.
