### PR TITLE
Nicer looking text selection, especially in light mode

### DIFF
--- a/crates/egui/src/layers.rs
+++ b/crates/egui/src/layers.rs
@@ -158,6 +158,11 @@ impl PaintList {
         self.0[idx.0].shape = Shape::Noop;
     }
 
+    /// Mutate the shape at the given index, if any.
+    pub fn mutate_shape(&mut self, idx: ShapeIdx, f: impl FnOnce(&mut ClippedShape)) {
+        self.0.get_mut(idx.0).map(f);
+    }
+
     /// Transform each [`Shape`] and clip rectangle by this much, in-place
     pub fn transform(&mut self, transform: TSTransform) {
         for ClippedShape { clip_rect, shape } in &mut self.0 {

--- a/crates/egui/src/text_selection/label_text_selection.rs
+++ b/crates/egui/src/text_selection/label_text_selection.rs
@@ -477,7 +477,7 @@ impl LabelSelectionState {
         }
     }
 
-    /// Returns indices of new vertices in the galley, if any.
+    /// Returns the painted selections, if any.
     fn on_label(
         &mut self,
         ui: &Ui,

--- a/crates/egui/src/text_selection/visuals.rs
+++ b/crates/egui/src/text_selection/visuals.rs
@@ -2,16 +2,20 @@ use std::sync::Arc;
 
 use crate::*;
 
-use self::layers::ShapeIdx;
-
 use super::CursorRange;
+
+#[derive(Clone, Debug)]
+pub struct RowVertexIndices {
+    pub row: usize,
+    pub vertex_indices: [u32; 6],
+}
 
 /// Adds text selection rectangles to the galley.
 pub fn paint_text_selection(
     galley: &mut Arc<Galley>,
     visuals: &Visuals,
     cursor_range: &CursorRange,
-    mut out_shaped_idx: Option<&mut Vec<ShapeIdx>>,
+    mut new_vertex_indices: Option<&mut Vec<RowVertexIndices>>,
 ) {
     if cursor_range.is_empty() {
         return;
@@ -75,8 +79,11 @@ pub fn paint_text_selection(
         mesh.indices[glyph_index_start..glyph_index_start + 6]
             .clone_from_slice(&selection_triangles);
 
-        if let Some(out_shaped_idx) = &mut out_shaped_idx {
-            // TODO
+        if let Some(new_vertex_indices) = &mut new_vertex_indices {
+            new_vertex_indices.push(RowVertexIndices {
+                row: ri,
+                vertex_indices: selection_triangles,
+            });
         }
     }
 }

--- a/crates/egui/src/text_selection/visuals.rs
+++ b/crates/egui/src/text_selection/visuals.rs
@@ -1,14 +1,15 @@
+use std::sync::Arc;
+
 use crate::*;
 
 use self::layers::ShapeIdx;
 
 use super::CursorRange;
 
+/// Adds text selection rectangles to the galley.
 pub fn paint_text_selection(
-    painter: &Painter,
+    galley: &mut Arc<Galley>,
     visuals: &Visuals,
-    galley_pos: Pos2,
-    galley: &Galley,
     cursor_range: &CursorRange,
     mut out_shaped_idx: Option<&mut Vec<ShapeIdx>>,
 ) {
@@ -16,14 +17,17 @@ pub fn paint_text_selection(
         return;
     }
 
-    // We paint the cursor selection on top of the text, so make it transparent:
-    let color = visuals.selection.bg_fill.linear_multiply(0.5);
+    // We need to modify the galley (add text selection painting to it),
+    // and so we need to clone it if it is shared:
+    let galley: &mut Galley = Arc::make_mut(galley);
+
+    let color = visuals.selection.bg_fill;
     let [min, max] = cursor_range.sorted_cursors();
     let min = min.rcursor;
     let max = max.rcursor;
 
     for ri in min.row..=max.row {
-        let row = &galley.rows[ri];
+        let row = &mut galley.rows[ri];
         let left = if ri == min.row {
             row.x_offset(min.column)
         } else {
@@ -39,13 +43,40 @@ pub fn paint_text_selection(
             };
             row.rect.right() + newline_size
         };
-        let rect = Rect::from_min_max(
-            galley_pos + vec2(left, row.min_y()),
-            galley_pos + vec2(right, row.max_y()),
-        );
-        let shape_idx = painter.rect_filled(rect, 0.0, color);
+
+        let rect = Rect::from_min_max(pos2(left, row.min_y()), pos2(right, row.max_y()));
+        let mesh = &mut row.visuals.mesh;
+
+        // Time to insert the selection rectangle into the row mesh.
+        // It should be on top (after) of any background in the galley,
+        // but behind (before) any glyphs. The row visuals has this information:
+        let glyph_index_start = row.visuals.glyph_index_start;
+
+        // Start by appending the selection rectangle to end of the mesh, as two triangles (= 6 indices):
+        let num_indices_before = mesh.indices.len();
+        mesh.add_colored_rect(rect, color);
+        assert_eq!(num_indices_before + 6, mesh.indices.len());
+
+        // Copy out the new triangles:
+        let selection_triangles = [
+            mesh.indices[num_indices_before],
+            mesh.indices[num_indices_before + 1],
+            mesh.indices[num_indices_before + 2],
+            mesh.indices[num_indices_before + 3],
+            mesh.indices[num_indices_before + 4],
+            mesh.indices[num_indices_before + 5],
+        ];
+
+        // Move every old triangle forwards by 6 indices to make room for the new triangle:
+        for i in (glyph_index_start..num_indices_before).rev() {
+            mesh.indices.swap(i, i + 6);
+        }
+        // Put the new triangle in place:
+        mesh.indices[glyph_index_start..glyph_index_start + 6]
+            .clone_from_slice(&selection_triangles);
+
         if let Some(out_shaped_idx) = &mut out_shaped_idx {
-            out_shaped_idx.push(shape_idx);
+            // TODO
         }
     }
 }

--- a/crates/egui/src/widgets/hyperlink.rs
+++ b/crates/egui/src/widgets/hyperlink.rs
@@ -36,7 +36,7 @@ impl Widget for Link {
         let Self { text } = self;
         let label = Label::new(text).sense(Sense::click());
 
-        let (galley_pos, mut galley, response) = label.layout_in_ui(ui);
+        let (galley_pos, galley, response) = label.layout_in_ui(ui);
         response
             .widget_info(|| WidgetInfo::labeled(WidgetType::Link, ui.is_enabled(), galley.text()));
 
@@ -52,11 +52,14 @@ impl Widget for Link {
 
             let selectable = ui.style().interaction.selectable_labels;
             if selectable {
-                LabelSelectionState::label_text_selection(ui, &response, galley_pos, &mut galley);
+                LabelSelectionState::label_text_selection(
+                    ui, &response, galley_pos, galley, color, underline,
+                );
+            } else {
+                ui.painter().add(
+                    epaint::TextShape::new(galley_pos, galley, color).with_underline(underline),
+                );
             }
-
-            ui.painter()
-                .add(epaint::TextShape::new(galley_pos, galley, color).with_underline(underline));
 
             if response.hovered() {
                 ui.ctx().set_cursor_icon(CursorIcon::PointingHand);

--- a/crates/egui/src/widgets/hyperlink.rs
+++ b/crates/egui/src/widgets/hyperlink.rs
@@ -36,7 +36,7 @@ impl Widget for Link {
         let Self { text } = self;
         let label = Label::new(text).sense(Sense::click());
 
-        let (galley_pos, galley, response) = label.layout_in_ui(ui);
+        let (galley_pos, mut galley, response) = label.layout_in_ui(ui);
         response
             .widget_info(|| WidgetInfo::labeled(WidgetType::Link, ui.is_enabled(), galley.text()));
 
@@ -50,14 +50,13 @@ impl Widget for Link {
                 Stroke::NONE
             };
 
-            ui.painter().add(
-                epaint::TextShape::new(galley_pos, galley.clone(), color).with_underline(underline),
-            );
-
             let selectable = ui.style().interaction.selectable_labels;
             if selectable {
-                LabelSelectionState::label_text_selection(ui, &response, galley_pos, &galley);
+                LabelSelectionState::label_text_selection(ui, &response, galley_pos, &mut galley);
             }
+
+            ui.painter()
+                .add(epaint::TextShape::new(galley_pos, galley, color).with_underline(underline));
 
             if response.hovered() {
                 ui.ctx().set_cursor_icon(CursorIcon::PointingHand);

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -245,7 +245,7 @@ impl Widget for Label {
 
         let selectable = self.selectable;
 
-        let (galley_pos, galley, mut response) = self.layout_in_ui(ui);
+        let (galley_pos, mut galley, mut response) = self.layout_in_ui(ui);
         response
             .widget_info(|| WidgetInfo::labeled(WidgetType::Label, ui.is_enabled(), galley.text()));
 
@@ -267,15 +267,15 @@ impl Widget for Label {
                 Stroke::NONE
             };
 
-            ui.painter().add(
-                epaint::TextShape::new(galley_pos, galley.clone(), response_color)
-                    .with_underline(underline),
-            );
-
             let selectable = selectable.unwrap_or_else(|| ui.style().interaction.selectable_labels);
             if selectable {
-                LabelSelectionState::label_text_selection(ui, &response, galley_pos, &galley);
+                LabelSelectionState::label_text_selection(ui, &response, galley_pos, &mut galley);
             }
+
+            ui.painter().add(
+                epaint::TextShape::new(galley_pos, galley, response_color)
+                    .with_underline(underline),
+            );
         }
 
         response

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -245,7 +245,7 @@ impl Widget for Label {
 
         let selectable = self.selectable;
 
-        let (galley_pos, mut galley, mut response) = self.layout_in_ui(ui);
+        let (galley_pos, galley, mut response) = self.layout_in_ui(ui);
         response
             .widget_info(|| WidgetInfo::labeled(WidgetType::Label, ui.is_enabled(), galley.text()));
 
@@ -269,13 +269,20 @@ impl Widget for Label {
 
             let selectable = selectable.unwrap_or_else(|| ui.style().interaction.selectable_labels);
             if selectable {
-                LabelSelectionState::label_text_selection(ui, &response, galley_pos, &mut galley);
+                LabelSelectionState::label_text_selection(
+                    ui,
+                    &response,
+                    galley_pos,
+                    galley,
+                    response_color,
+                    underline,
+                );
+            } else {
+                ui.painter().add(
+                    epaint::TextShape::new(galley_pos, galley, response_color)
+                        .with_underline(underline),
+                );
             }
-
-            ui.painter().add(
-                epaint::TextShape::new(galley_pos, galley, response_color)
-                    .with_underline(underline),
-            );
         }
 
         response

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -703,6 +703,7 @@ fn tessellate_row(
         add_row_backgrounds(job, row, &mut mesh);
     }
 
+    let glyph_index_start = mesh.indices.len();
     let glyph_vertex_start = mesh.vertices.len();
     tessellate_glyphs(point_scale, job, row, &mut mesh);
     let glyph_vertex_end = mesh.vertices.len();
@@ -730,6 +731,7 @@ fn tessellate_row(
     RowVisuals {
         mesh,
         mesh_bounds,
+        glyph_index_start,
         glyph_vertex_range: glyph_vertex_start..glyph_vertex_end,
     }
 }

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -554,6 +554,12 @@ pub struct RowVisuals {
     /// Does NOT include leading or trailing whitespace glyphs!!
     pub mesh_bounds: Rect,
 
+    /// The number of triangle indices added before the first glyph triangle.
+    ///
+    /// This can be used to insert more triangles after the background but before the glyphs,
+    /// i.e. for text selection visualization.
+    pub glyph_index_start: usize,
+
     /// The range of vertices in the mesh that contain glyphs (as opposed to background, underlines, strikethorugh, etc).
     ///
     /// The glyph vertices comes after backgrounds (if any), but before any underlines and strikethrough.
@@ -565,6 +571,7 @@ impl Default for RowVisuals {
         Self {
             mesh: Default::default(),
             mesh_bounds: Rect::NOTHING,
+            glyph_index_start: 0,
             glyph_vertex_range: 0..0,
         }
     }


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/4727

This changes the text selection painting from being painted on top of the text, to being painted behind the text, but in front of any text background. The result is much nicer looking text selection, especially in light mode:

### The new selections
<img width="198" alt="Screenshot 2024-08-27 at 18 58 35" src="https://github.com/user-attachments/assets/bd342946-299c-44ab-bc2d-2aa8ddbca8eb">
<img width="187" alt="Screenshot 2024-08-27 at 18 59 26" src="https://github.com/user-attachments/assets/352bed32-5150-49b9-a9f9-c7679a0d30b2">


### What selections used to look like
<img width="143" alt="Screenshot 2024-08-27 at 19 03 08" src="https://github.com/user-attachments/assets/f3cbd798-cfed-4ad4-aa3a-d7480efcfa3c">
<img width="143" alt="Screenshot 2024-08-27 at 19 03 23" src="https://github.com/user-attachments/assets/9925d18d-da82-4a44-8a98-ea6857ecc14f">


### New selection of some text with a background
<img width="134" alt="Screenshot 2024-08-27 at 18 59 12" src="https://github.com/user-attachments/assets/1d291d7f-efbd-4efd-b6d2-cd63c9fc4fa4">

