### PR TITLE
Fix: ScrollArea

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -988,9 +988,11 @@ impl Prepared {
                 let is_hovering_bar_area = (is_hovering_outer_rect
                     && ui.rect_contains_pointer(max_bar_rect))
                     || state.scroll_bar_interaction[d];
+
                 let is_hovering_bar_area_t = ui
                     .ctx()
                     .animate_bool_responsive(id.with((d, "bar_hover")), is_hovering_bar_area);
+
                 let width = show_factor
                     * lerp(
                         scroll_style.floating_width..=scroll_style.bar_width,

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -547,6 +547,7 @@ impl ScrollStyle {
         Self {
             floating: true,
             bar_width: 10.0,
+            bar_inner_margin: 0.0,
             floating_allocated_width: 6.0,
             foreground_color: false,
 

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -571,6 +571,7 @@ impl ScrollStyle {
         Self {
             floating: true,
             bar_width: 10.0,
+            bar_inner_margin: 0.0,
             foreground_color: true,
             floating_allocated_width: 0.0,
             dormant_background_opacity: 0.0,
@@ -647,6 +648,10 @@ impl ScrollStyle {
             ui.label("Minimum handle length");
         });
         ui.horizontal(|ui| {
+            ui.add(DragValue::new(bar_inner_margin).clamp_range(0.0..=32.0));
+            ui.label("Inner margin");
+        });
+        ui.horizontal(|ui| {
             ui.add(DragValue::new(bar_outer_margin).range(0.0..=32.0));
             ui.label("Outer margin");
         });
@@ -680,11 +685,6 @@ impl ScrollStyle {
                 opacity_ui(ui, active_handle_opacity);
                 opacity_ui(ui, interact_handle_opacity);
                 ui.end_row();
-            });
-        } else {
-            ui.horizontal(|ui| {
-                ui.add(DragValue::new(bar_inner_margin).range(0.0..=32.0));
-                ui.label("Inner margin");
             });
         }
     }

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -648,7 +648,7 @@ impl ScrollStyle {
             ui.label("Minimum handle length");
         });
         ui.horizontal(|ui| {
-            ui.add(DragValue::new(bar_inner_margin).clamp_range(0.0..=32.0));
+            ui.add(DragValue::new(bar_inner_margin).range(0.0..=32.0));
             ui.label("Inner margin");
         });
         ui.horizontal(|ui| {


### PR DESCRIPTION
This is needed to resolve the following explanation, which cannot be resolved by #4754.

                // Move the scrollbar so it is visible. This is needed in some cases.
                // For instance:
                // * When we have a vertical-only scroll area in a top level panel,
                //   and that panel is not wide enough for the contents.
                // * When one ScrollArea is nested inside another, and the outer
                //   is scrolled so that the scroll-bars of the inner ScrollArea (us)
                //   is outside the clip rectangle.
                // Really this should use the tighter clip_rect that ignores clip_rect_margin, but we don't store that.
                // clip_rect_margin is quite a hack. It would be nice to get rid of it.
