### PR TITLE
Update sampler along with texture on wgpu backend

### DIFF
--- a/crates/egui-wgpu/src/renderer.rs
+++ b/crates/egui-wgpu/src/renderer.rs
@@ -164,13 +164,14 @@ struct SlicedBuffer {
 }
 
 pub struct Texture {
-    /// The texture may be None if the `TextureId` is just a handle to a user-provided sampler.
+    /// The texture may be None if the `TextureId` is just a handle to a user-provided bind-group.
     pub texture: Option<wgpu::Texture>,
 
     /// Bindgroup for the texture + sampler.
     pub bind_group: wgpu::BindGroup,
 
-    /// Options describing the sampler used in the bind group. This may be None if the `TextureId` is just a handle to a user-provided sampler.
+    /// Options describing the sampler used in the bind group. This may be None if the `TextureId`
+    /// is just a handle to a user-provided bind-group.
     pub options: Option<epaint::textures::TextureOptions>,
 }
 


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes #5121
* [x] I have followed the instructions in the PR template

This unifies the code paths in `update_texture` somewhat, so that the texture sampler and bind group are always replaced.

Not sure whether removing and reinserting the texture from and into the `textures` map, or creating a new bind group, has much of a performance impact. An alternative, as described in #5121, would be to split the functionality for updating a texture's data from updating its options, so that we don't have to unconditionally update the bind group (or do something like store the options to check if they're changed).