### PR TITLE
Ensure `Window` scroll bars are at the window edges

### DIFF
--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -59,7 +59,7 @@ impl<'open> Window<'open> {
                 .with_stroke(false)
                 .min_size([96.0, 32.0])
                 .default_size([340.0, 420.0]), // Default inner size of a window
-            scroll: ScrollArea::neither(),
+            scroll: ScrollArea::neither().auto_shrink(false),
             collapsible: true,
             default_open: true,
             with_title_bar: true,


### PR DESCRIPTION
Set `auto_shrink(false)` on `Window`s `ScrollArea`.
This ensures that the scroll bars are always the outermost.

* Closes https://github.com/emilk/egui/pull/4602
