### PR TITLE
doc(emath): Add `top_left` as an alias for `left_top`, etc.

### DIFF
--- a/crates/emath/src/rect.rs
+++ b/crates/emath/src/rect.rs
@@ -542,6 +542,7 @@ impl Rect {
     }
 
     #[inline(always)]
+    #[doc(alias = "top_left")]
     pub fn left_top(&self) -> Pos2 {
         pos2(self.left(), self.top())
     }
@@ -552,6 +553,7 @@ impl Rect {
     }
 
     #[inline(always)]
+    #[doc(alias = "top_right")]
     pub fn right_top(&self) -> Pos2 {
         pos2(self.right(), self.top())
     }
@@ -567,6 +569,7 @@ impl Rect {
     }
 
     #[inline(always)]
+    #[doc(alias = "bottom_left")]
     pub fn left_bottom(&self) -> Pos2 {
         pos2(self.left(), self.bottom())
     }
@@ -577,6 +580,7 @@ impl Rect {
     }
 
     #[inline(always)]
+    #[doc(alias = "bottom_right")]
     pub fn right_bottom(&self) -> Pos2 {
         pos2(self.right(), self.bottom())
     }


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

# What

Adds `#[doc(alias = "top_left")]` as an alias for `left_top`, and so on for `right_top`, `right_bottom`, `left_bottom`. 

# Why

Extremely minor doc-only change, but I keep going to type "top left" to look for the top left of a rectangle.
I'm unsure whether this is just a british-english thing or an english-in-general thing, but `top left corner` is far more common than `left top corner`.
These doc aliases don't conflict with anything, and mean that rust-analyzer will suggest the correct function when I search for the wrong thing.

This improves ergonomics and discoverability in my opinion, even if not by much.