### PR TITLE
Allow setting a layer as a sublayer of another

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2374,6 +2374,17 @@ impl Context {
         self.memory_mut(|mem| mem.areas_mut().move_to_top(layer_id));
     }
 
+    /// Mark the `child` layer as a sublayer of `parent`.
+    ///
+    /// Sublayers are moved directly above the parent layer at the end of the frame. This is mainly
+    /// intended for adding a new [`Area`] inside a [`Window`].
+    ///
+    /// This currently only supports one level of nesting. If `parent` is a sublayer of another
+    /// layer, the behavior is unspecified.
+    pub fn set_sublayer(&self, parent: LayerId, child: LayerId) {
+        self.memory_mut(|mem| mem.areas_mut().set_sublayer(parent, child));
+    }
+
     /// Retrieve the [`LayerId`] of the top level windows.
     pub fn top_layer_id(&self) -> Option<LayerId> {
         self.memory(|mem| mem.areas().top_layer_id(Order::Middle))

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -1086,10 +1086,10 @@ impl Areas {
         visible_current_frame.clear();
         order.sort_by_key(|layer| (layer.order, wants_to_be_on_top.contains(layer)));
         wants_to_be_on_top.clear();
-
         // For all layers with sublayers, put the sublayers directly after the parent layer:
+        let sublayers = std::mem::take(sublayers);
         for (parent, children) in sublayers {
-            let mut moved_layers = vec![*parent];
+            let mut moved_layers = vec![parent];
             order.retain(|l| {
                 if children.contains(l) {
                     moved_layers.push(*l);
@@ -1098,7 +1098,7 @@ impl Areas {
                     true
                 }
             });
-            let Some(parent_pos) = order.iter().position(|l| l == parent) else {
+            let Some(parent_pos) = order.iter().position(|l| l == &parent) else {
                 continue;
             };
             order.splice(parent_pos..=parent_pos, moved_layers);

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -1086,6 +1086,8 @@ impl Areas {
         visible_current_frame.clear();
         order.sort_by_key(|layer| (layer.order, wants_to_be_on_top.contains(layer)));
         wants_to_be_on_top.clear();
+
+        // For all layers with sublayers, put the sublayers directly after the parent layer:
         for (parent, children) in sublayers {
             let mut moved_layers = vec![*parent];
             order.retain(|l| {

--- a/crates/egui_demo_lib/src/demo/pan_zoom.rs
+++ b/crates/egui_demo_lib/src/demo/pan_zoom.rs
@@ -110,11 +110,10 @@ impl super::View for PanZoom {
         .into_iter()
         .enumerate()
         {
+            let window_layer = ui.layer_id();
             let id = egui::Area::new(id.with(("subarea", i)))
                 .default_pos(pos)
-                // Need to cover up the pan_zoom demo window,
-                // but may also cover over other windows.
-                .order(egui::Order::Foreground)
+                .order(egui::Order::Middle)
                 .show(ui.ctx(), |ui| {
                     ui.set_clip_rect(transform.inverse() * rect);
                     egui::Frame::default()
@@ -130,6 +129,7 @@ impl super::View for PanZoom {
                 .response
                 .layer_id;
             ui.ctx().set_transform_layer(id, transform);
+            ui.ctx().set_sublayer(window_layer, id);
         }
     }
 }


### PR DESCRIPTION
When the layers are reordered at the end of the frame, the sublayers are
placed directly above their respective parents. This allows having Areas
inside Windows, e.g., for the pan-zoom container.

* Closes <https://github.com/emilk/egui/issues/4128>
