### PR TITLE
Fix viewport not working when minimized

### DIFF
--- a/crates/epaint/src/shadow.rs
+++ b/crates/epaint/src/shadow.rs
@@ -11,7 +11,7 @@ pub struct Shadow {
     /// Move the shadow by this much.
     ///
     /// For instance, a value of `[1.0, 2.0]` will move the shadow 1 point to the right and 2 points down,
-    /// causing a drop-shadow effet.
+    /// causing a drop-shadow effect.
     pub offset: Vec2,
 
     /// The width of the blur, i.e. the width of the fuzzy penumbra.


### PR DESCRIPTION
Fix: The viewport stops working when the program is minimized.   

Fix: Logically, the weird parts have been normalized.
                                                               
**Issue :**                                                                         
                                                                                      
The viewport stops working when the program is minimized.                             
                         
* Related #3321
* Related #3877                                                               
* Related #3985
* Closes #3972                                                                        
* Closes #4772
* Related #4832 
* Closes #4892
                                                                                     
**Solution :**                                                                      
                                                                                      
When `request_redraw()` is performed in Minimized state, the occasional screen tearing phenomenon has disappeared.
( Probably expected to be the effect of #4814 )                                       
                                                                                      
To address the issue of the `Immediate Viewport` not updating in Minimized state, we can call `request_redraw()`.

                       