### PR TITLE
Fix: more and more Wrap are added every time the mouse is moved.

### DIFF
--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -182,7 +182,7 @@ impl LayoutJob {
             // On a previous pass we may have rounded down by at most 0.5 and reported that as a width.
             // egui may then set that width as the max width for subsequent frames, and it is important
             // that we then don't wrap earlier.
-            self.wrap.max_width + 2.0
+            self.wrap.max_width + 16.0
         } else {
             self.wrap.max_width
         }

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -182,7 +182,7 @@ impl LayoutJob {
             // On a previous pass we may have rounded down by at most 0.5 and reported that as a width.
             // egui may then set that width as the max width for subsequent frames, and it is important
             // that we then don't wrap earlier.
-            self.wrap.max_width + 0.5
+            self.wrap.max_width + 2.0
         } else {
             self.wrap.max_width
         }


### PR DESCRIPTION
Fix Issues: more and more Wrap are added every time the mouse is moved.

* Related #5077
* Related #5079
* Closes #5084

`Here is an example of how this would solve the issue.`

Adding a value greater than `2.0` will prevent the `popup(=tooltip)` size from changing when you move the mouse.
If you add `16.0` ~ `20.0`, tooltips that were affected by other `tooltip`s will return to their original size.
If you add `25.0` or more, the size of the `tooltip` will continue to grow until there is no wrap.
May be, It seems to be affected by `line size` and `inner margin` of `tooltip`.
