### PR TITLE
Fix: The viewport stops working when the program is minimized.                        

### DIFF
--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -189,13 +189,8 @@ fn run_and_return(event_loop: &mut EventLoop<UserEvent>, mut winit_app: impl Win
 
             if let Some(window) = winit_app.window(*window_id) {
                 log::trace!("request_redraw for {window_id:?}");
-                let is_minimized = window.is_minimized().unwrap_or(false);
-                if is_minimized {
-                    false
-                } else {
-                    window.request_redraw();
-                    true
-                }
+                window.request_redraw();
+                true
             } else {
                 log::trace!("No window found for {window_id:?}");
                 false
@@ -347,13 +342,8 @@ fn run_and_exit(
 
             if let Some(window) = winit_app.window(*window_id) {
                 log::trace!("request_redraw for {window_id:?}");
-                let is_minimized = window.is_minimized().unwrap_or(false);
-                if is_minimized {
-                    false
-                } else {
-                    window.request_redraw();
-                    true
-                }
+                window.request_redraw();
+                true
             } else {
                 log::trace!("No window found for {window_id:?}");
                 false


### PR DESCRIPTION
Fix: The viewport stops working when the program is minimized.                        
                                                                                      
**Issue :**                                                                         
                                                                                      
The viewport stops working when the program is minimized.                             
                                                                                      
* Closes #3972                                                                        
* Closes #4772
                                                                                      
**Solution :**                                                                      
                                                                                      
When `request_redraw()` is performed in Minimized state, the occasional screen tearing phenomenon has disappeared.
( Probably expected to be the effect of #4814 )                                       
                                                                                      
To address the issue of the `Immediate Viewport` not updating in Minimized state, we can call `request_redraw()`.
