### PR TITLE
Add back `Context::set_visuals()`

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1733,6 +1733,19 @@ impl Context {
         self.style_mut_of(theme, |style| style.visuals = visuals);
     }
 
+    /// The [`crate::Visuals`] used by all subsequent windows, panels etc.
+    ///
+    /// You can also use [`Ui::visuals_mut`] to change the visuals of a single [`Ui`].
+    ///
+    /// Example:
+    /// ```
+    /// # let mut ctx = egui::Context::default();
+    /// ctx.set_visuals(egui::Visuals { panel_fill: egui::Color32::RED, ..Default::default() });
+    /// ```
+    pub fn set_visuals(&self, visuals: crate::Visuals) {
+        self.style_mut_of(self.theme(), |style| style.visuals = visuals);
+    }
+
     /// The number of physical pixels for each logical point.
     ///
     /// This is calculated as [`Self::zoom_factor`] * [`Self::native_pixels_per_point`]


### PR DESCRIPTION
My opinion is, it would be better to keep `Context::set_visuals()` so that you don't get confused.

* Related #4744
