### PR TITLE
Export module `egui::frame`

### DIFF
--- a/crates/egui/src/containers/mod.rs
+++ b/crates/egui/src/containers/mod.rs
@@ -5,7 +5,7 @@
 pub(crate) mod area;
 pub mod collapsing_header;
 mod combo_box;
-pub(crate) mod frame;
+pub mod frame;
 pub mod panel;
 pub mod popup;
 pub(crate) mod resize;


### PR DESCRIPTION
Remove the crate visibility of the frame module. Useful at least when using `Frame::begin` as otherwise the returned type is opaque to library users and prevents from creating containers that use `Frame` with a similar interface.

Alternative is to only export `frame::Prepared` as `PreparedFrame` or something, but I saw that other submodules of containers are already public.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes #2106
* [x] I have followed the instructions in the PR template
