### PR TITLE
Fix: The viewport stops working when the program is minimized.                        

### DIFF
--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -160,13 +160,8 @@ impl<T: WinitApp> WinitAppWrapper<T> {
 
                 if let Some(window) = self.winit_app.window(*window_id) {
                     log::trace!("request_redraw for {window_id:?}");
-                    let is_minimized = window.is_minimized().unwrap_or(false);
-                    if is_minimized {
-                        false
-                    } else {
-                        window.request_redraw();
-                        true
-                    }
+                    window.request_redraw();
+                    true
                 } else {
                     log::trace!("No window found for {window_id:?}");
                     false

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -277,6 +277,7 @@ impl<T: WinitApp> ApplicationHandler<UserEvent> for WinitAppWrapper<T> {
         event_loop_context::with_event_loop_context(event_loop, move || {
             let event_result = match event {
                 winit::event::WindowEvent::RedrawRequested => {
+                    // For minimize CPU usage, remove any remaining repaint time and then repaint.
                     self.windows_next_repaint_times.remove(&window_id);
                     self.winit_app.run_ui_and_paint(event_loop, window_id)
                 }

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -162,11 +162,10 @@ impl<T: WinitApp> WinitAppWrapper<T> {
                 if let Some(window) = self.winit_app.window(*window_id) {
                     log::trace!("request_redraw for {window_id:?}");
                     window.request_redraw();
-                    true
                 } else {
                     log::trace!("No window found for {window_id:?}");
-                    false
                 }
+                false
             });
 
         if let Some(next_repaint_time) = next_repaint_time {
@@ -277,8 +276,6 @@ impl<T: WinitApp> ApplicationHandler<UserEvent> for WinitAppWrapper<T> {
         event_loop_context::with_event_loop_context(event_loop, move || {
             let event_result = match event {
                 winit::event::WindowEvent::RedrawRequested => {
-                    // For minimize CPU usage, remove any remaining repaint time and then repaint.
-                    self.windows_next_repaint_times.remove(&window_id);
                     self.winit_app.run_ui_and_paint(event_loop, window_id)
                 }
                 _ => self.winit_app.window_event(event_loop, window_id, event),

--- a/crates/epaint/src/shadow.rs
+++ b/crates/epaint/src/shadow.rs
@@ -11,7 +11,7 @@ pub struct Shadow {
     /// Move the shadow by this much.
     ///
     /// For instance, a value of `[1.0, 2.0]` will move the shadow 1 point to the right and 2 points down,
-    /// causing a drop-shadow effet.
+    /// causing a drop-shadow effect.
     pub offset: Vec2,
 
     /// The width of the blur, i.e. the width of the fuzzy penumbra.


### PR DESCRIPTION
Fix: The viewport stops working when the program is minimized.                        
                                                                                      
**Issue :**                                                                         
                                                                                      
The viewport stops working when the program is minimized.                             
                         
* Related #3321
* Related #3877                                                               
* Related #3985
* Closes #3972                                                                        
* Closes #4772
* Related #4832 
                                                                                     
**Solution :**                                                                      
                                                                                      
When `request_redraw()` is performed in Minimized state, the occasional screen tearing phenomenon has disappeared.
( Probably expected to be the effect of #4814 )                                       
                                                                                      
To address the issue of the `Immediate Viewport` not updating in Minimized state, we can call `request_redraw()`.
