### PR TITLE
Fix: Handling `state.ime_enabled` in multiple `TextEdit` and Chinese

### DIFF
--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -836,6 +836,9 @@ pub struct TextCursorStyle {
 
     /// When blinking, this is how long the cursor is invisible.
     pub off_duration: f32,
+
+    /// Indicates whether the IME preedit is committed.
+    pub ime_preedit_finished: bool,
 }
 
 impl Default for TextCursorStyle {
@@ -846,6 +849,7 @@ impl Default for TextCursorStyle {
             blink: true,
             on_duration: 0.5,
             off_duration: 0.5,
+            ime_preedit_finished: false,
         }
     }
 }
@@ -2126,6 +2130,7 @@ impl TextCursorStyle {
             blink,
             on_duration,
             off_duration,
+            ime_preedit_finished,
         } = self;
 
         ui.horizontal(|ui| {
@@ -2158,6 +2163,8 @@ impl TextCursorStyle {
                 ui.end_row();
             });
         }
+
+        ui.checkbox(ime_preedit_finished, "IME preedit finished");
     }
 }
 

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -746,6 +746,10 @@ impl<'t> TextEdit<'t> {
             }
         }
 
+        if state.ime_enabled && response.lost_focus() {
+            state.ime_enabled = false;
+        }
+
         state.clone().store(ui.ctx(), id);
 
         if response.changed {

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -1016,7 +1016,9 @@ fn events(
                     if prediction == "\n" || prediction == "\r" {
                         None
                     } else {
-                        state.ime_enabled = false;
+                        if ui.visuals().text_cursor.ime_preedit_finished {
+                            state.ime_enabled = false;
+                        }
 
                         if !prediction.is_empty()
                             && cursor_range.secondary.ccursor.index


### PR DESCRIPTION
Fix: Handling `state.ime_enabled` in multiple `TextEdit`.

* Related #4358 
* Related #4436
* Related #4794 
* Related #4896
* Closes #4908 

Issues: When focus is moved elsewhere, you must set `ime_enabled` to 'false`, otherwise the IME will have problems when focus returns.

Issues: #4908 (Chinese)
Because there are differences in how Korean and Chinese are handled, `ui.visuals().text_cursor.ime_preedit_finished` is introduced.

For Chinese :
```
    ui.visuals_mut().text_cursor.ime_preedit_finished = true;
```
