### PR TITLE
Interactive `Ui`:s: add `UiBuilder::sense` and `Ui::response`

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -471,7 +471,7 @@ impl Area {
                     sense,
                     enabled,
                 },
-                false,
+                true,
             );
 
             if movable && move_response.dragged() {

--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -462,14 +462,17 @@ impl Area {
                 }
             });
 
-            let move_response = ctx.create_widget(WidgetRect {
-                id: interact_id,
-                layer_id,
-                rect: state.rect(),
-                interact_rect: state.rect(),
-                sense,
-                enabled,
-            });
+            let move_response = ctx.create_widget(
+                WidgetRect {
+                    id: interact_id,
+                    layer_id,
+                    rect: state.rect(),
+                    interact_rect: state.rect(),
+                    sense,
+                    enabled,
+                },
+                false,
+            );
 
             if movable && move_response.dragged() {
                 if let Some(pivot_pos) = &mut state.pivot_pos {

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -833,14 +833,17 @@ fn resize_interaction(
     }
 
     let is_dragging = |rect, id| {
-        let response = ctx.create_widget(WidgetRect {
-            layer_id,
-            id,
-            rect,
-            interact_rect: rect,
-            sense: Sense::drag(),
-            enabled: true,
-        });
+        let response = ctx.create_widget(
+            WidgetRect {
+                layer_id,
+                id,
+                rect,
+                interact_rect: rect,
+                sense: Sense::drag(),
+                enabled: true,
+            },
+            false,
+        );
         SideResponse {
             hover: response.hovered(),
             drag: response.dragged(),

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -842,7 +842,7 @@ fn resize_interaction(
                 sense: Sense::drag(),
                 enabled: true,
             },
-            false,
+            true,
         );
         SideResponse {
             hover: response.hovered(),

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1050,7 +1050,7 @@ impl Context {
     ///
     /// If the widget already exists, its state (sense, Rect, etc) will be updated.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn create_widget(&self, w: WidgetRect) -> Response {
+    pub(crate) fn create_widget(&self, w: WidgetRect, ignore_focus: bool) -> Response {
         // Remember this widget
         self.write(|ctx| {
             let viewport = ctx.viewport();
@@ -1060,12 +1060,12 @@ impl Context {
             // but also to know when we have reached the widget we are checking for cover.
             viewport.this_frame.widgets.insert(w.layer_id, w);
 
-            if w.sense.focusable {
+            if w.sense.focusable && !ignore_focus {
                 ctx.memory.interested_in_focus(w.id);
             }
         });
 
-        if !w.enabled || !w.sense.focusable || !w.layer_id.allow_interaction() {
+        if !w.enabled || !w.sense.focusable || !w.layer_id.allow_interaction() && !ignore_focus {
             // Not interested or allowed input:
             self.memory_mut(|mem| mem.surrender_focus(w.id));
         }
@@ -1078,7 +1078,7 @@ impl Context {
         let res = self.get_response(w);
 
         #[cfg(feature = "accesskit")]
-        if w.sense.focusable {
+        if w.sense.focusable && !ignore_focus {
             // Make sure anything that can receive focus has an AccessKit node.
             // TODO(mwcampbell): For nodes that are filled from widget info,
             // some information is written to the node twice.

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1051,7 +1051,7 @@ impl Context {
     /// If the widget already exists, its state (sense, Rect, etc) will be updated.
     ///
     /// `allow_focus` should usually be true, unless you call this function multiple times with the
-    /// same widget, then `allow_focus` should only be true once (like in [`Ui::new`] (true) and [`Ui::interact_bg`] (false)).
+    /// same widget, then `allow_focus` should only be true once (like in [`Ui::new`] (true) and [`Ui::remember_min_rect`] (false)).
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn create_widget(&self, w: WidgetRect, allow_focus: bool) -> Response {
         // Remember this widget

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1117,7 +1117,7 @@ impl Context {
     }
 
     /// Do all interaction for an existing widget, without (re-)registering it.
-    fn get_response(&self, widget_rect: WidgetRect) -> Response {
+    pub(crate) fn get_response(&self, widget_rect: WidgetRect) -> Response {
         let WidgetRect {
             id,
             layer_id,

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -706,7 +706,7 @@ impl MenuState {
 
             self.open_submenu(sub_id, pos);
         } else if open
-            && ui.interact_bg(Sense::hover()).contains_pointer()
+            && ui.interact_bg().contains_pointer()
             && !button.hovered()
             && !self.hovering_current_submenu(&pointer)
         {

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -706,7 +706,7 @@ impl MenuState {
 
             self.open_submenu(sub_id, pos);
         } else if open
-            && ui.read_response().contains_pointer()
+            && ui.response().contains_pointer()
             && !button.hovered()
             && !self.hovering_current_submenu(&pointer)
         {

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -706,7 +706,7 @@ impl MenuState {
 
             self.open_submenu(sub_id, pos);
         } else if open
-            && ui.interact_bg().contains_pointer()
+            && ui.read_response().contains_pointer()
             && !button.hovered()
             && !self.hovering_current_submenu(&pointer)
         {

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -866,7 +866,7 @@ impl Response {
                 sense: self.sense | sense,
                 enabled: self.enabled,
             },
-            false,
+            true,
         )
     }
 

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -857,14 +857,17 @@ impl Response {
             return self.clone();
         }
 
-        self.ctx.create_widget(WidgetRect {
-            layer_id: self.layer_id,
-            id: self.id,
-            rect: self.rect,
-            interact_rect: self.interact_rect,
-            sense: self.sense | sense,
-            enabled: self.enabled,
-        })
+        self.ctx.create_widget(
+            WidgetRect {
+                layer_id: self.layer_id,
+                id: self.id,
+                rect: self.rect,
+                interact_rect: self.interact_rect,
+                sense: self.sense | sense,
+                enabled: self.enabled,
+            },
+            false,
+        )
     }
 
     /// Adjust the scroll position until this UI becomes visible.

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -162,7 +162,7 @@ impl Ui {
                 sense,
                 enabled: ui.enabled,
             },
-            false,
+            true,
         );
 
         if disabled {
@@ -295,7 +295,7 @@ impl Ui {
                 sense,
                 enabled: child_ui.enabled,
             },
-            false,
+            true,
         );
 
         child_ui
@@ -973,7 +973,7 @@ impl Ui {
                 sense,
                 enabled: self.enabled,
             },
-            false,
+            true,
         )
     }
 
@@ -1011,7 +1011,7 @@ impl Ui {
                 sense: self.sense,
                 enabled: self.enabled,
             },
-            true,
+            false,
         )
     }
 

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2731,12 +2731,12 @@ impl Ui {
         builder: UiBuilder,
         content: impl FnOnce(&mut Self, Option<Response>) -> R,
     ) -> InnerResponse<R> {
-        let id_source = builder.id_source.unwrap_or(Id::new("interact_scope"));
-        let id = self.id.with(Id::new(id_source));
+        let id_salt = builder.id_salt.unwrap_or(Id::new("interact_scope"));
+        let id = self.id.with(Id::new(id_salt));
         let response = self.ctx().read_response(id);
 
         self.scope_dyn(
-            builder.sense(sense).id_source(id_source),
+            builder.sense(sense).id_salt(id_salt),
             Box::new(|ui| {
                 let inner = content(ui, response);
                 let response = ui.interact_bg();

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1002,7 +1002,7 @@ impl Ui {
     ///
     /// On the first frame, when the [`Ui`] is created, this will return a [`Response`] with a
     /// [`Rect`] of [`Rect::NOTHING`].
-    pub fn read_response(&self) -> Response {
+    pub fn response(&self) -> Response {
         // This is the inverse of Context::read_response. We prefer a response
         // based on last frame's widget rect since the one from this frame is Rect::NOTHING until
         // Ui::interact_bg is called or the Ui is dropped.
@@ -1027,7 +1027,7 @@ impl Ui {
     /// The rectangle of the [`Response`] (and interactive area) will be [`Self::min_rect`].
     /// You can customize the [`Sense`] via [`UiBuilder::sense`].
     // This is marked as deprecated for public use but still makes sense to use internally.
-    #[deprecated = "Use Ui::read_response instead"]
+    #[deprecated = "Use Uibuilder::sense with Ui::response instead"]
     pub fn interact_bg(&self) -> Response {
         // We remove the id from used_ids to prevent a duplicate id warning from showing
         // when the ui was created with `UiBuilder::sense`.
@@ -2886,6 +2886,7 @@ impl Drop for Ui {
     fn drop(&mut self) {
         if self.should_interact_bg_on_drop {
             #[allow(deprecated)]
+            // Register our final `min_rect`
             self.interact_bg();
         }
         register_rect(self, self.min_rect());

--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -1,6 +1,6 @@
 use std::{hash::Hash, sync::Arc};
 
-use crate::{Id, Layout, Rect, Style, UiStackInfo};
+use crate::{Id, Layout, Rect, Sense, Style, UiStackInfo};
 
 #[allow(unused_imports)] // Used for doclinks
 use crate::Ui;
@@ -21,6 +21,7 @@ pub struct UiBuilder {
     pub invisible: bool,
     pub sizing_pass: bool,
     pub style: Option<Arc<Style>>,
+    pub sense: Option<Sense>,
 }
 
 impl UiBuilder {
@@ -114,6 +115,12 @@ impl UiBuilder {
     #[inline]
     pub fn style(mut self, style: impl Into<Arc<Style>>) -> Self {
         self.style = Some(style.into());
+        self
+    }
+
+    /// Sense of the Ui. Should be the same as the one passed to [`Ui::interact_bg`]
+    pub fn sense(mut self, sense: Sense) -> Self {
+        self.sense = Some(sense);
         self
     }
 }

--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -118,9 +118,12 @@ impl UiBuilder {
         self
     }
 
-    /// Set if you want sense clicks and/or drags.
+    /// Set if you want sense clicks and/or drags. Default is [`Sense::hover`].
+    /// The sense will be registered below the Senses of any widgets contained in this [`Ui`], so
+    /// if the user clicks a button contained within this [`Ui`], that button will receive the click
+    /// instead.
     ///
-    /// The response can be read with [`Ui::response`].
+    /// The response can be read early with [`Ui::response`].
     #[inline]
     pub fn sense(mut self, sense: Sense) -> Self {
         self.sense = Some(sense);

--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -118,7 +118,9 @@ impl UiBuilder {
         self
     }
 
-    /// Sense of the Ui. Should be the same as the one passed to [`Ui::interact_bg`]
+    /// Set if you want sense clicks and/or drags.
+    ///
+    /// The response can be read with [`Ui::response`].
     #[inline]
     pub fn sense(mut self, sense: Sense) -> Self {
         self.sense = Some(sense);

--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -119,6 +119,7 @@ impl UiBuilder {
     }
 
     /// Sense of the Ui. Should be the same as the one passed to [`Ui::interact_bg`]
+    #[inline]
     pub fn sense(mut self, sense: Sense) -> Self {
         self.sense = Some(sense);
         self

--- a/crates/egui/src/widget_rect.rs
+++ b/crates/egui/src/widget_rect.rs
@@ -44,8 +44,8 @@ pub struct WidgetRect {
 
 /// Stores the [`WidgetRect`]s of all widgets generated during a single egui update/frame.
 ///
-/// All [`crate::Ui`]s have a [`WidgetRects`], but whether or not their rects are correct
-/// depends on if [`crate::Ui::interact_bg`] was ever called.
+/// All [`crate::Ui`]s have a [`WidgetRect`]. It is created in [`crate::Ui::new`] with [`Rect::NOTHING`]
+/// and updated with the correct [`Rect`] when the [`crate::Ui`] is dropped.
 #[derive(Default, Clone)]
 pub struct WidgetRects {
     /// All widgets, in painting order.

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -31,6 +31,7 @@ impl Default for Demos {
             Box::<super::font_book::FontBook>::default(),
             Box::<super::frame_demo::FrameDemo>::default(),
             Box::<super::highlighting::Highlighting>::default(),
+            Box::<super::interactive_container::InteractiveContainerDemo>::default(),
             Box::<super::MiscDemoWindow>::default(),
             Box::<super::multi_touch::MultiTouch>::default(),
             Box::<super::painting::Painting>::default(),

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -259,7 +259,8 @@ impl DemoWindows {
     fn desktop_ui(&mut self, ctx: &Context) {
         egui::SidePanel::right("egui_demo_panel")
             .resizable(false)
-            .default_width(150.0)
+            .default_width(160.0)
+            .min_width(160.0)
             .show(ctx, |ui| {
                 ui.add_space(4.0);
                 ui.vertical_centered(|ui| {

--- a/crates/egui_demo_lib/src/demo/interactive_container.rs
+++ b/crates/egui_demo_lib/src/demo/interactive_container.rs
@@ -10,7 +10,7 @@ pub struct InteractiveContainerDemo {
 
 impl crate::Demo for InteractiveContainerDemo {
     fn name(&self) -> &'static str {
-        "\u{20E3}TextEdit"
+        "\u{20E3} Interactive Container"
     }
 
     fn show(&mut self, ctx: &egui::Context, open: &mut bool) {

--- a/crates/egui_demo_lib/src/demo/interactive_container.rs
+++ b/crates/egui_demo_lib/src/demo/interactive_container.rs
@@ -17,6 +17,7 @@ impl crate::Demo for InteractiveContainerDemo {
         egui::Window::new(self.name())
             .open(open)
             .resizable(false)
+            .default_width(250.0)
             .show(ctx, |ui| {
                 use crate::View as _;
                 self.ui(ui);
@@ -30,7 +31,12 @@ impl crate::View for InteractiveContainerDemo {
             ui.add(crate::egui_github_link_file!());
         });
 
-        ui.label("This demo showcases how to use Ui::read_response to create interactive container widgets that may contain other widgets.");
+        ui.horizontal_wrapped(|ui| {
+            ui.spacing_mut().item_spacing.x = 0.0;
+            ui.label("This demo showcases how to use ");
+            ui.code("Ui::read_response");
+            ui.label(" to create interactive container widgets that may contain other widgets.");
+        });
 
         let response = ui
             .scope_builder(

--- a/crates/egui_demo_lib/src/demo/interactive_container.rs
+++ b/crates/egui_demo_lib/src/demo/interactive_container.rs
@@ -1,0 +1,81 @@
+use egui::{Frame, Label, RichText, Sense, UiBuilder, Widget};
+
+/// Showcase [`egui::Ui::read_response`].
+#[derive(PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(default))]
+pub struct InteractiveContainerDemo {
+    count: usize,
+}
+
+impl crate::Demo for InteractiveContainerDemo {
+    fn name(&self) -> &'static str {
+        "\u{20E3}TextEdit"
+    }
+
+    fn show(&mut self, ctx: &egui::Context, open: &mut bool) {
+        egui::Window::new(self.name())
+            .open(open)
+            .resizable(false)
+            .show(ctx, |ui| {
+                use crate::View as _;
+                self.ui(ui);
+            });
+    }
+}
+
+impl crate::View for InteractiveContainerDemo {
+    fn ui(&mut self, ui: &mut egui::Ui) {
+        ui.vertical_centered(|ui| {
+            ui.add(crate::egui_github_link_file!());
+        });
+
+        ui.label("This demo showcases how to use Ui::read_response to create interactive container widgets that may contain other widgets.");
+
+        let response = ui
+            .scope_builder(
+                UiBuilder::new()
+                    .id_salt("interactive_container")
+                    .sense(Sense::click()),
+                |ui| {
+                    let response = ui.read_response();
+                    let visuals = ui.style().interact(&response);
+                    let text_color = visuals.text_color();
+
+                    Frame::canvas(ui.style())
+                        .fill(visuals.bg_fill.gamma_multiply(0.3))
+                        .stroke(visuals.bg_stroke)
+                        .inner_margin(ui.spacing().menu_margin)
+                        .show(ui, |ui| {
+                            ui.set_width(ui.available_width());
+
+                            ui.add_space(32.0);
+                            ui.vertical_centered(|ui| {
+                                Label::new(
+                                    RichText::new(format!("{}", self.count))
+                                        .color(text_color)
+                                        .size(32.0),
+                                )
+                                .selectable(false)
+                                .ui(ui);
+                            });
+                            ui.add_space(32.0);
+
+                            ui.horizontal(|ui| {
+                                if ui.button("Reset").clicked() {
+                                    self.count = 0;
+                                }
+                                if ui.button("+ 100").clicked() {
+                                    self.count += 100;
+                                }
+                            });
+                        });
+                },
+            )
+            .response;
+
+        if response.clicked() {
+            self.count += 1;
+        }
+    }
+}

--- a/crates/egui_demo_lib/src/demo/interactive_container.rs
+++ b/crates/egui_demo_lib/src/demo/interactive_container.rs
@@ -1,6 +1,6 @@
 use egui::{Frame, Label, RichText, Sense, UiBuilder, Widget};
 
-/// Showcase [`egui::Ui::read_response`].
+/// Showcase [`egui::Ui::response`].
 #[derive(PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
@@ -34,7 +34,7 @@ impl crate::View for InteractiveContainerDemo {
         ui.horizontal_wrapped(|ui| {
             ui.spacing_mut().item_spacing.x = 0.0;
             ui.label("This demo showcases how to use ");
-            ui.code("Ui::read_response");
+            ui.code("Ui::response");
             ui.label(" to create interactive container widgets that may contain other widgets.");
         });
 
@@ -44,7 +44,7 @@ impl crate::View for InteractiveContainerDemo {
                     .id_salt("interactive_container")
                     .sense(Sense::click()),
                 |ui| {
-                    let response = ui.read_response();
+                    let response = ui.response();
                     let visuals = ui.style().interact(&response);
                     let text_color = visuals.text_color();
 

--- a/crates/egui_demo_lib/src/demo/mod.rs
+++ b/crates/egui_demo_lib/src/demo/mod.rs
@@ -15,6 +15,7 @@ pub mod extra_viewport;
 pub mod font_book;
 pub mod frame_demo;
 pub mod highlighting;
+pub mod interactive_container;
 pub mod misc_demo_window;
 pub mod multi_touch;
 pub mod paint_bezier;


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes #5053 
* [x] I have followed the instructions in the PR template


This fixes #5053 by adding a Sense parameter to UiBuilder, using that in Context::create_widget, so the Widget is registered with the right Sense / focusable. Additionally, I've added a ignore_focus param to create_widget, so the focus isn't surrendered / reregistered on Ui::interact_bg. 

The example from #5053 now works correctly: 

https://github.com/user-attachments/assets/a8a04b5e-7635-4e05-9ed8-e17d64910a35

<details><summary>Updated example code</summary>
<p>

```rust
            ui.button("I can focus");

            ui.scope_builder(
                UiBuilder::new()
                    .sense(Sense::click())
                    .id_source("focus_test"),
                |ui| {
                    ui.label("I can focus for a single frame");
                    let response = ui.interact_bg();
                    let t = if response.has_focus() {
                        "has focus"
                    } else {
                        "doesn't have focus"
                    };
                    ui.label(t);
                },
            );

            ui.button("I can't focus :(");
```

</p>
</details> 



---

Also, I've added `Ui::interact_scope` to make it easier to read a Ui's response in advance, without having to know about the internals of how the Ui Ids get created.

This makes it really easy to created interactive container elements or custom buttons, without having to use Galleys or Painter::add(Shape::Noop) to style based on the interaction.

<details><summary>
Example usage to create a simple button
</summary>
<p>


```rust
use eframe::egui;
use eframe::egui::{Frame, InnerResponse, Label, RichText, UiBuilder, Widget};
use eframe::NativeOptions;
use egui::{CentralPanel, Sense, WidgetInfo};

pub fn main() -> eframe::Result {
    eframe::run_simple_native("focus test", NativeOptions::default(), |ctx, _frame| {
        CentralPanel::default().show(ctx, |ui| {
            ui.button("Regular egui Button");
            custom_button(ui, |ui| {
                ui.label("Custom Button");
            });

            if custom_button(ui, |ui| {
                ui.label("You can even have buttons inside buttons:");

                if ui.button("button inside button").clicked() {
                    println!("Button inside button clicked!");
                }
            })
            .response
            .clicked()
            {
                println!("Custom button clicked!");
            }
        });
    })
}

fn custom_button<R>(
    ui: &mut egui::Ui,
    content: impl FnOnce(&mut egui::Ui) -> R,
) -> InnerResponse<R> {
    let auto_id = ui.next_auto_id();
    ui.skip_ahead_auto_ids(1);
    let response = ui.interact_scope(
        Sense::click(),
        UiBuilder::new().id_source(auto_id),
        |ui, response| {
            ui.style_mut().interaction.selectable_labels = false;
            let visuals = response
                .map(|r| ui.style().interact(&r))
                .unwrap_or(&ui.visuals().noninteractive());
            let text_color = visuals.text_color();

            Frame::none()
                .fill(visuals.bg_fill)
                .stroke(visuals.bg_stroke)
                .rounding(visuals.rounding)
                .inner_margin(ui.spacing().button_padding)
                .show(ui, |ui| {
                    ui.visuals_mut().override_text_color = Some(text_color);
                    content(ui)
                })
                .inner
        },
    );

    response
        .response
        .widget_info(|| WidgetInfo::new(egui::WidgetType::Button));

    response
}
```

</p>
</details> 


https://github.com/user-attachments/assets/281bd65f-f616-4621-9764-18fd0d07698b

