### PR TITLE
Fix textedit intrinsic size metric

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -525,13 +525,13 @@ impl<'t> TextEdit<'t> {
 
         let mut galley = layouter(ui, text.as_str(), wrap_width);
 
-        let desired_width = if clip_text {
+        let desired_inner_width = if clip_text {
             wrap_width // visual clipping with scroll in singleline input.
         } else {
             galley.size().x.max(wrap_width)
         };
         let desired_height = (desired_height_rows.at_least(1) as f32) * row_height;
-        let desired_inner_size = vec2(desired_width, galley.size().y.max(desired_height));
+        let desired_inner_size = vec2(desired_inner_width, galley.size().y.max(desired_height));
         let desired_outer_size = (desired_inner_size + margin.sum()).at_least(min_size);
         let (auto_id, outer_rect) = ui.allocate_space(desired_outer_size);
         let rect = outer_rect - margin; // inner rect (excluding frame/margin).
@@ -562,7 +562,7 @@ impl<'t> TextEdit<'t> {
             Sense::hover()
         };
         let mut response = ui.interact(outer_rect, id, sense);
-        response.intrinsic_size = Some(desired_outer_size);
+        response.intrinsic_size = Some(Vec2::new(desired_width, desired_outer_size.y));
 
         response.fake_primary_click = false; // Don't sent `OutputEvent::Clicked` when a user presses the space bar
 


### PR DESCRIPTION
Since textedit is doing the justify layout calculation itself, we need to report the original desired_size as intrinsic size, instead of the value passed to allocate_space.

I wonder though, is it still necessary that the TextEdit does the justify calculation itself instead of relying on the ui layout to do it? As far as I understand it, justify should be handled by the ui.allocate_space call.