### PR TITLE
Fix: `scroll_with_delta()` for `ScrollArea::vertical()` and `ScrollArea::horizontal()`

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -793,15 +793,7 @@ impl Prepared {
 
         let content_size = content_ui.min_size();
 
-        let scroll_delta = content_ui
-            .ctx()
-            .frame_state_mut(|state| std::mem::take(&mut state.scroll_delta));
-
         for d in 0..2 {
-            // FrameState::scroll_delta is inverted from the way we apply the delta, so we need to negate it.
-            let mut delta = -scroll_delta.0[d];
-            let mut animation = scroll_delta.1;
-
             // We always take both scroll targets regardless of which scroll axes are enabled. This
             // is to avoid them leaking to other scroll areas.
             let scroll_target = content_ui
@@ -809,6 +801,17 @@ impl Prepared {
                 .frame_state_mut(|state| state.scroll_target[d].take());
 
             if scroll_enabled[d] {
+                let scroll_delta_0 = content_ui
+                    .ctx()
+                    .frame_state_mut(|state| std::mem::take(&mut state.scroll_delta.0[d]));
+                let scroll_delta_1 = content_ui
+                    .ctx()
+                    .frame_state_mut(|state| std::mem::take(&mut state.scroll_delta.1));
+
+                // FrameState::scroll_delta is inverted from the way we apply the delta, so we need to negate it.
+                let mut delta = -scroll_delta_0;
+                let mut animation = scroll_delta_1;
+
                 if let Some(target) = scroll_target {
                     let frame_state::ScrollTarget {
                         range,

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -793,10 +793,6 @@ impl Prepared {
 
         let content_size = content_ui.min_size();
 
-        let scroll_delta_1 = content_ui
-            .ctx()
-            .frame_state_mut(|state| std::mem::take(&mut state.scroll_delta.1));
-
         for d in 0..2 {
             // We always take both scroll targets regardless of which scroll axes are enabled. This
             // is to avoid them leaking to other scroll areas.
@@ -805,9 +801,12 @@ impl Prepared {
                 .frame_state_mut(|state| state.scroll_target[d].take());
 
             if scroll_enabled[d] {
-                let scroll_delta_0 = content_ui
-                    .ctx()
-                    .frame_state_mut(|state| std::mem::take(&mut state.scroll_delta.0[d]));
+                let (scroll_delta_0, scroll_delta_1) = content_ui.ctx().frame_state_mut(|state| {
+                    (
+                        std::mem::take(&mut state.scroll_delta.0[d]),
+                        std::mem::take(&mut state.scroll_delta.1),
+                    )
+                });
 
                 // FrameState::scroll_delta is inverted from the way we apply the delta, so we need to negate it.
                 let mut delta = -scroll_delta_0;

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -793,6 +793,10 @@ impl Prepared {
 
         let content_size = content_ui.min_size();
 
+        let scroll_delta_1 = content_ui
+            .ctx()
+            .frame_state_mut(|state| std::mem::take(&mut state.scroll_delta.1));
+
         for d in 0..2 {
             // We always take both scroll targets regardless of which scroll axes are enabled. This
             // is to avoid them leaking to other scroll areas.
@@ -801,12 +805,9 @@ impl Prepared {
                 .frame_state_mut(|state| state.scroll_target[d].take());
 
             if scroll_enabled[d] {
-                let (scroll_delta_0, scroll_delta_1) = content_ui.ctx().frame_state_mut(|state| {
-                    (
-                        std::mem::take(&mut state.scroll_delta.0[d]),
-                        std::mem::take(&mut state.scroll_delta.1),
-                    )
-                });
+                let scroll_delta_0 = content_ui
+                    .ctx()
+                    .frame_state_mut(|state| std::mem::take(&mut state.scroll_delta.0[d]));
 
                 // FrameState::scroll_delta is inverted from the way we apply the delta, so we need to negate it.
                 let mut delta = -scroll_delta_0;

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -801,12 +801,12 @@ impl Prepared {
                 .frame_state_mut(|state| state.scroll_target[d].take());
 
             if scroll_enabled[d] {
-                let scroll_delta_0 = content_ui
-                    .ctx()
-                    .frame_state_mut(|state| std::mem::take(&mut state.scroll_delta.0[d]));
-                let scroll_delta_1 = content_ui
-                    .ctx()
-                    .frame_state_mut(|state| std::mem::take(&mut state.scroll_delta.1));
+                let (scroll_delta_0, scroll_delta_1) = content_ui.ctx().frame_state_mut(|state| {
+                    (
+                        std::mem::take(&mut state.scroll_delta.0[d]),
+                        std::mem::take(&mut state.scroll_delta.1),
+                    )
+                });
 
                 // FrameState::scroll_delta is inverted from the way we apply the delta, so we need to negate it.
                 let mut delta = -scroll_delta_0;


### PR DESCRIPTION
Fix: `scroll_with_delta()` for `ScrollArea::vertical()` and `ScrollArea::horizontal()`

We need to do this in order for `ScrollArea::vertical()` and `ScrollArea::horizontal()` to work even where they are divided or nested.

Pull requests :
* Related #4303 
* Related #4305
* Related #4584

