### PR TITLE
Make `serde` a default (opt-out) feature of `egui_extras`

### DIFF
--- a/crates/egui_extras/Cargo.toml
+++ b/crates/egui_extras/Cargo.toml
@@ -27,7 +27,7 @@ all-features = true
 
 
 [features]
-default = ["dep:mime_guess2"]
+default = ["dep:mime_guess2", "serde"]
 
 ## Shorthand for enabling the different types of image loaders (`file`, `http`, `image`, `svg`).
 all_loaders = ["file", "http", "image", "svg", "gif"]


### PR DESCRIPTION
This is a workaround for https://github.com/emilk/egui/issues/4771 to make it less likely to bite users