### PR TITLE
Temporary Fix: when selecting only a space or '\n' in TextEdit, the selection is not filled.

### DIFF
--- a/crates/egui/src/text_selection/label_text_selection.rs
+++ b/crates/egui/src/text_selection/label_text_selection.rs
@@ -593,8 +593,9 @@ impl LabelSelectionState {
 
         if let Some(cursor_range) = cursor_range {
             paint_text_selection(
+                ui,
+                galley_pos,
                 galley,
-                ui.visuals(),
                 &cursor_range,
                 Some(&mut new_vertex_indices),
             );

--- a/crates/egui/src/text_selection/visuals.rs
+++ b/crates/egui/src/text_selection/visuals.rs
@@ -12,8 +12,9 @@ pub struct RowVertexIndices {
 
 /// Adds text selection rectangles to the galley.
 pub fn paint_text_selection(
+    ui: &Ui,
+    galley_pos: crate::Pos2,
     galley: &mut Arc<Galley>,
-    visuals: &Visuals,
     cursor_range: &CursorRange,
     mut new_vertex_indices: Option<&mut Vec<RowVertexIndices>>,
 ) {
@@ -25,7 +26,7 @@ pub fn paint_text_selection(
     // and so we need to clone it if it is shared:
     let galley: &mut Galley = Arc::make_mut(galley);
 
-    let color = visuals.selection.bg_fill;
+    let color = ui.visuals().selection.bg_fill;
     let [min, max] = cursor_range.sorted_cursors();
     let min = min.rcursor;
     let max = max.rcursor;
@@ -47,6 +48,13 @@ pub fn paint_text_selection(
             };
             row.rect.right() + newline_size
         };
+
+        let rect = Rect::from_min_max(
+            galley_pos + vec2(left, row.min_y()),
+            galley_pos + vec2(right, row.max_y()),
+        );
+        let weak_color = color.linear_multiply(0.5);
+        let _shape_idx = ui.painter().rect_filled(rect, 0.0, weak_color);
 
         let rect = Rect::from_min_max(pos2(left, row.min_y()), pos2(right, row.max_y()));
         let mesh = &mut row.visuals.mesh;

--- a/crates/egui/src/text_selection/visuals.rs
+++ b/crates/egui/src/text_selection/visuals.rs
@@ -53,8 +53,7 @@ pub fn paint_text_selection(
             galley_pos + vec2(left, row.min_y()),
             galley_pos + vec2(right, row.max_y()),
         );
-        let weak_color = color.linear_multiply(0.5);
-        let _shape_idx = ui.painter().rect_filled(rect, 0.0, weak_color);
+        let _shape_idx = ui.painter().rect_filled(rect, 0.0, color);
 
         let rect = Rect::from_min_max(pos2(left, row.min_y()), pos2(right, row.max_y()));
         let mesh = &mut row.visuals.mesh;

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -702,7 +702,7 @@ impl<'t> TextEdit<'t> {
             if has_focus {
                 if let Some(cursor_range) = state.cursor.range(&galley) {
                     // Add text selection rectangles to the galley:
-                    paint_text_selection(&mut galley, ui.visuals(), &cursor_range, None);
+                    paint_text_selection(ui, galley_pos, &mut galley, &cursor_range, None);
                 }
             }
 


### PR DESCRIPTION
`This is a Temporary Example.`

Until someone finds a better way, use the old method of painting selections.

* Related #5017
* Related #5078
