### PR TITLE
Fix hello_world_par example on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,6 +2000,7 @@ version = "0.1.0"
 dependencies = [
  "eframe",
  "env_logger",
+ "winit",
 ]
 
 [[package]]

--- a/examples/hello_world_par/Cargo.toml
+++ b/examples/hello_world_par/Cargo.toml
@@ -15,9 +15,16 @@ workspace = true
 eframe = { workspace = true, default-features = false, features = [
     # accesskit struggles with threading
     "default_fonts",
+    "wayland",
+    "x11",
     "wgpu",
 ] }
 env_logger = { version = "0.10", default-features = false, features = [
     "auto-color",
     "humantime",
+] }
+# This is normally enabled by eframe/default, which is not being used here
+# because of accesskit, as mentioned above
+winit = { workspace = true, features = [
+    "default"
 ] }


### PR DESCRIPTION
This example does not use the default features from eframe in order to avoid accesskit, which panics when run from multiple threads, so it must manually enable the other default features in order to compile correctly on Linux.

* Closes <https://github.com/emilk/egui/issues/4682>
