### PR TITLE
egui_kittest: Allow customizing the snapshot threshold and path

### DIFF
--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -383,7 +383,7 @@ mod tests {
     use crate::demo::demo_app_windows::Demos;
     use egui::Vec2;
     use egui_kittest::kittest::Queryable;
-    use egui_kittest::Harness;
+    use egui_kittest::{Harness, SnapshotOptions};
 
     #[test]
     fn demos_should_match_snapshot() {
@@ -417,7 +417,13 @@ mod tests {
             // Run the app for some more frames...
             harness.run();
 
-            let result = harness.try_wgpu_snapshot(&format!("demos/{name}"));
+            let mut options = SnapshotOptions::default();
+            // The Bézier Curve demo needs a threshold of 2.1 to pass on linux
+            if name == "Bézier Curve" {
+                options.threshold = 2.1;
+            }
+
+            let result = harness.try_wgpu_snapshot_options(&format!("demos/{name}"), &options);
             if let Err(err) = result {
                 errors.push(err);
             }

--- a/crates/egui_kittest/README.md
+++ b/crates/egui_kittest/README.md
@@ -45,3 +45,9 @@ Running with `UPDATE_SNAPSHOTS=true` will still cause the tests to fail, but on 
 If you want to have multiple snapshots in the same test, it makes sense to collect the results in a `Vec` 
 ([look here](https://github.com/emilk/egui/blob/70a01138b77f9c5724a35a6ef750b9ae1ab9f2dc/crates/egui_demo_lib/src/demo/demo_app_windows.rs#L388-L427) for an example).
 This way they can all be updated at the same time.
+
+You should add the following to your `.gitignore`:
+```
+**/tests/snapshots/**/*.diff.png
+**/tests/snapshots/**/*.new.png
+```

--- a/crates/egui_kittest/README.md
+++ b/crates/egui_kittest/README.md
@@ -47,7 +47,7 @@ If you want to have multiple snapshots in the same test, it makes sense to colle
 This way they can all be updated at the same time.
 
 You should add the following to your `.gitignore`:
-```
+```gitignore
 **/tests/snapshots/**/*.diff.png
 **/tests/snapshots/**/*.new.png
 ```


### PR DESCRIPTION
This adds `egui_kittest::try_image_snapshot_options` and `egui_kittest::image_snapshot_options`, as well as `Harness::wgpu_snapshot_options` and `Harness::try_wgpu_snapshot_options`

* [X] I have followed the instructions in the PR template
