### PR TITLE
Fix: `ctx.set_fonts()` Doesn't Apply Fonts with Same Name

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -567,7 +567,7 @@ impl ContextImpl {
     }
 
     /// Load fonts unless already loaded.
-    fn update_fonts_mut(&mut self) {
+    pub(crate) fn update_fonts_mut(&mut self) {
         crate::profile_function!();
 
         let input = &self.viewport().input;
@@ -1725,27 +1725,11 @@ impl Context {
     ///
     /// The default `egui` fonts only support latin and cyrillic alphabets,
     /// but you can call this to install additional fonts that support e.g. korean characters.
-    ///
-    /// The new fonts will become active at the start of the next pass.
     pub fn set_fonts(&self, font_definitions: FontDefinitions) {
         crate::profile_function!();
 
-        let pixels_per_point = self.pixels_per_point();
-
-        let mut update_fonts = true;
-
-        self.read(|ctx| {
-            if let Some(current_fonts) = ctx.fonts.get(&pixels_per_point.into()) {
-                // NOTE: this comparison is expensive since it checks TTF data for equality
-                if current_fonts.lock().fonts.definitions() == &font_definitions {
-                    update_fonts = false; // no need to update
-                }
-            }
-        });
-
-        if update_fonts {
-            self.memory_mut(|mem| mem.new_font_definitions = Some(font_definitions));
-        }
+        self.memory_mut(|mem| mem.new_font_definitions = Some(font_definitions));
+        self.write(|ctx| ctx.update_fonts_mut());
     }
 
     /// Does the OS use dark or light mode?


### PR DESCRIPTION
If a font file named `my_font` is set using `ctx.set_fonts()` and then another font file with the same name is set again using `ctx.set_fonts()`, it won't be applied.

1. Additionally, it's recommended to apply fonts immediately using `ctx.set_fonts()`.
2. This will also allow you to reset the fonts and texture.

* Related #5233
* Closes #5252
