### PR TITLE
Fix: `Window::default_pos` does not work

### DIFF
--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -287,7 +287,9 @@ impl<'open> Window<'open> {
     /// Set initial size of the window.
     #[inline]
     pub fn default_size(mut self, default_size: impl Into<Vec2>) -> Self {
+        let default_size: Vec2 = default_size.into();
         self.resize = self.resize.default_size(default_size);
+        self.area = self.area.default_size(default_size);
         self
     }
 
@@ -295,6 +297,7 @@ impl<'open> Window<'open> {
     #[inline]
     pub fn default_width(mut self, default_width: f32) -> Self {
         self.resize = self.resize.default_width(default_width);
+        self.area = self.area.default_width(default_width);
         self
     }
 
@@ -302,6 +305,7 @@ impl<'open> Window<'open> {
     #[inline]
     pub fn default_height(mut self, default_height: f32) -> Self {
         self.resize = self.resize.default_height(default_height);
+        self.area = self.area.default_height(default_height);
         self
     }
 


### PR DESCRIPTION
Fix: Window::default_pos does not work

Issues: Since `default_size` is not applied to `area`, `style.spacing.default_area_size` is applied, causing problems.

* Closes #5314 
