### PR TITLE
Create a `UiBuilder` for building `Ui`s

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -532,16 +532,15 @@ impl Prepared {
     pub(crate) fn content_ui(&self, ctx: &Context) -> Ui {
         let max_rect = self.state.rect();
 
-        let clip_rect = self.constrain_rect; // Don't paint outside our bounds
-
         let mut ui = Ui::new(
             ctx.clone(),
             self.layer_id,
             self.layer_id.id,
-            max_rect,
-            clip_rect,
-            UiStackInfo::new(self.kind),
+            UiBuilder::new()
+                .ui_stack_info(UiStackInfo::new(self.kind))
+                .max_rect(max_rect),
         );
+        ui.set_clip_rect(self.constrain_rect); // Don't paint outside our bounds
 
         if self.fade_in {
             if let Some(last_became_visible_at) = self.state.last_became_visible_at {

--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -532,14 +532,18 @@ impl Prepared {
     pub(crate) fn content_ui(&self, ctx: &Context) -> Ui {
         let max_rect = self.state.rect();
 
-        let mut ui = Ui::new(
-            ctx.clone(),
-            self.layer_id,
-            self.layer_id.id,
-            UiBuilder::new()
-                .ui_stack_info(UiStackInfo::new(self.kind))
-                .max_rect(max_rect),
-        );
+        let mut ui_builder = UiBuilder::new()
+            .ui_stack_info(UiStackInfo::new(self.kind))
+            .max_rect(max_rect);
+
+        if !self.enabled {
+            ui_builder = ui_builder.disabled();
+        }
+        if self.sizing_pass {
+            ui_builder = ui_builder.sizing_pass();
+        }
+
+        let mut ui = Ui::new(ctx.clone(), self.layer_id, self.layer_id.id, ui_builder);
         ui.set_clip_rect(self.constrain_rect); // Don't paint outside our bounds
 
         if self.fade_in {
@@ -555,12 +559,6 @@ impl Prepared {
             }
         }
 
-        if !self.enabled {
-            ui.disable();
-        }
-        if self.sizing_pass {
-            ui.set_sizing_pass();
-        }
         ui
     }
 

--- a/crates/egui/src/containers/combo_box.rs
+++ b/crates/egui/src/containers/combo_box.rs
@@ -425,7 +425,7 @@ fn button_frame(
     outer_rect.set_height(outer_rect.height().at_least(interact_size.y));
 
     let inner_rect = outer_rect.shrink2(margin);
-    let mut content_ui = ui.child_ui(inner_rect, *ui.layout(), None);
+    let mut content_ui = ui.new_child(UiBuilder::new().max_rect(inner_rect));
     add_contents(&mut content_ui);
 
     let mut outer_rect = content_ui.min_rect().expand2(margin);

--- a/crates/egui/src/containers/frame.rs
+++ b/crates/egui/src/containers/frame.rs
@@ -250,10 +250,10 @@ impl Frame {
         inner_rect.max.x = inner_rect.max.x.max(inner_rect.min.x);
         inner_rect.max.y = inner_rect.max.y.max(inner_rect.min.y);
 
-        let content_ui = ui.child_ui(
-            inner_rect,
-            *ui.layout(),
-            Some(UiStackInfo::new(UiKind::Frame).with_frame(self)),
+        let content_ui = ui.new_child(
+            UiBuilder::new()
+                .ui_stack_info(UiStackInfo::new(UiKind::Frame).with_frame(self))
+                .max_rect(inner_rect),
         );
 
         // content_ui.set_clip_rect(outer_rect_bounds.shrink(self.stroke.width * 0.5)); // Can't do this since we don't know final size yet

--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -261,7 +261,7 @@ impl SidePanel {
             }
         }
 
-        let mut panel_ui = ui.child_from_builder(
+        let mut panel_ui = ui.new_child(
             UiBuilder::new()
                 .id_source(id)
                 .ui_stack_info(UiStackInfo::new(match side {
@@ -751,7 +751,7 @@ impl TopBottomPanel {
             }
         }
 
-        let mut panel_ui = ui.child_from_builder(
+        let mut panel_ui = ui.new_child(
             UiBuilder::new()
                 .id_source(id)
                 .ui_stack_info(UiStackInfo::new(match side {
@@ -1093,10 +1093,11 @@ impl CentralPanel {
         let Self { frame } = self;
 
         let panel_rect = ui.available_rect_before_wrap();
-        let mut panel_ui = ui.child_ui(
-            panel_rect,
-            Layout::top_down(Align::Min),
-            Some(UiStackInfo::new(UiKind::CentralPanel)),
+        let mut panel_ui = ui.new_child(
+            UiBuilder::new()
+                .ui_stack_info(UiStackInfo::new(UiKind::CentralPanel))
+                .max_rect(panel_rect)
+                .layout(Layout::top_down(Align::Min)),
         );
         panel_ui.set_clip_rect(panel_rect); // If we overflow, don't do so visibly (#4475)
 

--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -368,15 +368,13 @@ impl SidePanel {
         let layer_id = LayerId::background();
         let side = self.side;
         let available_rect = ctx.available_rect();
-        let clip_rect = ctx.screen_rect();
         let mut panel_ui = Ui::new(
             ctx.clone(),
             layer_id,
             self.id,
-            available_rect,
-            clip_rect,
-            UiStackInfo::default(),
+            UiBuilder::new().max_rect(available_rect),
         );
+        panel_ui.set_clip_rect(ctx.screen_rect());
 
         let inner_response = self.show_inside_dyn(&mut panel_ui, add_contents);
         let rect = inner_response.response.rect;
@@ -859,15 +857,13 @@ impl TopBottomPanel {
         let available_rect = ctx.available_rect();
         let side = self.side;
 
-        let clip_rect = ctx.screen_rect();
         let mut panel_ui = Ui::new(
             ctx.clone(),
             layer_id,
             self.id,
-            available_rect,
-            clip_rect,
-            UiStackInfo::default(), // set by show_inside_dyn
+            UiBuilder::new().max_rect(available_rect),
         );
+        panel_ui.set_clip_rect(ctx.screen_rect());
 
         let inner_response = self.show_inside_dyn(&mut panel_ui, add_contents);
         let rect = inner_response.response.rect;
@@ -1127,15 +1123,13 @@ impl CentralPanel {
         let layer_id = LayerId::background();
         let id = Id::new((ctx.viewport_id(), "central_panel"));
 
-        let clip_rect = ctx.screen_rect();
         let mut panel_ui = Ui::new(
             ctx.clone(),
             layer_id,
             id,
-            available_rect,
-            clip_rect,
-            UiStackInfo::default(), // set by show_inside_dyn
+            UiBuilder::new().max_rect(available_rect),
         );
+        panel_ui.set_clip_rect(ctx.screen_rect());
 
         let inner_response = self.show_inside_dyn(&mut panel_ui, add_contents);
 

--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -261,14 +261,15 @@ impl SidePanel {
             }
         }
 
-        let mut panel_ui = ui.child_ui_with_id_source(
+        let mut panel_ui = ui.child_from_builder(
             panel_rect,
-            Layout::top_down(Align::Min),
-            id,
-            Some(UiStackInfo::new(match side {
-                Side::Left => UiKind::LeftPanel,
-                Side::Right => UiKind::RightPanel,
-            })),
+            UiBuilder::new()
+                .id_source(id)
+                .ui_stack_info(UiStackInfo::new(match side {
+                    Side::Left => UiKind::LeftPanel,
+                    Side::Right => UiKind::RightPanel,
+                }))
+                .layout(Layout::top_down(Align::Min)),
         );
         panel_ui.expand_to_include_rect(panel_rect);
         panel_ui.set_clip_rect(panel_rect); // If we overflow, don't do so visibly (#4475)
@@ -750,14 +751,15 @@ impl TopBottomPanel {
             }
         }
 
-        let mut panel_ui = ui.child_ui_with_id_source(
+        let mut panel_ui = ui.child_from_builder(
             panel_rect,
-            Layout::top_down(Align::Min),
-            id,
-            Some(UiStackInfo::new(match side {
-                TopBottomSide::Top => UiKind::TopPanel,
-                TopBottomSide::Bottom => UiKind::BottomPanel,
-            })),
+            UiBuilder::new()
+                .id_source(id)
+                .ui_stack_info(UiStackInfo::new(match side {
+                    TopBottomSide::Top => UiKind::TopPanel,
+                    TopBottomSide::Bottom => UiKind::BottomPanel,
+                }))
+                .layout(Layout::top_down(Align::Min)),
         );
         panel_ui.expand_to_include_rect(panel_rect);
         panel_ui.set_clip_rect(panel_rect); // If we overflow, don't do so visibly (#4475)

--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -262,13 +262,13 @@ impl SidePanel {
         }
 
         let mut panel_ui = ui.child_from_builder(
-            panel_rect,
             UiBuilder::new()
                 .id_source(id)
                 .ui_stack_info(UiStackInfo::new(match side {
                     Side::Left => UiKind::LeftPanel,
                     Side::Right => UiKind::RightPanel,
                 }))
+                .max_rect(panel_rect)
                 .layout(Layout::top_down(Align::Min)),
         );
         panel_ui.expand_to_include_rect(panel_rect);
@@ -752,13 +752,13 @@ impl TopBottomPanel {
         }
 
         let mut panel_ui = ui.child_from_builder(
-            panel_rect,
             UiBuilder::new()
                 .id_source(id)
                 .ui_stack_info(UiStackInfo::new(match side {
                     TopBottomSide::Top => UiKind::TopPanel,
                     TopBottomSide::Bottom => UiKind::BottomPanel,
                 }))
+                .max_rect(panel_rect)
                 .layout(Layout::top_down(Align::Min)),
         );
         panel_ui.expand_to_include_rect(panel_rect);

--- a/crates/egui/src/containers/resize.rs
+++ b/crates/egui/src/containers/resize.rs
@@ -270,10 +270,10 @@ impl Resize {
 
         content_clip_rect = content_clip_rect.intersect(ui.clip_rect()); // Respect parent region
 
-        let mut content_ui = ui.child_ui(
-            inner_rect,
-            *ui.layout(),
-            Some(UiStackInfo::new(UiKind::Resize)),
+        let mut content_ui = ui.new_child(
+            UiBuilder::new()
+                .ui_stack_info(UiStackInfo::new(UiKind::Resize))
+                .max_rect(inner_rect),
         );
         content_ui.set_clip_rect(content_clip_rect);
 

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -560,10 +560,10 @@ impl ScrollArea {
         }
 
         let content_max_rect = Rect::from_min_size(inner_rect.min - state.offset, content_max_size);
-        let mut content_ui = ui.child_ui(
-            content_max_rect,
-            *ui.layout(),
-            Some(UiStackInfo::new(UiKind::ScrollArea)),
+        let mut content_ui = ui.new_child(
+            UiBuilder::new()
+                .ui_stack_info(UiStackInfo::new(UiKind::ScrollArea))
+                .max_rect(content_max_rect),
         );
 
         {

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -732,7 +732,7 @@ impl ScrollArea {
 
             let rect = Rect::from_x_y_ranges(ui.max_rect().x_range(), y_min..=y_max);
 
-            ui.allocate_ui_at_rect(rect, |viewport_ui| {
+            ui.allocate_new_ui(UiBuilder::new().max_rect(rect), |viewport_ui| {
                 viewport_ui.skip_ahead_auto_ids(min_row); // Make sure we get consistent IDs.
                 add_contents(viewport_ui, min_row..max_row)
             })

--- a/crates/egui/src/grid.rs
+++ b/crates/egui/src/grid.rs
@@ -425,11 +425,14 @@ impl Grid {
         // then we should pick a default layout that matches that alignment,
         // which we do here:
         let max_rect = ui.cursor().intersect(ui.max_rect());
-        ui.allocate_ui_at_rect(max_rect, |ui| {
-            if prev_state.is_none() {
-                // Hide the ui this frame, and make things as narrow as possible.
-                ui.set_sizing_pass();
-            }
+
+        let mut ui_builder = UiBuilder::new().max_rect(max_rect);
+        if prev_state.is_none() {
+            // Hide the ui this frame, and make things as narrow as possible.
+            ui_builder = ui_builder.sizing_pass();
+        }
+
+        ui.allocate_new_ui(ui_builder, |ui| {
             ui.horizontal(|ui| {
                 let is_color = color_picker.is_some();
                 let mut grid = GridLayout {

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -400,6 +400,7 @@ mod sense;
 pub mod style;
 pub mod text_selection;
 mod ui;
+mod ui_builder;
 mod ui_stack;
 pub mod util;
 pub mod viewport;
@@ -442,7 +443,7 @@ pub mod text {
     };
 }
 
-pub use {
+pub use self::{
     containers::*,
     context::{Context, RepaintCause, RequestRepaintInfo},
     data::{
@@ -467,6 +468,7 @@ pub use {
     style::{FontSelection, Style, TextStyle, Visuals},
     text::{Galley, TextFormat},
     ui::Ui,
+    ui_builder::UiBuilder,
     ui_stack::*,
     viewport::*,
     widget_rect::{WidgetRect, WidgetRects},

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -154,7 +154,7 @@ impl Ui {
     /// [`Self::scope`] if needed.
     ///
     /// When in doubt, use `None` for the `UiStackInfo` argument.
-    #[deprecated = "Use ui.child_from_builder instead"]
+    #[deprecated = "Use ui.new_child() instead"]
     pub fn child_ui(
         &mut self,
         max_rect: Rect,
@@ -172,7 +172,7 @@ impl Ui {
     /// Create a new [`Ui`] at a specific region with a specific id.
     ///
     /// When in doubt, use `None` for the `UiStackInfo` argument.
-    #[deprecated = "Use ui.child_from_builder instead"]
+    #[deprecated = "Use ui.new_child() instead"]
     pub fn child_ui_with_id_source(
         &mut self,
         max_rect: Rect,
@@ -1269,7 +1269,10 @@ impl Ui {
         let painter = self.painter().with_clip_rect(clip_rect);
         (response, painter)
     }
+}
 
+/// # Scrolling
+impl Ui {
     /// Adjust the scroll position of any parent [`ScrollArea`] so that the given [`Rect`] becomes visible.
     ///
     /// If `align` is [`Align::TOP`] it means "put the top of the rect at the top of the scroll area", etc.
@@ -2655,7 +2658,10 @@ impl Ui {
 
         (InnerResponse { inner, response }, payload)
     }
+}
 
+/// # Menues
+impl Ui {
     /// Close the menu we are in (including submenus), if any.
     ///
     /// See also: [`Self::menu_button`] and [`Response::context_menu`].

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2660,7 +2660,7 @@ impl Ui {
     }
 }
 
-/// # Menues
+/// # Menus
 impl Ui {
     /// Close the menu we are in (including submenus), if any.
     ///

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1563,6 +1563,7 @@ impl Ui {
     /// });
     /// # });
     /// ```
+    #[deprecated = "Use 'ui.scope_builder' instead"]
     pub fn add_visible_ui<R>(
         &mut self,
         visible: bool,
@@ -2076,6 +2077,7 @@ impl Ui {
     /// Push another level onto the [`UiStack`].
     ///
     /// You can use this, for instance, to tag a group of widgets.
+    #[deprecated = "Use 'ui.scope_builder' instead"]
     pub fn push_stack_info<R>(
         &mut self,
         ui_stack_info: UiStackInfo,

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1207,6 +1207,7 @@ impl Ui {
     /// If the contents overflow, more space will be allocated.
     /// When finished, the amount of space actually used (`min_rect`) will be allocated.
     /// So you can request a lot of space and then use less.
+    #[deprecated = "Use `allocate_new_ui` instead"]
     pub fn allocate_ui_at_rect<R>(
         &mut self,
         max_rect: Rect,
@@ -1445,9 +1446,12 @@ impl Ui {
     ///
     /// See also [`Self::add`] and [`Self::add_sized`].
     pub fn put(&mut self, max_rect: Rect, widget: impl Widget) -> Response {
-        self.allocate_ui_at_rect(max_rect, |ui| {
-            ui.centered_and_justified(|ui| ui.add(widget)).inner
-        })
+        self.allocate_new_ui(
+            UiBuilder::new()
+                .max_rect(max_rect)
+                .layout(Layout::centered_and_justified(Direction::TopDown)),
+            |ui| ui.add(widget),
+        )
         .inner
     }
 

--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -1,0 +1,86 @@
+use std::{hash::Hash, sync::Arc};
+
+use crate::{Id, Layout, Style, UiStackInfo};
+
+#[derive(Default)]
+pub struct UiBuilder {
+    pub id_source: Option<Id>,
+    pub ui_stack_info: UiStackInfo,
+    pub layout: Option<Layout>,
+    pub disabled: bool,
+    pub invisible: bool,
+    pub sizing_pass: bool,
+    pub style: Option<Arc<Style>>,
+}
+
+impl UiBuilder {
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Seed the child `Ui` with this `id_source`, which will be mixed
+    /// with the [`Ui::id`] of the parent.
+    ///
+    /// You should give each [`Ui`] an `id_source` that is unique
+    /// within the parent, or give it none at all.
+    #[inline]
+    pub fn id_source(mut self, id_source: impl Hash) -> Self {
+        self.id_source = Some(Id::new(id_source));
+        self
+    }
+
+    /// Provide some information about the new `Ui` being built.
+    #[inline]
+    pub fn ui_stack_info(mut self, ui_stack_info: UiStackInfo) -> Self {
+        self.ui_stack_info = ui_stack_info;
+        self
+    }
+
+    /// Override the layout.
+    ///
+    /// Will otherwise be inherited from the parent.
+    #[inline]
+    pub fn layout(mut self, layout: Layout) -> Self {
+        self.layout = Some(layout);
+        self
+    }
+
+    /// Make the new `Ui` disabled, i.e. grayed-out and non-interactive.
+    ///
+    /// Note that if the parent `Ui` is disabled, the child will always be disabled.
+    #[inline]
+    pub fn disabled(mut self) -> Self {
+        self.disabled = true;
+        self
+    }
+
+    /// Make the contents invisible.
+    ///
+    /// If the parent `Ui` is invisible, the child will always be invisible.
+    #[inline]
+    pub fn invisible(mut self) -> Self {
+        self.invisible = true;
+        self
+    }
+
+    /// Set to true in special cases where we do one frame
+    /// where we size up the contents of the Ui, without actually showing it.
+    ///
+    /// If the `sizing_pass` flag is set on the parent,
+    /// the child will inherit it automatically.
+    #[inline]
+    pub fn sizing_pass(mut self) -> Self {
+        self.sizing_pass = true;
+        self
+    }
+
+    /// Override the style.
+    ///
+    /// Otherwise will inherit the style of the parent.
+    #[inline]
+    pub fn style(mut self, style: impl Into<Arc<Style>>) -> Self {
+        self.style = Some(style.into());
+        self
+    }
+}

--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -7,6 +7,7 @@ use crate::{Id, Layout, Rect, Style, UiStackInfo};
 /// By default, everyhting is inherited from the parent,
 /// except for `max_rect` which by default is set to
 /// the parent [`Ui::available_rect_before_wrap`].
+#[must_use]
 #[derive(Default)]
 pub struct UiBuilder {
     pub id_source: Option<Id>,
@@ -81,10 +82,13 @@ impl UiBuilder {
 
     /// Make the contents invisible.
     ///
+    /// Will also diable the `Ui` (see [`Self::disable`]).
+    ///
     /// If the parent `Ui` is invisible, the child will always be invisible.
     #[inline]
     pub fn invisible(mut self) -> Self {
         self.invisible = true;
+        self.disabled = true;
         self
     }
 
@@ -96,6 +100,8 @@ impl UiBuilder {
     #[inline]
     pub fn sizing_pass(mut self) -> Self {
         self.sizing_pass = true;
+        self.invisible = true;
+        self.disabled = true;
         self
     }
 

--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -4,7 +4,7 @@ use crate::{Id, Layout, Rect, Style, UiStackInfo};
 
 /// Build a [`Ui`] as the chlild of another [`Ui`].
 ///
-/// By default, everyhting is inherited from the parent,
+/// By default, everything is inherited from the parent,
 /// except for `max_rect` which by default is set to
 /// the parent [`Ui::available_rect_before_wrap`].
 #[must_use]
@@ -82,7 +82,7 @@ impl UiBuilder {
 
     /// Make the contents invisible.
     ///
-    /// Will also diable the `Ui` (see [`Self::disable`]).
+    /// Will also disable the `Ui` (see [`Self::disable`]).
     ///
     /// If the parent `Ui` is invisible, the child will always be invisible.
     #[inline]

--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -2,6 +2,9 @@ use std::{hash::Hash, sync::Arc};
 
 use crate::{Id, Layout, Rect, Style, UiStackInfo};
 
+#[allow(unused_imports)] // Used for doclinks
+use crate::Ui;
+
 /// Build a [`Ui`] as the chlild of another [`Ui`].
 ///
 /// By default, everything is inherited from the parent,
@@ -82,7 +85,7 @@ impl UiBuilder {
 
     /// Make the contents invisible.
     ///
-    /// Will also disable the `Ui` (see [`Self::disable`]).
+    /// Will also disable the `Ui` (see [`Self::disabled`]).
     ///
     /// If the parent `Ui` is invisible, the child will always be invisible.
     #[inline]

--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -1,11 +1,17 @@
 use std::{hash::Hash, sync::Arc};
 
-use crate::{Id, Layout, Style, UiStackInfo};
+use crate::{Id, Layout, Rect, Style, UiStackInfo};
 
+/// Build a [`Ui`] as the chlild of another [`Ui`].
+///
+/// By default, everyhting is inherited from the parent,
+/// except for `max_rect` which by default is set to
+/// the parent [`Ui::available_rect_before_wrap`].
 #[derive(Default)]
 pub struct UiBuilder {
     pub id_source: Option<Id>,
     pub ui_stack_info: UiStackInfo,
+    pub max_rect: Option<Rect>,
     pub layout: Option<Layout>,
     pub disabled: bool,
     pub invisible: bool,
@@ -34,6 +40,24 @@ impl UiBuilder {
     #[inline]
     pub fn ui_stack_info(mut self, ui_stack_info: UiStackInfo) -> Self {
         self.ui_stack_info = ui_stack_info;
+        self
+    }
+
+    /// Set the max rectangle, within which widgets will go.
+    ///
+    /// New widgets will *try* to fit within this rectangle.
+    ///
+    /// Text labels will wrap to fit within `max_rect`.
+    /// Separator lines will span the `max_rect`.
+    ///
+    /// If a new widget doesn't fit within the `max_rect` then the
+    /// [`Ui`] will make room for it by expanding both `min_rect` and
+    ///
+    /// If not set, this will be set to the parent
+    /// [`Ui::available_rect_before_wrap`].
+    #[inline]
+    pub fn max_rect(mut self, max_rect: Rect) -> Self {
+        self.max_rect = Some(max_rect);
         self
     }
 

--- a/crates/egui_demo_lib/src/demo/widget_gallery.rs
+++ b/crates/egui_demo_lib/src/demo/widget_gallery.rs
@@ -61,10 +61,15 @@ impl crate::Demo for WidgetGallery {
 
 impl crate::View for WidgetGallery {
     fn ui(&mut self, ui: &mut egui::Ui) {
-        ui.add_enabled_ui(self.enabled, |ui| {
-            if !self.visible {
-                ui.set_invisible();
-            }
+        let mut ui_builder = egui::UiBuilder::new();
+        if !self.enabled {
+            ui_builder = ui_builder.disabled();
+        }
+        if !self.visible {
+            ui_builder = ui_builder.invisible();
+        }
+
+        ui.scope_builder(ui_builder, |ui| {
             ui.multiply_opacity(self.opacity);
 
             egui::Grid::new("my_grid")

--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -198,10 +198,10 @@ impl<'l> StripLayout<'l> {
         add_cell_contents: impl FnOnce(&mut Ui),
     ) -> Ui {
         let mut child_ui = self.ui.child_from_builder(
-            max_rect,
             UiBuilder::new()
                 .id_source(child_ui_id_source)
                 .ui_stack_info(egui::UiStackInfo::new(egui::UiKind::TableCell))
+                .max_rect(max_rect)
                 .layout(self.cell_layout),
         );
 

--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -1,4 +1,4 @@
-use egui::{Id, Pos2, Rect, Response, Sense, Ui};
+use egui::{Id, Pos2, Rect, Response, Sense, Ui, UiBuilder};
 
 #[derive(Clone, Copy)]
 pub(crate) enum CellSize {
@@ -197,11 +197,12 @@ impl<'l> StripLayout<'l> {
         child_ui_id_source: egui::Id,
         add_cell_contents: impl FnOnce(&mut Ui),
     ) -> Ui {
-        let mut child_ui = self.ui.child_ui_with_id_source(
+        let mut child_ui = self.ui.child_from_builder(
             max_rect,
-            self.cell_layout,
-            child_ui_id_source,
-            Some(egui::UiStackInfo::new(egui::UiKind::TableCell)),
+            UiBuilder::new()
+                .id_source(child_ui_id_source)
+                .ui_stack_info(egui::UiStackInfo::new(egui::UiKind::TableCell))
+                .layout(self.cell_layout),
         );
 
         if flags.clip {

--- a/crates/egui_extras/src/layout.rs
+++ b/crates/egui_extras/src/layout.rs
@@ -197,7 +197,7 @@ impl<'l> StripLayout<'l> {
         child_ui_id_source: egui::Id,
         add_cell_contents: impl FnOnce(&mut Ui),
     ) -> Ui {
-        let mut child_ui = self.ui.child_from_builder(
+        let mut child_ui = self.ui.new_child(
             UiBuilder::new()
                 .id_source(child_ui_id_source)
                 .ui_stack_info(egui::UiStackInfo::new(egui::UiKind::TableCell))

--- a/examples/custom_window_frame/src/main.rs
+++ b/examples/custom_window_frame/src/main.rs
@@ -71,7 +71,7 @@ fn custom_window_frame(ctx: &egui::Context, title: &str, add_contents: impl FnOn
             rect
         }
         .shrink(4.0);
-        let mut content_ui = ui.child_ui(content_rect, *ui.layout(), None);
+        let mut content_ui = ui.new_child(UiBuilder::new().max_rect(content_rect));
         add_contents(&mut content_ui);
     });
 }

--- a/examples/custom_window_frame/src/main.rs
+++ b/examples/custom_window_frame/src/main.rs
@@ -116,14 +116,17 @@ fn title_bar_ui(ui: &mut egui::Ui, title_bar_rect: eframe::epaint::Rect, title: 
         ui.ctx().send_viewport_cmd(ViewportCommand::StartDrag);
     }
 
-    ui.allocate_ui_at_rect(title_bar_rect, |ui| {
-        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+    ui.allocate_new_ui(
+        UiBuilder::new()
+            .max_rect(title_bar_rect)
+            .layout(egui::Layout::right_to_left(egui::Align::Center)),
+        |ui| {
             ui.spacing_mut().item_spacing.x = 0.0;
             ui.visuals_mut().button_frame = false;
             ui.add_space(8.0);
             close_maximize_minimize(ui);
-        });
-    });
+        },
+    );
 }
 
 /// Show some close/maximize/minimize buttons for the native window.

--- a/tests/test_viewports/src/main.rs
+++ b/tests/test_viewports/src/main.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use eframe::egui;
-use egui::{mutex::RwLock, Id, InnerResponse, ViewportBuilder, ViewportId};
+use egui::{mutex::RwLock, Id, InnerResponse, UiBuilder, ViewportBuilder, ViewportId};
 
 // Drag-and-drop between windows is not yet implemented, but if you wanna work on it, enable this:
 pub const DRAG_AND_DROP_TEST: bool = false;
@@ -457,7 +457,7 @@ fn drop_target<R>(
 
     let available_rect = ui.available_rect_before_wrap();
     let inner_rect = available_rect.shrink2(margin);
-    let mut content_ui = ui.child_ui(inner_rect, *ui.layout(), None);
+    let mut content_ui = ui.new_child(UiBuilder::new().max_rect(inner_rect));
     let ret = body(&mut content_ui);
 
     let outer_rect =


### PR DESCRIPTION
* Part of https://github.com/emilk/egui/issues/4634

The goals is to create fewer, more powerful entry points.


### Added
* `egui::UiBuilder`
* `Ui::allocate_new_ui`
* `Ui::new_child`

### Breaking changes
* `Ui::new` now takes a `UiBuilder`
* Deprecated
	* `ui.add_visible_ui`
	* `ui.allocate_ui_at_rect`
	* `ui.child_ui`
	* `ui.child_ui_with_id_source`
	* `ui.push_stack_info`