### PR TITLE
Revert "Fix: `Sides` did not apply the layout position correctly."

### DIFF
--- a/crates/egui/src/containers/sides.rs
+++ b/crates/egui/src/containers/sides.rs
@@ -78,7 +78,7 @@ impl Sides {
         let height = height.unwrap_or_else(|| ui.spacing().interact_size.y);
         let spacing = spacing.unwrap_or_else(|| ui.spacing().item_spacing.x);
 
-        let mut top_rect = ui.cursor();
+        let mut top_rect = ui.max_rect();
         top_rect.max.y = top_rect.min.y + height;
 
         let result_left;


### PR DESCRIPTION
Reverts emilk/egui#5232

I should have tested it first. `cursor` can contain infinites. There is a better fix to be found @zhatuokun