### PR TITLE
Fix bug causing tooltips with dynamic content to shrink

### DIFF
--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -790,6 +790,10 @@ impl Response {
     #[doc(alias = "tooltip")]
     pub fn on_hover_text_at_pointer(self, text: impl Into<WidgetText>) -> Self {
         self.on_hover_ui_at_pointer(|ui| {
+            // Prevent `Area` auto-sizing from shrinking tooltips with dynamic content.
+            // See https://github.com/emilk/egui/issues/5167
+            ui.set_max_width(ui.spacing().tooltip_width);
+
             ui.add(crate::widgets::Label::new(text));
         })
     }
@@ -803,6 +807,10 @@ impl Response {
     #[doc(alias = "tooltip")]
     pub fn on_hover_text(self, text: impl Into<WidgetText>) -> Self {
         self.on_hover_ui(|ui| {
+            // Prevent `Area` auto-sizing from shrinking tooltips with dynamic content.
+            // See https://github.com/emilk/egui/issues/5167
+            ui.set_max_width(ui.spacing().tooltip_width);
+
             ui.add(crate::widgets::Label::new(text));
         })
     }
@@ -822,6 +830,10 @@ impl Response {
     /// Show this text when hovering if the widget is disabled.
     pub fn on_disabled_hover_text(self, text: impl Into<WidgetText>) -> Self {
         self.on_disabled_hover_ui(|ui| {
+            // Prevent `Area` auto-sizing from shrinking tooltips with dynamic content.
+            // See https://github.com/emilk/egui/issues/5167
+            ui.set_max_width(ui.spacing().tooltip_width);
+
             ui.add(crate::widgets::Label::new(text));
         })
     }

--- a/tests/test_size_pass/src/main.rs
+++ b/tests/test_size_pass/src/main.rs
@@ -103,6 +103,12 @@ fn main() -> eframe::Result {
                     ui.label("World");
                     ui.label("Hellooooooooooooooooooooooooo");
                 });
+
+            ui.separator();
+
+            let time = ui.input(|i| i.time);
+            ui.label("Hover for a tooltip with changing content")
+                .on_hover_text(format!("A number: {}", time % 10.0));
         });
     })
 }


### PR DESCRIPTION
Affects `.on_hover_text(…)` with dynamic content (i.e. content that changes over time).

* Closes https://github.com/emilk/egui/issues/5167

`.on_hover_ui` with dynamic content can still hit the shrinking problem. The general solution depends on solving https://github.com/emilk/egui/issues/5138 but a work-around is to add this to your tooltips:

```diff
 response.on_hover_ui(|ui| {
+    ui.set_max_width(ui.spacing().tooltip_width);
     // …
 });
```
