### PR TITLE
Return `ScrollAreaOutput` from `Table::body`

### DIFF
--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -4,8 +4,8 @@
 //! Takes all available height, so if you want something below the table, put it in a strip.
 
 use egui::{
-    scroll_area::ScrollBarVisibility, Align, NumExt as _, Rangef, Rect, Response, ScrollArea, Ui,
-    Vec2, Vec2b,
+    scroll_area::{ScrollAreaOutput, ScrollBarVisibility},
+    Align, NumExt as _, Rangef, Rect, Response, ScrollArea, Ui, Vec2, Vec2b,
 };
 
 use crate::{
@@ -474,7 +474,7 @@ impl<'a> TableBuilder<'a> {
     }
 
     /// Create table body without a header row
-    pub fn body<F>(self, add_body_contents: F)
+    pub fn body<F>(self, add_body_contents: F) -> ScrollAreaOutput<()>
     where
         F: for<'b> FnOnce(TableBody<'b>),
     {
@@ -515,7 +515,7 @@ impl<'a> TableBuilder<'a> {
             scroll_options,
             sense,
         }
-        .body(add_body_contents);
+        .body(add_body_contents)
     }
 }
 
@@ -641,7 +641,7 @@ impl<'a> Table<'a> {
     }
 
     /// Create table body after adding a header row
-    pub fn body<F>(self, add_body_contents: F)
+    pub fn body<F>(self, add_body_contents: F) -> ScrollAreaOutput<()>
     where
         F: for<'b> FnOnce(TableBody<'b>),
     {
@@ -692,7 +692,7 @@ impl<'a> Table<'a> {
         let widths_ref = &state.column_widths;
         let max_used_widths_ref = &mut max_used_widths;
 
-        scroll_area.show(ui, move |ui| {
+        let scroll_area_out = scroll_area.show(ui, move |ui| {
             let mut scroll_to_y_range = None;
 
             let clip_rect = ui.clip_rect();
@@ -843,6 +843,7 @@ impl<'a> Table<'a> {
         state.max_used_widths = max_used_widths;
 
         state.store(ui, state_id);
+        scroll_area_out
     }
 }
 


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

added return ScrollAreaOutput.

This can be used to monitor the scroll progress of a table(usage example: custom scroll progress bar or lazy loading table)

* [X] I have followed the instructions in the PR template
