### PR TITLE
enable `manual_range_contains` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,7 @@ manual_clamp = "warn"
 manual_instant_elapsed = "warn"
 manual_let_else = "warn"
 manual_ok_or = "warn"
+manual_range_contains = "warn"
 manual_string_new = "warn"
 map_err_ignore = "warn"
 map_flatten = "warn"
@@ -261,6 +262,5 @@ should_panic_without_expect = "allow"
 too_many_lines = "allow"
 unwrap_used = "allow"                 # TODO(emilk): We really wanna warn on this one
 
-manual_range_contains = "allow"       # this one is just worse imho
 self_named_module_files = "allow"     # Disabled waiting on https://github.com/rust-lang/rust-clippy/issues/9602
 significant_drop_tightening = "allow" # Too many false positives

--- a/crates/ecolor/src/lib.rs
+++ b/crates/ecolor/src/lib.rs
@@ -104,7 +104,7 @@ fn fast_round(r: f32) -> u8 {
 pub fn test_srgba_conversion() {
     for b in 0..=255 {
         let l = linear_f32_from_gamma_u8(b);
-        assert!(0.0 <= l && l <= 1.0);
+        assert!((0.0..=1.0).contains(&l));
         assert_eq!(gamma_u8_from_linear_f32(l), b);
     }
 }

--- a/crates/ecolor/src/rgba.rs
+++ b/crates/ecolor/src/rgba.rs
@@ -98,22 +98,22 @@ impl Rgba {
 
     #[inline]
     pub fn from_luminance_alpha(l: f32, a: f32) -> Self {
-        debug_assert!(0.0 <= l && l <= 1.0);
-        debug_assert!(0.0 <= a && a <= 1.0);
+        debug_assert!((0.0..=1.0).contains(&l));
+        debug_assert!((0.0..=1.0).contains(&a));
         Self([l * a, l * a, l * a, a])
     }
 
     /// Transparent black
     #[inline]
     pub fn from_black_alpha(a: f32) -> Self {
-        debug_assert!(0.0 <= a && a <= 1.0);
+        debug_assert!((0.0..=1.0).contains(&a));
         Self([0.0, 0.0, 0.0, a])
     }
 
     /// Transparent white
     #[inline]
     pub fn from_white_alpha(a: f32) -> Self {
-        debug_assert!(0.0 <= a && a <= 1.0, "a: {a}");
+        debug_assert!((0.0..=1.0).contains(&a), "a: {a}");
         Self([a, a, a, a])
     }
 


### PR DESCRIPTION
Enabled the manual_range_contains lint 

* [x] I have followed the instructions in the PR template
