### PR TITLE
Expand max font atlas size from 8k to 16k

### DIFF
--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -589,7 +589,7 @@ impl FontsImpl {
             "pixels_per_point out of range: {pixels_per_point}"
         );
 
-        let texture_width = max_texture_side.at_most(8 * 1024);
+        let texture_width = max_texture_side.at_most(16 * 1024);
         let initial_height = 32; // Keep initial font atlas small, so it is fast to upload to GPU. This will expand as needed anyways.
         let atlas = TextureAtlas::new([texture_width, initial_height]);
 

--- a/crates/epaint/src/texture_atlas.rs
+++ b/crates/epaint/src/texture_atlas.rs
@@ -159,8 +159,8 @@ impl TextureAtlas {
     }
 
     fn max_height(&self) -> usize {
-        // the initial width is likely the max texture side size
-        self.image.width()
+        // likely the max texture height
+        self.image.height().max(self.image.width())
     }
 
     /// When this get high, it might be time to clear and start over!

--- a/crates/epaint/src/texture_atlas.rs
+++ b/crates/epaint/src/texture_atlas.rs
@@ -159,7 +159,7 @@ impl TextureAtlas {
     }
 
     fn max_height(&self) -> usize {
-        // likely the max texture height
+        // the initial width is set to the max size
         self.image.height().max(self.image.width())
     }
 


### PR DESCRIPTION
When using fonts with an average of 50,000 characters,
'epaint texture atlas overflowed!' may be printed and cause problems.
It is necessary to expand the max value related to texture.

* Closes #5256 
