### PR TITLE
iOS: Support putting UI next to the dynamic island

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -36,10 +36,14 @@ use winit::{
 };
 
 pub fn screen_size_in_pixels(window: &Window) -> egui::Vec2 {
-    #[cfg(target_os = "ios")]
-    let size = window.outer_size();
-    #[cfg(not(target_os = "ios"))]
-    let size = window.inner_size();
+    let size = if cfg!(target_os = "ios") {
+        // `outer_size` Includes the area behind the "dynamic island".
+        // It is up to the eframe user to make sure the dynamic island doesn't cover anything important.
+        // That will be easier once https://github.com/rust-windowing/winit/pull/3890 lands 
+        window.outer_size();
+    } else {
+		window.inner_size()
+	};
     egui::vec2(size.width as f32, size.height as f32)
 }
 

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -39,11 +39,11 @@ pub fn screen_size_in_pixels(window: &Window) -> egui::Vec2 {
     let size = if cfg!(target_os = "ios") {
         // `outer_size` Includes the area behind the "dynamic island".
         // It is up to the eframe user to make sure the dynamic island doesn't cover anything important.
-        // That will be easier once https://github.com/rust-windowing/winit/pull/3890 lands 
-        window.outer_size();
+        // That will be easier once https://github.com/rust-windowing/winit/pull/3890 lands
+        window.outer_size()
     } else {
-		window.inner_size()
-	};
+        window.inner_size()
+    };
     egui::vec2(size.width as f32, size.height as f32)
 }
 

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -36,6 +36,9 @@ use winit::{
 };
 
 pub fn screen_size_in_pixels(window: &Window) -> egui::Vec2 {
+    #[cfg(target_os = "ios")]
+    let size = window.outer_size();
+    #[cfg(not(target_os = "ios"))]
     let size = window.inner_size();
     egui::vec2(size.width as f32, size.height as f32)
 }


### PR DESCRIPTION
winit::Window::inner_size returns size of safe area on iOS. use winit::Window::outer_size on iOS
The dimensions of outer_size include the title bar and borders, but as far as I know there is no way to actually display the title bar or borders on iOS so it should be fine.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes #3547 
* [X] I have followed the instructions in the PR template
