### PR TITLE
Update all examples, all tests, and `egui_demo_app` to use `env_logger 0.11`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,10 +204,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "anstyle"
-version = "1.0.4"
+name = "anstream"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "anyhow"
@@ -819,6 +862,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
 name = "com"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,15 +1470,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.0"
+name = "env_filter"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
- "humantime",
- "is-terminal",
  "log",
- "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -2188,6 +2247,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2345,9 +2410,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lz4_flex"
@@ -4171,6 +4236,12 @@ dependencies = [
  "svgtypes",
  "tiny-skia-path",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version-compare"

--- a/crates/egui_demo_app/Cargo.toml
+++ b/crates/egui_demo_app/Cargo.toml
@@ -26,7 +26,12 @@ web_app = ["http", "persistence"]
 
 http = ["ehttp", "image", "poll-promise", "egui_extras/image"]
 image_viewer = ["image", "egui_extras/all_loaders", "rfd"]
-persistence = ["eframe/persistence", "egui/persistence", "serde", "egui_extras/serde"]
+persistence = [
+  "eframe/persistence",
+  "egui/persistence",
+  "serde",
+  "egui_extras/serde",
+]
 puffin = ["eframe/puffin", "dep:puffin", "dep:puffin_http"]
 serde = ["dep:serde", "egui_demo_lib/serde", "egui/serde"]
 syntect = ["egui_demo_lib/syntect"]
@@ -69,7 +74,7 @@ serde = { workspace = true, optional = true }
 
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
   "auto-color",
   "humantime",
 ] }

--- a/examples/confirm_exit/Cargo.toml
+++ b/examples/confirm_exit/Cargo.toml
@@ -16,7 +16,7 @@ eframe = { workspace = true, features = [
     "default",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/examples/custom_3d_glow/Cargo.toml
+++ b/examples/custom_3d_glow/Cargo.toml
@@ -16,7 +16,7 @@ eframe = { workspace = true, features = [
     "default",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/examples/custom_font/Cargo.toml
+++ b/examples/custom_font/Cargo.toml
@@ -16,7 +16,7 @@ eframe = { workspace = true, features = [
     "default",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/examples/custom_font_style/Cargo.toml
+++ b/examples/custom_font_style/Cargo.toml
@@ -16,7 +16,7 @@ eframe = { workspace = true, features = [
     "default",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/examples/custom_keypad/Cargo.toml
+++ b/examples/custom_keypad/Cargo.toml
@@ -20,7 +20,7 @@ eframe = { workspace = true, features = [
 # For image support:
 egui_extras = { workspace = true, features = ["default", "image"] }
 
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/examples/custom_window_frame/Cargo.toml
+++ b/examples/custom_window_frame/Cargo.toml
@@ -16,7 +16,7 @@ eframe = { workspace = true, features = [
     "default",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/examples/file_dialog/Cargo.toml
+++ b/examples/file_dialog/Cargo.toml
@@ -16,7 +16,7 @@ eframe = { workspace = true, features = [
     "default",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -20,7 +20,7 @@ eframe = { workspace = true, features = [
 # For image support:
 egui_extras = { workspace = true, features = ["default", "image"] }
 
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/examples/hello_world_par/Cargo.toml
+++ b/examples/hello_world_par/Cargo.toml
@@ -19,12 +19,10 @@ eframe = { workspace = true, default-features = false, features = [
     "x11",
     "wgpu",
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }
 # This is normally enabled by eframe/default, which is not being used here
 # because of accesskit, as mentioned above
-winit = { workspace = true, features = [
-    "default"
-] }
+winit = { workspace = true, features = ["default"] }

--- a/examples/hello_world_simple/Cargo.toml
+++ b/examples/hello_world_simple/Cargo.toml
@@ -16,7 +16,7 @@ eframe = { workspace = true, features = [
     "default",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/examples/images/Cargo.toml
+++ b/examples/images/Cargo.toml
@@ -17,7 +17,7 @@ eframe = { workspace = true, features = [
   "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
 egui_extras = { workspace = true, features = ["default", "all_loaders"] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
   "auto-color",
   "humantime",
 ] }

--- a/examples/keyboard_events/Cargo.toml
+++ b/examples/keyboard_events/Cargo.toml
@@ -16,7 +16,7 @@ eframe = { workspace = true, features = [
     "default",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/examples/multiple_viewports/Cargo.toml
+++ b/examples/multiple_viewports/Cargo.toml
@@ -18,7 +18,7 @@ eframe = { workspace = true, features = [
     "default",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/examples/popups/Cargo.toml
+++ b/examples/popups/Cargo.toml
@@ -12,7 +12,7 @@ eframe = { workspace = true, features = [
     "default",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/examples/puffin_profiler/Cargo.toml
+++ b/examples/puffin_profiler/Cargo.toml
@@ -21,7 +21,7 @@ eframe = { workspace = true, features = [
     "puffin",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/examples/screenshot/Cargo.toml
+++ b/examples/screenshot/Cargo.toml
@@ -20,7 +20,7 @@ eframe = { workspace = true, features = [
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
     "wgpu",
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/examples/serial_windows/Cargo.toml
+++ b/examples/serial_windows/Cargo.toml
@@ -16,7 +16,7 @@ eframe = { workspace = true, features = [
     "default",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/examples/user_attention/Cargo.toml
+++ b/examples/user_attention/Cargo.toml
@@ -15,7 +15,7 @@ eframe = { workspace = true, features = [
     "default",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/tests/test_inline_glow_paint/Cargo.toml
+++ b/tests/test_inline_glow_paint/Cargo.toml
@@ -17,7 +17,7 @@ eframe = { workspace = true, features = [
     "default",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/tests/test_size_pass/Cargo.toml
+++ b/tests/test_size_pass/Cargo.toml
@@ -18,7 +18,7 @@ eframe = { workspace = true, features = [
     "default",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }

--- a/tests/test_ui_stack/Cargo.toml
+++ b/tests/test_ui_stack/Cargo.toml
@@ -21,7 +21,7 @@ eframe = { workspace = true, features = [
 # For image support:
 egui_extras = { workspace = true, features = ["default", "image", "serde"] }
 
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
   "auto-color",
   "humantime",
 ] }

--- a/tests/test_viewports/Cargo.toml
+++ b/tests/test_viewports/Cargo.toml
@@ -18,7 +18,7 @@ eframe = { workspace = true, features = [
     "default",
     "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
 ] }
-env_logger = { version = "0.10", default-features = false, features = [
+env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
     "humantime",
 ] }


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [x] I have followed the instructions in the PR template

This PR updates all examples, all tests, and the `egui_demo_app` crate to use the latest version of env_logger, `0.11`. This helps to clean up the list of outdated crates listed when running `cargo outdated --root-deps-only --workspace`.

To ensure I didn't break anything, I ran `cargo test` both before and after the changes, and observed no changes in the output. Additionally, the CI run for my commit finished successfully: https://github.com/LikeLakers2/egui/actions/runs/10347887485

(P.S. I recommend updating your `Cargo.lock` at some point, as `cargo-outdated` also lists a bunch of crates that have new minor/patch versions.)