### PR TITLE
Add `Label::halign`

### DIFF
--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -26,6 +26,7 @@ pub struct Label {
     wrap_mode: Option<TextWrapMode>,
     sense: Option<Sense>,
     selectable: Option<bool>,
+    align: Option<Align>,
 }
 
 impl Label {
@@ -35,6 +36,7 @@ impl Label {
             wrap_mode: None,
             sense: None,
             selectable: None,
+            align: None,
         }
     }
 
@@ -73,6 +75,13 @@ impl Label {
     #[inline]
     pub fn extend(mut self) -> Self {
         self.wrap_mode = Some(TextWrapMode::Extend);
+        self
+    }
+
+    /// Set [`Self::align`] to [`Align`].
+    #[inline]
+    pub fn align(mut self, align: Align) -> Self {
+        self.align = Some(align);
         self
     }
 
@@ -211,7 +220,7 @@ impl Label {
                 layout_job.halign = Align::LEFT;
                 layout_job.justify = false;
             } else {
-                layout_job.halign = ui.layout().horizontal_placement();
+                layout_job.halign = self.align.unwrap_or(ui.layout().horizontal_placement());
                 layout_job.justify = ui.layout().horizontal_justify();
             };
 

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -79,7 +79,7 @@ impl Label {
     }
 
     /// Sets the horizontal alignment of the Label to the given `Align` value.
-    /// 
+    ///
     /// Set [`Self::align`] to [`Align`].
     #[inline]
     pub fn halign(mut self, align: Align) -> Self {

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -26,7 +26,7 @@ pub struct Label {
     wrap_mode: Option<TextWrapMode>,
     sense: Option<Sense>,
     selectable: Option<bool>,
-    align: Option<Align>,
+    halign: Option<Align>,
 }
 
 impl Label {
@@ -36,7 +36,7 @@ impl Label {
             wrap_mode: None,
             sense: None,
             selectable: None,
-            align: None,
+            halign: None,
         }
     }
 
@@ -83,7 +83,7 @@ impl Label {
     /// Set [`Self::align`] to [`Align`].
     #[inline]
     pub fn halign(mut self, align: Align) -> Self {
-        self.align = Some(align);
+        self.halign = Some(align);
         self
     }
 
@@ -222,7 +222,7 @@ impl Label {
                 layout_job.halign = Align::LEFT;
                 layout_job.justify = false;
             } else {
-                layout_job.halign = self.align.unwrap_or(ui.layout().horizontal_placement());
+                layout_job.halign = self.halign.unwrap_or(ui.layout().horizontal_placement());
                 layout_job.justify = ui.layout().horizontal_justify();
             };
 

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -78,9 +78,11 @@ impl Label {
         self
     }
 
+    /// Sets the horizontal alignment of the Label to the given `Align` value.
+    /// 
     /// Set [`Self::align`] to [`Align`].
     #[inline]
-    pub fn align(mut self, align: Align) -> Self {
+    pub fn halign(mut self, align: Align) -> Self {
         self.align = Some(align);
         self
     }

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -80,7 +80,7 @@ impl Label {
 
     /// Sets the horizontal alignment of the Label to the given `Align` value.
     ///
-    /// Set [`Self::align`] to [`Align`].
+    /// Set [`Self::halign`] to [`Align`].
     #[inline]
     pub fn halign(mut self, align: Align) -> Self {
         self.halign = Some(align);

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -79,8 +79,6 @@ impl Label {
     }
 
     /// Sets the horizontal alignment of the Label to the given `Align` value.
-    ///
-    /// Set [`Self::halign`] to [`Align`].
     #[inline]
     pub fn halign(mut self, align: Align) -> Self {
         self.halign = Some(align);


### PR DESCRIPTION
Function to specify `Align` to `Label`

There are cases where you want to display `Label` on the left or right regardless of other `Layout` specifications.

Before : Note the part showing the rust source code.
![20240818-1](https://github.com/user-attachments/assets/a08f7594-1ec1-4c6a-b96d-1a5f735d02c1)

After : Note the part showing the rust source code.
![20240818-2](https://github.com/user-attachments/assets/807ff9cf-f8cd-4415-9c78-b62869d1696d)
