### PR TITLE
Allow setting a fill color for ProgressBar track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ NOTE: this is just the changelog for the core `egui` crate. [`eframe`](crates/ef
 This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
+## Unreleased
+### Added ⭐
+* Add `ProgressBar::track_fill` if you want to set the fill color of the track manually. ( TODO: PR Link )
 
 ## 0.28.1 - 2024-07-05 - Tooltip tweaks
 ### ⭐ Added

--- a/crates/egui/src/widgets/progress_bar.rs
+++ b/crates/egui/src/widgets/progress_bar.rs
@@ -15,6 +15,7 @@ pub struct ProgressBar {
     desired_height: Option<f32>,
     text: Option<ProgressBarText>,
     fill: Option<Color32>,
+    track_fill: Option<Color32>,
     animate: bool,
     rounding: Option<Rounding>,
 }
@@ -28,6 +29,7 @@ impl ProgressBar {
             desired_height: None,
             text: None,
             fill: None,
+            track_fill: None,
             animate: false,
             rounding: None,
         }
@@ -51,6 +53,13 @@ impl ProgressBar {
     #[inline]
     pub fn fill(mut self, color: Color32) -> Self {
         self.fill = Some(color);
+        self
+    }
+
+    /// The fill color of the track.
+    #[inline]
+    pub fn track_fill(mut self, color: Color32) -> Self {
+        self.track_fill = Some(color);
         self
     }
 
@@ -101,6 +110,7 @@ impl Widget for ProgressBar {
             desired_height,
             text,
             fill,
+            track_fill,
             animate,
             rounding,
         } = self;
@@ -147,6 +157,15 @@ impl Widget for ProgressBar {
             } else {
                 bright
             };
+
+            if let Some(color) = track_fill {
+                ui.painter().rect(
+                    outer_rect,
+                    rounding,
+                    Color32::from(Rgba::from(color) * color_factor as f32),
+                    Stroke::NONE,
+                );
+            }
 
             ui.painter().rect(
                 inner_rect,


### PR DESCRIPTION
Here is the demo widget gallery with the `ProgressBar::track_fill` set to dark blue:

```rust
let progress_bar = egui::ProgressBar::new(progress)
    .show_percentage()
    .track_fill(egui::Color32::DARK_BLUE)
    .animate(*animate_progress_bar);
```

![track](https://github.com/user-attachments/assets/1c1a6493-5dc0-45fb-9ddb-54a9f10682f3)
