### PR TITLE
Add `Rect::scale_from_center`

### DIFF
--- a/crates/emath/src/rect.rs
+++ b/crates/emath/src/rect.rs
@@ -193,13 +193,13 @@ impl Rect {
 
     /// Scale up by this factor in each direction, keeping the center
     #[must_use]
-    pub fn scale(self, amnt: f32) -> Self {
-        self.scale2(Vec2::splat(amnt))
+    pub fn scale_from_center(self, amnt: f32) -> Self {
+        self.scale_from_center2(Vec2::splat(amnt))
     }
 
     /// Scale up by this factor in each direction, keeping the center
     #[must_use]
-    pub fn scale2(self, scale: Vec2) -> Self {
+    pub fn scale_from_center2(self, scale: Vec2) -> Self {
         Self::from_center_size(self.center(), self.size() * scale)
     }
 
@@ -730,10 +730,16 @@ mod tests {
         let c = pos2(100.0, 50.0);
         let r = Rect::from_center_size(c, vec2(30.0, 60.0));
 
-        assert_eq!(r.scale(2.0), Rect::from_center_size(c, vec2(60.0, 120.0)));
-        assert_eq!(r.scale(0.5), Rect::from_center_size(c, vec2(15.0, 30.0)));
         assert_eq!(
-            r.scale2(vec2(2.0, 3.0)),
+            r.scale_from_center(2.0),
+            Rect::from_center_size(c, vec2(60.0, 120.0))
+        );
+        assert_eq!(
+            r.scale_from_center(0.5),
+            Rect::from_center_size(c, vec2(15.0, 30.0))
+        );
+        assert_eq!(
+            r.scale_from_center2(vec2(2.0, 3.0)),
             Rect::from_center_size(c, vec2(60.0, 180.0))
         );
     }

--- a/crates/emath/src/rect.rs
+++ b/crates/emath/src/rect.rs
@@ -193,8 +193,8 @@ impl Rect {
 
     /// Scale up by this factor in each direction, keeping the center
     #[must_use]
-    pub fn scale_from_center(self, amnt: f32) -> Self {
-        self.scale_from_center2(Vec2::splat(amnt))
+    pub fn scale_from_center(self, scale_factor: f32) -> Self {
+        self.scale_from_center2(Vec2::splat(scale_factor))
     }
 
     /// Scale up by this factor in each direction, keeping the center

--- a/crates/emath/src/rect.rs
+++ b/crates/emath/src/rect.rs
@@ -191,6 +191,18 @@ impl Rect {
         Self::from_min_max(self.min - amnt, self.max + amnt)
     }
 
+    /// Scale up by this factor in each direction, keeping the center
+    #[must_use]
+    pub fn scale(self, amnt: f32) -> Self {
+        self.scale2(Vec2::splat(amnt))
+    }
+
+    /// Scale up by this factor in each direction, keeping the center
+    #[must_use]
+    pub fn scale2(self, scale: Vec2) -> Self {
+        Self::from_center_size(self.center(), self.size() * scale)
+    }
+
     /// Shrink by this much in each direction, keeping the center
     #[must_use]
     pub fn shrink(self, amnt: f32) -> Self {
@@ -711,6 +723,19 @@ mod tests {
         assert_eq!(r.distance_sq_to_pos(pos2(15.0, 5.0)), 25.0); // above
         assert_eq!(r.distance_sq_to_pos(pos2(15.0, 25.0)), 25.0); // below
         assert_eq!(r.distance_sq_to_pos(pos2(25.0, 5.0)), 50.0); // right and above
+    }
+
+    #[test]
+    fn scale_rect() {
+        let c = pos2(100.0, 50.0);
+        let r = Rect::from_center_size(c, vec2(30.0, 60.0));
+
+        assert_eq!(r.scale(2.0), Rect::from_center_size(c, vec2(60.0, 120.0)));
+        assert_eq!(r.scale(0.5), Rect::from_center_size(c, vec2(15.0, 30.0)));
+        assert_eq!(
+            r.scale2(vec2(2.0, 3.0)),
+            Rect::from_center_size(c, vec2(60.0, 180.0))
+        );
     }
 
     #[test]

--- a/crates/emath/src/rect.rs
+++ b/crates/emath/src/rect.rs
@@ -199,8 +199,8 @@ impl Rect {
 
     /// Scale up by this factor in each direction, keeping the center
     #[must_use]
-    pub fn scale_from_center2(self, scale: Vec2) -> Self {
-        Self::from_center_size(self.center(), self.size() * scale)
+    pub fn scale_from_center2(self, scale_factor: Vec2) -> Self {
+        Self::from_center_size(self.center(), self.size() * scale_factor)
     }
 
     /// Shrink by this much in each direction, keeping the center


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

I find myself wanting this API quite a lot, and I imagine it'll probably be useful for others.

# What?

This PR adds `Rect::scale` and `Rect::scale2` functions, which work a lot like `expand`, but instead multiply by a scale.

i.e.
```rs
rect.scale(2.0); // rect is 2x as big, still in same center
rect.scale2(vec2(1.5, 2.0)); // rect is 1.5x as big on x axis, 2.0x as big on y axis. still in same center
```

# Why?

Before this you either had to write this yourself or use a `expand` in a cumbersome way:
```rs
rect.expand2(vec2(rect.width() * scale.x / 2.0, rect.height() * scale.y / 2.0));
```

I find myself wanting to scale things up by a factor frequently enough, and it seems like a useful addition to have a multiply-based variant of `expand`.

I realise this is pretty minor, but it seems useful enough to me!