### PR TITLE
Add `DebugOptions::show_unaligned`

### DIFF
--- a/crates/ecolor/src/color32.rs
+++ b/crates/ecolor/src/color32.rs
@@ -47,6 +47,7 @@ impl Color32 {
     pub const LIGHT_RED: Self = Self::from_rgb(255, 128, 128);
 
     pub const YELLOW: Self = Self::from_rgb(255, 255, 0);
+    pub const ORANGE: Self = Self::from_rgb(255, 165, 0);
     pub const LIGHT_YELLOW: Self = Self::from_rgb(255, 255, 0xE0);
     pub const KHAKI: Self = Self::from_rgb(240, 230, 140);
 

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1166,6 +1166,13 @@ pub struct DebugOptions {
 
     /// Show interesting widgets under the mouse cursor.
     pub show_widget_hits: bool,
+
+    /// If true, highlight widgets that are not aligned to integer point coordinates.
+    ///
+    /// It's usually a good idea to keep to integer coordinates to avoid rounding issues.
+    ///
+    /// See <https://github.com/emilk/egui/issues/5163> for more.
+    pub show_unaligned: bool,
 }
 
 #[cfg(debug_assertions)]
@@ -1181,6 +1188,7 @@ impl Default for DebugOptions {
             show_resize: false,
             show_interactive_widgets: false,
             show_widget_hits: false,
+            show_unaligned: false,
         }
     }
 }
@@ -2190,6 +2198,7 @@ impl DebugOptions {
             show_resize,
             show_interactive_widgets,
             show_widget_hits,
+            show_unaligned,
         } = self;
 
         {
@@ -2218,6 +2227,11 @@ impl DebugOptions {
         );
 
         ui.checkbox(show_widget_hits, "Show widgets under mouse pointer");
+
+        ui.checkbox(
+            show_unaligned,
+            "Show rectangles not aligned to integer point coordinates",
+        );
 
         ui.vertical_centered(|ui| reset_button(ui, self, "Reset debug options"));
     }

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2962,7 +2962,32 @@ impl Drop for Ui {
 /// Show this rectangle to the user if certain debug options are set.
 #[cfg(debug_assertions)]
 fn register_rect(ui: &Ui, rect: Rect) {
+    use emath::Align2;
+
     let debug = ui.style().debug;
+
+    if debug.show_unaligned {
+        let unaligned_line = |p0: Pos2, p1: Pos2| {
+            let color = Color32::ORANGE;
+            let font_id = TextStyle::Monospace.resolve(ui.style());
+            ui.painter().line_segment([p0, p1], (1.0, color));
+            ui.painter()
+                .text(p0, Align2::LEFT_TOP, "Unaligned", font_id, color);
+        };
+
+        if rect.left().fract() != 0.0 {
+            unaligned_line(rect.left_top(), rect.left_bottom());
+        }
+        if rect.right().fract() != 0.0 {
+            unaligned_line(rect.right_top(), rect.right_bottom());
+        }
+        if rect.top().fract() != 0.0 {
+            unaligned_line(rect.left_top(), rect.right_top());
+        }
+        if rect.bottom().fract() != 0.0 {
+            unaligned_line(rect.left_bottom(), rect.right_bottom());
+        }
+    }
 
     let show_callstacks = debug.debug_on_hover
         || debug.debug_on_hover_with_all_modifiers && ui.input(|i| i.modifiers.all());


### PR DESCRIPTION
This tool highlights coordinates that are non-integer.

* Closes https://github.com/emilk/egui/issues/4927
* Will be used for https://github.com/emilk/egui/issues/5163

This is disabled by default (even in debug builds), because so many widgets cause un-alignment currently.

This is how it looks when enabled:
![image](https://github.com/user-attachments/assets/bb299443-7ad2-4e21-b600-d7538b8b7192)
