### PR TITLE
Fix: Backspace not working after IME input

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -350,16 +350,13 @@ impl State {
                             .events
                             .push(egui::Event::Ime(egui::ImeEvent::Preedit(text.clone())));
                     }
-                    winit::event::Ime::Preedit(_, None) => {
-                        self.ime_event_disable();
-                    }
                     winit::event::Ime::Commit(text) => {
                         self.egui_input
                             .events
                             .push(egui::Event::Ime(egui::ImeEvent::Commit(text.clone())));
                         self.ime_event_disable();
                     }
-                    winit::event::Ime::Disabled => {
+                    winit::event::Ime::Disabled | winit::event::Ime::Preedit(_, None) => {
                         self.ime_event_disable();
                     }
                 };

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -341,8 +341,7 @@ impl State {
                 // We use input_method_editor_started to manually insert CompositionStart
                 // between Commits.
                 match ime {
-                    winit::event::Ime::Enabled => {}
-                    winit::event::Ime::Preedit(_, None) => {
+                    winit::event::Ime::Enabled => {
                         self.ime_event_enable();
                     }
                     winit::event::Ime::Preedit(text, Some(_cursor)) => {
@@ -350,6 +349,9 @@ impl State {
                         self.egui_input
                             .events
                             .push(egui::Event::Ime(egui::ImeEvent::Preedit(text.clone())));
+                    }
+                    winit::event::Ime::Preedit(_, None) => {
+                        self.ime_event_disable();
                     }
                     winit::event::Ime::Commit(text) => {
                         self.egui_input


### PR DESCRIPTION
Fix: Changed the handling method of `Ime::Preedit(_, None)`

Fix: backspace fail after ime input

* Related #4358
* Related #4430 
* Related #4436
* Related #4794 
* Related #4896
* Closes #4908 

Issues: backspace fail after ime input
* #4908 (Chinese)

Changed the handling method of `Ime::Preedit(_, None)`
