### PR TITLE
Add `Response::intrinsic_size` to enable better layout in 3rd party crates

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1147,6 +1147,7 @@ impl Context {
             is_pointer_button_down_on: false,
             interact_pointer_pos: None,
             changed: false,
+            intrinsic_size: None,
         };
 
         self.write(|ctx| {

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -120,8 +120,15 @@ pub struct Response {
     pub changed: bool,
 
     /// The intrinsic / desired size of the widget.
+    ///
     /// For a button, this will be the size of the label + the frames padding,
     /// even if the button is laid out in a justified layout and the actual size will be larger.
+    ///
+    /// If this is `None`, use [`Self::rect`] instead.
+    ///
+    /// At the time of writing, this is only used by external crates
+    /// for improved layouting.
+    /// See for instance [`egui_flex`](https://github.com/lucasmerlin/hello_egui/tree/main/crates/egui_flex).
     pub intrinsic_size: Option<Vec2>,
 }
 

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -118,6 +118,11 @@ pub struct Response {
     /// Always `false` for something like a [`Button`](crate::Button).
     #[doc(hidden)]
     pub changed: bool,
+
+    /// The intrinsic / desired size of the widget.
+    /// For a button, this will be the size of the label + the frames padding,
+    /// even if the button is laid out in a justified layout and the actual size will be larger.
+    pub intrinsic_size: Option<Vec2>,
 }
 
 impl Response {
@@ -1137,6 +1142,7 @@ impl Response {
                 || other.is_pointer_button_down_on,
             interact_pointer_pos: self.interact_pointer_pos.or(other.interact_pointer_pos),
             changed: self.changed || other.changed,
+            intrinsic_size: None,
         }
     }
 }

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1035,7 +1035,9 @@ impl Ui {
     /// ```
     pub fn allocate_response(&mut self, desired_size: Vec2, sense: Sense) -> Response {
         let (id, rect) = self.allocate_space(desired_size);
-        self.interact(rect, id, sense)
+        let mut response = self.interact(rect, id, sense);
+        response.intrinsic_size = Some(desired_size);
+        response
     }
 
     /// Returns a [`Rect`] with exactly what you asked for.


### PR DESCRIPTION
This adds a `intrinsic_size` field to the Response struct which allows me to grow a egui button frame while still being able to know it's intrinsic size in [egui_flex](https://github.com/lucasmerlin/hello_egui/tree/main/crates/egui_flex)

* Related to https://github.com/emilk/egui/issues/4378#issuecomment-2333800938
* [X] I have followed the instructions in the PR template
