### PR TITLE
`egui_extras`: Fix file mime from path (wrong feature name)

### DIFF
--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -710,7 +710,7 @@ impl Modifiers {
     }
 
     /// Checks that the `ctrl/cmd` matches, and that the `shift/alt` of the argument is a subset
-    /// of the pressed ksey (`self`).
+    /// of the pressed key (`self`).
     ///
     /// This means that if the pattern has not set `shift`, then `self` can have `shift` set or not.
     ///

--- a/crates/egui_extras/src/loaders/file_loader.rs
+++ b/crates/egui_extras/src/loaders/file_loader.rs
@@ -80,12 +80,12 @@ impl BytesLoader for FileLoader {
                     move || {
                         let result = match std::fs::read(&path) {
                             Ok(bytes) => {
-                                #[cfg(feature = "mime_guess")]
+                                #[cfg(feature = "file")]
                                 let mime = mime_guess2::from_path(&path)
                                     .first_raw()
                                     .map(|v| v.to_owned());
 
-                                #[cfg(not(feature = "mime_guess"))]
+                                #[cfg(not(feature = "file"))]
                                 let mime = None;
 
                                 Ok(File {


### PR DESCRIPTION
Fix: features "mime_guess" to "file"

typo: 1

Is this what you intended?
If you intended to add `mime_guess` to `cargo.toml`, please drop it.
