### PR TITLE
Handle the IME event first in `TextEdit` to fix some bugs

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -425,7 +425,7 @@ impl<'t> TextEdit<'t> {
                         frame_rect,
                         visuals.rounding,
                         ui.visuals().extreme_bg_color,
-                        ui.visuals().widgets.noninteractive.bg_stroke, // TODO(emilk): we want to show something here, or a text-edit field doesn't "pop".
+                        visuals.bg_stroke, // TODO(emilk): we want to show something here, or a text-edit field doesn't "pop".
                     )
                 }
             } else {
@@ -858,7 +858,7 @@ fn events(
     let mut events = ui.input(|i| i.filtered_events(&event_filter));
 
     if state.ime_enabled {
-        ime_enabled_filter_events(&mut events);
+        remove_ime_incompatible_events(&mut events);
         // Process IME events first:
         events.sort_by_key(|e| !matches!(e, Event::Ime(_)));
     }
@@ -1062,7 +1062,7 @@ fn events(
 
 // ----------------------------------------------------------------------------
 
-fn ime_enabled_filter_events(events: &mut Vec<Event>) {
+fn remove_ime_incompatible_events(events: &mut Vec<Event>) {
     // Remove key events which cause problems while 'IME' is being used.
     // See https://github.com/emilk/egui/pull/4509
     events.retain(|event| {

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -425,7 +425,7 @@ impl<'t> TextEdit<'t> {
                         frame_rect,
                         visuals.rounding,
                         ui.visuals().extreme_bg_color,
-                        visuals.bg_stroke, // TODO(emilk): we want to show something here, or a text-edit field doesn't "pop".
+                        ui.visuals().widgets.noninteractive.bg_stroke, // TODO(emilk): we want to show something here, or a text-edit field doesn't "pop".
                     )
                 }
             } else {
@@ -855,7 +855,14 @@ fn events(
 
     let mut any_change = false;
 
-    let events = ui.input(|i| i.filtered_events(&event_filter));
+    let mut events = ui.input(|i| i.filtered_events(&event_filter));
+
+    if state.ime_enabled {
+        ime_enabled_filter_events(&mut events);
+        // Process IME events first:
+        events.sort_by_key(|e| !matches!(e, Event::Ime(_)));
+    }
+
     for event in &events {
         let did_mutate_text = match event {
             // First handle events that only changes the selection cursor, not the text:
@@ -1051,6 +1058,27 @@ fn events(
     );
 
     (any_change, cursor_range)
+}
+
+// ----------------------------------------------------------------------------
+
+fn ime_enabled_filter_events(events: &mut Vec<Event>) {
+    // Remove key events which cause problems while 'IME' is being used.
+    // See https://github.com/emilk/egui/pull/4509
+    events.retain(|event| {
+        !matches!(
+            event,
+            Event::Key { repeat: true, .. }
+                | Event::Key {
+                    key: Key::Backspace
+                        | Key::ArrowUp
+                        | Key::ArrowDown
+                        | Key::ArrowLeft
+                        | Key::ArrowRight,
+                    ..
+                }
+        )
+    });
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Handle the `IME` event first 
There is a need to handle the Ime event first.

Fix Issues : When you press `BackSpace`, the entire text is erased, and when you press another letter, it appears again.
Fix Issues : When you press `Left`, the character being entered will be copied once more.
Fix Issues : When you press `Enter`, `Enter` with `repeat` set is entered and `Enter` is entered twice.
Fix Issues : When you press a key in `IME` mode, `repeat` is often set.

Fix Issues : Since you may be selecting something in the IME, this also disables the `Arrow` keys.
