### PR TITLE
Don't hover things under tooltips

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -24,9 +24,6 @@ pub struct AreaState {
     /// Last known size.
     pub size: Vec2,
 
-    /// If false, clicks goes straight through to what is behind us. Useful for tooltips etc.
-    pub interactable: bool,
-
     /// At what time was this area first shown?
     ///
     /// Used to fade in the area.
@@ -397,12 +394,10 @@ impl Area {
                 pivot_pos: default_pos.unwrap_or_else(|| automatic_area_position(ctx)),
                 pivot,
                 size,
-                interactable,
                 last_became_visible_at: ctx.input(|i| i.time),
             }
         });
         state.pivot_pos = new_pos.unwrap_or(state.pivot_pos);
-        state.interactable = interactable;
 
         // TODO(emilk): if last frame was sizing pass, it should be considered invisible for smmother fade-in
         let visible_last_frame = ctx.memory(|mem| mem.areas().visible_last_frame(&layer_id));

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -498,7 +498,6 @@ impl ContextImpl {
                 pivot_pos: screen_rect.left_top(),
                 pivot: Align2::LEFT_TOP,
                 size: screen_rect.size(),
-                interactable: true,
                 last_became_visible_at: f64::NEG_INFINITY,
             },
         );

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -994,14 +994,13 @@ impl Areas {
             if self.is_visible(layer) {
                 if let Some(state) = self.areas.get(&layer.id) {
                     let mut rect = state.rect();
-                    if state.interactable {
-                        if let Some(transform) = layer_transforms.get(layer) {
-                            rect = *transform * rect;
-                        }
 
-                        if rect.contains(pos) {
-                            return Some(*layer);
-                        }
+                    if let Some(transform) = layer_transforms.get(layer) {
+                        rect = *transform * rect;
+                    }
+
+                    if rect.contains(pos) {
+                        return Some(*layer);
                     }
                 }
             }

--- a/crates/egui_demo_lib/src/demo/tooltips.rs
+++ b/crates/egui_demo_lib/src/demo/tooltips.rs
@@ -81,5 +81,12 @@ impl super::View for Tooltips {
                 .on_hover_ui(tooltip_ui)
                 .on_disabled_hover_ui(disabled_tooltip_ui);
         });
+
+        ui.separator(); // ---------------------------------------------------------
+
+        ui.label("This widget has a tooltip that fills the screen")
+            .on_hover_ui(|ui| {
+                ui.allocate_exact_size(ui.ctx().screen_rect().size() * 0.8, egui::Sense::hover());
+            });
     }
 }


### PR DESCRIPTION
The removed code was added in https://github.com/emilk/egui/pull/1240 to fix https://github.com/emilk/egui/issues/1239 but a better fix for that was added in https://github.com/emilk/egui/pull/4623

So: tooltips can now have interactive stuff in them, so when hovering a tooltip we should not hover things below them.