### PR TITLE
Fix empty grids repeatedly requesting a discard

### DIFF
--- a/crates/egui/src/grid.rs
+++ b/crates/egui/src/grid.rs
@@ -262,7 +262,9 @@ impl GridLayout {
     }
 
     pub(crate) fn save(&self) {
-        if self.curr_state != self.prev_state {
+        // We need to always save state on the first frame, otherwise request_discard
+        // would be called repeatedly (see #5132)
+        if self.curr_state != self.prev_state || self.is_first_frame {
             self.curr_state.clone().store(&self.ctx, self.id);
             self.ctx.request_repaint();
         }


### PR DESCRIPTION
* Closes <https://github.com/emilk/egui/issues/5132>
* [x] I have followed the instructions in the PR template

This does cause a slight difference in the amount of space allocated by a empty grid, is this a problem?
Before:

<img width="113" alt="image" src="https://github.com/user-attachments/assets/88c9c1a8-2ab8-4b01-8d57-0eb0655fa0e4">

After:

<img width="101" alt="image" src="https://github.com/user-attachments/assets/8e1c9d1b-54d6-43b9-9e37-2614dd90d6fe">
