### PR TITLE
add feature to disable text-to-pixel snapping during layout

### DIFF
--- a/crates/epaint/Cargo.toml
+++ b/crates/epaint/Cargo.toml
@@ -49,6 +49,13 @@ deadlock_detection = ["dep:backtrace"]
 ## If you plan on specifying your own fonts you may disable this feature.
 default_fonts = ["epaint_default_fonts"]
 
+## Disable text snapping to remove logic in text layout that rounds glyphs and kerning to
+## the nearest pixel. This is necessary to provide the sharpest text rendering with `ab_glyph`.
+## The side effect of such rounding is that text layout will likely be inconsistent across
+## different values of `pixel_per_point`. Disabling such "snapping" will make the text fuzzy,
+## but the layout will remain constant across `pixels_per_point`.
+disable_text_snapping = []
+
 ## Turn on the `log` feature, that makes egui log some errors using the [`log`](https://docs.rs/log) crate.
 log = ["dep:log"]
 

--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -67,6 +67,10 @@ pub struct FontImpl {
     ab_glyph_font: ab_glyph::FontArc,
 
     /// Maximum character height
+    #[cfg(feature = "disable_text_snapping")]
+    scale_in_pixels: f32,
+
+    #[cfg(not(feature = "disable_text_snapping"))]
     scale_in_pixels: u32,
 
     height_in_points: f32,
@@ -106,21 +110,23 @@ impl FontImpl {
             scale_in_points * tweak.baseline_offset_factor
         };
 
-        let y_offset_points = {
+        let y_offset_in_points = {
             let scale_in_points = scale_in_pixels / pixels_per_point;
             scale_in_points * tweak.y_offset_factor
         } + tweak.y_offset;
 
         // Center scaled glyphs properly:
         let height = ascent + descent;
-        let y_offset_points = y_offset_points - (1.0 - tweak.scale) * 0.5 * height;
+        let y_offset_in_points = y_offset_in_points - (1.0 - tweak.scale) * 0.5 * height;
 
         // Round to an even number of physical pixels to get even kerning.
         // See https://github.com/emilk/egui/issues/382
+        #[cfg(not(feature = "disable_text_snapping"))]
         let scale_in_pixels = scale_in_pixels.round() as u32;
 
         // Round to closest pixel:
-        let y_offset_in_points = (y_offset_points * pixels_per_point).round() / pixels_per_point;
+        #[cfg(not(feature = "disable_text_snapping"))]
+        let y_offset_in_points = (y_offset_in_points * pixels_per_point).round() / pixels_per_point;
 
         Self {
             name,
@@ -231,6 +237,21 @@ impl FontImpl {
         }
     }
 
+    #[cfg(feature = "disable_text_snapping")]
+    #[inline]
+    pub fn pair_kerning(
+        &self,
+        last_glyph_id: ab_glyph::GlyphId,
+        glyph_id: ab_glyph::GlyphId,
+    ) -> f32 {
+        use ab_glyph::{Font as _, ScaleFont};
+        self.ab_glyph_font
+            .as_scaled(self.scale_in_pixels)
+            .kern(last_glyph_id, glyph_id)
+            / self.pixels_per_point
+    }
+
+    #[cfg(not(feature = "disable_text_snapping"))]
     #[inline]
     pub fn pair_kerning(
         &self,
@@ -263,6 +284,7 @@ impl FontImpl {
         self.ascent
     }
 
+    #[allow(trivial_numeric_casts, clippy::unnecessary_cast)]
     fn allocate_glyph(&self, glyph_id: ab_glyph::GlyphId) -> GlyphInfo {
         assert!(glyph_id.0 != 0);
         use ab_glyph::{Font as _, ScaleFont};
@@ -333,6 +355,7 @@ pub struct Font {
     characters: Option<BTreeSet<char>>,
 
     replacement_glyph: (FontIndex, GlyphInfo),
+    #[cfg(not(feature = "disable_text_snapping"))]
     pixels_per_point: f32,
     row_height: f32,
     glyph_info_cache: ahash::HashMap<char, (FontIndex, GlyphInfo)>,
@@ -345,12 +368,14 @@ impl Font {
                 fonts,
                 characters: None,
                 replacement_glyph: Default::default(),
+                #[cfg(not(feature = "disable_text_snapping"))]
                 pixels_per_point: 1.0,
                 row_height: 0.0,
                 glyph_info_cache: Default::default(),
             };
         }
 
+        #[cfg(not(feature = "disable_text_snapping"))]
         let pixels_per_point = fonts[0].pixels_per_point();
         let row_height = fonts[0].row_height();
 
@@ -358,6 +383,7 @@ impl Font {
             fonts,
             characters: None,
             replacement_glyph: Default::default(),
+            #[cfg(not(feature = "disable_text_snapping"))]
             pixels_per_point,
             row_height,
             glyph_info_cache: Default::default(),
@@ -409,9 +435,17 @@ impl Font {
         })
     }
 
+    #[cfg(not(feature = "disable_text_snapping"))]
     #[inline(always)]
     pub fn round_to_pixel(&self, point: f32) -> f32 {
         (point * self.pixels_per_point).round() / self.pixels_per_point
+    }
+
+    #[cfg(feature = "disable_text_snapping")]
+    #[inline(always)]
+    #[allow(clippy::unused_self)]
+    pub fn round_to_pixel(&self, point: f32) -> f32 {
+        point
     }
 
     /// Height of one row of text. In points

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -26,9 +26,16 @@ impl PointScale {
         self.pixels_per_point
     }
 
+    #[cfg(not(feature = "disable_text_snapping"))]
     #[inline(always)]
     pub fn round_to_pixel(&self, point: f32) -> f32 {
         (point * self.pixels_per_point).round() / self.pixels_per_point
+    }
+
+    #[cfg(feature = "disable_text_snapping")]
+    #[inline(always)]
+    pub fn round_to_pixel(&self, point: f32) -> f32 {
+        point
     }
 
     #[inline(always)]

--- a/crates/epaint/tests/font.rs
+++ b/crates/epaint/tests/font.rs
@@ -1,0 +1,53 @@
+#[cfg(feature = "disable_text_snapping")]
+#[test]
+fn test_layout_sizes_without_snapping() {
+    let fonts1_0 = epaint::text::Fonts::new(1.0, 1024, epaint::text::FontDefinitions::default());
+    let fonts1_1 = epaint::text::Fonts::new(1.1, 1024, epaint::text::FontDefinitions::default());
+    let wrapping = epaint::text::TextWrapping {
+        max_width: 72.0 * 8.5 - 72.0,
+        ..Default::default()
+    };
+    let mut job = epaint::text::LayoutJob {
+        wrap: wrapping,
+        ..Default::default()
+    };
+    job.append(
+        "Hello, epaint! Thanks for the awesome GUI library!",
+        0.0,
+        epaint::text::TextFormat {
+            font_id: epaint::FontId::new(10.0, epaint::FontFamily::Proportional),
+            color: epaint::Color32::WHITE,
+            ..Default::default()
+        },
+    );
+    let galley1_0 = fonts1_0.layout_job(job.clone());
+    let galley1_1 = fonts1_1.layout_job(job.clone());
+    assert_eq!(galley1_0.rect.size(), galley1_1.rect.size());
+}
+
+#[test]
+fn test_layout_sizes_with_snapping() {
+    let fonts1_0 = epaint::text::Fonts::new(1.0, 1024, epaint::text::FontDefinitions::default());
+    let fonts1_1 = epaint::text::Fonts::new(1.1, 1024, epaint::text::FontDefinitions::default());
+    let wrapping = epaint::text::TextWrapping {
+        max_width: 72.0 * 8.5 - 72.0,
+        ..Default::default()
+    };
+    let mut job = epaint::text::LayoutJob {
+        wrap: wrapping,
+        ..Default::default()
+    };
+    job.append(
+        "Hello, epaint! Thanks for the awesome GUI library!",
+        0.0,
+        epaint::text::TextFormat {
+            font_id: epaint::FontId::new(10.0, epaint::FontFamily::Proportional),
+            color: epaint::Color32::WHITE,
+            ..Default::default()
+        },
+    );
+    let galley1_0 = fonts1_0.layout_job(job.clone());
+    let galley1_1 = fonts1_1.layout_job(job.clone());
+    assert_ne!(galley1_0.rect.height(), galley1_1.rect.height());
+    assert_ne!(galley1_0.rect.width(), galley1_1.rect.width());
+}


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

Recognizing that a switch to Cosmic Text is on the way per #56 , I also wanted to implement a temporary feature which disables what I call "text snapping"--i.e., where we round to the nearest pixel on the x and y axis when rendering text. This results in text being laid out in different ways across `pixel_per_point` values. Such snapping improves font rendering in the absence of other anti-aliasing approaches which will be provided by Cosmic Text. For some contexts, however, maintaining the layout is more important across `pixel_per_point` values. This feature allows for that until Cosmic Text saves the day.

* [X] I have followed the instructions in the PR template
