### PR TITLE
Clarified `eframe::run_simple_native()` persistence

### DIFF
--- a/crates/eframe/src/lib.rs
+++ b/crates/eframe/src/lib.rs
@@ -274,7 +274,9 @@ pub fn run_native(
 
 /// The simplest way to get started when writing a native app.
 ///
-/// This does NOT support persistence. For that you need to use [`run_native`].
+/// This does NOT support persistence of custom user data. For that you need to use [`run_native`].
+/// However, it DOES support persistence of egui data (window positions and sizes, how far the user has scrolled in a
+/// [`ScrollArea`](egui::ScrollArea), etc.) if the persistence feature is enabled.
 ///
 /// # Example
 /// ``` no_run


### PR DESCRIPTION
* [x] I have followed the instructions in the PR template

Clarified that `eframe::run_simple_native()` does in fact save some state (if persistence is enabled) but does not allow user to save state.