### PR TITLE
Remove dead code (`EpiIntegration::frame_start`)

### DIFF
--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -154,8 +154,6 @@ pub struct EpiIntegration {
     last_auto_save: Instant,
     pub beginning: Instant,
     is_first_frame: bool,
-    #[allow(dead_code)]
-    pub frame_start: Instant,
     pub egui_ctx: egui::Context,
     pending_full_output: egui::FullOutput,
 
@@ -228,7 +226,6 @@ impl EpiIntegration {
             app_icon_setter,
             beginning: Instant::now(),
             is_first_frame: true,
-            frame_start: Instant::now(),
         }
     }
 

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -154,6 +154,7 @@ pub struct EpiIntegration {
     last_auto_save: Instant,
     pub beginning: Instant,
     is_first_frame: bool,
+    #[allow(dead_code)]
     pub frame_start: Instant,
     pub egui_ctx: egui::Context,
     pending_full_output: egui::FullOutput,


### PR DESCRIPTION
`frame_start` appears to be deprecated now.
( Am I wrong? )

It would be a good idea to add `#[allow(dead_code)]` or remove `frame_start`.
