### PR TITLE
Fix: Popups do not appear in certain situations.

### DIFF
--- a/crates/egui/src/input_state/mod.rs
+++ b/crates/egui/src/input_state/mod.rs
@@ -932,6 +932,7 @@ impl PointerState {
                             press_origin.distance(pos) > self.input_options.max_click_dist;
                     }
 
+                    self.last_move_time = time;
                     self.pointer_events.push(PointerEvent::Moved(pos));
                 }
                 Event::PointerButton {
@@ -1027,15 +1028,6 @@ impl PointerState {
         }
 
         self.pos_history.flush(time);
-
-        self.velocity = if self.pos_history.len() >= 3 && self.pos_history.duration() > 0.01 {
-            self.pos_history.velocity().unwrap_or_default()
-        } else {
-            Vec2::default()
-        };
-        if self.velocity != Vec2::ZERO {
-            self.last_move_time = time;
-        }
 
         self.direction = self.pos_history.velocity().unwrap_or_default().normalized();
 

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -678,7 +678,8 @@ impl Response {
 
         let clicked_more_recently_than_moved =
             time_since_last_click < time_since_last_pointer_movement + 0.1;
-        if clicked_more_recently_than_moved {
+        if clicked_more_recently_than_moved && (self.clicked() || self.is_pointer_button_down_on())
+        {
             // It is common to click a widget and then rest the mouse there.
             // It would be annoying to then see a tooltip for it immediately.
             // Similarly, clicking should hide the existing tooltip.


### PR DESCRIPTION
Fix: Popups do not appear in certain situations.

* Closes #5080

The root cause is that `last_move_time` is not updated in certain situations (slow situations).

This might also be useful for drag etc.

```
        if clicked_more_recently_than_moved && (self.clicked() || self.is_pointer_button_down_on())
```

Alternatively, we can apply a specific time (0.5 to 1.0 seconds).

```
        if clicked_more_recently_than_moved && time_since_last_click < 1.0
```
