### PR TITLE
Force canvas/text input focus on touch for iOS web browsers

### DIFF
--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -248,6 +248,7 @@ web-sys = { workspace = true, features = [
   "Storage",
   "Touch",
   "TouchEvent",
+  "PointerEvent",
   "TouchList",
   "WebGl2RenderingContext",
   "WebglDebugRendererInfo",

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -264,3 +264,16 @@ pub fn percent_decode(s: &str) -> String {
         .decode_utf8_lossy()
         .to_string()
 }
+
+/// Returns `true` if the app is likely running on a mobile device.
+pub(crate) fn is_mobile() -> bool {
+    fn try_is_mobile() -> Option<bool> {
+        const MOBILE_DEVICE: [&str; 6] =
+            ["Android", "iPhone", "iPad", "iPod", "webOS", "BlackBerry"];
+
+        let user_agent = web_sys::window()?.navigator().user_agent().ok()?;
+        let is_mobile = MOBILE_DEVICE.iter().any(|&name| user_agent.contains(name));
+        Some(is_mobile)
+    }
+    try_is_mobile().unwrap_or(false)
+}

--- a/crates/eframe/src/web/text_agent.rs
+++ b/crates/eframe/src/web/text_agent.rs
@@ -5,7 +5,7 @@ use std::cell::Cell;
 
 use wasm_bindgen::prelude::*;
 
-use super::{AppRunner, WebRunner};
+use super::{is_mobile, AppRunner, WebRunner};
 
 pub struct TextAgent {
     input: web_sys::HtmlInputElement,
@@ -172,17 +172,4 @@ impl Drop for TextAgent {
     fn drop(&mut self) {
         self.input.remove();
     }
-}
-
-/// Returns `true` if the app is likely running on a mobile device.
-fn is_mobile() -> bool {
-    fn try_is_mobile() -> Option<bool> {
-        const MOBILE_DEVICE: [&str; 6] =
-            ["Android", "iPhone", "iPad", "iPod", "webOS", "BlackBerry"];
-
-        let user_agent = web_sys::window()?.navigator().user_agent().ok()?;
-        let is_mobile = MOBILE_DEVICE.iter().any(|&name| user_agent.contains(name));
-        Some(is_mobile)
-    }
-    try_is_mobile().unwrap_or(false)
 }


### PR DESCRIPTION
Related to #4569

- moved `is_mobile` from `eframe/src/web/text_agent.rs` to `eframe/src/web/mod.rs` and used it in `eframe/src/web/events.rs`
- added event listener for `pointerdown` event
- added event listener for `pointerup` event and forced the canvas to be focused when the event is received and therefore the on-screen keyboard appearing

This PR tries to fix iOS browsers issue where it doesn't focus the canvas/text input on touch and therefore not showing the on-screen keyboard. It does it by force focusing the canvas on `pointerup`