### PR TITLE
Remove the `directories` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,7 @@ dependencies = [
  "glow",
  "glutin",
  "glutin-winit",
+ "home",
  "image",
  "js-sys",
  "log",
@@ -1200,6 +1201,7 @@ dependencies = [
  "web-time",
  "wgpu",
  "winapi",
+ "windows-sys 0.52.0",
  "winit",
 ]
 
@@ -2059,11 +2061,11 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ document-features = " 0.2.8"
 glow = "0.13"
 glutin = "0.32.0"
 glutin-winit = "0.5.0"
+home = "0.5.9"
 image = { version = "0.25", default-features = false }
 log = { version = "0.4", features = ["std"] }
 nohash-hasher = "0.2"
@@ -95,6 +96,7 @@ wgpu = { version = "22.1.0", default-features = false, features = [
     # Make the renderer `Sync` even on wasm32, because it makes the code simpler:
     "fragile-send-sync-non-atomic-wasm",
 ] }
+windows-sys = "0.52"
 winit = { version = "0.30.5", default-features = false }
 
 [workspace.lints.rust]

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -57,12 +57,15 @@ android-native-activity = ["egui-winit/android-native-activity"]
 ## If you plan on specifying your own fonts you may disable this feature.
 default_fonts = ["egui/default_fonts"]
 
+# Enable the directories dependency for a more precise file path for the persistence feature.
+# Not needed if you provide your own path, or if the simpler default path resolvers are good enough.
+directories = ["dep:directories"]
+
 ## Use [`glow`](https://github.com/grovesNL/glow) for painting, via [`egui_glow`](https://github.com/emilk/egui/tree/master/crates/egui_glow).
 glow = ["dep:egui_glow", "dep:glow", "dep:glutin-winit", "dep:glutin"]
 
 ## Enable saving app state to disk.
 persistence = [
-  "directories",
   "egui-winit/serde",
   "egui/persistence",
   "ron",

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -57,15 +57,12 @@ android-native-activity = ["egui-winit/android-native-activity"]
 ## If you plan on specifying your own fonts you may disable this feature.
 default_fonts = ["egui/default_fonts"]
 
-## Enable the directories dependency for a more precise file path for the persistence feature.
-## Not needed if you provide your own path, or if the simpler default path resolvers are good enough.
-directories = ["dep:directories"]
-
 ## Use [`glow`](https://github.com/grovesNL/glow) for painting, via [`egui_glow`](https://github.com/emilk/egui/tree/master/crates/egui_glow).
 glow = ["dep:egui_glow", "dep:glow", "dep:glutin-winit", "dep:glutin"]
 
 ## Enable saving app state to disk.
 persistence = [
+  "dep:home",
   "egui-winit/serde",
   "egui/persistence",
   "ron",
@@ -150,7 +147,6 @@ image = { workspace = true, features = ["png"] } # Needed for app icon
 winit = { workspace = true, default-features = false, features = ["rwh_06"] }
 
 # optional native:
-directories = { version = "5", optional = true }
 egui-wgpu = { workspace = true, optional = true, features = [
   "winit",
 ] } # if wgpu is used, use it with winit
@@ -160,6 +156,7 @@ pollster = { version = "0.3", optional = true } # needed for wgpu
 # this can be done at the same time we expose x11/wayland features of winit crate.
 glutin = { workspace = true, optional = true }
 glutin-winit = { workspace = true, optional = true }
+home = { workspace = true, optional = true }
 puffin = { workspace = true, optional = true }
 wgpu = { workspace = true, optional = true, features = [
   # Let's enable some backends so that users can use `eframe` out-of-the-box
@@ -187,6 +184,7 @@ objc2-app-kit = { version = "0.2.0", features = [
 # windows:
 [target.'cfg(any(target_os = "windows"))'.dependencies]
 winapi = { version = "0.3.9", features = ["winuser"] }
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_UI_Shell", "Win32_System_Com"] }
 
 # -------------------------------------------
 # web:
@@ -255,3 +253,7 @@ wgpu = { workspace = true, optional = true, features = [
   # without having to explicitly opt-in to backends
   "webgpu",
 ] }
+
+# Native dev dependencies for testing
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+directories = "5"

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -57,8 +57,8 @@ android-native-activity = ["egui-winit/android-native-activity"]
 ## If you plan on specifying your own fonts you may disable this feature.
 default_fonts = ["egui/default_fonts"]
 
-# Enable the directories dependency for a more precise file path for the persistence feature.
-# Not needed if you provide your own path, or if the simpler default path resolvers are good enough.
+## Enable the directories dependency for a more precise file path for the persistence feature.
+## Not needed if you provide your own path, or if the simpler default path resolvers are good enough.
 directories = ["dep:directories"]
 
 ## Use [`glow`](https://github.com/grovesNL/glow) for painting, via [`egui_glow`](https://github.com/emilk/egui/tree/master/crates/egui_glow).

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -351,8 +351,8 @@ pub struct NativeOptions {
     /// persisted (only if the "persistence" feature is enabled).
     pub persist_window: bool,
 
-    /// The folder where `eframe` will store the app state. If not set, eframe will get the paths
-    /// from [directories].
+    /// The folder where `eframe` will store the app state. If not set, eframe will use a default
+    /// data storage path for each target system.
     pub persistence_path: Option<std::path::PathBuf>,
 
     /// Controls whether to apply dithering to minimize banding artifacts.

--- a/crates/eframe/src/native/file_storage.rs
+++ b/crates/eframe/src/native/file_storage.rs
@@ -15,7 +15,7 @@ use std::{
 /// which is:
 /// * Linux:   `/home/UserName/.local/share/APP_ID`
 /// * macOS:   `/Users/UserName/Library/Application Support/APP_ID`
-/// * Windows: `C:\Users\UserName\AppData\Roaming\APP_ID`
+/// * Windows: `C:\Users\UserName\AppData\Roaming\APP_ID\data`
 ///
 /// If the `directories` feature is not enabled, it uses a naive approximation that returns the
 /// same result for the most common systems.
@@ -59,7 +59,7 @@ fn naive_storage_dir(app_id: &str) -> Option<PathBuf> {
                 .join("Application Support")
                 .join(app_id.replace(|c: char| c.is_ascii_whitespace(), "-"))
         }),
-        OS::Windows => var_os("APPDATA").map(|s| PathBuf::from(s).join(app_id)),
+        OS::Windows => var_os("APPDATA").map(|s| PathBuf::from(s).join(app_id).join("data")),
         OS::Unknown | OS::Android | OS::IOS => None,
     }
 }

--- a/crates/eframe/src/native/file_storage.rs
+++ b/crates/eframe/src/native/file_storage.rs
@@ -223,7 +223,9 @@ mod tests {
     #[test]
     fn naive_path_matches_directories() {
         use super::{directories_storage_dir, naive_storage_dir};
-        for app_id in ["MyApp", "My App", "my_app", "my-app"] {
+        for app_id in [
+            "MyApp", "My App", "my_app", "my-app", "My.App", "my/app", "my:app", r"my\app",
+        ] {
             assert_eq!(directories_storage_dir(app_id), naive_storage_dir(app_id));
         }
     }


### PR DESCRIPTION
eframe now has its own logic to find the storage_dir to persist the app when the persistence feature is enabled, instead of using the directories crate. The directory should be the same as before (verified with a unit test).

* Closes <https://github.com/emilk/egui/issues/4884>
* [x] I have followed the instructions in the PR template
