### PR TITLE
Preserves the text cursor position when right-clicking in TextEdit

### DIFF
--- a/crates/egui/src/text_selection/text_cursor_state.rs
+++ b/crates/egui/src/text_selection/text_cursor_state.rs
@@ -124,6 +124,11 @@ impl TextCursorState {
             true
         } else if response.sense.drag {
             if response.hovered() && ui.input(|i| i.pointer.any_pressed()) {
+                // Preserves the text cursor position when right-clicking.
+                if ui.input(|i| i.pointer.secondary_down()) {
+                    return true;
+                }
+
                 // The start of a drag (or a click).
                 if ui.input(|i| i.modifiers.shift) {
                     if let Some(mut cursor_range) = self.range(galley) {


### PR DESCRIPTION
Preserves the text cursor position when right-clicking in TextEdit

**Advantages:**
1. Right-clicking allows you to maintain the cursor position or selection while gaining focus.
2. Right-dragging lets you specify a region starting from the current cursor position.

* Closes #4865
