### PR TITLE
Fix: Ensures correct IME behavior when the text input area gains or loses focus.

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -748,6 +748,10 @@ impl<'t> TextEdit<'t> {
 
         if state.ime_enabled && response.lost_focus() {
             state.ime_enabled = false;
+            if let Some(mut ccursor_range) = state.cursor.char_range() {
+                ccursor_range.secondary.index = ccursor_range.primary.index;
+                state.cursor.set_char_range(Some(ccursor_range));
+            }
         }
 
         state.clone().store(ui.ctx(), id);

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -1005,6 +1005,8 @@ fn events(
                     if text_mark == "\n" || text_mark == "\r" {
                         None
                     } else {
+                        state.ime_enabled = false;
+
                         // Empty prediction can be produced when user press backspace
                         // or escape during IME, so we clear current text.
                         let mut ccursor = text.delete_selected(&cursor_range);

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -746,8 +746,8 @@ impl<'t> TextEdit<'t> {
             }
         }
 
-        // IME-related processing when focus is lost in IME enabled state.
-        if state.ime_enabled && response.lost_focus() {
+        // IME-related processing when focus is gained or lost in IME enabled state.
+        if state.ime_enabled && (response.gained_focus() || response.lost_focus()) {
             state.ime_enabled = false;
             if let Some(mut ccursor_range) = state.cursor.char_range() {
                 ccursor_range.secondary.index = ccursor_range.primary.index;

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -746,6 +746,10 @@ impl<'t> TextEdit<'t> {
             }
         }
 
+        if state.ime_enabled && response.lost_focus() {
+            state.ime_enabled = false;
+        }
+
         state.clone().store(ui.ctx(), id);
 
         if response.changed {

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -1005,8 +1005,6 @@ fn events(
                     if text_mark == "\n" || text_mark == "\r" {
                         None
                     } else {
-                        state.ime_enabled = false;
-
                         // Empty prediction can be produced when user press backspace
                         // or escape during IME, so we clear current text.
                         let mut ccursor = text.delete_selected(&cursor_range);

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -746,12 +746,14 @@ impl<'t> TextEdit<'t> {
             }
         }
 
+        // IME-related processing when focus is lost in IME enabled state.
         if state.ime_enabled && response.lost_focus() {
             state.ime_enabled = false;
             if let Some(mut ccursor_range) = state.cursor.char_range() {
                 ccursor_range.secondary.index = ccursor_range.primary.index;
                 state.cursor.set_char_range(Some(ccursor_range));
             }
+            ui.input_mut(|i| i.events.retain(|e| !matches!(e, Event::Ime(_))));
         }
 
         state.clone().store(ui.ctx(), id);

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -746,7 +746,7 @@ impl<'t> TextEdit<'t> {
             }
         }
 
-        // IME-related processing when focus is gained or lost in IME enabled state.
+        // Ensures correct IME behavior when the text input area gains or loses focus.
         if state.ime_enabled && (response.gained_focus() || response.lost_focus()) {
             state.ime_enabled = false;
             if let Some(mut ccursor_range) = state.cursor.char_range() {


### PR DESCRIPTION
Fix: Ensures correct IME behavior when the text input area gains or loses focus.

Fix: Handling `state.ime_enabled` in multiple `TextEdit`.
Fix: A symptom of characters being copied when there are multiple TextEdits.

* Related #4137
* Related #4358 
* Closes #4374
* Related #4436
* Related #4794 
* Related #4908 

* Related #5008

Fix Issues: When focus is moved elsewhere, you must set `state.ime_enabled = false`, otherwise the IME will have problems when focus returns.

Fix Issues: A symptom of characters being copied when there are multiple TextEdits.
Deletes all current `IME events`, preventing them from being copied to `other TextEdits`, without saving the `TextEdit ID`, 

( Related Issues: Some `LINUX` seem to trigger an IME enable event on startup. So, when we gained focus, we do `state.ime_enabled = false`. )
