### PR TITLE
Add max click timings & distance to `Options`

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -489,7 +489,11 @@ impl ContextImpl {
                 &viewport.prev_frame.widgets,
                 &viewport.hits,
                 &viewport.input,
-                self.memory.interaction_mut(),
+                self.memory
+                    .interactions
+                    .entry(self.memory.viewport_id)
+                    .or_default(),
+                &self.memory.options,
             );
         }
 
@@ -2046,7 +2050,7 @@ impl ContextImpl {
 
         if repaint_needed {
             self.request_repaint(ended_viewport_id, RepaintCause::new());
-        } else if let Some(delay) = viewport.input.wants_repaint_after() {
+        } else if let Some(delay) = viewport.input.wants_repaint_after(&self.memory.options) {
             self.request_repaint_after(delay, ended_viewport_id, RepaintCause::new());
         }
 

--- a/crates/egui/src/interaction.rs
+++ b/crates/egui/src/interaction.rs
@@ -112,6 +112,7 @@ pub(crate) fn interact(
     hits: &WidgetHits,
     input: &InputState,
     interaction: &mut InteractionState,
+    options: &Options,
 ) -> InteractionSnapshot {
     crate::profile_function!();
 
@@ -140,7 +141,7 @@ pub(crate) fn interact(
         interaction.potential_drag_id = None;
     }
 
-    if input.is_long_touch() {
+    if input.is_long_touch(options) {
         // We implement "press-and-hold for context menu" on touch screens here
         if let Some(widget) = interaction
             .potential_click_id
@@ -172,7 +173,7 @@ pub(crate) fn interact(
             }
 
             PointerEvent::Released { click, button: _ } => {
-                if click.is_some() && !input.pointer.is_decidedly_dragging() {
+                if click.is_some() && !input.pointer.is_decidedly_dragging(options) {
                     if let Some(widget) = interaction
                         .potential_click_id
                         .and_then(|id| widgets.get(id))
@@ -196,7 +197,7 @@ pub(crate) fn interact(
                     // This widget is sensitive to both clicks and drags.
                     // When the mouse first is pressed, it could be either,
                     // so we postpone the decision until we know.
-                    input.pointer.is_decidedly_dragging()
+                    input.pointer.is_decidedly_dragging(options)
                 } else {
                     // This widget is just sensitive to drags, so we can mark it as dragged right away:
                     widget.sense.drag
@@ -209,7 +210,7 @@ pub(crate) fn interact(
         }
     }
 
-    if !input.pointer.could_any_button_be_click() {
+    if !input.pointer.could_any_button_be_click(options) {
         interaction.potential_click_id = None;
     }
 

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -266,6 +266,20 @@ pub struct Options {
     ///
     /// Default is `false`.
     pub reduce_texture_memory: bool,
+
+    /// If the pointer moves more than this, it won't become a click (but it is still a drag)
+    pub max_click_dist: f32,
+
+    /// If the pointer is down for longer than this it will no longer register as a click.
+    ///
+    /// If a touch is held for this many seconds while still,
+    /// then it will register as a "long-touch" which is equivalent to a secondary click.
+    ///
+    /// This is to support "press and hold for context menu" on touch screens.
+    pub max_click_duration: f64,
+
+    /// The new pointer press must come within this many seconds from previous pointer release
+    pub max_double_click_delay: f64,
 }
 
 impl Default for Options {
@@ -295,6 +309,10 @@ impl Default for Options {
             line_scroll_speed,
             scroll_zoom_speed: 1.0 / 200.0,
             reduce_texture_memory: false,
+
+            max_click_dist: 6.0,
+            max_click_duration: 0.8,
+            max_double_click_delay: 0.3,
         }
     }
 }
@@ -339,6 +357,10 @@ impl Options {
             line_scroll_speed,
             scroll_zoom_speed,
             reduce_texture_memory,
+
+            max_click_dist,
+            max_click_duration,
+            max_double_click_delay,
         } = self;
 
         use crate::Widget as _;
@@ -396,6 +418,35 @@ impl Options {
                     )
                     .on_hover_text("How fast to zoom with ctrl/cmd + scroll");
                 });
+
+                ui.horizontal(|ui| {
+                    ui.label("Max click distance");
+                    ui.add(
+                        crate::DragValue::new(max_click_dist)
+                            .range(0.0..=f32::INFINITY)
+                            .speed(1.0),
+                    )
+                    .on_hover_text("If the pointer moves more than this, it won't become a click (but it is still a drag)");
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Max click duration");
+                    ui.add(
+                        crate::DragValue::new(max_click_duration)
+                            .range(0.0..=f32::INFINITY)
+                            .speed(0.1),
+                    )
+                    .on_hover_text("If the pointer is down for longer than this it will no longer register as a click");
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Max double click delay");
+                    ui.add(
+                        crate::DragValue::new(max_double_click_delay)
+                            .range(0.0..=f32::INFINITY)
+                            .speed(0.1),
+                    )
+                    .on_hover_text("The new pointer press must come within this many seconds from previous pointer release");
+                });
+
             });
 
         ui.vertical_centered(|ui| crate::reset_button(ui, self, "Reset all"));

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2721,7 +2721,7 @@ fn register_rect(ui: &Ui, rect: Rect) {
         return;
     }
 
-    let is_clicking = ui.input(|i| i.pointer.could_any_button_be_click());
+    let is_clicking = ui.memory(|m| ui.input(|i| i.pointer.could_any_button_be_click(&m.options)));
 
     #[cfg(feature = "callstack")]
     let callstack = crate::callstack::capture();


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [x] I have followed the instructions in the PR template

Moves the click timing & distance constants to the Options struct so they can be configured by users.

Note: This need came up as part of my investigation of https://github.com/mvlabat/bevy_egui/issues/302. Essentially, on some platforms we are not guaranteed to have correct timekeeping so it's useful to be able to disable the max click duration in this case.