### PR TITLE
Prevent `TextEdit` widgets from sending fake primary clicks

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -539,6 +539,9 @@ impl<'t> TextEdit<'t> {
             Sense::hover()
         };
         let mut response = ui.interact(outer_rect, id, sense);
+
+        response.fake_primary_click = false; // remove fake primary clicks to prevent sending OutputEvent::Clicked
+
         let text_clip_rect = rect;
         let painter = ui.painter_at(text_clip_rect.expand(1.0)); // expand to avoid clipping cursor
 

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -540,7 +540,7 @@ impl<'t> TextEdit<'t> {
         };
         let mut response = ui.interact(outer_rect, id, sense);
 
-        response.fake_primary_click = false; // remove fake primary clicks to prevent sending OutputEvent::Clicked
+        response.fake_primary_click = false; // Don't sent `OutputEvent::Clicked` when a user presses the space bar
 
         let text_clip_rect = rect;
         let painter = ui.painter_at(text_clip_rect.expand(1.0)); // expand to avoid clipping cursor


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

This prevents TextEdit widgets from sending fake primary clicks when a user types Space / Enter. Small change but having Space / Enter send `OutputEvent::ValueChanged` instead of `OutputEvent::Clicked` makes more sense I believe.