### PR TITLE
Change default `max_scroll_height` of `egui::Table` to `f32::INFINITY`

### DIFF
--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -185,7 +185,7 @@ impl Default for TableScrollOptions {
             scroll_to_row: None,
             scroll_offset_y: None,
             min_scrolled_height: 200.0,
-            max_scroll_height: 800.0,
+            max_scroll_height: f32::INFINITY,
             auto_shrink: Vec2b::TRUE,
             scroll_bar_visibility: ScrollBarVisibility::VisibleWhenNeeded,
         }


### PR DESCRIPTION
`egui::Table` has a weirdly specific default `max_scroll_height` set to 800.0. This means that even with `vscroll(true)` and `auto_shrink([_, false])`, the table will not expend to the full available height. This PR changes this value to `f32::INFINITY`. This makes it consistent with the corresponding default value of `ScrollArea::max_size.y`, which is where that `max_scroll_height` ends up being used.