### PR TITLE
Fix Issues: more and more Wrap are added every time the mouse is moved.

### DIFF
--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -650,7 +650,7 @@ fn galley_from_rows(
             // we should let the user know.
         } else {
             // Make sure we don't go over the max wrap width the user picked:
-            rect.max.x = rect.max.x.at_most(rect.min.x + job.wrap.max_width).floor();
+            rect.max.x = rect.max.x.at_most(rect.min.x + job.wrap.max_width).round();
         }
     }
 


### PR DESCRIPTION
Fix Issues: more and more Wrap are added every time the mouse is moved.

* Related #5077
* Related #5079
* Closes #5084

Using `floor()` will cause the value of `wrap.max_width` to keep getting smaller. 
You should use `round()` or `ceil()` to prevent the value of `wrap.max_width` from getting smaller.
