### PR TITLE
Fix: `ScrollArea` repeatedly appears and disappears quickly issue.

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -967,9 +967,9 @@ impl Prepared {
             // left/rigth of a vertical scroll (d==1).
             let mut cross = if scroll_style.floating {
                 let max_bar_rect = if d == 0 {
-                    outer_rect.with_min_y(outer_rect.max.y - scroll_style.bar_width)
+                    outer_rect.with_min_y(outer_rect.max.y - scroll_style.bar_width - outer_margin)
                 } else {
-                    outer_rect.with_min_x(outer_rect.max.x - scroll_style.bar_width)
+                    outer_rect.with_min_x(outer_rect.max.x - scroll_style.bar_width - outer_margin)
                 };
                 let is_hovering_bar_area = is_hovering_outer_rect
                     && ui.rect_contains_pointer(max_bar_rect)

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -967,9 +967,9 @@ impl Prepared {
             // left/rigth of a vertical scroll (d==1).
             let mut cross = if scroll_style.floating {
                 let max_bar_rect = if d == 0 {
-                    outer_rect.with_min_y(outer_rect.max.y - scroll_style.allocated_width())
+                    outer_rect.with_min_y(outer_rect.max.y - scroll_style.bar_width)
                 } else {
-                    outer_rect.with_min_x(outer_rect.max.x - scroll_style.allocated_width())
+                    outer_rect.with_min_x(outer_rect.max.x - scroll_style.bar_width)
                 };
                 let is_hovering_bar_area = is_hovering_outer_rect
                     && ui.rect_contains_pointer(max_bar_rect)

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -960,10 +960,7 @@ impl Prepared {
             let main_range = Rangef::new(inner_rect.min[d], inner_rect.max[d]);
 
             // Margin on either side of the scroll bar:
-            let inner_margin = match scroll_style.floating {
-                true => 0.0,
-                false => show_factor * scroll_style.bar_inner_margin,
-            };
+            let inner_margin = show_factor * scroll_style.bar_inner_margin;
             let outer_margin = show_factor * scroll_style.bar_outer_margin;
 
             let mut max_cross = outer_rect.max[1 - d] - outer_margin;

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -960,6 +960,10 @@ impl Prepared {
             let main_range = Rangef::new(inner_rect.min[d], inner_rect.max[d]);
 
             // Margin on either side of the scroll bar:
+            let inner_margin = match scroll_style.floating {
+                true => 0.0,
+                false => show_factor * scroll_style.bar_inner_margin,
+            };
             let outer_margin = show_factor * scroll_style.bar_outer_margin;
 
             let mut max_cross = outer_rect.max[1 - d] - outer_margin;
@@ -1005,12 +1009,12 @@ impl Prepared {
 
             let outer_scroll_rect = if d == 0 {
                 Rect::from_min_max(
-                    pos2(inner_rect.left(), cross.min),
+                    pos2(inner_rect.left(), cross.min - inner_margin),
                     pos2(inner_rect.right(), cross.max),
                 )
             } else {
                 Rect::from_min_max(
-                    pos2(cross.min, inner_rect.top()),
+                    pos2(cross.min - inner_margin, inner_rect.top()),
                     pos2(cross.max, inner_rect.bottom()),
                 )
             };

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -1010,12 +1010,12 @@ impl Prepared {
             let outer_scroll_rect = if d == 0 {
                 Rect::from_min_max(
                     pos2(inner_rect.left(), cross.min - inner_margin),
-                    pos2(inner_rect.right(), cross.max),
+                    pos2(inner_rect.right(), cross.max + outer_margin),
                 )
             } else {
                 Rect::from_min_max(
                     pos2(cross.min - inner_margin, inner_rect.top()),
-                    pos2(cross.max, inner_rect.bottom()),
+                    pos2(cross.max + outer_margin, inner_rect.bottom()),
                 )
             };
 

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -401,7 +401,7 @@ pub struct ScrollStyle {
     /// When the user hovers the scroll bars they expand to [`Self::bar_width`].
     pub floating_width: f32,
 
-    /// How much space i allocated for a floating scroll bar?
+    /// How much space is allocated for a floating scroll bar?
     ///
     /// Normally this is zero, but you could set this to something small
     /// like 4.0 and set [`Self::dormant_handle_opacity`] and
@@ -499,7 +499,7 @@ impl ScrollStyle {
             active_background_opacity: 1.0,
             active_handle_opacity: 1.0,
 
-            // Be tranlucent when expanded so we can see the content
+            // Be translucent when expanded so we can see the content
             interact_background_opacity: 0.6,
             interact_handle_opacity: 0.6,
 
@@ -514,6 +514,7 @@ impl ScrollStyle {
         Self {
             floating: true,
             bar_width: 10.0,
+            bar_inner_margin: 0.0,
             foreground_color: true,
             floating_allocated_width: 0.0,
             dormant_background_opacity: 0.0,
@@ -590,6 +591,10 @@ impl ScrollStyle {
             ui.label("Minimum handle length");
         });
         ui.horizontal(|ui| {
+            ui.add(DragValue::new(bar_inner_margin).clamp_range(0.0..=32.0));
+            ui.label("Inner margin");
+        });
+        ui.horizontal(|ui| {
             ui.add(DragValue::new(bar_outer_margin).clamp_range(0.0..=32.0));
             ui.label("Outer margin");
         });
@@ -624,11 +629,6 @@ impl ScrollStyle {
                 opacity_ui(ui, interact_handle_opacity);
                 ui.end_row();
             });
-        } else {
-            ui.horizontal(|ui| {
-                ui.add(DragValue::new(bar_inner_margin).clamp_range(0.0..=32.0));
-                ui.label("Inner margin");
-            });
         }
     }
 }
@@ -652,7 +652,7 @@ pub struct Interaction {
     /// Radius of the interactive area of the corner of a window during drag-to-resize.
     pub resize_grab_radius_corner: f32,
 
-    /// If `false`, tooltips will show up anytime you hover anything, even is mouse is still moving
+    /// If `false`, tooltips will show up anytime you hover anything, even if mouse is still moving
     pub show_tooltips_only_when_still: bool,
 
     /// Delay in seconds before showing tooltips after the mouse stops moving
@@ -2118,7 +2118,7 @@ impl HandleShape {
 pub enum NumericColorSpace {
     /// RGB is 0-255 in gamma space.
     ///
-    /// Alpha is 0-255 in linear space .
+    /// Alpha is 0-255 in linear space.
     GammaByte,
 
     /// 0-1 in linear space.


### PR DESCRIPTION
If the mouse is at a specific position above the `ScrollArea` (in TextEdit?), the `ScrollArea` repeatedly appears and disappears quickly.
You can more easily find the issue if you set `Full bar width` to the maximum value of 32.

If there is a better way to fix this than the solution in this Pull Request, please revise it accordingly.
