### PR TITLE
Bug fix: report latest area size in `Area::show` response

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -544,15 +544,21 @@ impl Prepared {
             kind: _,
             layer_id,
             mut state,
-            move_response,
+            move_response: mut response,
             ..
         } = self;
 
         state.size = content_ui.min_size();
 
+        // Make sure we report back the correct size.
+        // Very important after the initial sizing pass, when the initial estimate of the size is way off.
+        let final_rect = state.rect();
+        response.rect = final_rect;
+        response.interact_rect = final_rect;
+
         ctx.memory_mut(|m| m.areas_mut().set_state(layer_id, state));
 
-        move_response
+        response
     }
 }
 

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -168,15 +168,17 @@ fn menu_popup<'c, R>(
             .inner
     });
 
+    let area_rect = area_response.response.rect;
+
     menu_state_arc.write().rect = if sizing_pass {
         // During the sizing pass we didn't know the size yet,
         // so we might have just constrained the position unnecessarily.
         // Therefore keep the original=desired position until the next frame.
-        Rect::from_min_size(pos, area_response.response.rect.size())
+        Rect::from_min_size(pos, area_rect.size())
     } else {
         // We knew the size, and this is where it ended up (potentially constrained to screen).
         // Remember it for the future:
-        area_response.response.rect
+        area_rect
     };
 
     area_response


### PR DESCRIPTION
Fixes a problem where menu popups would sometimes move after the first frame (glitch)