### PR TITLE
Make `Debug` format of `Vec2/Pos2/Rot2` respect user precision

### DIFF
--- a/crates/emath/src/pos2.rs
+++ b/crates/emath/src/pos2.rs
@@ -319,7 +319,11 @@ impl Div<f32> for Pos2 {
 
 impl fmt::Debug for Pos2 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[{:.3} {:.3}]", self.x, self.y)
+        if let Some(precision) = f.precision() {
+            write!(f, "[{1:.0$} {2:.0$}]", precision, self.x, self.y)
+        } else {
+            write!(f, "[{:.1} {:.1}]", self.x, self.y)
+        }
     }
 }
 

--- a/crates/emath/src/pos2.rs
+++ b/crates/emath/src/pos2.rs
@@ -319,7 +319,7 @@ impl Div<f32> for Pos2 {
 
 impl fmt::Debug for Pos2 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[{:.1} {:.1}]", self.x, self.y)
+        write!(f, "[{:.3} {:.3}]", self.x, self.y)
     }
 }
 

--- a/crates/emath/src/rot2.rs
+++ b/crates/emath/src/rot2.rs
@@ -91,12 +91,22 @@ impl Rot2 {
 
 impl std::fmt::Debug for Rot2 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Rot2 {{ angle: {:.3}°, length: {} }}",
-            self.angle().to_degrees(),
-            self.length()
-        )
+        if let Some(precision) = f.precision() {
+            write!(
+                f,
+                "Rot2 {{ angle: {:.2$}°, length: {} }}",
+                self.angle().to_degrees(),
+                self.length(),
+                precision
+            )
+        } else {
+            write!(
+                f,
+                "Rot2 {{ angle: {:.1}°, length: {} }}",
+                self.angle().to_degrees(),
+                self.length(),
+            )
+        }
     }
 }
 

--- a/crates/emath/src/rot2.rs
+++ b/crates/emath/src/rot2.rs
@@ -93,7 +93,7 @@ impl std::fmt::Debug for Rot2 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Rot2 {{ angle: {:.1}°, length: {} }}",
+            "Rot2 {{ angle: {:.3}°, length: {} }}",
             self.angle().to_degrees(),
             self.length()
         )

--- a/crates/emath/src/vec2.rs
+++ b/crates/emath/src/vec2.rs
@@ -468,7 +468,11 @@ impl Div<f32> for Vec2 {
 
 impl fmt::Debug for Vec2 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[{:.3} {:.3}]", self.x, self.y)
+        if let Some(precision) = f.precision() {
+            write!(f, "[{1:.0$} {2:.0$}]", precision, self.x, self.y)
+        } else {
+            write!(f, "[{:.1} {:.1}]", self.x, self.y)
+        }
     }
 }
 

--- a/crates/emath/src/vec2.rs
+++ b/crates/emath/src/vec2.rs
@@ -468,7 +468,7 @@ impl Div<f32> for Vec2 {
 
 impl fmt::Debug for Vec2 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[{:.1} {:.1}]", self.x, self.y)
+        write!(f, "[{:.3} {:.3}]", self.x, self.y)
     }
 }
 


### PR DESCRIPTION
* closes #4665

pretty self explanatory, i opted for 3 instead of 2 since i think that's what display does