### PR TITLE
Fix: `Event::Copy` and `Event::Cut` behave as if they select the entire text when there is no selection.

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -893,16 +893,15 @@ fn events(
 
             Event::Copy => {
                 if cursor_range.is_empty() {
-                    copy_if_not_password(ui, text.as_str().to_owned());
+                    None
                 } else {
                     copy_if_not_password(ui, cursor_range.slice_str(text.as_str()).to_owned());
+                    None
                 }
-                None
             }
             Event::Cut => {
                 if cursor_range.is_empty() {
-                    copy_if_not_password(ui, text.take());
-                    Some(CCursorRange::default())
+                    None
                 } else {
                     copy_if_not_password(ui, cursor_range.slice_str(text.as_str()).to_owned());
                     Some(CCursorRange::one(text.delete_selected(&cursor_range)))


### PR DESCRIPTION
Fix: `Event::Copy` and `Event::Cut` behave as if they select the entire text when there is no selection.

It's unexpected and disconcerting that this behavior occurs when there is no selected area.
