### PR TITLE
Always import emath directly when already a direct dependency

### DIFF
--- a/crates/egui/src/animation_manager.rs
+++ b/crates/egui/src/animation_manager.rs
@@ -1,7 +1,5 @@
-use crate::{
-    emath::{remap_clamp, NumExt as _},
-    Id, IdMap, InputState,
-};
+use crate::{Id, IdMap, InputState};
+use emath::{remap_clamp, NumExt as _};
 
 #[derive(Clone, Default)]
 pub(crate) struct AnimationManager {

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -3,9 +3,8 @@
 use std::{borrow::Cow, cell::RefCell, panic::Location, sync::Arc, time::Duration};
 
 use containers::area::AreaState;
-use epaint::{
-    emath::TSTransform, mutex::*, stats::*, text::Fonts, util::OrderedFloat, TessellationOptions, *,
-};
+use emath::{OrderedFloat, TSTransform};
+use epaint::{mutex::*, stats::*, *};
 
 use crate::{
     animation_manager::AnimationManager,
@@ -2364,7 +2363,7 @@ impl Context {
     #[deprecated = "Use `transform_layer_shapes` instead"]
     pub fn translate_layer(&self, layer_id: LayerId, delta: Vec2) {
         if delta != Vec2::ZERO {
-            let transform = emath::TSTransform::from_translation(delta);
+            let transform = TSTransform::from_translation(delta);
             self.transform_layer_shapes(layer_id, transform);
         }
     }

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -1,8 +1,9 @@
 //! The input needed by egui.
 
+use emath::{Pos2, Rect, Vec2};
 use epaint::ColorImage;
 
-use crate::{emath::*, Key, Theme, ViewportId, ViewportIdMap};
+use crate::{Key, Theme, ViewportId, ViewportIdMap};
 
 /// What the integrations provides to egui at the start of each frame.
 ///

--- a/crates/egui/src/input_state.rs
+++ b/crates/egui/src/input_state.rs
@@ -1,13 +1,14 @@
 mod touch_state;
 
 use crate::data::input::*;
-use crate::{emath::*, util::History};
+use crate::util::History;
 use std::{
     collections::{BTreeMap, HashSet},
     time::Duration,
 };
 
 pub use crate::Key;
+use emath::{vec2, NumExt, Pos2, Rect, Vec2};
 pub use touch_state::MultiTouchInfo;
 use touch_state::TouchState;
 
@@ -299,7 +300,7 @@ impl InputState {
 
         {
             let dt = stable_dt.at_most(0.1);
-            let t = crate::emath::exponential_smooth_factor(0.90, 0.1, dt); // reach _% in _ seconds. TODO(emilk): parameterize
+            let t = emath::exponential_smooth_factor(0.90, 0.1, dt); // reach _% in _ seconds. TODO(emilk): parameterize
 
             if unprocessed_scroll_delta != Vec2::ZERO {
                 for d in 0..2 {

--- a/crates/egui/src/input_state/touch_state.rs
+++ b/crates/egui/src/input_state/touch_state.rs
@@ -1,10 +1,7 @@
 use std::{collections::BTreeMap, fmt::Debug};
 
-use crate::{
-    data::input::TouchDeviceId,
-    emath::{normalized_angle, Pos2, Vec2},
-    Event, RawInput, TouchId, TouchPhase,
-};
+use crate::{data::input::TouchDeviceId, Event, RawInput, TouchId, TouchPhase};
+use emath::{normalized_angle, Pos2, Vec2};
 
 /// All you probably need to know about a multi-touch gesture.
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/crates/egui/src/layers.rs
+++ b/crates/egui/src/layers.rs
@@ -2,7 +2,8 @@
 //! are sometimes painted behind or in front of other things.
 
 use crate::{Id, *};
-use epaint::{emath::TSTransform, ClippedShape, Shape};
+use emath::TSTransform;
+use epaint::{ClippedShape, Shape};
 
 /// Different layer categories
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]

--- a/crates/egui/src/layout.rs
+++ b/crates/egui/src/layout.rs
@@ -1,6 +1,5 @@
-use crate::{emath::*, Align};
+use emath::{pos2, vec2, Align, Align2, NumExt, Pos2, Rect, Vec2};
 use std::f32::INFINITY;
-
 // ----------------------------------------------------------------------------
 
 /// This describes the bounds and existing contents of an [`Ui`][`crate::Ui`].

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -1,12 +1,12 @@
 #![warn(missing_docs)] // Let's keep this file well-documented.` to memory.rs
 
 use ahash::{HashMap, HashSet};
-use epaint::emath::TSTransform;
 
 use crate::{
-    area, vec2, EventFilter, Id, IdMap, LayerId, Order, Pos2, Rangef, RawInput, Rect, Style, Vec2,
-    ViewportId, ViewportIdMap, ViewportIdSet,
+    area, EventFilter, Id, IdMap, LayerId, Order, RawInput, Style, ViewportId, ViewportIdMap,
+    ViewportIdSet,
 };
+use emath::{vec2, Pos2, Rangef, Rect, TSTransform, Vec2};
 
 mod theme;
 pub use theme::Theme;

--- a/crates/egui/src/painter.rs
+++ b/crates/egui/src/painter.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use crate::{
-    emath::{Align2, Pos2, Rangef, Rect, Vec2},
     layers::{LayerId, PaintList, ShapeIdx},
     Color32, Context, FontId,
 };
+use emath::{Align2, Pos2, Rangef, Rect, Rot2, Vec2};
 use epaint::{
     text::{Fonts, Galley, LayoutJob},
     CircleShape, ClippedShape, PathStroke, RectShape, Rounding, Shape, Stroke,
@@ -391,7 +391,6 @@ impl Painter {
 
     /// Show an arrow starting at `origin` and going in the direction of `vec`, with the length `vec.length()`.
     pub fn arrow(&self, origin: Pos2, vec: Vec2, stroke: impl Into<Stroke>) {
-        use crate::emath::*;
         let rot = Rot2::from_angle(std::f32::consts::TAU / 10.0);
         let tip_length = vec.length() / 4.0;
         let tip = origin + vec;

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -1,10 +1,10 @@
 use std::{any::Any, sync::Arc};
 
 use crate::{
-    emath::{Align, Pos2, Rect, Vec2},
     frame_state, menu, AreaState, Context, CursorIcon, Id, LayerId, Order, PointerButton, Sense,
     Ui, WidgetRect, WidgetText,
 };
+use emath::{Align, Pos2, Rect, Vec2};
 // ----------------------------------------------------------------------------
 
 /// The result of adding a widget to a [`Ui`].

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -4,12 +4,10 @@
 
 use std::{collections::BTreeMap, ops::RangeInclusive, sync::Arc};
 
-use epaint::{Rounding, Shadow, Stroke};
+use emath::{pos2, vec2, Rangef, Rect, Vec2};
+use epaint::{Color32, FontFamily, FontId, Margin, Rounding, Shadow, Stroke};
 
-use crate::{
-    ecolor::*, emath::*, ComboBox, CursorIcon, FontFamily, FontId, Grid, Margin, Response,
-    RichText, WidgetText,
-};
+use crate::{ComboBox, CursorIcon, Grid, Response, RichText, WidgetText};
 
 /// How to format numbers in e.g. a [`crate::DragValue`].
 #[derive(Clone)]

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -3,11 +3,10 @@
 
 use std::{any::Any, hash::Hash, sync::Arc};
 
-use epaint::mutex::RwLock;
+use epaint::{mutex::RwLock, Fonts, Hsva};
 
 use crate::{
-    containers::*, ecolor::*, epaint::text::Fonts, layout::*, menu::MenuState, placer::Placer,
-    util::IdTypeMap, widgets::*, *,
+    containers::*, layout::*, menu::MenuState, placer::Placer, util::IdTypeMap, widgets::*, *,
 };
 // ----------------------------------------------------------------------------
 

--- a/crates/egui/src/util/mod.rs
+++ b/crates/egui/src/util/mod.rs
@@ -7,5 +7,5 @@ pub mod undoer;
 
 pub use id_type_map::IdTypeMap;
 
-pub use epaint::emath::History;
+pub use emath::History;
 pub use epaint::util::{hash, hash_with};

--- a/crates/egui/src/widgets/spinner.rs
+++ b/crates/egui/src/widgets/spinner.rs
@@ -1,4 +1,5 @@
-use epaint::{emath::lerp, vec2, Color32, Pos2, Rect, Shape, Stroke};
+use emath::{lerp, vec2, Pos2, Rect};
+use epaint::{Color32, Shape, Stroke};
 
 use crate::{Response, Sense, Ui, Widget, WidgetInfo, WidgetType};
 

--- a/crates/epaint/src/bezier.rs
+++ b/crates/epaint/src/bezier.rs
@@ -4,8 +4,7 @@
 use std::ops::Range;
 
 use crate::{shape::Shape, Color32, PathShape, PathStroke};
-use emath::*;
-
+use emath::{Pos2, Rect, RectTransform};
 // ----------------------------------------------------------------------------
 
 /// A cubic [Bézier Curve](https://en.wikipedia.org/wiki/B%C3%A9zier_curve).
@@ -763,6 +762,7 @@ fn cubic_for_each_local_extremum<F: FnMut(f32)>(p0: f32, p1: f32, p2: f32, p3: f
 #[cfg(test)]
 mod tests {
     use super::*;
+    use emath::pos2;
 
     #[test]
     fn test_quadratic_bounding_box() {

--- a/crates/epaint/src/lib.rs
+++ b/crates/epaint/src/lib.rs
@@ -78,7 +78,7 @@ pub use ecolor::hex_color;
 /// The default egui texture has the top-left corner pixel fully white.
 /// You need need use a clamping texture sampler for this to work
 /// (so it doesn't do bilinear blending with bottom right corner).
-pub const WHITE_UV: emath::Pos2 = emath::pos2(0.0, 0.0);
+pub const WHITE_UV: Pos2 = pos2(0.0, 0.0);
 
 /// What texture to use in a [`Mesh`] mesh.
 ///
@@ -110,7 +110,7 @@ impl Default for TextureId {
 pub struct ClippedShape {
     /// Clip / scissor rectangle.
     /// Only show the part of the [`Shape`] that falls within this.
-    pub clip_rect: emath::Rect,
+    pub clip_rect: Rect,
 
     /// The shape
     pub shape: Shape,
@@ -123,7 +123,7 @@ pub struct ClippedShape {
 pub struct ClippedPrimitive {
     /// Clip / scissor rectangle.
     /// Only show the part of the [`Mesh`] that falls within this.
-    pub clip_rect: emath::Rect,
+    pub clip_rect: Rect,
 
     /// What to paint - either a [`Mesh`] or a [`PaintCallback`].
     pub primitive: Primitive,

--- a/crates/epaint/src/mesh.rs
+++ b/crates/epaint/src/mesh.rs
@@ -1,5 +1,6 @@
+use emath::{Rot2, TSTransform};
+
 use crate::*;
-use emath::*;
 
 /// The 2D vertex type.
 ///

--- a/crates/epaint/src/shape.rs
+++ b/crates/epaint/src/shape.rs
@@ -7,7 +7,7 @@ use crate::{
     text::{FontId, Fonts, Galley},
     Color32, Mesh, Stroke, TextureId,
 };
-use emath::*;
+use emath::{pos2, Align2, Pos2, Rangef, Rect, TSTransform, Vec2};
 
 pub use crate::{CubicBezierShape, QuadraticBezierShape};
 

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -7,7 +7,7 @@
 
 use crate::texture_atlas::PreparedDisc;
 use crate::*;
-use emath::*;
+use emath::{remap, NumExt, Rot2};
 
 use self::color::ColorMode;
 use self::stroke::PathStroke;
@@ -520,7 +520,7 @@ impl Path {
 pub mod path {
     //! Helpers for constructing paths
     use crate::shape::Rounding;
-    use emath::*;
+    use emath::{pos2, Pos2, Rect};
 
     /// overwrites existing points
     pub fn rounded_rectangle(path: &mut Vec<Pos2>, rect: Rect, rounding: Rounding) {

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -59,7 +59,7 @@ impl std::hash::Hash for FontId {
     #[inline(always)]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let Self { size, family } = self;
-        emath::OrderedFloat(*size).hash(state);
+        OrderedFloat(*size).hash(state);
         family.hash(state);
     }
 }

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -1,9 +1,8 @@
 use std::ops::RangeInclusive;
 use std::sync::Arc;
 
-use emath::*;
-
 use crate::{stroke::PathStroke, text::font::Font, Color32, Mesh, Stroke, Vertex};
+use emath::{pos2, vec2, Align, NumExt, Pos2, Rect, Vec2};
 
 use super::{FontsImpl, Galley, Glyph, LayoutJob, LayoutSection, Row, RowVisuals};
 

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use super::{cursor::*, font::UvRect};
 use crate::{Color32, FontId, Mesh, Stroke};
-use emath::*;
+use emath::{pos2, vec2, Align, NumExt, OrderedFloat, Pos2, Rect, Vec2};
 
 /// Describes the task of laying out text.
 ///
@@ -191,7 +191,7 @@ impl std::hash::Hash for LayoutJob {
         text.hash(state);
         sections.hash(state);
         wrap.hash(state);
-        emath::OrderedFloat(*first_row_min_height).hash(state);
+        OrderedFloat(*first_row_min_height).hash(state);
         break_on_newline.hash(state);
         halign.hash(state);
         justify.hash(state);
@@ -300,9 +300,9 @@ impl std::hash::Hash for TextFormat {
             valign,
         } = self;
         font_id.hash(state);
-        emath::OrderedFloat(*extra_letter_spacing).hash(state);
+        OrderedFloat(*extra_letter_spacing).hash(state);
         if let Some(line_height) = *line_height {
-            emath::OrderedFloat(line_height).hash(state);
+            OrderedFloat(line_height).hash(state);
         }
         color.hash(state);
         background.hash(state);
@@ -400,7 +400,7 @@ impl std::hash::Hash for TextWrapping {
             break_anywhere,
             overflow_character,
         } = self;
-        emath::OrderedFloat(*max_width).hash(state);
+        OrderedFloat(*max_width).hash(state);
         max_rows.hash(state);
         break_anywhere.hash(state);
         overflow_character.hash(state);

--- a/crates/epaint/src/texture_handle.rs
+++ b/crates/epaint/src/texture_handle.rs
@@ -1,9 +1,8 @@
-use std::sync::Arc;
-
 use crate::{
-    emath::NumExt, mutex::RwLock, textures::TextureOptions, ImageData, ImageDelta, TextureId,
-    TextureManager,
+    mutex::RwLock, textures::TextureOptions, ImageData, ImageDelta, TextureId, TextureManager,
 };
+use emath::NumExt;
+use std::sync::Arc;
 
 /// Used to paint images.
 ///


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [x] I have followed the instructions in the PR template

A bit of cleaning up in the import/re-export jungle. Now, no wildcard imports from emath and if emath is already a direct dependency, import from emath, not crate::emath or crate::epaint::emath or ...

In some instances I have also moved a some epaint stuff, but the focus was on emath.