### PR TITLE
Persist `Area` positions again

### DIFF
--- a/crates/eframe/src/web/web_logger.rs
+++ b/crates/eframe/src/web/web_logger.rs
@@ -38,6 +38,8 @@ impl log::Log for WebLogger {
     }
 
     fn log(&self, record: &log::Record<'_>) {
+        #![allow(clippy::match_same_arms)]
+
         if !self.enabled(record.metadata()) {
             return;
         }

--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -8,12 +8,8 @@ use crate::*;
 ///
 /// Areas back [`crate::Window`]s and other floating containers,
 /// like tooltips and the popups of [`crate::ComboBox`].
-///
-/// Area state is intentionally NOT persisted between sessions,
-/// so that a bad tooltip or menu size won't be remembered forever.
-/// A resizable [`Window`] remembers the size the user picked using
-/// the state in the [`Resize`] container.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct AreaState {
     /// Last known position of the pivot.
     pub pivot_pos: Pos2,

--- a/crates/egui/src/containers/combo_box.rs
+++ b/crates/egui/src/containers/combo_box.rs
@@ -296,7 +296,12 @@ fn combo_box_dyn<'c, R>(
 
     let is_popup_open = ui.memory(|m| m.is_popup_open(popup_id));
 
-    let popup_height = ui.memory(|m| m.areas().get(popup_id).map_or(100.0, |state| state.size.y));
+    let popup_height = ui.memory(|m| {
+        m.areas()
+            .get(popup_id)
+            .and_then(|state| state.size)
+            .map_or(100.0, |size| size.y)
+    });
 
     let above_or_below =
         if ui.next_widget_position().y + ui.spacing().interact_size.y + popup_height

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -118,8 +118,9 @@ fn show_tooltip_at_avoid_dyn<'c, R>(
     });
 
     let tooltip_area_id = tooltip_id(widget_id, state.tooltip_count);
-    let expected_tooltip_size =
-        AreaState::load(ctx, tooltip_area_id).map_or(vec2(64.0, 32.0), |area| area.size);
+    let expected_tooltip_size = AreaState::load(ctx, tooltip_area_id)
+        .and_then(|area| area.size)
+        .unwrap_or(vec2(64.0, 32.0));
 
     let screen_rect = ctx.screen_rect();
 

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -497,9 +497,9 @@ impl ContextImpl {
             AreaState {
                 pivot_pos: screen_rect.left_top(),
                 pivot: Align2::LEFT_TOP,
-                size: screen_rect.size(),
+                size: Some(screen_rect.size()),
                 interactable: true,
-                last_became_visible_at: f64::NEG_INFINITY,
+                last_became_visible_at: None,
             },
         );
 

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -495,7 +495,7 @@ impl ContextImpl {
         self.memory.areas_mut().set_state(
             LayerId::background(),
             AreaState {
-                pivot_pos: screen_rect.left_top(),
+                pivot_pos: Some(screen_rect.left_top()),
                 pivot: Align2::LEFT_TOP,
                 size: Some(screen_rect.size()),
                 interactable: true,
@@ -2209,7 +2209,7 @@ impl Context {
     pub fn used_rect(&self) -> Rect {
         self.write(|ctx| {
             let mut used = ctx.viewport().frame_state.used_by_panels;
-            for window in ctx.memory.areas().visible_windows() {
+            for (_id, window) in ctx.memory.areas().visible_windows() {
                 used = used.union(window.rect());
             }
             used

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -934,9 +934,6 @@ impl Memory {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct Areas {
-    /// Area state is intentionally NOT persisted between sessions,
-    /// so that a bad tooltip or menu size won't be remembered forever.
-    #[cfg_attr(feature = "serde", serde(skip))]
     areas: IdMap<area::AreaState>,
 
     /// Back-to-front. Top is last.

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -1027,12 +1027,12 @@ impl Areas {
             .collect()
     }
 
-    pub(crate) fn visible_windows(&self) -> Vec<&area::AreaState> {
+    pub(crate) fn visible_windows(&self) -> impl Iterator<Item = (LayerId, &area::AreaState)> {
         self.visible_layer_ids()
-            .iter()
+            .into_iter()
             .filter(|layer| layer.order == crate::Order::Middle)
-            .filter_map(|layer| self.get(layer.id))
-            .collect()
+            .filter(|&layer| !self.is_sublayer(&layer))
+            .filter_map(|layer| Some((layer, self.get(layer.id)?)))
     }
 
     pub fn move_to_top(&mut self, layer_id: LayerId) {


### PR DESCRIPTION
* Reverts https://github.com/emilk/egui/pull/4577

We again persist area positions, but not sizes.