### PR TITLE
Add `Slider::max_decimals_opt`

### DIFF
--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -279,6 +279,12 @@ impl<'a> Slider<'a> {
         self
     }
 
+    #[inline]
+    pub fn max_decimals_opt(mut self, max_decimals: Option<usize>) -> Self {
+        self.max_decimals = max_decimals;
+        self
+    }
+
     /// Set an exact number of decimals to display.
     ///
     /// Values will also be rounded to this number of decimals.


### PR DESCRIPTION
As mentioned in #4950 I added `max_decimals_opt` to the Slider

* Closes <https://github.com/emilk/egui/issues/4950>
* [x] I have followed the instructions in the PR template
* [x] I ran the script in `scripts/check.sh`

