### PR TITLE
Reset `Memory::popup` to `None` if a popup was abandoned

### DIFF
--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -81,8 +81,7 @@ pub struct Memory {
 
     /// Which popup-window is open (if any)?
     /// Could be a combo box, color picker, menu etc.
-    /// The bool is used to detect if a popup was abandoned, that way we can reset `popup` back
-    /// to `None` at the end of the frame.
+    /// The bool is used to detect if a popup stopped showing before calling close_popup
     #[cfg_attr(feature = "persistence", serde(skip))]
     popup: Option<(Id, std::sync::Arc<AtomicBool>)>,
 


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes https://github.com/emilk/egui/issues/3657

## BEFORE

https://github.com/emilk/egui/assets/1410520/d35168ae-cde8-479a-bb4a-79873b5ce685

## AFTER

https://github.com/emilk/egui/assets/1410520/e9f367d8-38f0-4be1-b3d9-fda505c7b625

Notice that `WRONG` flashes for one frame. That's expected because on the frame the combo box disappears, `any_popup_open` still returns true, since we don't know it has disappeared until the end of the frame.

