### PR TITLE
Impl from Box<str> for WidgetText, RichText

### DIFF
--- a/crates/egui/src/widget_text.rs
+++ b/crates/egui/src/widget_text.rs
@@ -67,6 +67,27 @@ impl From<String> for RichText {
     }
 }
 
+impl From<&Box<str>> for RichText {
+    #[inline]
+    fn from(text: &Box<str>) -> Self {
+        Self::new(text.clone())
+    }
+}
+
+impl From<&mut Box<str>> for RichText {
+    #[inline]
+    fn from(text: &mut Box<str>) -> Self {
+        Self::new(text.clone())
+    }
+}
+
+impl From<Box<str>> for RichText {
+    #[inline]
+    fn from(text: Box<str>) -> Self {
+        Self::new(text)
+    }
+}
+
 impl From<Cow<'_, str>> for RichText {
     #[inline]
     fn from(text: Cow<'_, str>) -> Self {
@@ -697,6 +718,20 @@ impl From<&String> for WidgetText {
 impl From<String> for WidgetText {
     #[inline]
     fn from(text: String) -> Self {
+        Self::RichText(RichText::new(text))
+    }
+}
+
+impl From<&Box<str>> for WidgetText {
+    #[inline]
+    fn from(text: &Box<str>) -> Self {
+        Self::RichText(RichText::new(text.clone()))
+    }
+}
+
+impl From<Box<str>> for WidgetText {
+    #[inline]
+    fn from(text: Box<str>) -> Self {
         Self::RichText(RichText::new(text))
     }
 }


### PR DESCRIPTION
`Box<str>` is an immutable heap-allocated string slice.
This PR makes it more convenient to use them in labels for example.

Before this PR
```rust
let text: Box<str> = "Hello".into();
ui.label(text.into_string());

let text_ref: &Box<str> = &"Hello".into();
ui.label(text_ref.clone().into_string());
// or
ui.label(text_ref.as_ref());
// or
ui.label(&**text_ref);
```
After this PR
```rust
let text: Box<str> = "Hello".into();
ui.label(text);

let text_ref: &Box<str> = &"Hello".into();
ui.label(text_ref);
```

* [x] I have followed the instructions in the PR template
