### PR TITLE
Fix bug causing wrong-fire of `ViewportCommand::Visible`

### DIFF
--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -728,7 +728,7 @@ impl ViewportBuilder {
         }
 
         if let Some(new_visible) = new_visible {
-            if Some(new_visible) != self.active {
+            if Some(new_visible) != self.visible {
                 self.visible = Some(new_visible);
                 commands.push(ViewportCommand::Visible(new_visible));
             }


### PR DESCRIPTION
Fix: variable name issue

I'm not sure, if there's any particular reason to do `self.active` .
I thought `self.visible` was the original intention.
