### PR TITLE
Fix missing `winit` feature in `egui_glow`

### DIFF
--- a/crates/egui_glow/Cargo.toml
+++ b/crates/egui_glow/Cargo.toml
@@ -69,7 +69,7 @@ document-features = { workspace = true, optional = true }
 # Native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 puffin = { workspace = true, optional = true }
-winit = { workspace = true, optional = true, default-features = false }
+winit = { workspace = true, optional = true, default-features = false, features = ["rwh_06"] }
 
 # Web:
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
Since #4849, running `./scripts/check.sh` fails with:
```
...

error[E0277]: the trait bound `ActiveEventLoop: raw_window_handle::borrowed::HasDisplayHandle` is not satisfied
  --> crates/egui_glow/src/winit.rs:43:13
   |
43 |             event_loop,
   |             ^^^^^^^^^^ the trait `raw_window_handle::borrowed::HasDisplayHandle` is not implemented for `ActiveEventLoop`
   |
   = help: the following other types implement trait `raw_window_handle::borrowed::HasDisplayHandle`:
             raw_window_handle::borrowed::DisplayHandle<'a>
             &H
             &mut H
   = note: required for the cast from `&ActiveEventLoop` to `&dyn raw_window_handle::borrowed::HasDisplayHandle`
```

This PR adds the missing `rwh_06` to the winit dependency (in egui-glow).

* [x] I have followed the instructions in the PR template
