### PR TITLE
Remove the need for setting `web_sys_unstable_apis`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,2 @@
-# clipboard api is still unstable, so web-sys requires the below flag to be passed for copy (ctrl + c) to work
-# https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html
-# check status at https://developer.mozilla.org/en-US/docs/Web/API/Clipboard#browser_compatibility
-# we don't use `[build]` because of rust analyzer's build cache invalidation https://github.com/emilk/eframe_template/issues/93
-[target.wasm32-unknown-unknown]
-rustflags = ["--cfg=web_sys_unstable_apis"]
-
 [alias]
 xtask = "run --quiet --package xtask --"

--- a/.github/workflows/deploy_web_demo.yml
+++ b/.github/workflows/deploy_web_demo.yml
@@ -22,11 +22,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # web_sys_unstable_apis is required to enable the web_sys clipboard API which eframe web uses,
-  # as well as by the wasm32-backend of the wgpu crate.
-  # https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Clipboard.html
-  # https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html
-  RUSTFLAGS: --cfg=web_sys_unstable_apis -D warnings
+  RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
 
 jobs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,11 +3,7 @@ on: [ push, pull_request ]
 name: Rust
 
 env:
-  # web_sys_unstable_apis is required to enable the web_sys clipboard API which eframe web uses,
-  # as well as by the wasm32-backend of the wgpu crate.
-  # https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Clipboard.html
-  # https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html
-  RUSTFLAGS: --cfg=web_sys_unstable_apis -D warnings
+  RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
 
 jobs:

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -21,7 +21,6 @@ include = [
 
 [package.metadata.docs.rs]
 all-features = true
-rustc-args = ["--cfg=web_sys_unstable_apis"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [lints]

--- a/crates/eframe/README.md
+++ b/crates/eframe/README.md
@@ -28,8 +28,6 @@ You need to either use `edition = "2021"`, or set `resolver = "2"` in the `[work
 
 You can opt-in to the using [`egui_wgpu`](https://github.com/emilk/egui/tree/master/crates/egui_wgpu) for rendering by enabling the `wgpu` feature and setting `NativeOptions::renderer` to `Renderer::Wgpu`.
 
-To get copy-paste working on web, you need to compile with `export RUSTFLAGS=--cfg=web_sys_unstable_apis`.
-
 ## Alternatives
 `eframe` is not the only way to write an app using `egui`! You can also try [`egui-miniquad`](https://github.com/not-fl3/egui-miniquad), [`bevy_egui`](https://github.com/mvlabat/bevy_egui), [`egui_sdl2_gl`](https://github.com/ArjunNair/egui_sdl2_gl), and others.
 

--- a/crates/eframe/src/lib.rs
+++ b/crates/eframe/src/lib.rs
@@ -10,9 +10,6 @@
 //! call [`crate::run_native`] from your `main.rs`, and/or use `eframe::WebRunner` from your `lib.rs`.
 //!
 //! ## Compiling for web
-//! To get copy-paste working on web, you need to compile with
-//! `export RUSTFLAGS=--cfg=web_sys_unstable_apis`.
-//!
 //! You need to install the `wasm32` target with `rustup target add wasm32-unknown-unknown`.
 //!
 //! Build the `.wasm` using `cargo build --target wasm32-unknown-unknown`

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -276,13 +276,9 @@ impl AppRunner {
             super::open_url(&open.url, open.new_tab);
         }
 
-        #[cfg(web_sys_unstable_apis)]
         if !copied_text.is_empty() {
             super::set_clipboard_text(&copied_text);
         }
-
-        #[cfg(not(web_sys_unstable_apis))]
-        let _ = copied_text;
 
         if self.has_focus() {
             // The eframe app has focus.

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -279,7 +279,6 @@ pub(crate) fn on_keyup(event: web_sys::KeyboardEvent, runner: &mut AppRunner) {
 }
 
 fn install_copy_cut_paste(runner_ref: &WebRunner, target: &EventTarget) -> Result<(), JsValue> {
-    #[cfg(web_sys_unstable_apis)]
     runner_ref.add_event_listener(target, "paste", |event: web_sys::ClipboardEvent, runner| {
         if let Some(data) = event.clipboard_data() {
             if let Ok(text) = data.get_data("text") {
@@ -294,7 +293,6 @@ fn install_copy_cut_paste(runner_ref: &WebRunner, target: &EventTarget) -> Resul
         }
     })?;
 
-    #[cfg(web_sys_unstable_apis)]
     runner_ref.add_event_listener(target, "cut", |event: web_sys::ClipboardEvent, runner| {
         if runner.input.raw.focused {
             runner.input.raw.events.push(egui::Event::Cut);
@@ -311,7 +309,6 @@ fn install_copy_cut_paste(runner_ref: &WebRunner, target: &EventTarget) -> Resul
         event.prevent_default();
     })?;
 
-    #[cfg(web_sys_unstable_apis)]
     runner_ref.add_event_listener(target, "copy", |event: web_sys::ClipboardEvent, runner| {
         if runner.input.raw.focused {
             runner.input.raw.events.push(egui::Event::Copy);

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -168,7 +168,6 @@ fn set_cursor_icon(cursor: egui::CursorIcon) -> Option<()> {
 }
 
 /// Set the clipboard text.
-#[cfg(web_sys_unstable_apis)]
 fn set_clipboard_text(s: &str) {
     if let Some(window) = web_sys::window() {
         let promise = window.navigator().clipboard().write_text(s);

--- a/crates/eframe/src/web/web_runner.rs
+++ b/crates/eframe/src/web/web_runner.rs
@@ -35,11 +35,6 @@ impl WebRunner {
     /// Will install a panic handler that will catch and log any panics
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        #[cfg(not(web_sys_unstable_apis))]
-        log::warn!(
-            "eframe compiled without RUSTFLAGS='--cfg=web_sys_unstable_apis'. Copying text won't work."
-        );
-
         let panic_handler = PanicHandler::install();
 
         Self {

--- a/scripts/build_demo_web.sh
+++ b/scripts/build_demo_web.sh
@@ -5,11 +5,6 @@ cd "$script_path/.."
 
 ./scripts/setup_web.sh
 
-# This is required to enable the web_sys clipboard API which eframe web uses
-# https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Clipboard.html
-# https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html
-export RUSTFLAGS=--cfg=web_sys_unstable_apis
-
 CRATE_NAME="egui_demo_app"
 
 FEATURES="web_app"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -11,9 +11,7 @@ set -x
 
 cargo +1.75.0 install --quiet typos-cli
 
-# web_sys_unstable_apis is required to enable the web_sys clipboard API which eframe web uses,
-# as well as by the wasm32-backend of the wgpu crate.
-export RUSTFLAGS="--cfg=web_sys_unstable_apis -D warnings"
+export RUSTFLAGS="-D warnings"
 export RUSTDOCFLAGS="-D warnings" # https://github.com/emilk/egui/pull/1454
 
 # Fast checks first:

--- a/scripts/wasm_bindgen_check.sh
+++ b/scripts/wasm_bindgen_check.sh
@@ -14,11 +14,6 @@ fi
 CRATE_NAME="egui_demo_app"
 FEATURES="glow,http,persistence"
 
-# This is required to enable the web_sys clipboard API which eframe web uses
-# https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Clipboard.html
-# https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html
-export RUSTFLAGS=--cfg=web_sys_unstable_apis
-
 echo "Building rust…"
 BUILD=debug # debug builds are faster
 


### PR DESCRIPTION
* No longer required since https://github.com/emilk/egui/pull/4980

And despite some outdated comments, wgpu/WebGPU doesn't need it either
