### PR TITLE
Abort drags when pressing escape key

### DIFF
--- a/crates/egui/src/drag_and_drop.rs
+++ b/crates/egui/src/drag_and_drop.rs
@@ -27,14 +27,15 @@ impl DragAndDrop {
     }
 
     fn end_frame(ctx: &Context) {
-        let pointer_released = ctx.input(|i| i.pointer.any_released());
+        let abort_dnd =
+            ctx.input(|i| i.pointer.any_released() || i.key_pressed(crate::Key::Escape));
 
         let mut is_dragging = false;
 
         ctx.data_mut(|data| {
             let state = data.get_temp_mut_or_default::<Self>(Id::NULL);
 
-            if pointer_released {
+            if abort_dnd {
                 state.payload = None;
             }
 

--- a/crates/egui/src/interaction.rs
+++ b/crates/egui/src/interaction.rs
@@ -134,6 +134,12 @@ pub(crate) fn interact(
     let mut dragged = prev_snapshot.dragged;
     let mut long_touched = None;
 
+    if input.key_pressed(Key::Escape) {
+        // Abort dragging on escape
+        dragged = None;
+        interaction.potential_drag_id = None;
+    }
+
     if input.is_long_touch() {
         // We implement "press-and-hold for context menu" on touch screens here
         if let Some(widget) = interaction


### PR DESCRIPTION
This is useful to undo a drag-and-drop, for instance
