### PR TITLE
Add `WidgetType::RadioGroup`

### DIFF
--- a/crates/egui/src/data/output.rs
+++ b/crates/egui/src/data/output.rs
@@ -640,6 +640,7 @@ impl WidgetInfo {
             WidgetType::Button => "button",
             WidgetType::Checkbox => "checkbox",
             WidgetType::RadioButton => "radio",
+            WidgetType::RadioGroup => "radio group",
             WidgetType::SelectableLabel => "selectable",
             WidgetType::ComboBox => "combo",
             WidgetType::Slider => "slider",

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -618,6 +618,9 @@ pub enum WidgetType {
 
     RadioButton,
 
+    /// A group of radio buttons.
+    RadioGroup,
+
     SelectableLabel,
 
     ComboBox,

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -992,6 +992,7 @@ impl Response {
             }
             WidgetType::Checkbox => Role::CheckBox,
             WidgetType::RadioButton => Role::RadioButton,
+            WidgetType::RadioGroup => Role::RadioGroup,
             WidgetType::SelectableLabel => Role::Button,
             WidgetType::ComboBox => Role::ComboBox,
             WidgetType::Slider => Role::Slider,


### PR DESCRIPTION
Extracted out of #4805

I'm using this widget type in [`egui-theme-switch`] but since it's not built in I have to call `accesskit_node_builder` which is a bit cumbersome :)

* [x] I have followed the instructions in the PR template

[`egui-theme-switch`]: https://github.com/bash/egui-theme-switch/blob/main/src/lib.rs