### PR TITLE
Add return value to `with_accessibility_parent`

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2887,9 +2887,9 @@ impl Context {
     /// the function is still called, but with no other effect.
     ///
     /// No locks are held while the given closure is called.
-    #[allow(clippy::unused_self)]
+    #[allow(clippy::unused_self, clippy::let_and_return)]
     #[inline]
-    pub fn with_accessibility_parent(&self, _id: Id, f: impl FnOnce()) {
+    pub fn with_accessibility_parent<R>(&self, _id: Id, f: impl FnOnce() -> R) -> R {
         // TODO(emilk): this isn't thread-safe - another thread can call this function between the push/pop calls
         #[cfg(feature = "accesskit")]
         self.frame_state_mut(|fs| {
@@ -2898,7 +2898,7 @@ impl Context {
             }
         });
 
-        f();
+        let result = f();
 
         #[cfg(feature = "accesskit")]
         self.frame_state_mut(|fs| {
@@ -2906,6 +2906,8 @@ impl Context {
                 assert_eq!(state.parent_stack.pop(), Some(_id));
             }
         });
+
+        result
     }
 
     /// If AccessKit support is active for the current frame, get or create


### PR DESCRIPTION
Extracted out of #4805

In [`egui-theme-switch`] I'm allocating a response inside the closure passed to `with_accessibility_parent` so that my radio buttons have the radio group as parent.

I'm working around the lack of return value with a custom extension trait for now: [`ContextExt`]

* [x] I have followed the instructions in the PR template

[`egui-theme-switch`]: https://github.com/bash/egui-theme-switch/blob/main/src/lib.rs
[`ContextExt`]: https://github.com/bash/egui-theme-switch/blob/main/src/context_ext.rs