### PR TITLE
Make sure to call `raw_input_hook` on web

### DIFF
--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -188,7 +188,9 @@ impl AppRunner {
     /// The result can be painted later with a call to [`Self::run_and_paint`] or [`Self::paint`].
     pub fn logic(&mut self) {
         let canvas_size = super::canvas_size_in_points(self.canvas(), self.egui_ctx());
-        let raw_input = self.input.new_frame(canvas_size);
+        let mut raw_input = self.input.new_frame(canvas_size);
+
+        self.app.raw_input_hook(&self.egui_ctx, &mut raw_input);
 
         let full_output = self.egui_ctx.run(raw_input, |egui_ctx| {
             self.app.update(egui_ctx, &mut self.frame);


### PR DESCRIPTION
## What's new
* Extends @varphone's excellent `raw_input_hook` idea from https://github.com/emilk/egui/pull/4008 to `web/app_runner`.

## Details
Debugging this locally after my app's `raw_input_hook` wasn't being called, I realized it's not in the code path of eframe's web runner, only the native integration. Below is a toy example running on the web.

https://github.com/emilk/egui/assets/8173478/d470b7e6-d393-4ead-9745-3aafc72ae6bc

