### PR TITLE
Fix issue where nested side panels can't be resized larger than their contents

### DIFF
--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -284,21 +284,19 @@ impl SidePanel {
             add_contents(ui)
         });
 
-        let rect = inner_response.response.rect;
-
         {
             let mut cursor = ui.cursor();
             match side {
                 Side::Left => {
-                    cursor.min.x = rect.max.x;
+                    cursor.min.x = panel_rect.max.x;
                 }
                 Side::Right => {
-                    cursor.max.x = rect.min.x;
+                    cursor.max.x = panel_rect.min.x;
                 }
             }
             ui.set_cursor(cursor);
         }
-        ui.expand_to_include_rect(rect);
+        ui.expand_to_include_rect(panel_rect);
 
         if resizable {
             // Now we do the actual resize interaction, on top of all the contents.
@@ -330,7 +328,7 @@ impl SidePanel {
         }
 
         // Keep this rect snapped so that panel content can be pixel-perfect
-        let rect = ui.painter().round_rect_to_pixels(rect);
+        let rect = ui.painter().round_rect_to_pixels(panel_rect);
 
         PanelState { rect }.store(ui.ctx(), id);
 


### PR DESCRIPTION
This fixes an issue where a panel could not be resized to a size larger than it's content layout rect when using nested panels. The issue shows both when nesting panels in panels, and when nesting panels in a window. I have created a github project as a repro here: 
https://github.com/teddemunnik/egui_inner_panel_repro/blob/master/src/main.rs

https://github.com/user-attachments/assets/f812b7eb-1f24-4d43-8396-eec31dea3794

https://github.com/user-attachments/assets/a84a4a21-117a-45a9-be0a-a932dc83b1e4



* [x] I have followed the instructions in the PR template