### PR TITLE
egui-wgpu: Fix docs.rs build

### DIFF
--- a/crates/egui-wgpu/Cargo.toml
+++ b/crates/egui-wgpu/Cargo.toml
@@ -37,7 +37,7 @@ default = ["fragile-send-sync-non-atomic-wasm"]
 puffin = ["dep:puffin"]
 
 ## Enable [`winit`](https://docs.rs/winit) integration. On Linux, requires either `wayland` or `x11`
-winit = ["dep:winit"]
+winit = ["dep:winit", "winit/rwh_06"]
 
 ## Enables Wayland support for winit.
 wayland = ["winit?/wayland"]


### PR DESCRIPTION
This enables the rwh_06 feature in winit which is required to correctly build egui-wgpu
- fixes #5202

