### PR TITLE
Replace "an ui" with "a ui"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -855,7 +855,7 @@ egui_extras::install_image_loaders(egui_ctx);
 * Added `Slider::step_by` ([1225](https://github.com/emilk/egui/pull/1225)).
 * Added `Context::move_to_top` and `Context::top_most_layer` for managing the layer on the top ([#1242](https://github.com/emilk/egui/pull/1242)).
 * Support a subset of macOS' emacs input field keybindings in `TextEdit` ([#1243](https://github.com/emilk/egui/pull/1243)).
-* Added ability to scroll an UI into view without specifying an alignment ([1247](https://github.com/emilk/egui/pull/1247)).
+* Added ability to scroll a UI into view without specifying an alignment ([1247](https://github.com/emilk/egui/pull/1247)).
 * Added `Ui::scroll_to_rect` ([1252](https://github.com/emilk/egui/pull/1252)).
 
 ### 🔧 Changed

--- a/crates/egui/src/layout.rs
+++ b/crates/egui/src/layout.rs
@@ -53,7 +53,7 @@ impl Region {
     }
 
     /// Ensure we are big enough to contain the given X-coordinate.
-    /// This is sometimes useful to expand an ui to stretch to a certain place.
+    /// This is sometimes useful to expand a ui to stretch to a certain place.
     pub fn expand_to_include_x(&mut self, x: f32) {
         self.min_rect.extend_with_x(x);
         self.max_rect.extend_with_x(x);
@@ -61,7 +61,7 @@ impl Region {
     }
 
     /// Ensure we are big enough to contain the given Y-coordinate.
-    /// This is sometimes useful to expand an ui to stretch to a certain place.
+    /// This is sometimes useful to expand a ui to stretch to a certain place.
     pub fn expand_to_include_y(&mut self, y: f32) {
         self.min_rect.extend_with_y(y);
         self.max_rect.extend_with_y(y);

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -916,13 +916,13 @@ impl Ui {
     }
 
     /// Ensure we are big enough to contain the given x-coordinate.
-    /// This is sometimes useful to expand an ui to stretch to a certain place.
+    /// This is sometimes useful to expand a ui to stretch to a certain place.
     pub fn expand_to_include_x(&mut self, x: f32) {
         self.placer.expand_to_include_x(x);
     }
 
     /// Ensure we are big enough to contain the given y-coordinate.
-    /// This is sometimes useful to expand an ui to stretch to a certain place.
+    /// This is sometimes useful to expand a ui to stretch to a certain place.
     pub fn expand_to_include_y(&mut self, y: f32) {
         self.placer.expand_to_include_y(y);
     }

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -21,7 +21,7 @@ use crate::{
 /// }
 /// # });
 /// ```
-#[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
+#[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct Button<'a> {
     image: Option<Image<'a>>,
     text: Option<WidgetText>,

--- a/crates/egui/src/widgets/checkbox.rs
+++ b/crates/egui/src/widgets/checkbox.rs
@@ -16,7 +16,7 @@ use crate::{
 /// ui.add(egui::Checkbox::new(&mut my_bool, "Checked"));
 /// # });
 /// ```
-#[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
+#[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct Checkbox<'a> {
     checked: &'a mut bool,
     text: WidgetText,

--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -34,7 +34,7 @@ fn set(get_set_value: &mut GetSetValue<'_>, value: f64) {
 /// ui.add(egui::DragValue::new(&mut my_f32).speed(0.1));
 /// # });
 /// ```
-#[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
+#[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct DragValue<'a> {
     get_set_value: GetSetValue<'a>,
     speed: f64,

--- a/crates/egui/src/widgets/hyperlink.rs
+++ b/crates/egui/src/widgets/hyperlink.rs
@@ -23,7 +23,7 @@ use self::text_selection::LabelSelectionState;
 /// }
 /// # });
 /// ```
-#[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
+#[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct Link {
     text: WidgetText,
 }
@@ -88,7 +88,7 @@ impl Widget for Link {
 /// ui.add(egui::Hyperlink::from_label_and_url("My favorite repo", "https://github.com/emilk/egui"));
 /// # });
 /// ```
-#[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
+#[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct Hyperlink {
     url: String,
     text: WidgetText,

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -42,7 +42,7 @@ use crate::{
 /// # });
 /// ```
 ///
-#[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
+#[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 #[derive(Debug, Clone)]
 pub struct Image<'a> {
     source: ImageSource<'a>,

--- a/crates/egui/src/widgets/image_button.rs
+++ b/crates/egui/src/widgets/image_button.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// A clickable image within a frame.
-#[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
+#[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 #[derive(Clone, Debug)]
 pub struct ImageButton<'a> {
     pub(crate) image: Image<'a>,

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -23,7 +23,7 @@ use self::text_selection::LabelSelectionState;
 ///
 /// For full control of the text you can use [`crate::text::LayoutJob`]
 /// as argument to [`Self::new`].
-#[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
+#[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct Label {
     text: WidgetText,
     wrap_mode: Option<TextWrapMode>,

--- a/crates/egui/src/widgets/mod.rs
+++ b/crates/egui/src/widgets/mod.rs
@@ -57,7 +57,7 @@ pub use self::{
 /// Tip: you can `impl Widget for &mut YourThing { }`.
 ///
 /// `|ui: &mut Ui| -> Response { … }` also implements [`Widget`].
-#[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
+#[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub trait Widget {
     /// Allocate space, interact, paint, and return a [`Response`].
     ///

--- a/crates/egui/src/widgets/progress_bar.rs
+++ b/crates/egui/src/widgets/progress_bar.rs
@@ -11,7 +11,7 @@ enum ProgressBarText {
 /// A simple progress bar.
 ///
 /// See also: [`crate::Spinner`].
-#[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
+#[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct ProgressBar {
     progress: f32,
     desired_width: Option<f32>,

--- a/crates/egui/src/widgets/radio_button.rs
+++ b/crates/egui/src/widgets/radio_button.rs
@@ -22,7 +22,7 @@ use crate::{
 /// }
 /// # });
 /// ```
-#[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
+#[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct RadioButton {
     checked: bool,
     text: WidgetText,

--- a/crates/egui/src/widgets/selected_label.rs
+++ b/crates/egui/src/widgets/selected_label.rs
@@ -21,7 +21,7 @@ use crate::{NumExt, Response, Sense, TextStyle, Ui, Widget, WidgetInfo, WidgetTe
 /// }
 /// # });
 /// ```
-#[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
+#[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct SelectableLabel {
     selected: bool,
     text: WidgetText,

--- a/crates/egui/src/widgets/separator.rs
+++ b/crates/egui/src/widgets/separator.rs
@@ -11,7 +11,7 @@ use crate::{vec2, Response, Sense, Ui, Vec2, Widget};
 /// ui.add(egui::Separator::default());
 /// # });
 /// ```
-#[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
+#[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct Separator {
     spacing: f32,
     grow: f32,

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -94,7 +94,7 @@ pub enum SliderClamping {
 /// ```
 ///
 /// The default [`Slider`] size is set by [`crate::style::Spacing::slider_width`].
-#[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
+#[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct Slider<'a> {
     get_set_value: GetSetValue<'a>,
     range: RangeInclusive<f64>,

--- a/crates/egui/src/widgets/spinner.rs
+++ b/crates/egui/src/widgets/spinner.rs
@@ -5,7 +5,7 @@ use crate::{Response, Sense, Ui, Widget, WidgetInfo, WidgetType};
 /// A spinner widget used to indicate loading.
 ///
 /// See also: [`crate::ProgressBar`].
-#[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
+#[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 #[derive(Default)]
 pub struct Spinner {
     /// Uses the style's `interact_size` if `None`.

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -60,7 +60,7 @@ use super::{TextEditOutput, TextEditState};
 ///
 /// ## Other
 /// The background color of a [`crate::TextEdit`] is [`crate::Visuals::extreme_bg_color`].
-#[must_use = "You should put this widget in an ui with `ui.add(widget);`"]
+#[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct TextEdit<'t> {
     text: &'t mut dyn TextBuffer,
     hint_text: WidgetText,


### PR DESCRIPTION
Since ui's initial sound is a "y", it should be "a ui", not "an ui". 
Replaced case-sensitively using regex `([aA])n ([uU][iI])` replacement `$1 $2`

* [x] I have followed the instructions in the PR template
