### PR TITLE
eframe: Improve `glow` context switching

### DIFF
--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -1235,7 +1235,7 @@ impl GlutinWindowContext {
                 change_gl_context(
                     &mut self.current_gl_context,
                     &mut self.not_current_gl_context,
-                    &gl_surface,
+                    gl_surface,
                 );
                 gl_surface.resize(
                     self.current_gl_context

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -588,6 +588,7 @@ impl GlowWinitRunning {
             let GlutinWindowContext {
                 viewports,
                 current_gl_context,
+                not_current_gl_context,
                 ..
             } = &mut *glutin;
             let viewport = &viewports[&viewport_id];
@@ -602,7 +603,7 @@ impl GlowWinitRunning {
 
             {
                 frame_timer.pause();
-                change_gl_context(current_gl_context, gl_surface);
+                change_gl_context(current_gl_context, not_current_gl_context, gl_surface);
                 frame_timer.resume();
             }
 
@@ -645,6 +646,7 @@ impl GlowWinitRunning {
         let GlutinWindowContext {
             viewports,
             current_gl_context,
+            not_current_gl_context,
             ..
         } = &mut *glutin;
 
@@ -664,7 +666,7 @@ impl GlowWinitRunning {
         {
             // We may need to switch contexts again, because of immediate viewports:
             frame_timer.pause();
-            change_gl_context(current_gl_context, gl_surface);
+            change_gl_context(current_gl_context, not_current_gl_context, gl_surface);
             frame_timer.resume();
         }
 
@@ -866,6 +868,7 @@ impl GlowWinitRunning {
 
 fn change_gl_context(
     current_gl_context: &mut Option<glutin::context::PossiblyCurrentContext>,
+    not_current_gl_context: &mut Option<glutin::context::NotCurrentContext>,
     gl_surface: &glutin::surface::Surface<glutin::surface::WindowSurface>,
 ) {
     crate::profile_function!();
@@ -884,7 +887,9 @@ fn change_gl_context(
         }
     }
 
-    let not_current = {
+    let not_current = if let Some(not_current_context) = not_current_gl_context.take() {
+        not_current_context
+    } else {
         crate::profile_scope!("make_not_current");
         current_gl_context
             .take()
@@ -1227,7 +1232,11 @@ impl GlutinWindowContext {
 
         if let Some(viewport) = self.viewports.get(&viewport_id) {
             if let Some(gl_surface) = &viewport.gl_surface {
-                change_gl_context(&mut self.current_gl_context, gl_surface);
+                change_gl_context(
+                    &mut self.current_gl_context,
+                    &mut self.not_current_gl_context,
+                    &gl_surface,
+                );
                 gl_surface.resize(
                     self.current_gl_context
                         .as_ref()
@@ -1459,6 +1468,7 @@ fn render_immediate_viewport(
 
     let GlutinWindowContext {
         current_gl_context,
+        not_current_gl_context,
         viewports,
         ..
     } = &mut *glutin;
@@ -1479,7 +1489,7 @@ fn render_immediate_viewport(
 
     let screen_size_in_pixels: [u32; 2] = window.inner_size().into();
 
-    change_gl_context(current_gl_context, gl_surface);
+    change_gl_context(current_gl_context, not_current_gl_context, gl_surface);
 
     let current_gl_context = current_gl_context.as_ref().unwrap();
 


### PR DESCRIPTION
Improved `change_gl_context()`

**Before:** 
Create a new `not_current_glcontext`. 

**After:**
If `not_current_glcontext` exists, apply it. Otherwise, create it. 

This will make the program smoother when dragging, etc. 
