### PR TITLE
Update `glow` to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,7 +1177,7 @@ dependencies = [
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
- "glow",
+ "glow 0.14.0",
  "glutin",
  "glutin-winit",
  "image",
@@ -1326,7 +1326,7 @@ dependencies = [
  "document-features",
  "egui",
  "egui-winit",
- "glow",
+ "glow 0.14.0",
  "glutin",
  "glutin-winit",
  "log",
@@ -1822,6 +1822,18 @@ name = "glow"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glow"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f865cbd94bd355b89611211e49508da98a1fce0ad755c1e8448fb96711b24528"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -4493,7 +4505,7 @@ dependencies = [
  "block",
  "cfg_aliases 0.1.1",
  "core-graphics-types",
- "glow",
+ "glow 0.13.1",
  "glutin_wgl_sys",
  "gpu-alloc",
  "gpu-allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ backtrace = "0.3"
 bytemuck = "1.7.2"
 criterion = { version = "0.5.1", default-features = false }
 document-features = " 0.2.8"
-glow = "0.13"
+glow = "0.14"
 glutin = "0.32.0"
 glutin-winit = "0.5.0"
 image = { version = "0.25", default-features = false }

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -5,10 +5,6 @@
 //! There is a bunch of improvements we could do,
 //! like removing a bunch of `unwraps`.
 
-// `clippy::arc_with_non_send_sync`: `glow::Context` was accidentally non-Sync in glow 0.13,
-// but that will be fixed in future releases of glow.
-// https://github.com/grovesNL/glow/commit/c4a5f7151b9b4bbb380faa06ec27415235d1bf7e
-#![allow(clippy::arc_with_non_send_sync)]
 #![allow(clippy::undocumented_unsafe_blocks)]
 
 use std::{cell::RefCell, num::NonZeroU32, rc::Rc, sync::Arc, time::Instant};

--- a/crates/egui_glow/examples/pure_glow.rs
+++ b/crates/egui_glow/examples/pure_glow.rs
@@ -3,8 +3,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 #![allow(rustdoc::missing_crate_level_docs)] // it's an example
 #![allow(clippy::undocumented_unsafe_blocks)]
-#![allow(clippy::arc_with_non_send_sync)]
-// `clippy::arc_with_non_send_sync`: `glow::Context` was accidentally non-Sync in glow 0.13, but that will be fixed in future releases of glow: https://github.com/grovesNL/glow/commit/c4a5f7151b9b4bbb380faa06ec27415235d1bf7e
 #![allow(unsafe_code)]
 
 use std::num::NonZeroU32;

--- a/deny.toml
+++ b/deny.toml
@@ -59,6 +59,8 @@ skip = [
   { name = "time" },           # old version pulled in by unmaintianed crate 'chrono'
   { name = "windows-core" },   # old version via accesskit_windows
   { name = "windows" },        # old version via accesskit_windows
+  { name = "glow" },           # ignore glow. See #4952
+
 ]
 skip-tree = [
   { name = "criterion" },     # dev-dependency

--- a/deny.toml
+++ b/deny.toml
@@ -59,7 +59,7 @@ skip = [
   { name = "time" },           # old version pulled in by unmaintianed crate 'chrono'
   { name = "windows-core" },   # old version via accesskit_windows
   { name = "windows" },        # old version via accesskit_windows
-  { name = "glow" },           # ignore glow. See #4952
+  { name = "glow" },           # wgpu uses an old `glow`, but realistically no one uses _both_ `egui_wgpu` and `egui_glow`, so we won't get a duplicate dependency
 
 ]
 skip-tree = [


### PR DESCRIPTION
Before making this PR, I did take notice of a similar PR, https://github.com/emilk/egui/pull/4833, but as it appears to be abandoned, I decided to make this PR.

**Missing**
One of the checks doesn't pass as wgpu still uses glow `0.13.1`

```shell
cargo deny --all-features --log-level error --target aarch64-apple-darwin check
```

* [x] I have followed the instructions in the PR template
