### PR TITLE
Fix: Selectable whether to key handling in IME

### DIFF
--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -870,7 +870,7 @@ pub struct TextEditStyle {
 impl Default for TextEditStyle {
     fn default() -> Self {
         Self {
-            ime_key_handling: true,
+            ime_key_handling: !cfg!(target_os = "linux"),
         }
     }
 }

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -870,7 +870,10 @@ pub struct TextEditStyle {
 impl Default for TextEditStyle {
     fn default() -> Self {
         Self {
-            ime_key_handling: !cfg!(target_os = "linux"),
+            #[cfg(target_os = "linux")]
+            ime_key_handling: false,
+            #[cfg(not(target_os = "linux"))]
+            ime_key_handling: true,
         }
     }
 }

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -870,9 +870,6 @@ pub struct TextEditStyle {
 impl Default for TextEditStyle {
     fn default() -> Self {
         Self {
-            #[cfg(target_os = "linux")]
-            ime_key_handling: false,
-            #[cfg(not(target_os = "linux"))]
             ime_key_handling: true,
         }
     }

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -857,6 +857,24 @@ impl Default for TextCursorStyle {
     }
 }
 
+/// Defines the style and behavior of a `TextEdit`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(default))]
+pub struct TextEditStyle {
+    /// Indicates whether to provide assistance for IME input.
+    /// Such as backspace and arrow keys handling.
+    pub ime_key_handling: bool,
+}
+
+impl Default for TextEditStyle {
+    fn default() -> Self {
+        Self {
+            ime_key_handling: true,
+        }
+    }
+}
+
 /// Controls the visual style (colors etc) of egui.
 ///
 /// You can change the visuals of a [`Ui`] with [`Ui::visuals_mut`]
@@ -934,6 +952,9 @@ pub struct Visuals {
 
     /// How the text cursor acts.
     pub text_cursor: TextCursorStyle,
+
+    /// Defines the style and behavior of a TextEdit.
+    pub text_edit: TextEditStyle,
 
     /// Allow child widgets to be just on the border and still have a stroke with some thickness
     pub clip_rect_margin: f32,
@@ -1317,6 +1338,7 @@ impl Visuals {
             resize_corner_size: 12.0,
 
             text_cursor: Default::default(),
+            text_edit: Default::default(),
 
             clip_rect_margin: 3.0, // should be at least half the size of the widest frame stroke + max WidgetVisuals::expansion
             button_frame: true,
@@ -1994,6 +2016,7 @@ impl Visuals {
             resize_corner_size,
 
             text_cursor,
+            text_edit,
 
             clip_rect_margin,
             button_frame,
@@ -2051,6 +2074,10 @@ impl Visuals {
 
         ui.collapsing("Text cursor", |ui| {
             text_cursor.ui(ui);
+        });
+
+        ui.collapsing("Text Edit", |ui| {
+            text_edit.ui(ui);
         });
 
         ui.collapsing("Window", |ui| {
@@ -2183,6 +2210,14 @@ impl TextCursorStyle {
                 ui.end_row();
             });
         }
+    }
+}
+
+impl TextEditStyle {
+    fn ui(&mut self, ui: &mut Ui) {
+        let Self { ime_key_handling } = self;
+
+        ui.checkbox(ime_key_handling, "IME key handling");
     }
 }
 

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -881,7 +881,10 @@ fn events(
     let mut events = ui.input(|i| i.filtered_events(&event_filter));
 
     if state.ime_enabled {
-        remove_ime_incompatible_events(&mut events);
+        if ui.visuals().text_edit.ime_key_handling {
+            remove_ime_incompatible_events(&mut events);
+        }
+
         // Process IME events first:
         events.sort_by_key(|e| !matches!(e, Event::Ime(_)));
     }


### PR DESCRIPTION
Fix: Selectable whether to key handling in IME

Fix Issues: Backspace & arrow keys are completely broken

* Related #4912
* Closes #5008
* Closes #5085
* Closes #5181

How about the default value is false on Linux and true on other platforms?
it's `target_os` lint error.
```
impl Default for TextEditStyle {
    fn default() -> Self {
        Self {
            #[cfg(target_os = "linux")]
            ime_key_handling: false,
            #[cfg(not(target_os = "linux"))]
            ime_key_handling: true,
        }
    }
}
```
