### PR TITLE
``egui-wgpu``: Ensure that ``WgpuConfiguration`` is ``Send + Sync``

### DIFF
--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -230,7 +230,8 @@ pub struct WgpuConfiguration {
     pub supported_backends: wgpu::Backends,
 
     /// Configuration passed on device request, given an adapter
-    pub device_descriptor: Arc<dyn Fn(&wgpu::Adapter) -> wgpu::DeviceDescriptor<'static>>,
+    pub device_descriptor:
+        Arc<dyn Fn(&wgpu::Adapter) -> wgpu::DeviceDescriptor<'static> + Send + Sync>,
 
     /// Present mode used for the primary surface.
     pub present_mode: wgpu::PresentMode,
@@ -248,7 +249,7 @@ pub struct WgpuConfiguration {
     pub power_preference: wgpu::PowerPreference,
 
     /// Callback for surface errors.
-    pub on_surface_error: Arc<dyn Fn(wgpu::SurfaceError) -> SurfaceErrorAction>,
+    pub on_surface_error: Arc<dyn Fn(wgpu::SurfaceError) -> SurfaceErrorAction + Send + Sync>,
 }
 
 impl std::fmt::Debug for WgpuConfiguration {


### PR DESCRIPTION
As far as I can tell, there's no reason that this shouldn't be the case