### PR TITLE
Fix: On windows, Strange IME display

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -832,8 +832,7 @@ impl State {
             if self.allow_ime != ime.allowed_ime {
                 self.allow_ime = ime.allowed_ime;
                 crate::profile_scope!("set_ime_allowed");
-                self.egui_ctx
-                    .send_viewport_cmd(ViewportCommand::IMEAllowed(self.allow_ime));
+                window.set_ime_allowed(self.allow_ime);
             }
 
             let pixels_per_point = pixels_per_point(&self.egui_ctx, window);
@@ -845,8 +844,16 @@ impl State {
             if ime.visible && is_need_cursor_area {
                 self.ime_rect_px = Some(ime_rect_px);
                 crate::profile_scope!("set_ime_cursor_area");
-                self.egui_ctx
-                    .send_viewport_cmd(ViewportCommand::IMERect(ime.cursor_rect));
+                window.set_ime_cursor_area(
+                    winit::dpi::PhysicalPosition {
+                        x: ime_rect_px.min.x,
+                        y: ime_rect_px.min.y,
+                    },
+                    winit::dpi::PhysicalSize {
+                        width: ime_rect_px.width(),
+                        height: ime_rect_px.height(),
+                    },
+                );
             } else {
                 self.ime_rect_px = None;
             }

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -828,34 +828,28 @@ impl State {
             self.clipboard.set(copied_text);
         }
 
-        let allow_ime = ime.is_some();
-        if self.allow_ime != allow_ime {
-            self.allow_ime = allow_ime;
-            crate::profile_scope!("set_ime_allowed");
-            window.set_ime_allowed(allow_ime);
-        }
-
         if let Some(ime) = ime {
+            if self.allow_ime != ime.allowed_ime {
+                self.allow_ime = ime.allowed_ime;
+                crate::profile_scope!("set_ime_allowed");
+                self.egui_ctx
+                    .send_viewport_cmd(ViewportCommand::IMEAllowed(self.allow_ime));
+            }
+
             let pixels_per_point = pixels_per_point(&self.egui_ctx, window);
-            let ime_rect_px = pixels_per_point * ime.rect;
-            if self.ime_rect_px != Some(ime_rect_px)
-                || self.egui_ctx.input(|i| !i.events.is_empty())
-            {
+            let ime_rect_px = ime.cursor_rect * pixels_per_point;
+
+            let is_need_cursor_area = self.ime_rect_px != Some(ime_rect_px)
+                && self.egui_ctx.input(|i| !i.events.is_empty());
+
+            if ime.visible && is_need_cursor_area {
                 self.ime_rect_px = Some(ime_rect_px);
                 crate::profile_scope!("set_ime_cursor_area");
-                window.set_ime_cursor_area(
-                    winit::dpi::PhysicalPosition {
-                        x: ime_rect_px.min.x,
-                        y: ime_rect_px.min.y,
-                    },
-                    winit::dpi::PhysicalSize {
-                        width: ime_rect_px.width(),
-                        height: ime_rect_px.height(),
-                    },
-                );
+                self.egui_ctx
+                    .send_viewport_cmd(ViewportCommand::IMERect(ime.cursor_rect));
+            } else {
+                self.ime_rect_px = None;
             }
-        } else {
-            self.ime_rect_px = None;
         }
 
         #[cfg(feature = "accesskit")]
@@ -1441,14 +1435,18 @@ fn process_viewport_command(
             let winit_icon = icon.and_then(|icon| to_winit_icon(&icon));
             window.set_window_icon(winit_icon);
         }
-        ViewportCommand::IMERect(rect) => {
+        ViewportCommand::IMERect(ime_rect) => {
+            let ime_rect_px = ime_rect * pixels_per_point;
             window.set_ime_cursor_area(
-                PhysicalPosition::new(pixels_per_point * rect.min.x, pixels_per_point * rect.min.y),
-                PhysicalSize::new(
-                    pixels_per_point * rect.size().x,
-                    pixels_per_point * rect.size().y,
-                ),
+                PhysicalPosition::new(ime_rect_px.min.x, ime_rect_px.min.y),
+                PhysicalSize::new(ime_rect_px.width(), ime_rect_px.height()),
             );
+
+            egui_ctx.output_mut(|o| {
+                if let Some(ime) = &mut o.ime {
+                    ime.cursor_rect = ime_rect;
+                }
+            });
         }
         ViewportCommand::IMEAllowed(v) => window.set_ime_allowed(v),
         ViewportCommand::IMEPurpose(p) => window.set_ime_purpose(match p {

--- a/crates/egui/src/data/output.rs
+++ b/crates/egui/src/data/output.rs
@@ -70,6 +70,12 @@ impl FullOutput {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct IMEOutput {
+    /// is visible IME?
+    pub visible: bool,
+
+    /// is allowed IME?
+    pub allowed_ime: bool,
+
     /// Where the [`crate::TextEdit`] is located on screen.
     pub rect: crate::Rect,
 

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -694,6 +694,12 @@ pub struct TextCursorStyle {
 
     /// When blinking, this is how long the cursor is invisible.
     pub off_duration: f32,
+
+    /// Whether the IME (Input Method Editor) is allowed.
+    pub ime_allowed: bool,
+
+    /// Whether the IME should be visible.
+    pub ime_visible: bool,
 }
 
 impl Default for TextCursorStyle {
@@ -704,6 +710,8 @@ impl Default for TextCursorStyle {
             blink: true,
             on_duration: 0.5,
             off_duration: 0.5,
+            ime_allowed: true,
+            ime_visible: false,
         }
     }
 }
@@ -1979,6 +1987,8 @@ impl TextCursorStyle {
             blink,
             on_duration,
             off_duration,
+            ime_allowed,
+            ime_visible,
         } = self;
 
         ui.horizontal(|ui| {
@@ -2011,6 +2021,10 @@ impl TextCursorStyle {
                 ui.end_row();
             });
         }
+
+        ui.checkbox(ime_allowed, "Whether the IME is allowed.");
+
+        ui.checkbox(ime_visible, "Whether the IME should be visible");
     }
 }
 

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -2022,7 +2022,7 @@ impl TextCursorStyle {
             });
         }
 
-        ui.checkbox(ime_allowed, "Whether the IME is allowed.");
+        ui.checkbox(ime_allowed, "Whether the IME is allowed");
 
         ui.checkbox(ime_visible, "Whether the IME should be visible");
     }

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -729,9 +729,13 @@ impl<'t> TextEdit<'t> {
                             .unwrap_or_default();
 
                         ui.ctx().output_mut(|o| {
+                            let mut ime_cursor_rect = primary_cursor_rect;
+                            ime_cursor_rect.max.x += primary_cursor_rect.height();
                             o.ime = Some(crate::output::IMEOutput {
+                                visible: true,
+                                allowed_ime: true,
                                 rect: transform * rect,
-                                cursor_rect: transform * primary_cursor_rect,
+                                cursor_rect: transform * ime_cursor_rect,
                             });
                         });
                     }

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -732,8 +732,8 @@ impl<'t> TextEdit<'t> {
                             let mut ime_cursor_rect = primary_cursor_rect;
                             ime_cursor_rect.max.x += primary_cursor_rect.height();
                             o.ime = Some(crate::output::IMEOutput {
-                                visible: true,
-                                allowed_ime: true,
+                                visible: ui.visuals().text_cursor.ime_visible,
+                                allowed_ime: ui.visuals().text_cursor.ime_allowed,
                                 rect: transform * rect,
                                 cursor_rect: transform * ime_cursor_rect,
                             });


### PR DESCRIPTION
Fix: On windows, Strange IME display

* Related #4254
* Related #4269
* Closes #4362 

1. Fix: On windows, Strange IME display after update #4269
2. `IME allowed` selectable
3. `IME visible` selectable
4. The IME was appearing in a strange place, now it displays below the text cursor.

  
