### PR TITLE
`display:none` on Input inserted by `TextAgent`

### DIFF
--- a/crates/eframe/src/web/text_agent.rs
+++ b/crates/eframe/src/web/text_agent.rs
@@ -34,6 +34,7 @@ impl TextAgent {
         style.set_property("height", "1px")?;
         style.set_property("caret-color", "transparent")?;
         style.set_property("position", "absolute")?;
+        style.set_property("display", "none")?;
         style.set_property("top", "0")?;
         style.set_property("left", "0")?;
         document.body().unwrap().append_child(&input)?;


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/4987
* [x] I have followed the instructions in the PR template

There isn't much to discuss as the change is very limited in scope. Doing this seems to break nothing for me, even on a mobile device while it fixes the regression explained in the linked issue.