### PR TITLE
egui-winit: Remove implicit `accesskit_winit` feature

### DIFF
--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -24,7 +24,7 @@ rustdoc-args = ["--generate-link-to-definition"]
 default = ["clipboard", "links", "wayland", "winit/default", "x11"]
 
 ## Enable platform accessibility API implementations through [AccessKit](https://accesskit.dev/).
-accesskit = ["accesskit_winit", "egui/accesskit"]
+accesskit = ["dep:accesskit_winit", "egui/accesskit"]
 
 # Allow crates to choose an android-activity backend via Winit
 # - It's important that most applications should not have to depend on android-activity directly, and can


### PR DESCRIPTION
This is controlled by the `accesskit` feature and nothing needs the implicit `accesskit_winit` feature, so use `dep:` syntax to prevent it from being created.

* [x] I have followed the instructions in the PR template
