### PR TITLE
Fix: call `save` when hiding tab, and `update` when focusing it

### DIFF
--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -176,6 +176,12 @@ impl AppRunner {
     ///
     /// Technically: does either the canvas or the [`TextAgent`] have focus?
     pub fn has_focus(&self) -> bool {
+        let window = web_sys::window().unwrap();
+        let document = window.document().unwrap();
+        if document.hidden() {
+            return false;
+        }
+
         super::has_focus(self.canvas()) || self.text_agent.has_focus()
     }
 

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -61,6 +61,7 @@ pub(crate) fn install_event_handlers(runner_ref: &WebRunner) -> Result<(), JsVal
     let document = window.document().unwrap();
     let canvas = runner_ref.try_lock().unwrap().canvas().clone();
 
+    install_blur_focus(runner_ref, &document)?;
     install_blur_focus(runner_ref, &canvas)?;
 
     prevent_default_and_stop_propagation(

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -110,11 +110,6 @@ fn install_blur_focus(runner_ref: &WebRunner, target: &EventTarget) -> Result<()
         let closure = move |_event: web_sys::MouseEvent, runner: &mut AppRunner| {
             log::trace!("{} {event_name:?}", runner.canvas().id());
             runner.update_focus();
-
-            if event_name == "blur" {
-                // This might be a good time to save the state
-                runner.save();
-            }
         };
 
         runner_ref.add_event_listener(target, event_name, closure)?;

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -107,7 +107,7 @@ pub(crate) fn install_event_handlers(runner_ref: &WebRunner) -> Result<(), JsVal
 fn install_blur_focus(runner_ref: &WebRunner, target: &EventTarget) -> Result<(), JsValue> {
     // NOTE: because of the text agent we sometime miss 'blur' events,
     // so we also poll the focus state each frame in `AppRunner::logic`.
-    for event_name in ["blur", "focus"] {
+    for event_name in ["blur", "focus", "visibilitychange"] {
         let closure = move |_event: web_sys::MouseEvent, runner: &mut AppRunner| {
             log::trace!("{} {event_name:?}", runner.canvas().id());
             runner.update_focus();


### PR DESCRIPTION
Fix for a regression in 0.28

* `App::save` will now be called when the web app is hidden (e.g. goes to a background tab)
* `App::update` will now be called when the web app is un-hidden (e.g. becomes the foreground tab)