### PR TITLE
Add `Options::input_options` for click-delay etc

### DIFF
--- a/crates/egui/src/input_state/mod.rs
+++ b/crates/egui/src/input_state/mod.rs
@@ -55,8 +55,7 @@ impl InputOptions {
             max_click_duration,
             max_double_click_delay,
         } = self;
-        use crate::containers::*;
-        CollapsingHeader::new("InputOptions")
+        crate::containers::CollapsingHeader::new("InputOptions")
             .default_open(false)
             .show(ui, |ui| {
                 ui.horizontal(|ui| {
@@ -226,6 +225,8 @@ pub struct InputState {
     pub events: Vec<Event>,
 
     /// Input state management configuration.
+    ///
+    /// This gets copied from `egui::Options` at the start of each frame for convenience.
     input_options: InputOptions,
 }
 
@@ -428,7 +429,7 @@ impl InputState {
             keys_down,
             events: new.events.clone(), // TODO(emilk): remove clone() and use raw.events
             raw: new,
-            input_options: self.input_options,
+            input_options: options.input_options.clone(),
         }
     }
 
@@ -867,6 +868,8 @@ pub struct PointerState {
     pub(crate) pointer_events: Vec<PointerEvent>,
 
     /// Input state management configuration.
+    ///
+    /// This gets copied from `egui::Options` at the start of each frame for convenience.
     input_options: InputOptions,
 }
 

--- a/crates/egui/src/memory/mod.rs
+++ b/crates/egui/src/memory/mod.rs
@@ -254,6 +254,9 @@ pub struct Options {
     /// Controls the speed at which we zoom in when doing ctrl/cmd + scroll.
     pub scroll_zoom_speed: f32,
 
+    /// Options related to input state handling.
+    pub input_options: crate::input_state::InputOptions,
+
     /// If `true`, `egui` will discard the loaded image data after
     /// the texture is loaded onto the GPU to reduce memory usage.
     ///
@@ -294,6 +297,7 @@ impl Default for Options {
             // Input:
             line_scroll_speed,
             scroll_zoom_speed: 1.0 / 200.0,
+            input_options: Default::default(),
             reduce_texture_memory: false,
         }
     }
@@ -338,6 +342,7 @@ impl Options {
 
             line_scroll_speed,
             scroll_zoom_speed,
+            input_options,
             reduce_texture_memory,
         } = self;
 
@@ -396,6 +401,7 @@ impl Options {
                     )
                     .on_hover_text("How fast to zoom with ctrl/cmd + scroll");
                 });
+                input_options.ui(ui);
             });
 
         ui.vertical_centered(|ui| crate::reset_button(ui, self, "Reset all"));


### PR DESCRIPTION
This takes 3 hardcoded constants from `input_state.rs` and puts them in a `InputOptions` struct that then gets added to `Options`. This allows adjusting these values at runtime, for example, to increase `MAX_CLICK_DIST` for touchscreen usage.

* [x] I have followed the instructions in the PR template
