### PR TITLE
Try to improve support for .notdef glyphs through `FontTweak`

### DIFF
--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -78,6 +78,8 @@ pub struct FontImpl {
     pixels_per_point: f32,
     glyph_info_cache: RwLock<ahash::HashMap<char, GlyphInfo>>, // TODO(emilk): standard Mutex
     atlas: Arc<Mutex<TextureAtlas>>,
+
+    fallbacks: [char; 2],
 }
 
 impl FontImpl {
@@ -132,6 +134,7 @@ impl FontImpl {
             pixels_per_point,
             glyph_info_cache: Default::default(),
             atlas,
+            fallbacks: tweak.fallbacks.unwrap_or(['◻', '?']),
         }
     }
 
@@ -363,20 +366,23 @@ impl Font {
             glyph_info_cache: Default::default(),
         };
 
-        const PRIMARY_REPLACEMENT_CHAR: char = '◻'; // white medium square
-        const FALLBACK_REPLACEMENT_CHAR: char = '?'; // fallback for the fallback
-
-        let replacement_glyph = slf
-            .glyph_info_no_cache_or_fallback(PRIMARY_REPLACEMENT_CHAR)
-            .or_else(|| slf.glyph_info_no_cache_or_fallback(FALLBACK_REPLACEMENT_CHAR))
+        // For each font, find the first available fallback character
+        slf.replacement_glyph = slf
+            .fonts
+            .iter()
+            .enumerate()
+            .find_map(|(font_index, font_impl)| {
+                font_impl.fallbacks.iter().find_map(|chr| {
+                    font_impl
+                        .glyph_info(*chr)
+                        .map(|glyph_info| (font_index, glyph_info))
+                })
+            })
             .unwrap_or_else(|| {
                 #[cfg(feature = "log")]
-                log::warn!(
-                    "Failed to find replacement characters {PRIMARY_REPLACEMENT_CHAR:?} or {FALLBACK_REPLACEMENT_CHAR:?}. Will use empty glyph."
-                );
+                log::warn!("Failed to find replacement characters. Will use empty glyph.");
                 (0, GlyphInfo::default())
             });
-        slf.replacement_glyph = replacement_glyph;
 
         slf
     }
@@ -434,7 +440,7 @@ impl Font {
 
     /// Can we display this glyph?
     pub fn has_glyph(&mut self, c: char) -> bool {
-        self.glyph_info(c) != self.replacement_glyph // TODO(emilk): this is a false negative if the user asks about the replacement character itself 🤦‍♂️
+        self.glyph_info_no_cache_or_fallback(c).is_some()
     }
 
     /// Can we display all the glyphs in this text?

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -174,6 +174,10 @@ pub struct FontTweak {
     /// A positive value shifts the text downwards.
     /// A negative value shifts it upwards.
     pub baseline_offset_factor: f32,
+
+    /// Fallback characters for this font
+    /// The default value is handled to be either the square character, or the question mark.
+    pub fallbacks: Option<[char; 2]>,
 }
 
 impl Default for FontTweak {
@@ -183,6 +187,7 @@ impl Default for FontTweak {
             y_offset_factor: 0.0,
             y_offset: 0.0,
             baseline_offset_factor: -0.0333, // makes the default fonts look more centered in buttons and such
+            fallbacks: None,
         }
     }
 }


### PR DESCRIPTION
The idea consists of adding `fallbacks` to the `FontTweak` structure, which then get used in egui's `Font` (actually a wrapper over multiple `FontImpl`) to identify fallback characters. We look through each wrapped `FontImpl`, stopping in the first fallback character we found, defaulting to the empty glyph if none is found.

Example output when replacing the user font by `MaterialSymbolsSharp` in the egui custom font example:
![image](https://github.com/emilk/egui/assets/563936/b833d585-64d5-4068-a96d-87a6f16dd0ce)

```rust
impl eframe::App for MyApp {
    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
        egui::CentralPanel::default().show(ctx, |ui| {
            ui.heading("\u{E834} egui using custom fonts");
            ui.text_edit_multiline(&mut self.text);
        });
    }
}
```

Note that as it is (mostly due to my very limited understanding of fonts in general), this isn't enough to load .notdef properly, even with a user-definied fallback character set. I suspect this however has to do with `ttf_parser` seemingly not actually loading .notdef.

* Closes <https://github.com/emilk/egui/issues/3526> (this one was technically originally closed by <https://github.com/emilk/egui/pull/4542>)
* See <https://github.com/emilk/egui/issues/4642>
