### PR TITLE
Fix `Id` clash in `Frame` styling widget

### DIFF
--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -2484,7 +2484,8 @@ impl Widget for &mut crate::Frame {
                 ui.end_row();
 
                 ui.label("Outer margin");
-                ui.add(outer_margin);
+                // Push Id to avoid clashes in the Margin widget's Grid
+                ui.push_id("outer", |ui| ui.add(outer_margin));
                 ui.end_row();
 
                 ui.label("Rounding");


### PR DESCRIPTION
As we have two Margin widgets in the same UI and this widget has a Grid with a hardcoded Id, we have to force a different Id to one of them to avoid clashes.

* Closes <https://github.com/emilk/egui/issues/4965>
* [x] I have followed the instructions in the PR template
