### PR TITLE
Add a menu button with text and image 

### DIFF
--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -118,6 +118,24 @@ pub fn menu_custom_button<R>(
     stationary_menu_button_impl(ui, button, Box::new(add_contents))
 }
 
+/// Construct a top level menu with an image in a menu bar. This would be e.g. "File", "Edit" etc.
+///
+/// Responds to primary clicks.
+///
+/// Returns `None` if the menu is not open.
+#[deprecated = "Use `menu_custom_button` instead"]
+pub fn menu_image_button<R>(
+    ui: &mut Ui,
+    image_button: ImageButton<'_>,
+    add_contents: impl FnOnce(&mut Ui) -> R,
+) -> InnerResponse<Option<R>> {
+    stationary_menu_button_impl(
+        ui,
+        Button::image(image_button.image),
+        Box::new(add_contents),
+    )
+}
+
 /// Construct a nested sub menu in another menu.
 ///
 /// Opens on hover.

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -118,6 +118,19 @@ pub fn menu_image_button<R>(
     stationary_menu_image_impl(ui, image_button, Box::new(add_contents))
 }
 
+/// Construct a top level menu with an image and a text in a menu bar. This would be e.g. "File", "Edit" etc.
+///
+/// Responds to primary clicks.
+///
+/// Returns `None` if the menu is not open.
+pub fn menu_text_image_button<R>(
+    ui: &mut Ui,
+    image_button: Button<'_>,
+    add_contents: impl FnOnce(&mut Ui) -> R,
+) -> InnerResponse<Option<R>> {
+    stationary_menu_text_image_impl(ui, image_button, Box::new(add_contents))
+}
+
 /// Construct a nested sub menu in another menu.
 ///
 /// Opens on hover.
@@ -218,6 +231,24 @@ fn stationary_menu_impl<'c, R>(
 fn stationary_menu_image_impl<'c, R>(
     ui: &mut Ui,
     image_button: ImageButton<'_>,
+    add_contents: Box<dyn FnOnce(&mut Ui) -> R + 'c>,
+) -> InnerResponse<Option<R>> {
+    let bar_id = ui.id();
+
+    let mut bar_state = BarState::load(ui.ctx(), bar_id);
+    let button_response = ui.add(image_button);
+    let inner = bar_state.bar_menu(&button_response, add_contents);
+
+    bar_state.store(ui.ctx(), bar_id);
+    InnerResponse::new(inner.map(|r| r.inner), button_response)
+}
+
+/// Build a top level menu with an text and image button.
+///
+/// Responds to primary clicks.
+fn stationary_menu_text_image_impl<'c, R>(
+    ui: &mut Ui,
+    image_button: Button<'_>,
     add_contents: Box<dyn FnOnce(&mut Ui) -> R + 'c>,
 ) -> InnerResponse<Option<R>> {
     let bar_id = ui.id();

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -105,30 +105,17 @@ pub fn menu_button<R>(
     stationary_menu_impl(ui, title, Box::new(add_contents))
 }
 
-/// Construct a top level menu with an image in a menu bar. This would be e.g. "File", "Edit" etc.
+/// Construct a top level menu with a custom button in a menu bar.
 ///
 /// Responds to primary clicks.
 ///
 /// Returns `None` if the menu is not open.
-pub fn menu_image_button<R>(
+pub fn menu_custom_button<R>(
     ui: &mut Ui,
-    image_button: ImageButton<'_>,
+    button: Button<'_>,
     add_contents: impl FnOnce(&mut Ui) -> R,
 ) -> InnerResponse<Option<R>> {
-    stationary_menu_image_impl(ui, image_button, Box::new(add_contents))
-}
-
-/// Construct a top level menu with an image and a text in a menu bar. This would be e.g. "File", "Edit" etc.
-///
-/// Responds to primary clicks.
-///
-/// Returns `None` if the menu is not open.
-pub fn menu_text_image_button<R>(
-    ui: &mut Ui,
-    image_button: Button<'_>,
-    add_contents: impl FnOnce(&mut Ui) -> R,
-) -> InnerResponse<Option<R>> {
-    stationary_menu_text_image_impl(ui, image_button, Box::new(add_contents))
+    stationary_menu_button_impl(ui, button, Box::new(add_contents))
 }
 
 /// Construct a nested sub menu in another menu.
@@ -228,33 +215,15 @@ fn stationary_menu_impl<'c, R>(
 /// Build a top level menu with an image button.
 ///
 /// Responds to primary clicks.
-fn stationary_menu_image_impl<'c, R>(
+fn stationary_menu_button_impl<'c, R>(
     ui: &mut Ui,
-    image_button: ImageButton<'_>,
+    button: Button<'_>,
     add_contents: Box<dyn FnOnce(&mut Ui) -> R + 'c>,
 ) -> InnerResponse<Option<R>> {
     let bar_id = ui.id();
 
     let mut bar_state = BarState::load(ui.ctx(), bar_id);
-    let button_response = ui.add(image_button);
-    let inner = bar_state.bar_menu(&button_response, add_contents);
-
-    bar_state.store(ui.ctx(), bar_id);
-    InnerResponse::new(inner.map(|r| r.inner), button_response)
-}
-
-/// Build a top level menu with an text and image button.
-///
-/// Responds to primary clicks.
-fn stationary_menu_text_image_impl<'c, R>(
-    ui: &mut Ui,
-    image_button: Button<'_>,
-    add_contents: Box<dyn FnOnce(&mut Ui) -> R + 'c>,
-) -> InnerResponse<Option<R>> {
-    let bar_id = ui.id();
-
-    let mut bar_state = BarState::load(ui.ctx(), bar_id);
-    let button_response = ui.add(image_button);
+    let button_response = ui.add(button);
     let inner = bar_state.bar_menu(&button_response, add_contents);
 
     bar_state.store(ui.ctx(), bar_id);

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2594,7 +2594,7 @@ impl Ui {
         add_contents: impl FnOnce(&mut Ui) -> R,
     ) -> InnerResponse<Option<R>> {
         if let Some(menu_state) = self.menu_state.clone() {
-            menu::submenu_button(self, menu_state, String::new(), add_contents)
+            menu::submenu_button(self, menu_state, title, add_contents)
         } else {
             menu::menu_text_image_button(self, Button::image_and_text(image, title), add_contents)
         }

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2543,16 +2543,19 @@ impl Ui {
     /// If called from within a menu this will instead create a button for a sub-menu.
     ///
     /// ```ignore
+    /// # egui::__run_test_ui(|ui| {
     /// let img = egui::include_image!("../assets/ferris.png");
     ///
-    /// ui.menu_image_button(img, |ui| {
+    /// ui.menu_image_button(title, img, |ui| {
     ///     ui.menu_button("My sub-menu", |ui| {
     ///         if ui.button("Close the menu").clicked() {
     ///             ui.close_menu();
     ///         }
     ///     });
     /// });
+    /// # });
     /// ```
+    ///     
     ///
     /// See also: [`Self::close_menu`] and [`Response::context_menu`].
     #[inline]
@@ -2572,17 +2575,19 @@ impl Ui {
     ///
     /// If called from within a menu this will instead create a button for a sub-menu.
     ///
-    /// ```ignore
+    /// ```
+    /// # egui::__run_test_ui(|ui| {
     /// let img = egui::include_image!("../assets/ferris.png");
     /// let title = "My Menu";
     ///
-    /// ui.menu_text_image_button(title, img, |ui| {
+    /// ui.menu_image_text_button(img, title, |ui| {
     ///     ui.menu_button("My sub-menu", |ui| {
     ///         if ui.button("Close the menu").clicked() {
     ///             ui.close_menu();
     ///         }
     ///     });
     /// });
+    /// # });
     /// ```
     ///
     /// See also: [`Self::close_menu`] and [`Response::context_menu`].

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2567,6 +2567,38 @@ impl Ui {
             menu::menu_image_button(self, ImageButton::new(image), add_contents)
         }
     }
+
+    /// Create a menu button with an image and a text that when clicked will show the given menu.
+    ///
+    /// If called from within a menu this will instead create a button for a sub-menu.
+    ///
+    /// ```ignore
+    /// let img = egui::include_image!("../assets/ferris.png");
+    /// let title = "My Menu";
+    ///
+    /// ui.menu_text_image_button(title, img, |ui| {
+    ///     ui.menu_button("My sub-menu", |ui| {
+    ///         if ui.button("Close the menu").clicked() {
+    ///             ui.close_menu();
+    ///         }
+    ///     });
+    /// });
+    /// ```
+    ///
+    /// See also: [`Self::close_menu`] and [`Response::context_menu`].
+    #[inline]
+    pub fn menu_text_image_button<'a, R>(
+        &mut self,
+        title: impl Into<WidgetText>,
+        image: impl Into<Image<'a>>,
+        add_contents: impl FnOnce(&mut Ui) -> R,
+    ) -> InnerResponse<Option<R>> {
+        if let Some(menu_state) = self.menu_state.clone() {
+            menu::submenu_button(self, menu_state, String::new(), add_contents)
+        } else {
+            menu::menu_text_image_button(self, Button::image_and_text(image, title), add_contents)
+        }
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2564,7 +2564,7 @@ impl Ui {
         if let Some(menu_state) = self.menu_state.clone() {
             menu::submenu_button(self, menu_state, String::new(), add_contents)
         } else {
-            menu::menu_image_button(self, ImageButton::new(image), add_contents)
+            menu::menu_custom_button(self, Button::image(image), add_contents)
         }
     }
 
@@ -2596,7 +2596,7 @@ impl Ui {
         if let Some(menu_state) = self.menu_state.clone() {
             menu::submenu_button(self, menu_state, title, add_contents)
         } else {
-            menu::menu_text_image_button(self, Button::image_and_text(image, title), add_contents)
+            menu::menu_custom_button(self, Button::image_and_text(image, title), add_contents)
         }
     }
 }

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2587,10 +2587,10 @@ impl Ui {
     ///
     /// See also: [`Self::close_menu`] and [`Response::context_menu`].
     #[inline]
-    pub fn menu_text_image_button<'a, R>(
+    pub fn menu_image_text_button<'a, R>(
         &mut self,
-        title: impl Into<WidgetText>,
         image: impl Into<Image<'a>>,
+        title: impl Into<WidgetText>,
         add_contents: impl FnOnce(&mut Ui) -> R,
     ) -> InnerResponse<Option<R>> {
         if let Some(menu_state) = self.menu_state.clone() {

--- a/crates/egui/src/widgets/image_button.rs
+++ b/crates/egui/src/widgets/image_button.rs
@@ -4,7 +4,7 @@ use crate::*;
 #[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
 #[derive(Clone, Debug)]
 pub struct ImageButton<'a> {
-    image: Image<'a>,
+    pub(crate) image: Image<'a>,
     sense: Sense,
     frame: bool,
     selected: bool,


### PR DESCRIPTION
In order to make it possible that all buttons can have the same style with a text and an image I created a `menu_text_image_button`.

It works the same way as all the other menu buttons.