### PR TITLE
Center-align all text vertically

### DIFF
--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -199,7 +199,7 @@ pub struct Style {
 
     /// How to vertically align text.
     ///
-    /// Default depends on layout.
+    /// Set to `None` to use align that depends on the current layout.
     pub override_text_valign: Option<Align>,
 
     /// The [`FontFamily`] and size you want to use for a specific [`TextStyle`].
@@ -1207,7 +1207,7 @@ impl Default for Style {
         Self {
             override_font_id: None,
             override_text_style: None,
-            override_text_valign: None,
+            override_text_valign: Some(Align::Center),
             text_styles: default_text_styles(),
             drag_value_text_style: TextStyle::Button,
             number_formatter: NumberFormatter(Arc::new(emath::format_with_decimals_in_range)),

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -4,6 +4,7 @@
 
 use std::{collections::BTreeMap, ops::RangeInclusive, sync::Arc};
 
+use emath::Align;
 use epaint::{text::FontTweak, Rounding, Shadow, Stroke};
 
 use crate::{
@@ -195,6 +196,11 @@ pub struct Style {
     /// On most widgets you can also set an explicit text style,
     /// which will take precedence over this.
     pub override_font_id: Option<FontId>,
+
+    /// How to vertically align text.
+    ///
+    /// Default depends on layout.
+    pub override_text_valign: Option<Align>,
 
     /// The [`FontFamily`] and size you want to use for a specific [`TextStyle`].
     ///
@@ -1201,6 +1207,7 @@ impl Default for Style {
         Self {
             override_font_id: None,
             override_text_style: None,
+            override_text_valign: None,
             text_styles: default_text_styles(),
             drag_value_text_style: TextStyle::Button,
             number_formatter: NumberFormatter(Arc::new(emath::format_with_decimals_in_range)),
@@ -1501,6 +1508,7 @@ impl Style {
         let Self {
             override_font_id,
             override_text_style,
+            override_text_valign,
             text_styles,
             drag_value_text_style,
             number_formatter: _, // can't change callbacks in the UI
@@ -1534,7 +1542,7 @@ impl Style {
             ui.end_row();
 
             ui.label("Override text style");
-            crate::ComboBox::from_id_salt("Override text style")
+            crate::ComboBox::from_id_salt("override_text_style")
                 .selected_text(match override_text_style {
                     None => "None".to_owned(),
                     Some(override_text_style) => override_text_style.to_string(),
@@ -1546,6 +1554,28 @@ impl Style {
                         let text =
                             crate::RichText::new(style.to_string()).text_style(style.clone());
                         ui.selectable_value(override_text_style, Some(style), text);
+                    }
+                });
+            ui.end_row();
+
+            fn valign_name(valign: Align) -> &'static str {
+                match valign {
+                    Align::TOP => "Top",
+                    Align::Center => "Center",
+                    Align::BOTTOM => "Bottom",
+                }
+            }
+
+            ui.label("Override text valign");
+            crate::ComboBox::from_id_salt("override_text_valign")
+                .selected_text(match override_text_valign {
+                    None => "None",
+                    Some(override_text_valign) => valign_name(*override_text_valign),
+                })
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(override_text_valign, None, "None");
+                    for align in [Align::TOP, Align::Center, Align::BOTTOM] {
+                        ui.selectable_value(override_text_valign, Some(align), valign_name(align));
                     }
                 });
             ui.end_row();

--- a/crates/egui/src/text_selection/accesskit_text.rs
+++ b/crates/egui/src/text_selection/accesskit_text.rs
@@ -77,7 +77,7 @@ pub fn update_accesskit_for_text_widget(
                     value.push(glyph.chr);
                     character_lengths.push((value.len() - old_len) as _);
                     character_positions.push(glyph.pos.x - row.rect.min.x);
-                    character_widths.push(glyph.size.x);
+                    character_widths.push(glyph.advance_width);
                 }
 
                 if row.ends_with_newline {

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -621,8 +621,7 @@ impl Ui {
     #[inline]
     pub fn text_valign(&self) -> Align {
         #![allow(clippy::unused_self)]
-        // We currently always center-align, because that makes emojis and text nice and centered everywhere.
-        Align::Center
+        Align::BOTTOM
     }
 
     /// Create a painter for a sub-region of this Ui.

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -620,8 +620,9 @@ impl Ui {
     /// How to vertically align text
     #[inline]
     pub fn text_valign(&self) -> Align {
-        #![allow(clippy::unused_self)]
-        Align::BOTTOM
+        self.style()
+            .override_text_valign
+            .unwrap_or_else(|| self.layout().vertical_align())
     }
 
     /// Create a painter for a sub-region of this Ui.

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -617,6 +617,14 @@ impl Ui {
         self.wrap_mode() == TextWrapMode::Wrap
     }
 
+    /// How to vertically align text
+    #[inline]
+    pub fn text_valign(&self) -> Align {
+        #![allow(clippy::unused_self)]
+        // We currently always center-align, because that makes emojis and text nice and centered everywhere.
+        Align::Center
+    }
+
     /// Create a painter for a sub-region of this Ui.
     ///
     /// The clip-rect of the returned [`Painter`] will be the intersection

--- a/crates/egui/src/widget_text.rs
+++ b/crates/egui/src/widget_text.rs
@@ -648,7 +648,7 @@ impl WidgetText {
         available_width: f32,
         fallback_font: impl Into<FontSelection>,
     ) -> Arc<Galley> {
-        let valign = ui.layout().vertical_align();
+        let valign = ui.text_valign();
         let style = ui.style();
 
         let wrap_mode = wrap_mode.unwrap_or_else(|| ui.wrap_mode());

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -251,9 +251,9 @@ impl Widget for Button<'_> {
         if image.is_some() && galley.is_some() {
             desired_size.x += ui.spacing().icon_spacing;
         }
-        if let Some(text) = &galley {
-            desired_size.x += text.size().x;
-            desired_size.y = desired_size.y.max(text.size().y);
+        if let Some(galley) = &galley {
+            desired_size.x += galley.size().x;
+            desired_size.y = desired_size.y.max(galley.size().y);
         }
         if let Some(shortcut_galley) = &shortcut_galley {
             desired_size.x += gap_before_shortcut_text + shortcut_galley.size().x;

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -162,7 +162,7 @@ impl Label {
             return (pos, galley, response);
         }
 
-        let valign = ui.layout().vertical_align();
+        let valign = ui.text_valign();
         let mut layout_job = self
             .text
             .into_layout_job(ui.style(), FontSelection::Default, valign);

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -580,8 +580,17 @@ fn text_layout_demo(ui: &mut Ui) {
     };
 
     job.append(
-        "This is a demonstration of ",
+        "This",
         first_row_indentation,
+        TextFormat {
+            color: default_color,
+            font_id: FontId::proportional(20.0),
+            ..Default::default()
+        },
+    );
+    job.append(
+        " is a demonstration of ",
+        0.0,
         TextFormat {
             color: default_color,
             ..Default::default()
@@ -632,7 +641,7 @@ fn text_layout_demo(ui: &mut Ui) {
         "mixing ",
         0.0,
         TextFormat {
-            font_id: FontId::proportional(17.0),
+            font_id: FontId::proportional(20.0),
             color: default_color,
             ..Default::default()
         },

--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -469,14 +469,10 @@ impl Font {
     }
 
     pub(crate) fn ascent(&self) -> f32 {
-        if self.fonts.is_empty() {
-            self.row_height
+        if let Some(first) = self.fonts.first() {
+            first.ascent()
         } else {
-            let mut max_ascent = 0.0;
-            for font in &self.fonts {
-                max_ascent = f32::max(max_ascent, font.ascent());
-            }
-            max_ascent
+            self.row_height
         }
     }
 

--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -468,6 +468,18 @@ impl Font {
         (Some(font_impl), glyph_info)
     }
 
+    pub(crate) fn ascent(&self) -> f32 {
+        if self.fonts.is_empty() {
+            self.row_height
+        } else {
+            let mut max_ascent = 0.0;
+            for font in &self.fonts {
+                max_ascent = f32::max(max_ascent, font.ascent());
+            }
+            max_ascent
+        }
+    }
+
     fn glyph_info_no_cache_or_fallback(&mut self, c: char) -> Option<(FontIndex, GlyphInfo)> {
         for (font_index, font_impl) in self.fonts.iter().enumerate() {
             if let Some(glyph_info) = font_impl.glyph_info(c) {

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -189,7 +189,7 @@ impl Default for FontTweak {
             scale: 1.0,
             y_offset_factor: 0.0,
             y_offset: 0.0,
-            baseline_offset_factor: -0.0333, // makes the default fonts look more centered in buttons and such
+            baseline_offset_factor: 0.0,
         }
     }
 }
@@ -270,30 +270,30 @@ impl Default for FontDefinitions {
 
         let mut families = BTreeMap::new();
 
+        // We tweak the fonts slightly to improve their vertical alignment in buttons etc:
         font_data.insert("Hack".to_owned(), FontData::from_static(HACK_REGULAR));
-        font_data.insert(
-            "Ubuntu-Light".to_owned(),
-            FontData::from_static(UBUNTU_LIGHT),
-        );
 
         // Some good looking emojis. Use as first priority:
         font_data.insert(
             "NotoEmoji-Regular".to_owned(),
             FontData::from_static(NOTO_EMOJI_REGULAR).tweak(FontTweak {
-                scale: 0.81, // make it smaller
+                scale: 0.81,             // Make smaller
+                y_offset_factor: -0.120, // Move up
                 ..Default::default()
             }),
+        );
+
+        font_data.insert(
+            "Ubuntu-Light".to_owned(),
+            FontData::from_static(UBUNTU_LIGHT),
         );
 
         // Bigger emojis, and more. <http://jslegers.github.io/emoji-icon-font/>:
         font_data.insert(
             "emoji-icon-font".to_owned(),
             FontData::from_static(EMOJI_ICON).tweak(FontTweak {
-                scale: 0.88, // make it smaller
-
-                // probably not correct, but this does make texts look better (#2724 for details)
-                y_offset_factor: 0.11, // move glyphs down to better align with common fonts
-                baseline_offset_factor: -0.11, // ...now the entire row is a bit down so shift it back
+                scale: 0.90,           // Make smaller
+                y_offset_factor: 0.09, // Move down
                 ..Default::default()
             }),
         );

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -270,14 +270,13 @@ impl Default for FontDefinitions {
 
         let mut families = BTreeMap::new();
 
-        // We tweak the fonts slightly to improve their vertical alignment in buttons etc:
         font_data.insert("Hack".to_owned(), FontData::from_static(HACK_REGULAR));
 
         // Some good looking emojis. Use as first priority:
         font_data.insert(
             "NotoEmoji-Regular".to_owned(),
             FontData::from_static(NOTO_EMOJI_REGULAR).tweak(FontTweak {
-                scale: 0.81,             // Make smaller
+                scale: 0.81, // Make smaller
                 ..Default::default()
             }),
         );
@@ -291,7 +290,7 @@ impl Default for FontDefinitions {
         font_data.insert(
             "emoji-icon-font".to_owned(),
             FontData::from_static(EMOJI_ICON).tweak(FontTweak {
-                scale: 0.90,           // Make smaller
+                scale: 0.90, // Make smaller
                 ..Default::default()
             }),
         );

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -278,7 +278,6 @@ impl Default for FontDefinitions {
             "NotoEmoji-Regular".to_owned(),
             FontData::from_static(NOTO_EMOJI_REGULAR).tweak(FontTweak {
                 scale: 0.81,             // Make smaller
-                y_offset_factor: -0.120, // Move up
                 ..Default::default()
             }),
         );
@@ -293,7 +292,6 @@ impl Default for FontDefinitions {
             "emoji-icon-font".to_owned(),
             FontData::from_static(EMOJI_ICON).tweak(FontTweak {
                 scale: 0.90,           // Make smaller
-                y_offset_factor: 0.09, // Move down
                 ..Default::default()
             }),
         );

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -607,7 +607,7 @@ fn galley_from_rows(
         }
         max_row_height = point_scale.round_to_pixel(max_row_height);
 
-        // Now position each glyph:
+        // Now position each glyph vertically:
         for glyph in &mut row.glyphs {
             let format = &job.sections[glyph.section_index as usize].format;
 
@@ -619,7 +619,7 @@ fn galley_from_rows(
 
                 // When mixing different `FontImpl` (e.g. latin and emojis),
                 // we always center the difference:
-                + 0.5 * (glyph.line_height - glyph.font_impl_height);
+                + 0.5 * (glyph.font_height - glyph.font_impl_height);
 
             glyph.pos.y = point_scale.round_to_pixel(glyph.pos.y);
         }

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -604,7 +604,12 @@ fn galley_from_rows(
 
             glyph.pos.y = cursor_y
                 + glyph.font_impl_ascent
-                + format.valign.to_factor() * (row_height - glyph.font_impl_height);
+
+                + format.valign.to_factor() * (row_height - glyph.font_impl_height)
+
+                // When mixing different `FontImpl` (e.g. latin and emojis),
+                // we always center the difference:
+                + 0.5 * (glyph.font_impl_height - glyph.size.y);
 
             glyph.pos.y = point_scale.round_to_pixel(glyph.pos.y);
         }

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -172,7 +172,8 @@ fn layout_section(
                 chr,
                 pos: pos2(paragraph.cursor_x, f32::NAN),
                 size: vec2(glyph_info.advance_width, line_height),
-                ascent: font.ascent(),
+                font_impl_ascent: font_impl.map_or(0.0, |f| f.ascent()),
+                font_ascent: font.ascent(),
                 uv_rect: glyph_info.uv_rect,
                 section_index,
             });
@@ -392,7 +393,8 @@ fn replace_last_glyph_with_overflow_character(
             chr: overflow_character,
             pos: pos2(x, f32::NAN),
             size: vec2(replacement_glyph_info.advance_width, line_height),
-            ascent: font.ascent(),
+            font_impl_ascent: font_impl.map_or(0.0, |f| f.ascent()),
+            font_ascent: font.ascent(),
             uv_rect: replacement_glyph_info.uv_rect,
             section_index,
         });
@@ -404,13 +406,14 @@ fn replace_last_glyph_with_overflow_character(
 
         let x = 0.0; // TODO(emilk): heed paragraph leading_space 😬
 
-        let (_, replacement_glyph_info) = font.font_impl_and_glyph_info(overflow_character);
+        let (font_impl, replacement_glyph_info) = font.font_impl_and_glyph_info(overflow_character);
 
         row.glyphs.push(Glyph {
             chr: overflow_character,
             pos: pos2(x, f32::NAN),
             size: vec2(replacement_glyph_info.advance_width, line_height),
-            ascent: font.ascent(),
+            font_impl_ascent: font_impl.map_or(0.0, |f| f.ascent()),
+            font_ascent: font.ascent(),
             uv_rect: replacement_glyph_info.uv_rect,
             section_index,
         });
@@ -596,8 +599,9 @@ fn galley_from_rows(
         for glyph in &mut row.glyphs {
             let format = &job.sections[glyph.section_index as usize].format;
 
-            glyph.pos.y =
-                cursor_y + glyph.ascent + format.valign.to_factor() * (row_height - glyph.size.y);
+            glyph.pos.y = cursor_y
+                + glyph.font_impl_ascent
+                + format.valign.to_factor() * (row_height - glyph.size.y);
 
             glyph.pos.y = point_scale.round_to_pixel(glyph.pos.y);
         }

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -172,6 +172,7 @@ fn layout_section(
                 chr,
                 pos: pos2(paragraph.cursor_x, f32::NAN),
                 size: vec2(glyph_info.advance_width, line_height),
+                font_impl_height: font_impl.map_or(0.0, |f| f.row_height()),
                 font_impl_ascent: font_impl.map_or(0.0, |f| f.ascent()),
                 font_ascent: font.ascent(),
                 uv_rect: glyph_info.uv_rect,
@@ -393,6 +394,7 @@ fn replace_last_glyph_with_overflow_character(
             chr: overflow_character,
             pos: pos2(x, f32::NAN),
             size: vec2(replacement_glyph_info.advance_width, line_height),
+            font_impl_height: font_impl.map_or(0.0, |f| f.row_height()),
             font_impl_ascent: font_impl.map_or(0.0, |f| f.ascent()),
             font_ascent: font.ascent(),
             uv_rect: replacement_glyph_info.uv_rect,
@@ -412,6 +414,7 @@ fn replace_last_glyph_with_overflow_character(
             chr: overflow_character,
             pos: pos2(x, f32::NAN),
             size: vec2(replacement_glyph_info.advance_width, line_height),
+            font_impl_height: font_impl.map_or(0.0, |f| f.row_height()),
             font_impl_ascent: font_impl.map_or(0.0, |f| f.ascent()),
             font_ascent: font.ascent(),
             uv_rect: replacement_glyph_info.uv_rect,
@@ -595,13 +598,13 @@ fn galley_from_rows(
         }
         row_height = point_scale.round_to_pixel(row_height);
 
-        // Now positions each glyph:
+        // Now position each glyph:
         for glyph in &mut row.glyphs {
             let format = &job.sections[glyph.section_index as usize].format;
 
             glyph.pos.y = cursor_y
                 + glyph.font_impl_ascent
-                + format.valign.to_factor() * (row_height - glyph.size.y);
+                + format.valign.to_factor() * (row_height - glyph.font_impl_height);
 
             glyph.pos.y = point_scale.round_to_pixel(glyph.pos.y);
         }

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -605,11 +605,12 @@ fn galley_from_rows(
             glyph.pos.y = cursor_y
                 + glyph.font_impl_ascent
 
-                + format.valign.to_factor() * (row_height - glyph.font_impl_height)
+                // Apply valign to the different in height of the entire row, and the height of this `Font`:
+                + format.valign.to_factor() * (row_height - glyph.size.y)
 
                 // When mixing different `FontImpl` (e.g. latin and emojis),
                 // we always center the difference:
-                + 0.5 * (glyph.font_impl_height - glyph.size.y);
+                + 0.5 * (glyph.size.y - glyph.font_impl_height);
 
             glyph.pos.y = point_scale.round_to_pixel(glyph.pos.y);
         }

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -172,7 +172,7 @@ fn layout_section(
                 chr,
                 pos: pos2(paragraph.cursor_x, f32::NAN),
                 size: vec2(glyph_info.advance_width, line_height),
-                ascent: font_impl.map_or(0.0, |font| font.ascent()), // Failure to find the font here would be weird
+                ascent: font.ascent(),
                 uv_rect: glyph_info.uv_rect,
                 section_index,
             });
@@ -392,7 +392,7 @@ fn replace_last_glyph_with_overflow_character(
             chr: overflow_character,
             pos: pos2(x, f32::NAN),
             size: vec2(replacement_glyph_info.advance_width, line_height),
-            ascent: font_impl.map_or(0.0, |font| font.ascent()), // Failure to find the font here would be weird
+            ascent: font.ascent(),
             uv_rect: replacement_glyph_info.uv_rect,
             section_index,
         });
@@ -404,13 +404,13 @@ fn replace_last_glyph_with_overflow_character(
 
         let x = 0.0; // TODO(emilk): heed paragraph leading_space 😬
 
-        let (font_impl, replacement_glyph_info) = font.font_impl_and_glyph_info(overflow_character);
+        let (_, replacement_glyph_info) = font.font_impl_and_glyph_info(overflow_character);
 
         row.glyphs.push(Glyph {
             chr: overflow_character,
             pos: pos2(x, f32::NAN),
             size: vec2(replacement_glyph_info.advance_width, line_height),
-            ascent: font_impl.map_or(0.0, |font| font.ascent()), // Failure to find the font here would be weird
+            ascent: font.ascent(),
             uv_rect: replacement_glyph_info.uv_rect,
             section_index,
         });

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -279,6 +279,13 @@ pub struct TextFormat {
 
     /// If you use a small font and [`Align::TOP`] you
     /// can get the effect of raised text.
+    ///
+    /// If you use a small font and [`Align::BOTTOM`]
+    /// you get the effect of a subscript.
+    ///
+    /// If you use [`Align::center`], you get text that is centered
+    /// around a common center-line, which is nice when mixining emojis
+    /// and normal text in e.g. a button.
     pub valign: Align,
     // TODO(emilk): lowered
 }
@@ -295,7 +302,7 @@ impl Default for TextFormat {
             italics: false,
             underline: Stroke::NONE,
             strikethrough: Stroke::NONE,
-            valign: Align::BOTTOM,
+            valign: Align::Center,
         }
     }
 }

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -608,19 +608,22 @@ pub struct Glyph {
     /// Logical position: pos.y is the same for all chars of the same [`TextFormat`].
     pub pos: Pos2,
 
-    /// `ascent` value from the `Font`
+    pub advance_width: f32,
+
+    /// Height of this row
+    pub line_height: f32,
+
+    /// [`Font::ascent`]
     pub font_ascent: f32,
 
-    /// `row_height` value from the `FontImpl`
+    /// [`Font::row_height`]
+    pub font_height: f32,
+
+    /// [`FontImpl::row_height`]
     pub font_impl_height: f32,
 
-    /// `ascent` value from the `FontImpl`
+    /// [`FontImpl::ascent`]
     pub font_impl_ascent: f32,
-
-    /// Advance width and line height.
-    ///
-    /// Does not control the visual size of the glyph (see [`Self::uv_rect`] for that).
-    pub size: Vec2,
 
     /// Position and size of the glyph in the font texture, in texels.
     pub uv_rect: UvRect,
@@ -630,14 +633,20 @@ pub struct Glyph {
 }
 
 impl Glyph {
+    #[inline]
+    pub fn size(&self) -> Vec2 {
+        Vec2::new(self.advance_width, self.line_height)
+    }
+
+    #[inline]
     pub fn max_x(&self) -> f32 {
-        self.pos.x + self.size.x
+        self.pos.x + self.advance_width
     }
 
     /// Same y range for all characters with the same [`TextFormat`].
     #[inline]
     pub fn logical_rect(&self) -> Rect {
-        Rect::from_min_size(self.pos - vec2(0.0, self.font_ascent), self.size)
+        Rect::from_min_size(self.pos - vec2(0.0, self.font_ascent), self.size())
     }
 }
 

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -613,7 +613,7 @@ pub struct Glyph {
     /// Height of this row of text.
     ///
     /// Usually same as [`Self::font_height`],
-    /// unless explicitly overriden by [`TextFormat::line_height`].
+    /// unless explicitly overridden by [`TextFormat::line_height`].
     pub line_height: f32,
 
     /// [`Font::ascent`]

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -283,11 +283,10 @@ pub struct TextFormat {
     /// If you use a small font and [`Align::BOTTOM`]
     /// you get the effect of a subscript.
     ///
-    /// If you use [`Align::center`], you get text that is centered
+    /// If you use [`Align::Center`], you get text that is centered
     /// around a common center-line, which is nice when mixining emojis
     /// and normal text in e.g. a button.
     pub valign: Align,
-    // TODO(emilk): lowered
 }
 
 impl Default for TextFormat {

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -610,7 +610,10 @@ pub struct Glyph {
 
     pub advance_width: f32,
 
-    /// Height of this row
+    /// Height of this row of text.
+    ///
+    /// Usually same as [`Self::font_height`],
+    /// unless explicitly overriden by [`TextFormat::line_height`].
     pub line_height: f32,
 
     /// [`Font::ascent`]

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -608,8 +608,11 @@ pub struct Glyph {
     /// Logical position: pos.y is the same for all chars of the same [`TextFormat`].
     pub pos: Pos2,
 
-    /// `ascent` value from the font
-    pub ascent: f32,
+    /// `ascent` value from the `Font`
+    pub font_ascent: f32,
+
+    /// `ascent` value from the `FontImpl`
+    pub font_impl_ascent: f32,
 
     /// Advance width and line height.
     ///
@@ -631,7 +634,7 @@ impl Glyph {
     /// Same y range for all characters with the same [`TextFormat`].
     #[inline]
     pub fn logical_rect(&self) -> Rect {
-        Rect::from_min_size(self.pos - vec2(0.0, self.ascent), self.size)
+        Rect::from_min_size(self.pos - vec2(0.0, self.font_ascent), self.size)
     }
 }
 

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -301,7 +301,7 @@ impl Default for TextFormat {
             italics: false,
             underline: Stroke::NONE,
             strikethrough: Stroke::NONE,
-            valign: Align::Center,
+            valign: Align::BOTTOM,
         }
     }
 }

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -611,6 +611,9 @@ pub struct Glyph {
     /// `ascent` value from the `Font`
     pub font_ascent: f32,
 
+    /// `row_height` value from the `FontImpl`
+    pub font_impl_height: f32,
+
     /// `ascent` value from the `FontImpl`
     pub font_impl_ascent: f32,
 

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -608,6 +608,7 @@ pub struct Glyph {
     /// Logical position: pos.y is the same for all chars of the same [`TextFormat`].
     pub pos: Pos2,
 
+    /// Logical width of the glyph.
     pub advance_width: f32,
 
     /// Height of this row of text.
@@ -616,17 +617,17 @@ pub struct Glyph {
     /// unless explicitly overridden by [`TextFormat::line_height`].
     pub line_height: f32,
 
-    /// [`Font::ascent`]
+    /// The ascent of this font.
     pub font_ascent: f32,
 
-    /// [`Font::row_height`]
+    /// The row/line height of this font.
     pub font_height: f32,
 
-    /// [`FontImpl::row_height`]
-    pub font_impl_height: f32,
-
-    /// [`FontImpl::ascent`]
+    /// The ascent of the sub-font within the font ("FontImpl").
     pub font_impl_ascent: f32,
+
+    /// The row/line height of the sub-font within the font ("FontImpl").
+    pub font_impl_height: f32,
 
     /// Position and size of the glyph in the font texture, in texels.
     pub uv_rect: UvRect,


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/4929
* Builds on top of https://github.com/emilk/egui/pull/2724 by @lictex (ptal!)
* Implement `Center` and `Max` vertical text alignment properly
* Change default vertical alignment of text to centering

The end result is that text centers better in buttons and other places, especially when mixing in emojis.
Before, mixing text of different heights (e.g. emojis and latin text) in a label or button would cause the text to jump vertically.

## Before
This is `master`, with custom `FontTweak` to move fonts up and down:
<img width="1714" alt="image" src="https://github.com/user-attachments/assets/a10e2927-e824-4580-baea-124c0b38a527">
<img width="102" alt="image" src="https://github.com/user-attachments/assets/cd41f415-197b-42cd-9558-d46d63c21dcb">


## After
This PR, with the default (zero) `FontTweak`

<img width="102" alt="image" src="https://github.com/user-attachments/assets/15e7d896-66b1-4996-ab58-dd1850b19a63">

<img width="1714" alt="image" src="https://github.com/user-attachments/assets/54ec708c-7698-4754-b1fc-fea0fd240ec9">
