### PR TITLE
In `Options::ui()`, display only one of `Light` and `Dark`

### DIFF
--- a/crates/egui/src/memory/mod.rs
+++ b/crates/egui/src/memory/mod.rs
@@ -342,6 +342,8 @@ impl Options {
 impl Options {
     /// Show the options in the ui.
     pub fn ui(&mut self, ui: &mut crate::Ui) {
+        let theme = self.theme();
+
         let Self {
             dark_style, // covered above
             light_style,
@@ -388,12 +390,15 @@ impl Options {
             .show(ui, |ui| {
                 theme_preference.radio_buttons(ui);
 
-                CollapsingHeader::new("Dark")
-                    .default_open(true)
-                    .show(ui, |ui| std::sync::Arc::make_mut(dark_style).ui(ui));
-                CollapsingHeader::new("Light")
-                    .default_open(true)
-                    .show(ui, |ui| std::sync::Arc::make_mut(light_style).ui(ui));
+                if theme == Theme::Dark {
+                    CollapsingHeader::new("Dark")
+                        .default_open(true)
+                        .show(ui, |ui| std::sync::Arc::make_mut(dark_style).ui(ui));
+                } else {
+                    CollapsingHeader::new("Light")
+                        .default_open(true)
+                        .show(ui, |ui| std::sync::Arc::make_mut(light_style).ui(ui));
+                }
             });
 
         CollapsingHeader::new("✒ Painting")


### PR DESCRIPTION
In `Options::ui()`, display only one of `Light` and `Dark`

* Related #4744

Alternatively, `Collapsing Header` shows both, and there is also a way to open only the selected theme `Collapsing Header` and force close the other side.
