### PR TITLE
Only show one tooltip per layer at a time

### DIFF
--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -124,7 +124,12 @@ fn show_tooltip_at_dyn<'c, R>(
     }
 
     // if there are multiple tooltips open they should use the same common_id for the `tooltip_size` caching to work.
-    let mut state = ctx.frame_state(|fs| {
+    let mut state = ctx.frame_state_mut(|fs| {
+        // Remember that this is the widget showing the tooltip:
+        fs.tooltip_state
+            .per_layer_tooltip_widget
+            .insert(parent_layer, widget_id);
+
         fs.tooltip_state
             .widget_tooltips
             .get(&widget_id)

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -78,7 +78,7 @@ pub fn show_tooltip_for<R>(
 ) -> R {
     let is_touch_screen = ctx.input(|i| i.any_touches());
     let allow_placing_below = !is_touch_screen; // There is a finger below.
-    show_tooltip_at_avoid_dyn(
+    show_tooltip_at_dyn(
         ctx,
         parent_layer,
         widget_id,
@@ -100,7 +100,7 @@ pub fn show_tooltip_at<R>(
 ) -> R {
     let allow_placing_below = true;
     let rect = Rect::from_center_size(suggested_position, Vec2::ZERO);
-    show_tooltip_at_avoid_dyn(
+    show_tooltip_at_dyn(
         ctx,
         parent_layer,
         widget_id,
@@ -110,7 +110,7 @@ pub fn show_tooltip_at<R>(
     )
 }
 
-fn show_tooltip_at_avoid_dyn<'c, R>(
+fn show_tooltip_at_dyn<'c, R>(
     ctx: &Context,
     parent_layer: LayerId,
     widget_id: Id,

--- a/crates/egui/src/frame_state.rs
+++ b/crates/egui/src/frame_state.rs
@@ -1,13 +1,27 @@
 use crate::{id::IdSet, *};
 
+/// Reset at the start of each frame.
 #[derive(Clone, Debug, Default)]
 pub struct TooltipFrameState {
+    /// If a tooltip has been shown this frame, where was it?
+    /// This is used to prevent multiple tooltips to cover each other.
     pub widget_tooltips: IdMap<PerWidgetTooltipState>,
+
+    /// For each layer, which widget is showing a tooltip (if any)?
+    ///
+    /// Only one widget per layer may show a tooltip.
+    /// But if a tooltip contains a tooltip, you can show a tooltip on top of a tooltip.
+    pub per_layer_tooltip_widget: ahash::HashMap<LayerId, Id>,
 }
 
 impl TooltipFrameState {
     pub fn clear(&mut self) {
-        self.widget_tooltips.clear();
+        let Self {
+            widget_tooltips,
+            per_layer_tooltip_widget,
+        } = self;
+        widget_tooltips.clear();
+        per_layer_tooltip_widget.clear();
     }
 }
 
@@ -51,9 +65,6 @@ pub struct FrameState {
     /// How much space is used by panels.
     pub used_by_panels: Rect,
 
-    /// If a tooltip has been shown this frame, where was it?
-    /// This is used to prevent multiple tooltips to cover each other.
-    /// Reset at the start of each frame.
     pub tooltip_state: TooltipFrameState,
 
     /// The current scroll area should scroll to this range (horizontal, vertical).

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -645,6 +645,22 @@ impl Response {
             }
         }
 
+        let is_other_tooltip_open = self.ctx.prev_frame_state(|fs| {
+            if let Some(already_open_tooltip) = fs
+                .tooltip_state
+                .per_layer_tooltip_widget
+                .get(&self.layer_id)
+            {
+                already_open_tooltip != &self.id
+            } else {
+                false
+            }
+        });
+        if is_other_tooltip_open {
+            // We only allow one tooltip per layer. First one wins. It is up to that tooltip to close itself.
+            return false;
+        }
+
         // Fast early-outs:
         if self.enabled {
             if !self.hovered || !self.ctx.input(|i| i.pointer.has_pointer()) {

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -545,7 +545,13 @@ impl Response {
     /// Show this UI when hovering if the widget is disabled.
     pub fn on_disabled_hover_ui(self, add_contents: impl FnOnce(&mut Ui)) -> Self {
         if !self.enabled && self.should_show_hover_ui() {
-            crate::containers::show_tooltip_for(&self.ctx, self.id, &self.rect, add_contents);
+            crate::containers::show_tooltip_for(
+                &self.ctx,
+                self.layer_id,
+                self.id,
+                &self.rect,
+                add_contents,
+            );
         }
         self
     }
@@ -553,7 +559,12 @@ impl Response {
     /// Like `on_hover_ui`, but show the ui next to cursor.
     pub fn on_hover_ui_at_pointer(self, add_contents: impl FnOnce(&mut Ui)) -> Self {
         if self.enabled && self.should_show_hover_ui() {
-            crate::containers::show_tooltip_at_pointer(&self.ctx, self.id, add_contents);
+            crate::containers::show_tooltip_at_pointer(
+                &self.ctx,
+                self.layer_id,
+                self.id,
+                add_contents,
+            );
         }
         self
     }
@@ -562,14 +573,13 @@ impl Response {
     ///
     /// This can be used to give attention to a widget during a tutorial.
     pub fn show_tooltip_ui(&self, add_contents: impl FnOnce(&mut Ui)) {
-        let mut rect = self.rect;
-        if let Some(transform) = self
-            .ctx
-            .memory(|m| m.layer_transforms.get(&self.layer_id).copied())
-        {
-            rect = transform * rect;
-        }
-        crate::containers::show_tooltip_for(&self.ctx, self.id, &rect, add_contents);
+        crate::containers::show_tooltip_for(
+            &self.ctx,
+            self.layer_id,
+            self.id,
+            &self.rect,
+            add_contents,
+        );
     }
 
     /// Always show this tooltip, even if disabled and the user isn't hovering it.


### PR DESCRIPTION
Before, you could accidentally get multiple tooltips if a tooltips was interactive (e.g. had a link in it) and on the way to interact with it you would hover another widget with a tooltip.

This PR ensures that each `LayerId` only has one tooltip open at a time. You can still have a tooltip for an item inside of a tooltip.