### PR TITLE
Fix custom_window_frame example

### DIFF
--- a/examples/custom_window_frame/src/main.rs
+++ b/examples/custom_window_frame/src/main.rs
@@ -112,7 +112,7 @@ fn title_bar_ui(ui: &mut egui::Ui, title_bar_rect: eframe::epaint::Rect, title: 
             .send_viewport_cmd(ViewportCommand::Maximized(!is_maximized));
     }
 
-    if title_bar_response.dragged_by(PointerButton::Primary) {
+    if title_bar_response.drag_started_by(PointerButton::Primary) {
         ui.ctx().send_viewport_cmd(ViewportCommand::StartDrag);
     }
 


### PR DESCRIPTION
Using `dragged_by` caused the `StartDrag` command to be spammed, which in turn caused that you couldn't stop dragging the frame because the window was repeatly being told to start dragging. Use `drag_started_by` which will only send the `StartDrag` command once at the begin.