### PR TITLE
Add basic test for egui accesskit output.

### DIFF
--- a/crates/egui/tests/accesskit.rs
+++ b/crates/egui/tests/accesskit.rs
@@ -3,6 +3,38 @@
 use accesskit::Role;
 use egui::{Context, RawInput};
 
+/// Baseline test that asserts there are no spurious nodes in the
+/// accesskit output when the ui is empty.
+///
+/// This gives reasonable certainty that any nodes appearing in the other accesskit outputs
+/// are put there because of the widgets rendered.
+#[test]
+fn empty_ui_should_return_tree_with_only_root_window() {
+    let ctx = Context::default();
+    ctx.enable_accesskit();
+
+    let output = ctx.run(RawInput::default(), |ctx| {
+        egui::CentralPanel::default().show(ctx, |_| {});
+    });
+
+    let tree_update = output
+        .platform_output
+        .accesskit_update
+        .expect("Missing accesskit update");
+
+    let tree = tree_update.tree.unwrap();
+
+    assert_eq!(
+        tree_update.nodes.len(),
+        1,
+        "Empty ui should produce only the root window."
+    );
+    let (id, root) = &tree_update.nodes[0];
+
+    assert_eq!(*id, tree.root);
+    assert_eq!(root.role(), Role::Window);
+}
+
 #[test]
 fn button_text() {
     let button_text = "This is a test button!";
@@ -19,8 +51,45 @@ fn button_text() {
         .accesskit_update
         .expect("Missing accesskit update")
         .nodes;
+
+    assert_eq!(
+        nodes.len(),
+        2,
+        "Expected only the root node and the button."
+    );
+
     nodes
         .iter()
         .find(|(_, node)| node.role() == Role::Button && node.name() == Some(button_text))
         .expect("Button should exist in the accesskit output");
+}
+
+#[test]
+fn toggle_button_text() {
+    let button_text = "A toggle button";
+
+    let ctx = Context::default();
+    ctx.enable_accesskit();
+
+    let mut selected = false;
+    let output = ctx.run(RawInput::default(), |ctx| {
+        egui::CentralPanel::default().show(ctx, |ui| ui.toggle_value(&mut selected, button_text));
+    });
+
+    let nodes = output
+        .platform_output
+        .accesskit_update
+        .expect("Missing accesskit update")
+        .nodes;
+
+    assert_eq!(
+        nodes.len(),
+        2,
+        "Expected only the root node and the button."
+    );
+
+    nodes
+        .iter()
+        .find(|(_, node)| node.role() == Role::ToggleButton && node.name() == Some(button_text))
+        .expect("Toggle button should exist in the accesskit output");
 }

--- a/crates/egui/tests/accesskit.rs
+++ b/crates/egui/tests/accesskit.rs
@@ -1,0 +1,26 @@
+//! Tests the accesskit accessibility output of egui.
+
+use accesskit::Role;
+use egui::{Context, RawInput};
+
+#[test]
+fn button_text() {
+    let button_text = "This is a test button!";
+
+    let ctx = Context::default();
+    ctx.enable_accesskit();
+
+    let output = ctx.run(RawInput::default(), |ctx| {
+        egui::CentralPanel::default().show(ctx, |ui| ui.button(button_text));
+    });
+
+    let nodes = output
+        .platform_output
+        .accesskit_update
+        .expect("Missing accesskit update")
+        .nodes;
+    nodes
+        .iter()
+        .find(|(_, node)| node.role() == Role::Button && node.name() == Some(button_text))
+        .expect("Button should exist in the accesskit output");
+}


### PR DESCRIPTION
For a project I am currently attempting to use the acceskit output of egui to preform end-to-end integration tests of my application. However, the output is currently quite basic (buttons for example don't report that they are disabled).

Before adding new features to the acceskit integration, I thought it would be a good idea to add some testing to egui's accesskit output.
I have started with a simple test for button texts, to get feedback on whether this is the correct direction to go in.