### PR TITLE
Provides Rect::new()

### DIFF
--- a/crates/emath/src/rect.rs
+++ b/crates/emath/src/rect.rs
@@ -70,6 +70,14 @@ impl Rect {
     };
 
     #[inline(always)]
+    pub const fn new(min_x: f32, min_y: f32, max_x: f32, max_y: f32) -> Self {
+        Self {
+            min: pos2(min_x, min_y),
+            max: pos2(max_x, max_y),
+        }
+    }
+
+    #[inline(always)]
     pub const fn from_min_max(min: Pos2, max: Pos2) -> Self {
         Self { min, max }
     }

--- a/crates/emath/src/rect.rs
+++ b/crates/emath/src/rect.rs
@@ -69,6 +69,7 @@ impl Rect {
         max: Pos2::ZERO,
     };
 
+    /// Creates a new `Rect` instance from its minimum and maximum positions.
     #[inline(always)]
     pub const fn new(min_x: f32, min_y: f32, max_x: f32, max_y: f32) -> Self {
         Self {


### PR DESCRIPTION
I've sometimes wondered why there's no Rect::new() , but I see no reason why it shouldn't be provided.
