### PR TITLE
Fix cargo test in check.sh

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -29,7 +29,7 @@ cargo check --quiet  --all-targets
 cargo check --quiet  --all-targets --all-features
 cargo check --quiet  -p egui_demo_app --lib --target wasm32-unknown-unknown
 cargo check --quiet  -p egui_demo_app --lib --target wasm32-unknown-unknown --all-features
-# TODO(lucasmerlin) re-enable --all-features once the tests work with the unity feature
+# TODO(#5297) re-enable --all-features once the tests work with the unity feature
 cargo test  --quiet --all-targets
 cargo test  --quiet --doc # slow - checks all doc-tests
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -29,7 +29,8 @@ cargo check --quiet  --all-targets
 cargo check --quiet  --all-targets --all-features
 cargo check --quiet  -p egui_demo_app --lib --target wasm32-unknown-unknown
 cargo check --quiet  -p egui_demo_app --lib --target wasm32-unknown-unknown --all-features
-cargo test  --quiet --all-targets --all-features
+# TODO(lucasmerlin) re-enable --all-features once the tests work with the unity feature
+cargo test  --quiet --all-targets
 cargo test  --quiet --doc # slow - checks all doc-tests
 
 cargo check --quiet -p eframe --no-default-features --features "glow"


### PR DESCRIPTION
The check.sh script was broken in #5166, this fixes it
* Related to #5297 
* [x] I have followed the instructions in the PR template
