### PR TITLE
Enable rustdoc `generate-link-to-definition` feature on docs.rs

### DIFF
--- a/crates/ecolor/Cargo.toml
+++ b/crates/ecolor/Cargo.toml
@@ -21,6 +21,7 @@ workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--generate-link-to-definition"]
 
 [lib]
 

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -22,6 +22,7 @@ include = [
 [package.metadata.docs.rs]
 all-features = true
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
+rustdoc-args = ["--generate-link-to-definition"]
 
 [lints]
 workspace = true

--- a/crates/egui-wgpu/Cargo.toml
+++ b/crates/egui-wgpu/Cargo.toml
@@ -28,7 +28,7 @@ workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-
+rustdoc-args = ["--generate-link-to-definition"]
 
 [features]
 default = []

--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-
+rustdoc-args = ["--generate-link-to-definition"]
 
 [features]
 default = ["clipboard", "links", "wayland", "winit/default", "x11"]

--- a/crates/egui/Cargo.toml
+++ b/crates/egui/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--generate-link-to-definition"]
 
 [lib]
 

--- a/crates/egui_demo_app/Cargo.toml
+++ b/crates/egui_demo_app/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--generate-link-to-definition"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/egui_demo_lib/Cargo.toml
+++ b/crates/egui_demo_lib/Cargo.toml
@@ -24,6 +24,7 @@ workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--generate-link-to-definition"]
 
 [lib]
 

--- a/crates/egui_extras/Cargo.toml
+++ b/crates/egui_extras/Cargo.toml
@@ -22,6 +22,7 @@ workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--generate-link-to-definition"]
 
 [lib]
 

--- a/crates/egui_glow/Cargo.toml
+++ b/crates/egui_glow/Cargo.toml
@@ -24,7 +24,7 @@ workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-
+rustdoc-args = ["--generate-link-to-definition"]
 
 [features]
 default = []

--- a/crates/emath/Cargo.toml
+++ b/crates/emath/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--generate-link-to-definition"]
 
 [lib]
 

--- a/crates/epaint/Cargo.toml
+++ b/crates/epaint/Cargo.toml
@@ -23,6 +23,7 @@ workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--generate-link-to-definition"]
 
 [lib]
 

--- a/crates/epaint_default_fonts/Cargo.toml
+++ b/crates/epaint_default_fonts/Cargo.toml
@@ -27,3 +27,4 @@ workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--generate-link-to-definition"]


### PR DESCRIPTION
You can see this feature in action [here](https://docs.rs/sysinfo/latest/src/sysinfo/common/system.rs.html#46) or on any of dtolnay's crates and many others. I found myself going through your project code recently on docs.rs and I was a bit sad I couldn't have this feature enabled. This should fix it at next release. :)