### PR TITLE
Fix: hint text follows the alignment set on the `TextEdit`

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -682,7 +682,11 @@ impl<'t> TextEdit<'t> {
                         hint_text_font_id,
                     )
                 };
-                painter.galley(rect.min, galley, hint_text_color);
+                let galley_pos = align
+                    .align_size_within_rect(galley.size(), rect)
+                    .intersect(rect)
+                    .min;
+                painter.galley(galley_pos, galley, hint_text_color);
             }
 
             if ui.memory(|mem| mem.has_focus(id)) {


### PR DESCRIPTION
Updated the `show_content` method of the `TextEdit` widget so that the requested text alignment (if any) is also applied to the hint text.

Currently, hint text is always aligned to the top left of the widget, which may be inconsistent with the actual location of text entered by the user. I think it's more intuitive for the hint text to be positioned as if the user had entered the same text themselves.

Here are some comparisons of the difference between how the hint text and the entered text looks, before and after this change:

### Previous Behaviour
![Prev](https://github.com/user-attachments/assets/8cd7858f-833e-4946-84f1-ff1ede60c64d)


### Updated Behaviour
![Update](https://github.com/user-attachments/assets/2596dd44-d6f9-4376-9012-5b074fc2cdea)

* [x] I have followed the instructions in the PR template
