### PR TITLE
Introduce type parameter for plot points

### DIFF
--- a/crates/egui_plot/src/items/values.rs
+++ b/crates/egui_plot/src/items/values.rs
@@ -1,6 +1,6 @@
 use std::ops::{Bound, RangeBounds, RangeInclusive};
 
-use egui::{Pos2, Shape, Stroke, Vec2};
+use egui::{Id, Pos2, Shape, Stroke, Vec2};
 
 use crate::transform::PlotBounds;
 
@@ -362,7 +362,7 @@ pub enum PlotGeometry<'a> {
     None,
 
     /// Point values (X-Y graphs)
-    Points(&'a [PlotPoint]),
+    Points(&'a [PlotPoint], Option<Id>),
 
     /// Rectangles (examples: boxes or bars)
     // Has currently no data, as it would require copying rects or iterating a list of pointers.

--- a/crates/egui_plot/src/lib.rs
+++ b/crates/egui_plot/src/lib.rs
@@ -37,7 +37,7 @@ use axis::AxisWidget;
 use items::{horizontal_line, rulers_color, vertical_line};
 use legend::LegendWidget;
 
-type LabelFormatterFn<'a> = dyn Fn(&str, &PlotPoint) -> String + 'a;
+type LabelFormatterFn<'a> = dyn Fn(&str, &PlotPoint, Option<(Id, usize)>) -> String + 'a;
 pub type LabelFormatter<'a> = Option<Box<LabelFormatterFn<'a>>>;
 
 type GridSpacerFn<'a> = dyn Fn(GridInput) -> Vec<GridMark> + 'a;
@@ -405,7 +405,7 @@ impl<'a> Plot<'a> {
     /// ```
     pub fn label_formatter(
         mut self,
-        label_formatter: impl Fn(&str, &PlotPoint) -> String + 'a,
+        label_formatter: impl Fn(&str, &PlotPoint, Option<(Id, usize)>) -> String + 'a,
     ) -> Self {
         self.label_formatter = Some(Box::new(label_formatter));
         self
@@ -1699,6 +1699,7 @@ impl<'a> PreparedPlot<'a> {
             items::rulers_at_value(
                 pointer,
                 value,
+                None,
                 "",
                 &plot,
                 shapes,


### PR DESCRIPTION
In order to supply custom data to plot points for use mainly in the label_formatter this introduces a new field which stores userdata.

Hovering over a plot point | Hovering over anything else
-|-
![image](https://github.com/emilk/egui/assets/174022351/55511bd4-8e28-439c-a66e-164b78371da9)|![image](https://github.com/emilk/egui/assets/174022351/8075ce29-b365-4bae-bd34-0375738efe9b)

Of course this requires PlotPoint to have a generic type parameter which then requires lots of other structs to be generic too.

The userdata field is optional, since a PlotPoint can be a Point supplied by the user when constructing a plot item, but it can also be generated by the library.

A demo for this is implemented as you can see in the screenshot.

Of course I would like there to be an easier way to do this, but currently I'm not aware of any.