### PR TITLE
Workaround for wgpu crash when surface is dropped last

### DIFF
--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -96,6 +96,17 @@ pub struct Painter {
     surfaces: ViewportIdMap<SurfaceState>,
 }
 
+impl Drop for Painter {
+    fn drop(&mut self) {
+        // Drop surfaces before dropping the render state.
+        //
+        // This is a workaround for a bug in wgpu 22.0.0.
+        // Fixed in https://github.com/gfx-rs/wgpu/pull/6052
+        // Remove with wgpu 22.1.0 update!
+        self.surfaces.clear();
+    }
+}
+
 impl Painter {
     /// Manages [`wgpu`] state, including surface state, required to render egui.
     ///


### PR DESCRIPTION
* Fixes https://github.com/emilk/egui/issues/4874
* Details see https://github.com/gfx-rs/wgpu/pull/6052