### PR TITLE
early out in `should_show_hover_ui()`

### DIFF
--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -599,6 +599,9 @@ impl Response {
         if self.ctx.memory(|mem| mem.everything_is_visible()) {
             return true;
         }
+        if !self.hovered() {
+            return false;
+        }
 
         let any_open_popups = self.ctx.prev_pass_state(|fs| {
             fs.layers


### PR DESCRIPTION
`should_show_hover_ui()` only works on hover, so it's better to come out early.
Is there something different from what you intended or is there a problem?
