### PR TITLE
add forget_image function to Image

### DIFF
--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -289,6 +289,18 @@ impl<'a> Image<'a> {
     }
 
     #[inline]
+    pub fn forget_image(&self, ctx: &Context) {
+        let uri = match &self.source {
+            ImageSource::Uri(uri) => Some(uri),
+            ImageSource::Bytes { uri, bytes } => Some(uri),
+            _ => None,
+        };
+        if let Some(uri) = uri {
+            ctx.forget_image(uri)
+        }
+    }
+
+    #[inline]
     pub fn source(&'a self, ctx: &Context) -> ImageSource<'a> {
         match &self.source {
             ImageSource::Uri(uri) if is_gif_uri(uri) => {


### PR DESCRIPTION
Image::source returns a modified ImageSource when the image is a gif. 