### PR TITLE
Respect `Style::override_font_id` in `RichText`

### DIFF
--- a/crates/egui/src/widget_text.rs
+++ b/crates/egui/src/widget_text.rs
@@ -359,6 +359,9 @@ impl RichText {
                     || fallback_font.resolve(style),
                     |text_style| text_style.resolve(style),
                 );
+            if let Some(fid) = style.override_font_id.clone() {
+                font_id = fid;
+            }
             if let Some(size) = size {
                 font_id.size = size;
             }


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

Currently `Style::override_font_id` does not affect widgets with their `TextStyle` like `Button`s, `ComboBox`es, `CheckBox`es, etc. This PR fixes this behavior such that all widgets using default configuration of `RichText` are affected by this setting.
* [x] I have followed the instructions in the PR template
