### PR TITLE
Add close_button option to test_viewports

### DIFF
--- a/tests/test_viewports/src/main.rs
+++ b/tests/test_viewports/src/main.rs
@@ -61,7 +61,7 @@ impl ViewportState {
         }))
     }
 
-    pub fn show(vp_state: Arc<RwLock<Self>>, ctx: &egui::Context, close_button: bool) {
+    pub fn show(vp_state: Arc<RwLock<Self>>, ctx: &egui::Context) {
         if !vp_state.read().visible {
             return;
         }
@@ -71,7 +71,6 @@ impl ViewportState {
 
         let viewport = ViewportBuilder::default()
             .with_title(&title)
-            .with_close_button(close_button)
             .with_inner_size([500.0, 500.0]);
 
         if immediate {
@@ -81,7 +80,7 @@ impl ViewportState {
                     vp_state.visible = false;
                 }
                 show_as_popup(ctx, class, &title, vp_id.into(), |ui: &mut egui::Ui| {
-                    generic_child_ui(ui, &mut vp_state, close_button);
+                    generic_child_ui(ui, &mut vp_state);
                 });
             });
         } else {
@@ -102,7 +101,7 @@ impl ViewportState {
                         ui.label(format!("Callback has been reused {current_count} times"));
                         *count.write() += 1;
 
-                        generic_child_ui(ui, &mut vp_state, close_button);
+                        generic_child_ui(ui, &mut vp_state);
                     },
                 );
             });
@@ -119,7 +118,6 @@ impl ViewportState {
 
 pub struct App {
     top: Vec<Arc<RwLock<ViewportState>>>,
-    close_button: bool,
 }
 
 impl Default for App {
@@ -153,7 +151,6 @@ impl Default for App {
                     ],
                 ),
             ],
-            close_button: true,
         }
     }
 }
@@ -170,11 +167,10 @@ impl eframe::App for App {
                         viewport.write().set_visible_recursive(true);
                     }
                 }
-                ui.checkbox(&mut self.close_button, "with close button");
                 ctx.set_embed_viewports(embed_viewports);
             }
 
-            generic_ui(ui, &self.top, self.close_button);
+            generic_ui(ui, &self.top);
         });
     }
 }
@@ -195,7 +191,7 @@ fn show_as_popup(
     }
 }
 
-fn generic_child_ui(ui: &mut egui::Ui, vp_state: &mut ViewportState, close_button: bool) {
+fn generic_child_ui(ui: &mut egui::Ui, vp_state: &mut ViewportState) {
     ui.horizontal(|ui| {
         ui.label("Title:");
         if ui.text_edit_singleline(&mut vp_state.title).changed() {
@@ -207,10 +203,10 @@ fn generic_child_ui(ui: &mut egui::Ui, vp_state: &mut ViewportState, close_butto
         }
     });
 
-    generic_ui(ui, &vp_state.children, close_button);
+    generic_ui(ui, &vp_state.children);
 }
 
-fn generic_ui(ui: &mut egui::Ui, children: &[Arc<RwLock<ViewportState>>], close_button: bool) {
+fn generic_ui(ui: &mut egui::Ui, children: &[Arc<RwLock<ViewportState>>]) {
     let container_id = ui.id();
 
     let ctx = ui.ctx().clone();
@@ -294,7 +290,7 @@ fn generic_ui(ui: &mut egui::Ui, children: &[Arc<RwLock<ViewportState>>], close_
                 *visible
             };
             if visible {
-                ViewportState::show(child.clone(), &ctx, close_button);
+                ViewportState::show(child.clone(), &ctx);
             }
         }
     }

--- a/tests/test_viewports/src/main.rs
+++ b/tests/test_viewports/src/main.rs
@@ -61,7 +61,7 @@ impl ViewportState {
         }))
     }
 
-    pub fn show(vp_state: Arc<RwLock<Self>>, ctx: &egui::Context) {
+    pub fn show(vp_state: Arc<RwLock<Self>>, ctx: &egui::Context, close_button: bool) {
         if !vp_state.read().visible {
             return;
         }
@@ -71,6 +71,7 @@ impl ViewportState {
 
         let viewport = ViewportBuilder::default()
             .with_title(&title)
+            .with_close_button(close_button)
             .with_inner_size([500.0, 500.0]);
 
         if immediate {
@@ -80,7 +81,7 @@ impl ViewportState {
                     vp_state.visible = false;
                 }
                 show_as_popup(ctx, class, &title, vp_id.into(), |ui: &mut egui::Ui| {
-                    generic_child_ui(ui, &mut vp_state);
+                    generic_child_ui(ui, &mut vp_state, close_button);
                 });
             });
         } else {
@@ -101,7 +102,7 @@ impl ViewportState {
                         ui.label(format!("Callback has been reused {current_count} times"));
                         *count.write() += 1;
 
-                        generic_child_ui(ui, &mut vp_state);
+                        generic_child_ui(ui, &mut vp_state, close_button);
                     },
                 );
             });
@@ -118,6 +119,7 @@ impl ViewportState {
 
 pub struct App {
     top: Vec<Arc<RwLock<ViewportState>>>,
+    close_button: bool,
 }
 
 impl Default for App {
@@ -151,6 +153,7 @@ impl Default for App {
                     ],
                 ),
             ],
+            close_button: true,
         }
     }
 }
@@ -167,10 +170,11 @@ impl eframe::App for App {
                         viewport.write().set_visible_recursive(true);
                     }
                 }
+                ui.checkbox(&mut self.close_button, "with close button");
                 ctx.set_embed_viewports(embed_viewports);
             }
 
-            generic_ui(ui, &self.top);
+            generic_ui(ui, &self.top, self.close_button);
         });
     }
 }
@@ -191,7 +195,7 @@ fn show_as_popup(
     }
 }
 
-fn generic_child_ui(ui: &mut egui::Ui, vp_state: &mut ViewportState) {
+fn generic_child_ui(ui: &mut egui::Ui, vp_state: &mut ViewportState, close_button: bool) {
     ui.horizontal(|ui| {
         ui.label("Title:");
         if ui.text_edit_singleline(&mut vp_state.title).changed() {
@@ -203,10 +207,10 @@ fn generic_child_ui(ui: &mut egui::Ui, vp_state: &mut ViewportState) {
         }
     });
 
-    generic_ui(ui, &vp_state.children);
+    generic_ui(ui, &vp_state.children, close_button);
 }
 
-fn generic_ui(ui: &mut egui::Ui, children: &[Arc<RwLock<ViewportState>>]) {
+fn generic_ui(ui: &mut egui::Ui, children: &[Arc<RwLock<ViewportState>>], close_button: bool) {
     let container_id = ui.id();
 
     let ctx = ui.ctx().clone();
@@ -290,7 +294,7 @@ fn generic_ui(ui: &mut egui::Ui, children: &[Arc<RwLock<ViewportState>>]) {
                 *visible
             };
             if visible {
-                ViewportState::show(child.clone(), &ctx);
+                ViewportState::show(child.clone(), &ctx, close_button);
             }
         }
     }


### PR DESCRIPTION
This make the test excercise the window recreation logic, that resulted in several bugs - see #4862

Adds a check box that turns the close button on and off for child windows