### PR TITLE
[feat] Very lazy mode for eframe

### DIFF
--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -123,6 +123,9 @@ x11 = ["egui-winit/x11", "egui-wgpu?/x11", "egui_glow?/x11"]
 ## This is used to generate images for examples.
 __screenshot = []
 
+## Experimental: remove hoverable effects on some widgets from egui and do not re-render without effects, for very lazy rendering
+very_lazy = ["egui/very_lazy", "egui-winit/very_lazy"]
+
 [dependencies]
 egui = { workspace = true, default-features = false, features = [
   "bytemuck",

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -299,7 +299,10 @@ impl EpiIntegration {
         viewport_ui_cb: Option<&DeferredViewportUiCallback>,
         mut raw_input: egui::RawInput,
     ) -> egui::FullOutput {
-        raw_input.time = Some(self.beginning.elapsed().as_secs_f64());
+        #[cfg(not(feature = "very_lazy"))] // required as egui-winit uses the original time
+        {
+            raw_input.time = Some(self.beginning.elapsed().as_secs_f64());
+        }
 
         let close_requested = raw_input.viewport().close_requested();
 

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -466,7 +466,7 @@ impl WinitApp for WgpuWinitApp {
                         }
 
                         if let Some(window) = viewport.window.as_ref() {
-                            EventResult::RepaintNext(window.id());
+                            EventResult::RepaintNext(window.id())
                         } else {
                             EventResult::Wait
                         }

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -454,6 +454,7 @@ impl WinitApp for WgpuWinitApp {
                 device_id: _,
                 event: winit::event::DeviceEvent::MouseMotion { delta },
             } => {
+                #[cfg(not(feature = "very_lazy"))]
                 if let Some(running) = &mut self.running {
                     let mut shared = running.shared.borrow_mut();
                     if let Some(viewport) = shared
@@ -465,7 +466,7 @@ impl WinitApp for WgpuWinitApp {
                         }
 
                         if let Some(window) = viewport.window.as_ref() {
-                            EventResult::RepaintNext(window.id())
+                            EventResult::RepaintNext(window.id());
                         } else {
                             EventResult::Wait
                         }
@@ -473,6 +474,22 @@ impl WinitApp for WgpuWinitApp {
                         EventResult::Wait
                     }
                 } else {
+                    EventResult::Wait
+                }
+
+                #[cfg(feature = "very_lazy")]
+                {
+                    if let Some(running) = &mut self.running {
+                        let mut shared = running.shared.borrow_mut();
+                        if let Some(viewport) = shared
+                            .focused_viewport
+                            .and_then(|viewport| shared.viewports.get_mut(&viewport))
+                        {
+                            if let Some(egui_winit) = viewport.egui_winit.as_mut() {
+                                egui_winit.on_mouse_motion(*delta);
+                            }
+                        }
+                    }
                     EventResult::Wait
                 }
             }

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -202,16 +202,18 @@ impl AppRunner {
         }
     }
 
+    pub(crate) fn raw_input(&mut self) -> egui::RawInput {
+        let canvas_size = super::canvas_size_in_points(self.canvas(), self.egui_ctx());
+        self.input.new_frame(canvas_size)
+    }
+
     /// Runs the logic, but doesn't paint the result.
     ///
     /// The result can be painted later with a call to [`Self::run_and_paint`] or [`Self::paint`].
     pub fn logic(&mut self) {
         // We sometimes miss blur/focus events due to the text agent, so let's just poll each frame:
         self.update_focus();
-
-        let canvas_size = super::canvas_size_in_points(self.canvas(), self.egui_ctx());
-        let mut raw_input = self.input.new_frame(canvas_size);
-
+        let mut raw_input = self.raw_input();
         self.app.raw_input_hook(&self.egui_ctx, &mut raw_input);
 
         let full_output = self.egui_ctx.run(raw_input, |egui_ctx| {

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -446,7 +446,33 @@ fn install_mousemove(runner_ref: &WebRunner, target: &EventTarget) -> Result<(),
             egui::pos2(event.client_x() as f32, event.client_y() as f32),
         ) {
             runner.input.raw.events.push(egui::Event::PointerMoved(pos));
-            runner.needs_repaint.repaint_asap();
+
+            #[cfg(feature = "very_lazy")]
+            {
+                let raw_input = runner.raw_input();
+                runner.egui_ctx().detect_interaction(raw_input);
+                let (repaint, is_drag) = runner.egui_ctx().viewport(|v| {
+                    (
+                        !v.interact_widgets.hovered.is_empty(),
+                        v.interact_widgets.dragged.is_some(),
+                    )
+                });
+                if repaint {
+                    runner.needs_repaint.repaint_asap();
+                    if !is_drag {
+                        runner.egui_ctx().undo_interaction();
+                    }
+                } else {
+                    runner.input.raw.events.pop();
+                    runner.egui_ctx().undo_interaction();
+                }
+            }
+
+            #[cfg(not(feature = "very_lazy"))]
+            {
+                runner.needs_repaint.repaint_asap();
+            }
+
             event.stop_propagation();
             event.prevent_default();
         }

--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -57,6 +57,9 @@ wayland = ["winit/wayland", "bytemuck"]
 ## Enables compiling for x11.
 x11 = ["winit/x11", "bytemuck"]
 
+## Experimental: do not re-render for hovering without effects, for very lazy rendering
+very_lazy = ["egui/very_lazy"]
+
 [dependencies]
 egui = { workspace = true, default-features = false, features = ["log"] }
 

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -299,6 +299,26 @@ impl State {
             }
             WindowEvent::CursorMoved { position, .. } => {
                 self.on_cursor_moved(window, *position);
+
+                #[cfg(feature = "very_lazy")]
+                {
+                    let raw_input = self.take_egui_input(window);
+                    // raw_input.time = None;
+                    self.egui_ctx.detect_interaction(raw_input);
+                    let repaint = self.egui_ctx.viewport(|v| {
+                        let widgets = &v.interact_widgets;
+                        !&widgets.hovered.is_empty()
+                    });
+                    if !repaint {
+                        self.egui_ctx.undo_interaction();
+                    }
+                    EventResponse {
+                        repaint,
+                        consumed: self.egui_ctx.is_using_pointer(),
+                    }
+                }
+
+                #[cfg(not(feature = "very_lazy"))]
                 EventResponse {
                     repaint: true,
                     consumed: self.egui_ctx.is_using_pointer(),

--- a/crates/egui/Cargo.toml
+++ b/crates/egui/Cargo.toml
@@ -77,6 +77,9 @@ serde = ["dep:serde", "epaint/serde", "accesskit?/serde"]
 ## Change Vertex layout to be compatible with unity
 unity = ["epaint/unity"]
 
+## Experimental: remove hoverable effects on some widgets, for very lazy rendering
+very_lazy = []
+
 
 [dependencies]
 emath = { workspace = true, default-features = false }

--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -451,11 +451,11 @@ impl Area {
             let interact_id = layer_id.id.with("move");
             let sense = sense.unwrap_or_else(|| {
                 if movable {
-                    Sense::drag()
+                    Sense::drag().no_hover()
                 } else if interactable {
-                    Sense::click() // allow clicks to bring to front
+                    Sense::click().no_hover() // allow clicks to bring to front
                 } else {
-                    Sense::hover()
+                    Sense::hover().no_hover()
                 }
             });
 

--- a/crates/egui/src/containers/frame.rs
+++ b/crates/egui/src/containers/frame.rs
@@ -317,7 +317,7 @@ impl Prepared {
     ///
     /// This can be called before or after [`Self::paint`].
     pub fn allocate_space(&self, ui: &mut Ui) -> Response {
-        ui.allocate_rect(self.content_with_margin(), Sense::hover())
+        ui.allocate_rect(self.content_with_margin(), Sense::hover().no_hover())
     }
 
     /// Paint the frame.

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -195,7 +195,7 @@ fn show_tooltip_at_dyn<'c, R>(
         .pivot(pivot)
         .fixed_pos(anchor)
         .default_width(ctx.style().spacing.tooltip_width)
-        .sense(Sense::hover()) // don't click to bring to front
+        .sense(Sense::hover().no_hover()) // don't click to bring to front
         .show(ctx, |ui| {
             // By default the text in tooltips aren't selectable.
             // This means that most tooltips aren't interactable,

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -597,7 +597,7 @@ impl ScrollArea {
             // or we will steal input from the widgets we contain.
             let content_response_option = state
                 .interact_rect
-                .map(|rect| ui.interact(rect, id.with("area"), Sense::drag()));
+                .map(|rect| ui.interact(rect, id.with("area"), Sense::drag().no_hover()));
 
             if content_response_option.map(|response| response.dragged()) == Some(true) {
                 for d in 0..2 {
@@ -1043,9 +1043,9 @@ impl Prepared {
 
             let interact_id = id.with(d);
             let sense = if self.scrolling_enabled {
-                Sense::click_and_drag()
+                Sense::click_and_drag().no_hover()
             } else {
-                Sense::hover()
+                Sense::hover().no_hover()
             };
             let response = ui.interact(outer_scroll_rect, interact_id, sense);
 

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -845,7 +845,7 @@ fn resize_interaction(
             id,
             rect,
             interact_rect: rect,
-            sense: Sense::drag(),
+            sense: Sense::drag().no_hover(),
             enabled: true,
         });
         SideResponse {
@@ -1155,7 +1155,7 @@ impl TitleBar {
         let double_click_rect = self.rect.shrink2(vec2(32.0, 0.0));
 
         if ui
-            .interact(double_click_rect, self.id, Sense::click())
+            .interact(double_click_rect, self.id, Sense::click().no_hover())
             .double_clicked()
             && collapsible
         {

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -400,40 +400,17 @@ struct ContextImpl {
     accesskit_node_classes: accesskit::NodeClassSet,
 
     loaders: Arc<Loaders>,
+
+    interaction_valid: bool,
+    hover_listeners: std::collections::HashSet<Id>,
 }
 
 impl ContextImpl {
-    fn begin_frame_mut(&mut self, mut new_raw_input: RawInput) {
-        let viewport_id = new_raw_input.viewport_id;
-        let parent_id = new_raw_input
-            .viewports
-            .get(&viewport_id)
-            .and_then(|v| v.parent)
-            .unwrap_or_default();
-        let ids = ViewportIdPair::from_self_and_parent(viewport_id, parent_id);
-
-        let is_outermost_viewport = self.viewport_stack.is_empty(); // not necessarily root, just outermost immediate viewport
-        self.viewport_stack.push(ids);
-
-        self.begin_frame_repaint_logic(viewport_id);
-
-        let viewport = self.viewports.entry(viewport_id).or_default();
-
-        if is_outermost_viewport {
-            if let Some(new_zoom_factor) = self.new_zoom_factor.take() {
-                let ratio = self.memory.options.zoom_factor / new_zoom_factor;
-                self.memory.options.zoom_factor = new_zoom_factor;
-
-                let input = &viewport.input;
-                // This is a bit hacky, but is required to avoid jitter:
-                let mut rect = input.screen_rect;
-                rect.min = (ratio * rect.min.to_vec2()).to_pos2();
-                rect.max = (ratio * rect.max.to_vec2()).to_pos2();
-                new_raw_input.screen_rect = Some(rect);
-                // We should really scale everything else in the input too,
-                // but the `screen_rect` is the most important part.
-            }
+    pub(crate) fn detect_interaction(&mut self, new_raw_input: RawInput) {
+        if self.interaction_valid {
+            return;
         }
+
         let native_pixels_per_point = new_raw_input
             .viewport()
             .native_pixels_per_point
@@ -442,9 +419,9 @@ impl ContextImpl {
 
         let all_viewport_ids: ViewportIdSet = self.all_viewport_ids();
 
-        let viewport = self.viewports.entry(self.viewport_id()).or_default();
-
         self.memory.begin_frame(&new_raw_input, &all_viewport_ids);
+
+        let viewport = self.viewports.entry(self.viewport_id()).or_default();
 
         viewport.input = std::mem::take(&mut viewport.input).begin_frame(
             new_raw_input,
@@ -453,9 +430,7 @@ impl ContextImpl {
             &self.memory.options,
         );
 
-        let screen_rect = viewport.input.screen_rect;
-
-        viewport.this_frame.begin_frame(screen_rect);
+        viewport.this_frame.begin_frame(viewport.input.screen_rect);
 
         {
             let area_order = self.memory.areas().order_map();
@@ -493,7 +468,47 @@ impl ContextImpl {
                 &viewport.input,
                 self.memory.interaction_mut(),
             );
+
+            self.interaction_valid = true;
         }
+    }
+
+    fn begin_frame_mut(&mut self, mut new_raw_input: RawInput) {
+        self.hover_listeners.clear();
+        let viewport_id = new_raw_input.viewport_id;
+        let parent_id = new_raw_input
+            .viewports
+            .get(&viewport_id)
+            .and_then(|v| v.parent)
+            .unwrap_or_default();
+        let ids = ViewportIdPair::from_self_and_parent(viewport_id, parent_id);
+
+        let is_outermost_viewport = self.viewport_stack.is_empty(); // not necessarily root, just outermost immediate viewport
+        self.viewport_stack.push(ids);
+
+        self.begin_frame_repaint_logic(viewport_id);
+
+        let viewport = self.viewports.entry(viewport_id).or_default();
+
+        if is_outermost_viewport {
+            if let Some(new_zoom_factor) = self.new_zoom_factor.take() {
+                let ratio = self.memory.options.zoom_factor / new_zoom_factor;
+                self.memory.options.zoom_factor = new_zoom_factor;
+
+                let input = &viewport.input;
+                // This is a bit hacky, but is required to avoid jitter:
+                let mut rect = input.screen_rect;
+                rect.min = (ratio * rect.min.to_vec2()).to_pos2();
+                rect.max = (ratio * rect.max.to_vec2()).to_pos2();
+                new_raw_input.screen_rect = Some(rect);
+                // We should really scale everything else in the input too,
+                // but the `screen_rect` is the most important part.
+            }
+        }
+
+        let viewport = self.viewports.entry(self.viewport_id()).or_default();
+
+        let screen_rect = viewport.input.screen_rect;
 
         // Ensure we register the background area so panels and background ui can catch clicks:
         self.memory.areas_mut().set_state(
@@ -522,6 +537,8 @@ impl ContextImpl {
                 parent_stack: vec![id],
             });
         }
+        self.detect_interaction(new_raw_input);
+        self.interaction_valid = false;
 
         self.update_fonts_mut();
     }
@@ -721,6 +738,18 @@ impl Context {
     /// Do read-write (exclusive access) transaction on Context
     fn write<R>(&self, writer: impl FnOnce(&mut ContextImpl) -> R) -> R {
         writer(&mut self.0.write())
+    }
+
+    /// Perform a interaction detection wrt the given input
+    pub fn detect_interaction(&self, raw_input: RawInput) {
+        self.write(|ctx| ctx.detect_interaction(raw_input));
+    }
+
+    /// Undo the interaction detection when the context is not updated immediately
+    pub fn undo_interaction(&self) {
+        self.write(|ctx| {
+            ctx.interaction_valid = false;
+        });
     }
 
     /// Run the ui code for one frame.

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -402,7 +402,6 @@ struct ContextImpl {
     loaders: Arc<Loaders>,
 
     interaction_valid: bool,
-    hover_listeners: std::collections::HashSet<Id>,
 }
 
 impl ContextImpl {
@@ -474,7 +473,6 @@ impl ContextImpl {
     }
 
     fn begin_frame_mut(&mut self, mut new_raw_input: RawInput) {
-        self.hover_listeners.clear();
         let viewport_id = new_raw_input.viewport_id;
         let parent_id = new_raw_input
             .viewports

--- a/crates/egui/src/interaction.rs
+++ b/crates/egui/src/interaction.rs
@@ -247,6 +247,7 @@ pub(crate) fn interact(
             .chain(&dragged)
             .chain(&long_touched)
             .copied()
+            // .filter(|id| widgets.get(*id).is_some_and(|w| w.sense.hoverable))
             .collect()
     } else {
         // We may be hovering a an interactive widget or two.
@@ -272,10 +273,16 @@ pub(crate) fn interact(
         let drag_order = hits.drag.and_then(|w| order(w.id)).unwrap_or(0);
         let top_interactive_order = click_order.max(drag_order);
 
-        let mut hovered: IdSet = hits.click.iter().chain(&hits.drag).map(|w| w.id).collect();
+        let mut hovered: IdSet = hits
+            .click
+            .iter()
+            .chain(&hits.drag)
+            .filter(|w| w.sense.hoverable)
+            .map(|w| w.id)
+            .collect();
 
         for w in &hits.contains_pointer {
-            if top_interactive_order <= order(w.id).unwrap_or(0) {
+            if top_interactive_order <= order(w.id).unwrap_or(0) && w.sense.hoverable {
                 hovered.insert(w.id);
             }
         }

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -179,7 +179,7 @@ fn menu_popup<'c, R>(
         .order(Order::Foreground)
         .fixed_pos(pos)
         .default_width(ctx.style().spacing.menu_width)
-        .sense(Sense::hover());
+        .sense(Sense::hover().no_hover());
 
     let mut sizing_pass = false;
 
@@ -701,7 +701,7 @@ impl MenuState {
 
             self.open_submenu(sub_id, pos);
         } else if open
-            && ui.interact_bg(Sense::hover()).contains_pointer()
+            && ui.interact_bg(Sense::hover().no_hover()).contains_pointer()
             && !button.hovered()
             && !self.hovering_current_submenu(&pointer)
         {

--- a/crates/egui/src/sense.rs
+++ b/crates/egui/src/sense.rs
@@ -13,6 +13,8 @@ pub struct Sense {
     /// Anything interactive + labels that can be focused
     /// for the benefit of screen readers.
     pub focusable: bool,
+
+    pub hoverable: bool,
 }
 
 impl std::fmt::Debug for Sense {
@@ -21,6 +23,7 @@ impl std::fmt::Debug for Sense {
             click,
             drag,
             focusable,
+            hoverable,
         } = self;
 
         write!(f, "Sense {{")?;
@@ -33,19 +36,34 @@ impl std::fmt::Debug for Sense {
         if *focusable {
             write!(f, " focusable")?;
         }
+        if *hoverable {
+            write!(f, " hoverable")?;
+        }
         write!(f, " }}")
     }
 }
 
 impl Sense {
+    /// Senses no clicks or drags or mouse hover.
+    /// Using `hover().no_hover()` for now for max backward compatibility
+    #[inline]
+    pub fn none() -> Self {
+        Self {
+            click: false,
+            drag: false,
+            focusable: false,
+            hoverable: false,
+        }
+    }
+
     /// Senses no clicks or drags. Only senses mouse hover.
-    #[doc(alias = "none")]
     #[inline]
     pub fn hover() -> Self {
         Self {
             click: false,
             drag: false,
             focusable: false,
+            hoverable: true,
         }
     }
 
@@ -57,6 +75,7 @@ impl Sense {
             click: false,
             drag: false,
             focusable: true,
+            hoverable: true,
         }
     }
 
@@ -67,6 +86,7 @@ impl Sense {
             click: true,
             drag: false,
             focusable: true,
+            hoverable: true,
         }
     }
 
@@ -77,6 +97,7 @@ impl Sense {
             click: false,
             drag: true,
             focusable: true,
+            hoverable: true,
         }
     }
 
@@ -94,6 +115,7 @@ impl Sense {
             click: true,
             drag: true,
             focusable: true,
+            hoverable: true,
         }
     }
 
@@ -105,6 +127,7 @@ impl Sense {
             click: self.click | other.click,
             drag: self.drag | other.drag,
             focusable: self.focusable | other.focusable,
+            hoverable: self.hoverable | other.hoverable,
         }
     }
 
@@ -112,6 +135,21 @@ impl Sense {
     #[inline]
     pub fn interactive(&self) -> bool {
         self.click || self.drag
+    }
+
+    /// Experimental: disables hovering
+    #[inline]
+    pub fn no_hover(self) -> Self {
+        #[cfg(feature = "very_lazy")]
+        {
+            Self {
+                hoverable: false,
+                ..self
+            }
+        }
+
+        #[cfg(not(feature = "very_lazy"))]
+        self
     }
 }
 

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -118,7 +118,7 @@ impl Ui {
             layer_id: ui.layer_id(),
             rect: start_rect,
             interact_rect: start_rect,
-            sense: Sense::hover(),
+            sense: Sense::hover().no_hover(),
             enabled: ui.enabled,
         });
 
@@ -192,7 +192,7 @@ impl Ui {
             layer_id: child_ui.layer_id(),
             rect: start_rect,
             interact_rect: start_rect,
-            sense: Sense::hover(),
+            sense: Sense::hover().no_hover(),
             enabled: child_ui.enabled,
         });
 
@@ -1139,7 +1139,7 @@ impl Ui {
         self.placer
             .advance_after_rects(final_child_rect, final_child_rect, item_spacing);
 
-        let response = self.interact(final_child_rect, child_ui.id, Sense::hover());
+        let response = self.interact(final_child_rect, child_ui.id, Sense::hover().no_hover());
         InnerResponse::new(ret, response)
     }
 
@@ -1164,7 +1164,7 @@ impl Ui {
             self.spacing().item_spacing,
         );
 
-        let response = self.interact(final_child_rect, child_ui.id, Sense::hover());
+        let response = self.interact(final_child_rect, child_ui.id, Sense::hover().no_hover());
         InnerResponse::new(ret, response)
     }
 
@@ -1177,7 +1177,7 @@ impl Ui {
     /// # use std::f32::consts::TAU;
     /// # egui::__run_test_ui(|ui| {
     /// let size = Vec2::splat(16.0);
-    /// let (response, painter) = ui.allocate_painter(size, Sense::hover());
+    /// let (response, painter) = ui.allocate_painter(size, Sense::hover().no_hover());
     /// let rect = response.rect;
     /// let c = rect.center();
     /// let r = rect.width() / 2.0 - 1.0;
@@ -2004,7 +2004,7 @@ impl Ui {
             self.child_ui_with_id_source(child_rect, *self.layout(), id_source, ui_stack_info);
         self.next_auto_id_source = next_auto_id_source; // HACK: we want `scope` to only increment this once, so that `ui.scope` is equivalent to `ui.allocate_space`.
         let ret = add_contents(&mut child_ui);
-        let response = self.allocate_rect(child_ui.min_rect(), Sense::hover());
+        let response = self.allocate_rect(child_ui.min_rect(), Sense::hover().no_hover());
         InnerResponse::new(ret, response)
     }
 
@@ -2091,7 +2091,7 @@ impl Ui {
             }
         }
 
-        let response = self.allocate_rect(child_ui.min_rect(), Sense::hover());
+        let response = self.allocate_rect(child_ui.min_rect(), Sense::hover().no_hover());
         InnerResponse::new(ret, response)
     }
 
@@ -2289,7 +2289,10 @@ impl Ui {
         let item_spacing = self.spacing().item_spacing;
         self.placer.advance_after_rects(rect, rect, item_spacing);
 
-        InnerResponse::new(inner, self.interact(rect, child_ui.id, Sense::hover()))
+        InnerResponse::new(
+            inner,
+            self.interact(rect, child_ui.id, Sense::hover().no_hover()),
+        )
     }
 
     /// This will make the next added widget centered and justified in the available space.

--- a/crates/egui/src/widgets/color_picker.rs
+++ b/crates/egui/src/widgets/color_picker.rs
@@ -52,7 +52,7 @@ pub fn show_color(ui: &mut Ui, color: impl Into<Color32>, desired_size: Vec2) ->
 }
 
 fn show_color32(ui: &mut Ui, color: Color32, desired_size: Vec2) -> Response {
-    let (rect, response) = ui.allocate_at_least(desired_size, Sense::hover());
+    let (rect, response) = ui.allocate_at_least(desired_size, Sense::hover().no_hover());
     if ui.is_rect_visible(rect) {
         show_color_at(ui.painter(), color, rect);
     }

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -72,7 +72,7 @@ impl<'a> Image<'a> {
                 source,
                 texture_options: Default::default(),
                 image_options: Default::default(),
-                sense: Sense::hover(),
+                sense: Sense::hover().no_hover(),
                 size,
                 show_loading_spinner: None,
             }

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -120,6 +120,7 @@ impl Label {
             } else {
                 Sense::hover()
             }
+            .no_hover()
         });
 
         if selectable {
@@ -232,7 +233,7 @@ impl Widget for Label {
         // Interactive = the uses asked to sense interaction.
         // We DON'T want to have the color respond just because the text is selectable;
         // the cursor is enough to communicate that.
-        let interactive = self.sense.map_or(false, |sense| sense != Sense::hover());
+        let interactive = self.sense.map_or(false, |sense| sense.interactive());
 
         let selectable = self.selectable;
 

--- a/crates/egui/src/widgets/progress_bar.rs
+++ b/crates/egui/src/widgets/progress_bar.rs
@@ -111,7 +111,7 @@ impl Widget for ProgressBar {
             desired_width.unwrap_or_else(|| ui.available_size_before_wrap().x.at_least(96.0));
         let height = desired_height.unwrap_or(ui.spacing().interact_size.y);
         let (outer_rect, response) =
-            ui.allocate_exact_size(vec2(desired_width, height), Sense::hover());
+            ui.allocate_exact_size(vec2(desired_width, height), Sense::hover().no_hover());
 
         response.widget_info(|| {
             let mut info = if let Some(ProgressBarText::Custom(text)) = &text {

--- a/crates/egui/src/widgets/separator.rs
+++ b/crates/egui/src/widgets/separator.rs
@@ -108,7 +108,7 @@ impl Widget for Separator {
             vec2(spacing, available_space.y)
         };
 
-        let (rect, response) = ui.allocate_at_least(size, Sense::hover());
+        let (rect, response) = ui.allocate_at_least(size, Sense::hover().no_hover());
 
         if ui.is_rect_visible(response.rect) {
             let stroke = ui.visuals().widgets.noninteractive.bg_stroke;

--- a/crates/egui/src/widgets/spinner.rs
+++ b/crates/egui/src/widgets/spinner.rs
@@ -65,7 +65,7 @@ impl Widget for Spinner {
         let size = self
             .size
             .unwrap_or_else(|| ui.style().spacing.interact_size.y);
-        let (rect, response) = ui.allocate_exact_size(vec2(size, size), Sense::hover());
+        let (rect, response) = ui.allocate_exact_size(vec2(size, size), Sense::hover().no_hover());
         response.widget_info(|| WidgetInfo::new(WidgetType::ProgressIndicator));
         self.paint_at(ui, rect);
 

--- a/crates/egui_demo_app/Cargo.toml
+++ b/crates/egui_demo_app/Cargo.toml
@@ -26,7 +26,12 @@ web_app = ["http", "persistence"]
 
 http = ["ehttp", "image", "poll-promise", "egui_extras/image"]
 image_viewer = ["image", "egui_extras/all_loaders", "rfd"]
-persistence = ["eframe/persistence", "egui/persistence", "serde", "egui_extras/serde"]
+persistence = [
+  "eframe/persistence",
+  "egui/persistence",
+  "serde",
+  "egui_extras/serde",
+]
 puffin = ["eframe/puffin", "dep:puffin", "dep:puffin_http"]
 serde = ["dep:serde", "egui_demo_lib/serde", "egui/serde"]
 syntect = ["egui_demo_lib/syntect"]
@@ -35,6 +40,9 @@ glow = ["eframe/glow"]
 wgpu = ["eframe/wgpu", "bytemuck", "dep:wgpu"]
 wayland = ["eframe/wayland"]
 x11 = ["eframe/x11"]
+
+## Experimental: remove hoverable effects on some widgets from egui and do not re-render without effects, for very lazy rendering
+very_lazy = ["eframe/very_lazy"]
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = [

--- a/crates/egui_demo_app/src/apps/custom3d_glow.rs
+++ b/crates/egui_demo_app/src/apps/custom3d_glow.rs
@@ -55,7 +55,7 @@ impl eframe::App for Custom3d {
 impl Custom3d {
     fn custom_painting(&mut self, ui: &mut egui::Ui) {
         let (rect, response) =
-            ui.allocate_exact_size(egui::Vec2::splat(300.0), egui::Sense::drag());
+            ui.allocate_exact_size(egui::Vec2::splat(300.0), egui::Sense::drag().no_hover());
 
         self.angle += response.drag_motion().x * 0.01;
 

--- a/crates/egui_demo_app/src/apps/custom3d_wgpu.rs
+++ b/crates/egui_demo_app/src/apps/custom3d_wgpu.rs
@@ -174,7 +174,7 @@ impl egui_wgpu::CallbackTrait for CustomTriangleCallback {
 impl Custom3d {
     fn custom_painting(&mut self, ui: &mut egui::Ui) {
         let (rect, response) =
-            ui.allocate_exact_size(egui::Vec2::splat(300.0), egui::Sense::drag());
+            ui.allocate_exact_size(egui::Vec2::splat(300.0), egui::Sense::drag().no_hover());
 
         self.angle += response.drag_motion().x * 0.01;
         ui.painter().add(egui_wgpu::Callback::new_paint_callback(

--- a/crates/egui_demo_app/src/frame_history.rs
+++ b/crates/egui_demo_app/src/frame_history.rs
@@ -62,7 +62,7 @@ impl FrameHistory {
         // TODO(emilk): we should not use `slider_width` as default graph width.
         let height = ui.spacing().slider_width;
         let size = vec2(ui.available_size_before_wrap().x, height);
-        let (rect, response) = ui.allocate_at_least(size, Sense::hover());
+        let (rect, response) = ui.allocate_at_least(size, Sense::hover().no_hover());
         let style = ui.style().noninteractive();
 
         let graph_top_cpu_usage = 0.010;

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -166,7 +166,7 @@ impl View for MiscDemoWindow {
                     ui.label("You can pretty easily paint your own small icons:");
                     use std::f32::consts::TAU;
                     let size = Vec2::splat(16.0);
-                    let (response, painter) = ui.allocate_painter(size, Sense::hover());
+                    let (response, painter) = ui.allocate_painter(size, Sense::hover().no_hover());
                     let rect = response.rect;
                     let c = rect.center();
                     let r = rect.width() / 2.0 - 1.0;
@@ -186,7 +186,7 @@ impl View for MiscDemoWindow {
                     for i in 0..100 {
                         let r = i as f32 * 0.5;
                         let size = Vec2::splat(2.0 * r + 5.0);
-                        let (rect, _response) = ui.allocate_at_least(size, Sense::hover());
+                        let (rect, _response) = ui.allocate_at_least(size, Sense::hover().no_hover());
                         ui.painter()
                             .circle_filled(rect.center(), r, ui.visuals().text_color());
                     }
@@ -381,7 +381,7 @@ impl BoxPainting {
 
         ui.horizontal_wrapped(|ui| {
             for _ in 0..self.num_boxes {
-                let (rect, _response) = ui.allocate_at_least(self.size, Sense::hover());
+                let (rect, _response) = ui.allocate_at_least(self.size, Sense::hover().no_hover());
                 ui.painter().rect(
                     rect,
                     self.rounding,

--- a/crates/egui_demo_lib/src/demo/multi_touch.rs
+++ b/crates/egui_demo_lib/src/demo/multi_touch.rs
@@ -70,7 +70,7 @@ impl crate::View for MultiTouch {
 
             // set up the drawing canvas with normalized coordinates:
             let (response, painter) =
-                ui.allocate_painter(ui.available_size_before_wrap(), Sense::drag());
+                ui.allocate_painter(ui.available_size_before_wrap(), Sense::drag().no_hover());
 
             // normalize painter coordinates to ±1 units in each direction with [0,0] in the center:
             let painter_proportions = response.rect.square_proportions();

--- a/crates/egui_demo_lib/src/demo/paint_bezier.rs
+++ b/crates/egui_demo_lib/src/demo/paint_bezier.rs
@@ -81,7 +81,7 @@ impl PaintBezier {
 
     pub fn ui_content(&mut self, ui: &mut Ui) -> egui::Response {
         let (response, painter) =
-            ui.allocate_painter(Vec2::new(ui.available_width(), 300.0), Sense::hover());
+            ui.allocate_painter(Vec2::new(ui.available_width(), 300.0), Sense::hover().no_hover());
 
         let to_screen = emath::RectTransform::from_to(
             Rect::from_min_size(Pos2::ZERO, response.rect.size()),

--- a/crates/egui_demo_lib/src/demo/painting.rs
+++ b/crates/egui_demo_lib/src/demo/painting.rs
@@ -32,7 +32,7 @@ impl Painting {
 
     pub fn ui_content(&mut self, ui: &mut Ui) -> egui::Response {
         let (mut response, painter) =
-            ui.allocate_painter(ui.available_size_before_wrap(), Sense::drag());
+            ui.allocate_painter(ui.available_size_before_wrap(), Sense::drag().no_hover());
 
         let to_screen = emath::RectTransform::from_to(
             Rect::from_min_size(Pos2::ZERO, response.rect.square_proportions()),

--- a/crates/egui_demo_lib/src/demo/pan_zoom.rs
+++ b/crates/egui_demo_lib/src/demo/pan_zoom.rs
@@ -38,7 +38,7 @@ impl crate::View for PanZoom {
         ui.separator();
 
         let (id, rect) = ui.allocate_space(ui.available_size());
-        let response = ui.interact(rect, id, egui::Sense::click_and_drag());
+        let response = ui.interact(rect, id, egui::Sense::click_and_drag().no_hover());
         // Allow dragging the background as well.
         if response.dragged() {
             self.transform.translation += response.drag_delta();

--- a/crates/egui_demo_lib/src/demo/scrolling.rs
+++ b/crates/egui_demo_lib/src/demo/scrolling.rs
@@ -223,7 +223,7 @@ fn huge_content_painter(ui: &mut egui::Ui) {
                 used_rect = used_rect.union(text_rect);
             }
 
-            ui.allocate_rect(used_rect, Sense::hover()); // make sure it is visible!
+            ui.allocate_rect(used_rect, Sense::hover().no_hover()); // make sure it is visible!
         });
 }
 

--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -186,7 +186,7 @@ impl<'l> StripLayout<'l> {
         let before = self.cursor;
         self.cursor += delta;
         let rect = Rect::from_two_pos(before, self.cursor);
-        self.ui.allocate_rect(rect, Sense::hover());
+        self.ui.allocate_rect(rect, Sense::hover().no_hover());
     }
 
     /// Return the Ui to which the contents where added
@@ -227,6 +227,6 @@ impl<'l> StripLayout<'l> {
         rect.set_right(self.max.x);
         rect.set_bottom(self.max.y);
 
-        self.ui.allocate_rect(rect, Sense::hover())
+        self.ui.allocate_rect(rect, Sense::hover().no_hover())
     }
 }

--- a/crates/egui_extras/src/strip.rs
+++ b/crates/egui_extras/src/strip.rs
@@ -58,7 +58,7 @@ impl<'a> StripBuilder<'a> {
             sizing: Default::default(),
             clip: false,
             cell_layout,
-            sense: egui::Sense::hover(),
+            sense: egui::Sense::hover().no_hover(),
         }
     }
 
@@ -76,7 +76,7 @@ impl<'a> StripBuilder<'a> {
         self
     }
 
-    /// What should strip cells sense for? Default: [`egui::Sense::hover()`].
+    /// What should strip cells sense for? Default: [`egui::Sense::hover().no_hover()`].
     #[inline]
     pub fn sense(mut self, sense: egui::Sense) -> Self {
         self.sense = sense;

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -261,7 +261,7 @@ impl<'a> TableBuilder<'a> {
         self
     }
 
-    /// What should table cells sense for? (default: [`egui::Sense::hover()`]).
+    /// What should table cells sense for? (default: [`egui::Sense::hover().no_hover()`]).
     #[inline]
     pub fn sense(mut self, sense: egui::Sense) -> Self {
         self.sense = sense;


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* This pull request addresses a proposal from <https://github.com/emilk/egui/issues/724>
* [x] I have followed the instructions in the PR template

This pull request:
- adds experimental very lazy mode (`very_lazy` feature) for eframe, under which moving cursor over non-hoverable elements no longer triggers a repaint. Works for both native and web.
- removes hover senses from some official widgets

Outstanding problems:
1. glow integration and epi integration use internal timing, which is not obtainable in egui-winit. These lines are disabled on the feature.
2. elements who change the cursor type on mouse enter still needs to be hover-able. 