### PR TITLE
Add `TableRow::set_hovered`

### DIFF
--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -1256,6 +1256,12 @@ impl<'a, 'b> TableRow<'a, 'b> {
         self.selected = selected;
     }
 
+    /// Set the hovered highlight state for cells added after a call to this function.
+    #[inline]
+    pub fn set_hovered(&mut self, hovered: bool) {
+        self.hovered = hovered;
+    }
+
     /// Returns a union of the [`Response`]s of the cells added to the row up to this point.
     ///
     /// You need to add at least one row to the table before calling this function.


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->
I added a util function `set_hovered` to change the hovered state of a row from tables in  `egui_extras` which matches the already present `set_selected` function. 

* [x] I have followed the instructions in the PR template
