### PR TITLE
Add Into bound into id methods

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -127,8 +127,8 @@ impl Area {
     ///
     /// The `id` must be globally unique.
     #[inline]
-    pub fn id(mut self, id: Id) -> Self {
-        self.id = id;
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = id.into();
         self
     }
 

--- a/crates/egui/src/containers/resize.rs
+++ b/crates/egui/src/containers/resize.rs
@@ -61,8 +61,8 @@ impl Default for Resize {
 impl Resize {
     /// Assign an explicit and globally unique id.
     #[inline]
-    pub fn id(mut self, id: Id) -> Self {
-        self.id = Some(id);
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = Some(id.into());
         self
     }
 

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -69,8 +69,8 @@ impl<'open> Window<'open> {
 
     /// Assign a unique id to the Window. Required if the title changes, or is shared with another window.
     #[inline]
-    pub fn id(mut self, id: Id) -> Self {
-        self.area = self.area.id(id);
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.area = self.area.id(id.into());
         self
     }
 

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -151,8 +151,8 @@ impl<'t> TextEdit<'t> {
 
     /// Use if you want to set an explicit [`Id`] for this widget.
     #[inline]
-    pub fn id(mut self, id: Id) -> Self {
-        self.id = Some(id);
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = Some(id.into());
         self
     }
 

--- a/crates/egui_plot/src/items/mod.rs
+++ b/crates/egui_plot/src/items/mod.rs
@@ -200,8 +200,8 @@ impl HLine {
 
     /// Set the line's id which is used to identify it in the plot's response.
     #[inline]
-    pub fn id(mut self, id: Id) -> Self {
-        self.id = Some(id);
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = Some(id.into());
         self
     }
 }
@@ -348,8 +348,8 @@ impl VLine {
 
     /// Set the line's id which is used to identify it in the plot's response.
     #[inline]
-    pub fn id(mut self, id: Id) -> Self {
-        self.id = Some(id);
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = Some(id.into());
         self
     }
 }
@@ -504,8 +504,8 @@ impl Line {
 
     /// Set the line's id which is used to identify it in the plot's response.
     #[inline]
-    pub fn id(mut self, id: Id) -> Self {
-        self.id = Some(id);
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = Some(id.into());
         self
     }
 }
@@ -698,8 +698,8 @@ impl Polygon {
 
     /// Set the polygon's id which is used to identify it in the plot's response.
     #[inline]
-    pub fn id(mut self, id: Id) -> Self {
-        self.id = Some(id);
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = Some(id.into());
         self
     }
 }
@@ -836,8 +836,8 @@ impl Text {
 
     /// Set the text's id which is used to identify it in the plot's response.
     #[inline]
-    pub fn id(mut self, id: Id) -> Self {
-        self.id = Some(id);
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = Some(id.into());
         self
     }
 }
@@ -1013,8 +1013,8 @@ impl Points {
 
     /// Set the points' id which is used to identify them in the plot's response.
     #[inline]
-    pub fn id(mut self, id: Id) -> Self {
-        self.id = Some(id);
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = Some(id.into());
         self
     }
 }
@@ -1254,8 +1254,8 @@ impl Arrows {
 
     /// Set the arrows' id which is used to identify them in the plot's response.
     #[inline]
-    pub fn id(mut self, id: Id) -> Self {
-        self.id = Some(id);
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = Some(id.into());
         self
     }
 }
@@ -1678,8 +1678,8 @@ impl BarChart {
 
     /// Set the bar chart's id which is used to identify it in the plot's response.
     #[inline]
-    pub fn id(mut self, id: Id) -> Self {
-        self.id = Some(id);
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = Some(id.into());
         self
     }
 }
@@ -1852,8 +1852,8 @@ impl BoxPlot {
 
     /// Set the box plot's id which is used to identify it in the plot's response.
     #[inline]
-    pub fn id(mut self, id: Id) -> Self {
-        self.id = Some(id);
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = Some(id.into());
         self
     }
 }

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -241,8 +241,8 @@ impl<'a> Plot<'a> {
     ///
     /// This is the same `Id` that can be used for [`PlotMemory::load`].
     #[inline]
-    pub fn id(mut self, id: Id) -> Self {
-        self.id = Some(id);
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = Some(id.into());
         self
     }
 


### PR DESCRIPTION
I've felt the need for this several times, and assigning ids adds a little bit of friction by having the user call into() when passing a `String` or `&str`.

This PR adds the `Into` trait bound on the `id` method that reduces this small friction from the end user.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes <https://github.com/emilk/egui/issues/THE_RELEVANT_ISSUE>
