### PR TITLE
Add `clamp_to_range_on_drag` option to `DragValue` and `clamp_to_range_on_value_drag` option to `Slider`

### DIFF
--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -39,7 +39,6 @@ pub struct DragValue<'a> {
     suffix: String,
     range: RangeInclusive<f64>,
     clamp_to_range: bool,
-    clamp_to_range_on_drag: bool,
     min_decimals: usize,
     max_decimals: Option<usize>,
     custom_formatter: Option<NumFormatter<'a>>,
@@ -71,7 +70,6 @@ impl<'a> DragValue<'a> {
             suffix: Default::default(),
             range: f64::NEG_INFINITY..=f64::INFINITY,
             clamp_to_range: true,
-            clamp_to_range_on_drag: true,
             min_decimals: 0,
             max_decimals: None,
             custom_formatter: None,
@@ -117,20 +115,6 @@ impl<'a> DragValue<'a> {
     #[inline]
     pub fn clamp_to_range(mut self, clamp_to_range: bool) -> Self {
         self.clamp_to_range = clamp_to_range;
-        self
-    }
-
-    /// If set to `true`, dragging will clamp the value to the sliding
-    /// [`Self::range`] (if any).
-    ///
-    /// If set to `false`, the value can be dragged outside of the
-    /// sliding [`Self::range`] (if [`Self::clamp_to_range`] is also
-    /// `false`).
-    ///
-    /// Default: `true`.
-    #[inline]
-    pub fn clamp_to_range_on_drag(mut self, clamp_to_range_on_drag: bool) -> Self {
-        self.clamp_to_range_on_drag = clamp_to_range_on_drag;
         self
     }
 
@@ -405,7 +389,6 @@ impl<'a> Widget for DragValue<'a> {
             speed,
             range,
             clamp_to_range,
-            clamp_to_range_on_drag,
             prefix,
             suffix,
             min_decimals,
@@ -624,7 +607,7 @@ impl<'a> Widget for DragValue<'a> {
                     );
                     let rounded_new_value =
                         emath::round_to_decimals(rounded_new_value, auto_decimals);
-                    let rounded_new_value = if clamp_to_range_on_drag || clamp_to_range {
+                    let rounded_new_value = if clamp_to_range {
                         clamp_value_to_range(rounded_new_value, range.clone())
                     } else {
                         rounded_new_value

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -70,7 +70,6 @@ pub struct Slider<'a> {
     range: RangeInclusive<f64>,
     spec: SliderSpec,
     clamp_to_range: bool,
-    clamp_to_range_on_value_drag: bool,
     smart_aim: bool,
     show_value: bool,
     orientation: SliderOrientation,
@@ -121,7 +120,6 @@ impl<'a> Slider<'a> {
                 largest_finite: f64::INFINITY,
             },
             clamp_to_range: true,
-            clamp_to_range_on_value_drag: true,
             smart_aim: true,
             show_value: true,
             orientation: SliderOrientation::Horizontal,
@@ -221,19 +219,6 @@ impl<'a> Slider<'a> {
     #[inline]
     pub fn clamp_to_range(mut self, clamp_to_range: bool) -> Self {
         self.clamp_to_range = clamp_to_range;
-        self
-    }
-
-    /// If set to `true`, the value, when dragged will be clamped to the slider range.
-    ///
-    /// If set to `false`, the value, when dragged will not be clamped
-    /// to the slider range (if [`Self::clamp_to_range`] is also
-    /// `false`).
-    ///
-    /// Default: `true`.
-    #[inline]
-    pub fn clamp_to_range_on_value_drag(mut self, clamp_to_range_on_value_drag: bool) -> Self {
-        self.clamp_to_range_on_value_drag = clamp_to_range_on_value_drag;
         self
     }
 
@@ -828,7 +813,6 @@ impl<'a> Slider<'a> {
                 .speed(speed)
                 .range(self.range.clone())
                 .clamp_to_range(self.clamp_to_range)
-                .clamp_to_range_on_drag(self.clamp_to_range_on_value_drag)
                 .min_decimals(self.min_decimals)
                 .max_decimals_opt(self.max_decimals)
                 .suffix(self.suffix.clone())

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -70,6 +70,7 @@ pub struct Slider<'a> {
     range: RangeInclusive<f64>,
     spec: SliderSpec,
     clamp_to_range: bool,
+    clamp_to_range_on_value_drag: bool,
     smart_aim: bool,
     show_value: bool,
     orientation: SliderOrientation,
@@ -120,6 +121,7 @@ impl<'a> Slider<'a> {
                 largest_finite: f64::INFINITY,
             },
             clamp_to_range: true,
+            clamp_to_range_on_value_drag: true,
             smart_aim: true,
             show_value: true,
             orientation: SliderOrientation::Horizontal,
@@ -219,6 +221,19 @@ impl<'a> Slider<'a> {
     #[inline]
     pub fn clamp_to_range(mut self, clamp_to_range: bool) -> Self {
         self.clamp_to_range = clamp_to_range;
+        self
+    }
+
+    /// If set to `true`, the value, when dragged will be clamped to the slider range.
+    ///
+    /// If set to `false`, the value, when dragged will not be clamped
+    /// to the slider range (if [`Self::clamp_to_range`] is also
+    /// `false`).
+    ///
+    /// Default: `true`.
+    #[inline]
+    pub fn clamp_to_range_on_value_drag(mut self, clamp_to_range_on_value_drag: bool) -> Self {
+        self.clamp_to_range_on_value_drag = clamp_to_range_on_value_drag;
         self
     }
 
@@ -813,6 +828,7 @@ impl<'a> Slider<'a> {
                 .speed(speed)
                 .range(self.range.clone())
                 .clamp_to_range(self.clamp_to_range)
+                .clamp_to_range_on_drag(self.clamp_to_range_on_value_drag)
                 .min_decimals(self.min_decimals)
                 .max_decimals_opt(self.max_decimals)
                 .suffix(self.suffix.clone())

--- a/crates/egui_demo_lib/src/demo/sliders.rs
+++ b/crates/egui_demo_lib/src/demo/sliders.rs
@@ -10,6 +10,7 @@ pub struct Sliders {
     pub max: f64,
     pub logarithmic: bool,
     pub clamp_to_range: bool,
+    pub clamp_to_range_on_value_drag: bool,
     pub smart_aim: bool,
     pub step: f64,
     pub use_steps: bool,
@@ -27,6 +28,7 @@ impl Default for Sliders {
             max: 10000.0,
             logarithmic: true,
             clamp_to_range: false,
+            clamp_to_range_on_value_drag: false,
             smart_aim: true,
             step: 10.0,
             use_steps: false,
@@ -62,6 +64,7 @@ impl crate::View for Sliders {
             max,
             logarithmic,
             clamp_to_range,
+            clamp_to_range_on_value_drag,
             smart_aim,
             step,
             use_steps,
@@ -98,6 +101,7 @@ impl crate::View for Sliders {
                 Slider::new(&mut value_i32, (*min as i32)..=(*max as i32))
                     .logarithmic(*logarithmic)
                     .clamp_to_range(*clamp_to_range)
+                    .clamp_to_range_on_value_drag(*clamp_to_range_on_value_drag)
                     .smart_aim(*smart_aim)
                     .orientation(orientation)
                     .text("i32 demo slider")
@@ -111,6 +115,7 @@ impl crate::View for Sliders {
                 Slider::new(value, (*min)..=(*max))
                     .logarithmic(*logarithmic)
                     .clamp_to_range(*clamp_to_range)
+                    .clamp_to_range_on_value_drag(*clamp_to_range_on_value_drag)
                     .smart_aim(*smart_aim)
                     .orientation(orientation)
                     .text("f64 demo slider")
@@ -190,7 +195,12 @@ impl crate::View for Sliders {
 
         ui.checkbox(clamp_to_range, "Clamp to range");
         ui.label("If true, the slider will clamp incoming and outgoing values to the given range.");
-        ui.label("If false, the slider can shows values outside its range, and you can manually enter values outside the range.");
+        ui.label("If false, the slider can show values outside its range, and you can manually enter values outside the range.");
+        ui.add_space(8.0);
+
+        ui.checkbox(clamp_to_range_on_value_drag, "Clamp to range on value drag");
+        ui.label("If true, the value when dragged will be clamped to the given range.");
+        ui.label("If false, the value when dragged will not be clamped to the given range (if value is not clamped to range).");
         ui.add_space(8.0);
 
         ui.checkbox(smart_aim, "Smart Aim");

--- a/crates/egui_demo_lib/src/demo/sliders.rs
+++ b/crates/egui_demo_lib/src/demo/sliders.rs
@@ -10,7 +10,6 @@ pub struct Sliders {
     pub max: f64,
     pub logarithmic: bool,
     pub clamp_to_range: bool,
-    pub clamp_to_range_on_value_drag: bool,
     pub smart_aim: bool,
     pub step: f64,
     pub use_steps: bool,
@@ -28,7 +27,6 @@ impl Default for Sliders {
             max: 10000.0,
             logarithmic: true,
             clamp_to_range: false,
-            clamp_to_range_on_value_drag: false,
             smart_aim: true,
             step: 10.0,
             use_steps: false,
@@ -64,7 +62,6 @@ impl crate::View for Sliders {
             max,
             logarithmic,
             clamp_to_range,
-            clamp_to_range_on_value_drag,
             smart_aim,
             step,
             use_steps,
@@ -101,7 +98,6 @@ impl crate::View for Sliders {
                 Slider::new(&mut value_i32, (*min as i32)..=(*max as i32))
                     .logarithmic(*logarithmic)
                     .clamp_to_range(*clamp_to_range)
-                    .clamp_to_range_on_value_drag(*clamp_to_range_on_value_drag)
                     .smart_aim(*smart_aim)
                     .orientation(orientation)
                     .text("i32 demo slider")
@@ -115,7 +111,6 @@ impl crate::View for Sliders {
                 Slider::new(value, (*min)..=(*max))
                     .logarithmic(*logarithmic)
                     .clamp_to_range(*clamp_to_range)
-                    .clamp_to_range_on_value_drag(*clamp_to_range_on_value_drag)
                     .smart_aim(*smart_aim)
                     .orientation(orientation)
                     .text("f64 demo slider")
@@ -196,11 +191,6 @@ impl crate::View for Sliders {
         ui.checkbox(clamp_to_range, "Clamp to range");
         ui.label("If true, the slider will clamp incoming and outgoing values to the given range.");
         ui.label("If false, the slider can show values outside its range, and you can manually enter values outside the range.");
-        ui.add_space(8.0);
-
-        ui.checkbox(clamp_to_range_on_value_drag, "Clamp to range on value drag");
-        ui.label("If true, the value when dragged will be clamped to the given range.");
-        ui.label("If false, the value when dragged will not be clamped to the given range (if value is not clamped to range).");
         ui.add_space(8.0);
 
         ui.checkbox(smart_aim, "Smart Aim");


### PR DESCRIPTION
Added `egui::DragValue::clamp_to_range_on_drag` and `egui::Slider::clamp_to_range_on_value_drag` to allow the user to determine if the value should be clamped while dragging.

The default for `egui::DragValue::clamp_to_range_on_drag` and `egui::Slider::clamp_to_range_on_value_drag` is set to `true`. This means the default behavior mimics `0.28`.

If the default behavior must match `0.27`, `egui::DragValue::clamp_to_range_on_drag` should be `true` and `egui::Slider::clamp_to_range_on_value_drag` should be `false`.

* Closes https://github.com/emilk/egui/issues/4881
* [x] I have followed the instructions in the PR template

https://github.com/user-attachments/assets/1ec81142-8ab3-4eb2-a9c9-afb61426dffc
