### PR TITLE
Free textures after submitting queue instead of before with wgpu renderer

### DIFF
--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -684,6 +684,9 @@ impl Painter {
             vsync_sec += start.elapsed().as_secs_f32();
         };
 
+        // Free textures marked for destruction **after** queue submit since they might still be used in the current frame.
+        // Calling `wgpu::Texture::destroy` on a texture that is still in use would invalidate the command buffer(s) it is used in.
+        // However, once we called `wgpu::Queue::submit`, it is up for wgpu to determine how long the underlying gpu resource has to live.
         {
             let mut renderer = render_state.renderer.write();
             for id in &textures_delta.free {

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -668,13 +668,6 @@ impl Painter {
             );
         }
 
-        {
-            let mut renderer = render_state.renderer.write();
-            for id in &textures_delta.free {
-                renderer.free_texture(id);
-            }
-        }
-
         let encoded = {
             crate::profile_scope!("CommandEncoder::finish");
             encoder.finish()
@@ -690,6 +683,13 @@ impl Painter {
                 .submit(user_cmd_bufs.into_iter().chain([encoded]));
             vsync_sec += start.elapsed().as_secs_f32();
         };
+
+        {
+            let mut renderer = render_state.renderer.write();
+            for id in &textures_delta.free {
+                renderer.free_texture(id);
+            }
+        }
 
         let screenshot = if capture {
             self.screen_capture_state


### PR DESCRIPTION
* Closes #5224

I'm unfamiliar with wgpu, so I'd like someone to confirm, that calling `wgpu::Texture` _after_ `wgpu::Queue::submit` is in fact the right thing to do.