### PR TITLE
Update to wgpu 22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4432,9 +4432,9 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu"
-version = "22.0.0"
+version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87e07e87a179614940ad845397e03201847453a37b43a31a3b54eee2e6e32ce"
+checksum = "e1d1c4ba43f80542cf63a0a6ed3134629ae73e8ab51e4b765a67f3aa062eb433"
 dependencies = [
  "arrayvec",
  "cfg_aliases 0.1.1",
@@ -4457,9 +4457,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "22.0.0"
+version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f191908a21968991463fcf3b42cb6c9648c0fb7fa301b8fc733bc21a9ed9bd"
+checksum = "0348c840d1051b8e86c3bcd31206080c5e71e5933dabd79be1ce732b0b2f089a"
 dependencies = [
  "arrayvec",
  "bit-vec 0.7.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ web-time = "1.1.0" # Timekeeping for native and web
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = "0.3.58"
-wgpu = { version = "22.0.0", default-features = false, features = [
+wgpu = { version = "22.1.0", default-features = false, features = [
     # Make the renderer `Sync` even on wasm32, because it makes the code simpler:
     "fragile-send-sync-non-atomic-wasm",
 ] }

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -96,17 +96,6 @@ pub struct Painter {
     surfaces: ViewportIdMap<SurfaceState>,
 }
 
-impl Drop for Painter {
-    fn drop(&mut self) {
-        // Drop surfaces before dropping the render state.
-        //
-        // This is a workaround for a bug in wgpu 22.0.0.
-        // Fixed in https://github.com/gfx-rs/wgpu/pull/6052
-        // Remove with wgpu 22.1.0 update!
-        self.surfaces.clear();
-    }
-}
-
 impl Painter {
     /// Manages [`wgpu`] state, including surface state, required to render egui.
     ///


### PR DESCRIPTION
Updates to wgpu 22.1, removing a workaround that was needed for wgpu 22.0