### PR TITLE
Add `Image::uri()`

### DIFF
--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -283,7 +283,9 @@ impl<'a> Image<'a> {
         }
     }
 
-    /// Get the `uri` that this image.
+    /// Returns the URI of the image.
+    ///
+    /// For GIFs, returns the URI without the frame number.
     #[inline]
     pub fn uri(&self) -> Option<&str> {
         let uri = self.source.uri()?;

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -284,6 +284,21 @@ impl<'a> Image<'a> {
     }
 
     #[inline]
+    pub fn uri(&self) -> Option<&str> {
+        let mut uri: Option<&str> = match &self.source {
+            ImageSource::Bytes { uri, .. } | ImageSource::Uri(uri) => Some(uri),
+            ImageSource::Texture(_) => None,
+        };
+
+        if is_gif_uri(uri.unwrap_or_default()) {
+            if let Ok((gif_uri, _index)) = decode_gif_uri(uri.unwrap_or_default()) {
+                uri = Some(gif_uri);
+            }
+        }
+        uri
+    }
+
+    #[inline]
     pub fn image_options(&self) -> &ImageOptions {
         &self.image_options
     }

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -283,16 +283,16 @@ impl<'a> Image<'a> {
         }
     }
 
+    /// Get the `uri` that this image.
     #[inline]
     pub fn uri(&self) -> Option<&str> {
-        let mut uri = self.source.uri();
+        let uri = self.source.uri()?;
 
-        if is_gif_uri(uri.unwrap_or_default()) {
-            if let Ok((gif_uri, _index)) = decode_gif_uri(uri.unwrap_or_default()) {
-                uri = Some(gif_uri);
-            }
+        if let Ok((gif_uri, _index)) = decode_gif_uri(uri) {
+            Some(gif_uri)
+        } else {
+            Some(uri)
         }
-        uri
     }
 
     #[inline]

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -285,10 +285,7 @@ impl<'a> Image<'a> {
 
     #[inline]
     pub fn uri(&self) -> Option<&str> {
-        let mut uri: Option<&str> = match &self.source {
-            ImageSource::Bytes { uri, .. } | ImageSource::Uri(uri) => Some(uri),
-            ImageSource::Texture(_) => None,
-        };
+        let mut uri = self.source.uri();
 
         if is_gif_uri(uri.unwrap_or_default()) {
             if let Ok((gif_uri, _index)) = decode_gif_uri(uri.unwrap_or_default()) {


### PR DESCRIPTION
`uri()` for image

The advantages of this are :

1. No need for `ctx()` and `source()`
2. Displays `name.gif#0` as `name.gif`
