### PR TITLE
Use the largest ascent as the ascent for a font

### DIFF
--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -468,6 +468,18 @@ impl Font {
         (Some(font_impl), glyph_info)
     }
 
+    pub(crate) fn ascent(&self) -> f32 {
+        if self.fonts.is_empty() {
+            self.row_height
+        } else {
+            let mut max_ascent = 0.0;
+            for font in &self.fonts {
+                max_ascent = f32::max(max_ascent, font.ascent());
+            }
+            max_ascent
+        }
+    }
+
     fn glyph_info_no_cache_or_fallback(&mut self, c: char) -> Option<(FontIndex, GlyphInfo)> {
         for (font_index, font_impl) in self.fonts.iter().enumerate() {
             if let Some(glyph_info) = font_impl.glyph_info(c) {

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -189,7 +189,7 @@ impl Default for FontTweak {
             scale: 1.0,
             y_offset_factor: 0.0,
             y_offset: 0.0,
-            baseline_offset_factor: -0.0333, // makes the default fonts look more centered in buttons and such
+            baseline_offset_factor: 0.0,
         }
     }
 }
@@ -289,11 +289,8 @@ impl Default for FontDefinitions {
         font_data.insert(
             "emoji-icon-font".to_owned(),
             FontData::from_static(EMOJI_ICON).tweak(FontTweak {
-                scale: 0.88, // make it smaller
-
-                // probably not correct, but this does make texts look better (#2724 for details)
-                y_offset_factor: 0.11, // move glyphs down to better align with common fonts
-                baseline_offset_factor: -0.11, // ...now the entire row is a bit down so shift it back
+                scale: 0.88,           // Make it smaller
+                y_offset_factor: 0.04, // Move down slightly
                 ..Default::default()
             }),
         );

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -172,7 +172,7 @@ fn layout_section(
                 chr,
                 pos: pos2(paragraph.cursor_x, f32::NAN),
                 size: vec2(glyph_info.advance_width, line_height),
-                ascent: font_impl.map_or(0.0, |font| font.ascent()), // Failure to find the font here would be weird
+                ascent: font.ascent(),
                 uv_rect: glyph_info.uv_rect,
                 section_index,
             });
@@ -392,7 +392,7 @@ fn replace_last_glyph_with_overflow_character(
             chr: overflow_character,
             pos: pos2(x, f32::NAN),
             size: vec2(replacement_glyph_info.advance_width, line_height),
-            ascent: font_impl.map_or(0.0, |font| font.ascent()), // Failure to find the font here would be weird
+            ascent: font.ascent(),
             uv_rect: replacement_glyph_info.uv_rect,
             section_index,
         });
@@ -404,13 +404,13 @@ fn replace_last_glyph_with_overflow_character(
 
         let x = 0.0; // TODO(emilk): heed paragraph leading_space 😬
 
-        let (font_impl, replacement_glyph_info) = font.font_impl_and_glyph_info(overflow_character);
+        let (_, replacement_glyph_info) = font.font_impl_and_glyph_info(overflow_character);
 
         row.glyphs.push(Glyph {
             chr: overflow_character,
             pos: pos2(x, f32::NAN),
             size: vec2(replacement_glyph_info.advance_width, line_height),
-            ascent: font_impl.map_or(0.0, |font| font.ascent()), // Failure to find the font here would be weird
+            ascent: font.ascent(),
             uv_rect: replacement_glyph_info.uv_rect,
             section_index,
         });


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/4929
* Builds on top of https://github.com/emilk/egui/pull/2724 by @lictex (ptal!)

I think we need both this _and_ some sort of centering (like in https://github.com/emilk/egui/pull/5117) – I'll experiment more. Maybe we should to take the `FontImpl` ascent _and_ the `Font` ascent into account when centering 🤔 