### PR TITLE
Deprecate `ui.set_sizing_pass`

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -543,7 +543,7 @@ impl Prepared {
             ui_builder = ui_builder.disabled();
         }
         if self.sizing_pass {
-            ui_builder = ui_builder.sizing_pass();
+            ui_builder = ui_builder.sizing_pass().invisible();
         }
 
         let mut ui = Ui::new(ctx.clone(), self.layer_id, self.layer_id.id, ui_builder);

--- a/crates/egui/src/grid.rs
+++ b/crates/egui/src/grid.rs
@@ -435,7 +435,7 @@ impl Grid {
         let mut ui_builder = UiBuilder::new().max_rect(max_rect);
         if prev_state.is_none() {
             // Hide the ui this frame, and make things as narrow as possible.
-            ui_builder = ui_builder.sizing_pass();
+            ui_builder = ui_builder.sizing_pass().invisible();
         }
 
         ui.allocate_new_ui(ui_builder, |ui| {

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -223,7 +223,6 @@ impl Ui {
         let id_salt = id_salt.unwrap_or_else(|| Id::from("child"));
         let max_rect = max_rect.unwrap_or_else(|| self.available_rect_before_wrap());
         let mut layout = layout.unwrap_or(*self.layout());
-        let invisible = invisible;
         let enabled = self.enabled && !disabled && !invisible;
         if invisible {
             painter.set_invisible();

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -119,8 +119,7 @@ impl Ui {
         let max_rect = max_rect.unwrap_or_else(|| ctx.screen_rect());
         let clip_rect = max_rect;
         let layout = layout.unwrap_or_default();
-        let invisible = invisible || sizing_pass;
-        let disabled = disabled || invisible || sizing_pass;
+        let disabled = disabled || invisible;
         let style = style.unwrap_or_else(|| ctx.style());
 
         let placer = Placer::new(max_rect, layout);
@@ -139,7 +138,7 @@ impl Ui {
             style,
             placer,
             enabled: true,
-            sizing_pass: false,
+            sizing_pass,
             menu_state: None,
             stack: Arc::new(ui_stack),
         };
@@ -160,9 +159,6 @@ impl Ui {
         }
         if invisible {
             ui.set_invisible();
-        }
-        if sizing_pass {
-            ui.set_sizing_pass();
         }
 
         ui
@@ -227,8 +223,8 @@ impl Ui {
         let id_salt = id_salt.unwrap_or_else(|| Id::from("child"));
         let max_rect = max_rect.unwrap_or_else(|| self.available_rect_before_wrap());
         let mut layout = layout.unwrap_or(*self.layout());
-        let invisible = invisible || sizing_pass;
-        let enabled = self.enabled && !disabled && !invisible && !sizing_pass;
+        let invisible = invisible;
+        let enabled = self.enabled && !disabled && !invisible;
         if invisible {
             painter.set_invisible();
         }
@@ -293,6 +289,7 @@ impl Ui {
     /// This will also turn the Ui invisible.
     /// Should be called right after [`Self::new`], if at all.
     #[inline]
+    #[deprecated = "Use UiBuilder.sizing_pass().invisible()"]
     pub fn set_sizing_pass(&mut self) {
         self.sizing_pass = true;
         self.set_invisible();

--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -103,8 +103,6 @@ impl UiBuilder {
     #[inline]
     pub fn sizing_pass(mut self) -> Self {
         self.sizing_pass = true;
-        self.invisible = true;
-        self.disabled = true;
         self
     }
 


### PR DESCRIPTION
Use `UiBuilder::new().sizing_pass().invisible()` instead.

Also changes `UiBuilder::sizing_pass` to no longer turn the ui invisible. You'll have to opt-in to that instead when it makes sense, e.g. for the first frame of a tooltip, but not when auto-sizing a column in a `Table`.
