### PR TITLE
Request focus on a TextEdit when clicked

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -576,7 +576,7 @@ impl<'t> TextEdit<'t> {
                     is_being_dragged,
                 );
 
-                if did_interact {
+                if did_interact || response.clicked() {
                     ui.memory_mut(|mem| mem.request_focus(response.id));
                 }
             }


### PR DESCRIPTION
This request focus on a TextEdit when clicked, so that touch events on Android can now focus it.

This looks like a reasonable fix for https://github.com/emilk/egui/issues/4941.