### PR TITLE
Use Style's font size in egui_extras::syntax_highlighting

### DIFF
--- a/crates/egui_demo_app/src/apps/http_app.rs
+++ b/crates/egui_demo_app/src/apps/http_app.rs
@@ -224,7 +224,11 @@ fn syntax_highlighting(
     let extension = extension_and_rest.first()?;
     let theme = egui_extras::syntax_highlighting::CodeTheme::from_style(&ctx.style());
     Some(ColoredText(egui_extras::syntax_highlighting::highlight(
-        ctx, &theme, text, extension,
+        ctx,
+        &ctx.style(),
+        &theme,
+        text,
+        extension,
     )))
 }
 

--- a/crates/egui_demo_lib/src/demo/code_editor.rs
+++ b/crates/egui_demo_lib/src/demo/code_editor.rs
@@ -67,7 +67,8 @@ impl crate::View for CodeEditor {
             });
         }
 
-        let mut theme = egui_extras::syntax_highlighting::CodeTheme::from_memory(ui.ctx());
+        let mut theme =
+            egui_extras::syntax_highlighting::CodeTheme::from_memory(ui.ctx(), ui.style());
         ui.collapsing("Theme", |ui| {
             ui.group(|ui| {
                 theme.ui(ui);
@@ -76,8 +77,13 @@ impl crate::View for CodeEditor {
         });
 
         let mut layouter = |ui: &egui::Ui, string: &str, wrap_width: f32| {
-            let mut layout_job =
-                egui_extras::syntax_highlighting::highlight(ui.ctx(), &theme, string, language);
+            let mut layout_job = egui_extras::syntax_highlighting::highlight(
+                ui.ctx(),
+                ui.style(),
+                &theme,
+                string,
+                language,
+            );
             layout_job.wrap.max_width = wrap_width;
             ui.fonts(|f| f.layout_job(layout_job))
         };

--- a/crates/egui_demo_lib/src/demo/code_example.rs
+++ b/crates/egui_demo_lib/src/demo/code_example.rs
@@ -130,7 +130,8 @@ impl crate::View for CodeExample {
 
         ui.separator();
 
-        let mut theme = egui_extras::syntax_highlighting::CodeTheme::from_memory(ui.ctx());
+        let mut theme =
+            egui_extras::syntax_highlighting::CodeTheme::from_memory(ui.ctx(), ui.style());
         ui.collapsing("Theme", |ui| {
             theme.ui(ui);
             theme.store_in_memory(ui.ctx());

--- a/crates/egui_demo_lib/src/lib.rs
+++ b/crates/egui_demo_lib/src/lib.rs
@@ -21,7 +21,7 @@ pub use rendering_test::ColorTest;
 /// View some Rust code with syntax highlighting and selection.
 pub(crate) fn rust_view_ui(ui: &mut egui::Ui, code: &str) {
     let language = "rs";
-    let theme = egui_extras::syntax_highlighting::CodeTheme::from_memory(ui.ctx());
+    let theme = egui_extras::syntax_highlighting::CodeTheme::from_memory(ui.ctx(), ui.style());
     egui_extras::syntax_highlighting::code_view_ui(ui, &theme, code, language);
 }
 


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->
* Closes https://github.com/emilk/egui/issues/3549
* [X] I have followed the instructions in the PR template

The syntax highlighting font size was always hardcoded to 12 or 10 depending on what case it was hitting (so not consistent). This is particularly noticeable when you increase the font size to something larger for the rest of the ui.

With this the default monospace font size is used by default.

Since the issue is closely related to  #3549 I decided to implement the ability to use override_font_id too.

## Visualized

Default monospace is set to 15 in all the pictures

Before/After without syntect:
![normal](https://github.com/user-attachments/assets/0d058720-47ff-49e7-af77-30d48f5e138c)


Before/after _with_ syntect:
![syntect](https://github.com/user-attachments/assets/e5c380fe-ced1-40ee-b4b1-c26cec18a840)

Font override after without/with syntect (monospace = 20):
![override](https://github.com/user-attachments/assets/efd1b759-3f97-4673-864a-5a18afc64099)

### Breaking changes

- `CodeTheme::dark` and `CodeTheme::light` takes in the font size
- `CodeTheme::from_memory` takes in `Style`
- `highlight` function takes in `Style`
