### PR TITLE
Use id_salt on Table ScrollArea

### DIFF
--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -743,6 +743,7 @@ impl<'a> Table<'a> {
         let cursor_position = ui.cursor().min;
 
         let mut scroll_area = ScrollArea::new([false, vscroll])
+            .id_salt(state_id.with("__scroll_area"))
             .drag_to_scroll(drag_to_scroll)
             .stick_to_bottom(stick_to_bottom)
             .min_scrolled_height(min_scrolled_height)


### PR DESCRIPTION
The salt is based on the table's `state_id`.

* Closes https://github.com/emilk/egui/issues/5281
* [x] I have followed the instructions in the PR template
