### PR TITLE
Fix: `Response::hover_pos` returns incorrect positions with layer transforms

### DIFF
--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -468,7 +468,7 @@ impl Response {
                 .ctx
                 .memory(|m| m.layer_transforms.get(&self.layer_id).copied())
             {
-                pos = transform * pos;
+                pos = transform.inverse() * pos;
             }
             Some(pos)
         } else {


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

When layer transforms are present, the `Response::hover_pos` function in egui returns `transform * pos` instead of `transform.inverse() * pos`. This is incorrect and isn't consistent with [how egui calculates other interaction positions](https://github.com/emilk/egui/blob/master/crates/egui/src/context.rs#L1193).

See: https://github.com/emilk/egui/blob/master/crates/egui/src/response.rs#L471

This PR fixes this bug, changing `transform` to `transform.inverse()`. Nothing fancy here, just a one-line change. `scripts/check.sh` runs successfully.


Below are videos of before and after with a modified version of the web demo. I added another entry after https://github.com/emilk/egui/blob/master/crates/egui_demo_lib/src/demo/pan_zoom.rs#L108 with a debug rectangle drawn at the return value of `hover_pos`:
```rust
(
    egui::Pos2::new(120.0, 120.0),
    Box::new(|ui, _state| {
        let response =
            ui.allocate_response(egui::Vec2::splat(128.0), egui::Sense::hover());
        ui.painter().rect_filled(
            egui::Rect::from_center_size(
                response.hover_pos().unwrap_or_default(),
                egui::Vec2::splat(8.0),
            ),
            egui::Rounding::ZERO,
            egui::Color32::DEBUG_COLOR,
        );
        response
    }),
),
```

Without the fix:
https://github.com/emilk/egui/assets/104604363/241cfcab-88ab-459b-8f4d-3367da3aa392

With the fix:
https://github.com/emilk/egui/assets/104604363/e52a7263-44c7-42c1-be46-1ecadc025625



