### PR TITLE
Refactor: use `if let` instead of `for` on `Option`s

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1926,10 +1926,10 @@ impl Context {
                         paint_widget_id(widget, "hovered", Color32::WHITE);
                     }
                 }
-                for &widget in &clicked {
+                while let Some(widget) = clicked {
                     paint_widget_id(widget, "clicked", Color32::RED);
                 }
-                for &widget in &dragged {
+                while let Some(widget) = dragged {
                     paint_widget_id(widget, "dragged", Color32::GREEN);
                 }
             }
@@ -1948,10 +1948,10 @@ impl Context {
                     paint_widget(widget, "contains_pointer", Color32::BLUE);
                 }
             }
-            for widget in &click {
+            while let Some(widget) = &click {
                 paint_widget(widget, "click", Color32::RED);
             }
-            for widget in &drag {
+            while let Some(widget) = &drag {
                 paint_widget(widget, "drag", Color32::GREEN);
             }
         }

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1926,10 +1926,10 @@ impl Context {
                         paint_widget_id(widget, "hovered", Color32::WHITE);
                     }
                 }
-                while let Some(widget) = clicked {
+                if let Some(widget) = clicked {
                     paint_widget_id(widget, "clicked", Color32::RED);
                 }
-                while let Some(widget) = dragged {
+                if let Some(widget) = dragged {
                     paint_widget_id(widget, "dragged", Color32::GREEN);
                 }
             }
@@ -1948,10 +1948,10 @@ impl Context {
                     paint_widget(widget, "contains_pointer", Color32::BLUE);
                 }
             }
-            while let Some(widget) = &click {
+            if let Some(widget) = &click {
                 paint_widget(widget, "click", Color32::RED);
             }
-            while let Some(widget) = &drag {
+            if let Some(widget) = &drag {
                 paint_widget(widget, "drag", Color32::GREEN);
             }
         }


### PR DESCRIPTION
This is recommended by `rust-analyzer`

It might be a good idea to fix this to appease `rust-analyzer`.
