### PR TITLE
Update MSRV from 1.76 to 1.77

### DIFF
--- a/.github/workflows/deploy_web_demo.yml
+++ b/.github/workflows/deploy_web_demo.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           profile: minimal
           target: wasm32-unknown-unknown
-          toolchain: 1.76.0
+          toolchain: 1.77.0
           override: true
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.76.0
+          toolchain: 1.77.0
 
       - name: Install packages (Linux)
         if: runner.os == 'Linux'
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.76.0
+          toolchain: 1.77.0
           targets: wasm32-unknown-unknown
 
       - run: sudo apt-get update && sudo apt-get install libgtk-3-dev libatk1.0-dev
@@ -155,7 +155,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
-          rust-version: "1.76.0"
+          rust-version: "1.77.0"
           log-level: error
           command: check
           arguments: --target  ${{ matrix.target }}
@@ -170,7 +170,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.76.0
+          toolchain: 1.77.0
           targets: aarch64-linux-android
 
       - name: Set up cargo cache
@@ -189,7 +189,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.76.0
+          toolchain: 1.77.0
           targets: aarch64-apple-ios
 
       - name: Set up cargo cache
@@ -208,7 +208,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.76.0
+          toolchain: 1.77.0
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
@@ -232,7 +232,7 @@ jobs:
           lfs: true
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.76.0
+          toolchain: 1.77.0
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 [workspace.package]
 edition = "2021"
 license = "MIT OR Apache-2.0"
-rust-version = "1.76"
+rust-version = "1.77"
 version = "0.29.1"
 
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,7 +3,7 @@
 # -----------------------------------------------------------------------------
 # Section identical to scripts/clippy_wasm/clippy.toml:
 
-msrv = "1.76"
+msrv = "1.77"
 
 allow-unwrap-in-tests = true
 

--- a/crates/ecolor/src/hex_color_macro.rs
+++ b/crates/ecolor/src/hex_color_macro.rs
@@ -40,11 +40,10 @@
 macro_rules! hex_color {
     ($s:literal) => {{
         let array = $crate::color_hex::color_from_hex!($s);
-        if array.len() == 3 {
-            $crate::Color32::from_rgb(array[0], array[1], array[2])
-        } else {
-            #[allow(unconditional_panic)]
-            $crate::Color32::from_rgba_unmultiplied(array[0], array[1], array[2], array[3])
+        match array.as_slice() {
+            [r, g, b] => $crate::Color32::from_rgb(*r, *g, *b),
+            [r, g, b, a] => $crate::Color32::from_rgba_unmultiplied(*r, *g, *b, *a),
+            _ => panic!("Invalid hex color length: expected 3 (RGB) or 4 (RGBA) bytes"),
         }
     }};
 }

--- a/crates/eframe/src/native/event_loop_context.rs
+++ b/crates/eframe/src/native/event_loop_context.rs
@@ -2,7 +2,7 @@ use std::cell::Cell;
 use winit::event_loop::ActiveEventLoop;
 
 thread_local! {
-    static CURRENT_EVENT_LOOP: Cell<Option<*const ActiveEventLoop>> = Cell::new(None);
+    static CURRENT_EVENT_LOOP: Cell<Option<*const ActiveEventLoop>> = const { Cell::new(None) };
 }
 
 struct EventLoopGuard;

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -37,7 +37,7 @@ fn with_event_loop<R>(
     mut native_options: epi::NativeOptions,
     f: impl FnOnce(&mut EventLoop<UserEvent>, epi::NativeOptions) -> R,
 ) -> Result<R> {
-    thread_local!(static EVENT_LOOP: std::cell::RefCell<Option<EventLoop<UserEvent>>> = std::cell::RefCell::new(None));
+    thread_local!(static EVENT_LOOP: std::cell::RefCell<Option<EventLoop<UserEvent>>> = const { std::cell::RefCell::new(None) });
 
     EVENT_LOOP.with(|event_loop| {
         // Since we want to reference NativeOptions when creating the EventLoop we can't

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -3,7 +3,7 @@
 //! Try the live web demo: <https://www.egui.rs/#demo>. Read more about egui at <https://github.com/emilk/egui>.
 //!
 //! `egui` is in heavy development, with each new version having breaking changes.
-//! You need to have rust 1.76.0 or later to use `egui`.
+//! You need to have rust 1.77.0 or later to use `egui`.
 //!
 //! To quickly get started with egui, you can take a look at [`eframe_template`](https://github.com/emilk/eframe_template)
 //! which uses [`eframe`](https://docs.rs/eframe).

--- a/examples/confirm_exit/Cargo.toml
+++ b/examples/confirm_exit/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/examples/custom_3d_glow/Cargo.toml
+++ b/examples/custom_3d_glow/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/examples/custom_font/Cargo.toml
+++ b/examples/custom_font/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/examples/custom_font_style/Cargo.toml
+++ b/examples/custom_font_style/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["tami5 <kkharji@proton.me>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/examples/custom_keypad/Cargo.toml
+++ b/examples/custom_keypad/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Varphone Wong <varphone@qq.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/examples/custom_style/Cargo.toml
+++ b/examples/custom_style/Cargo.toml
@@ -3,7 +3,7 @@ name = "custom_style"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/examples/custom_window_frame/Cargo.toml
+++ b/examples/custom_window_frame/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/examples/file_dialog/Cargo.toml
+++ b/examples/file_dialog/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/examples/hello_world_par/Cargo.toml
+++ b/examples/hello_world_par/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Maxim Osipenko <maxim1999max@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/examples/hello_world_simple/Cargo.toml
+++ b/examples/hello_world_simple/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/examples/images/Cargo.toml
+++ b/examples/images/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Jan Procházka <github.com/jprochazk>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/examples/keyboard_events/Cargo.toml
+++ b/examples/keyboard_events/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Jose Palazon <jose@palako.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/examples/multiple_viewports/Cargo.toml
+++ b/examples/multiple_viewports/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/examples/puffin_profiler/Cargo.toml
+++ b/examples/puffin_profiler/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/examples/screenshot/Cargo.toml
+++ b/examples/screenshot/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/examples/serial_windows/Cargo.toml
+++ b/examples/serial_windows/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/examples/user_attention/Cargo.toml
+++ b/examples/user_attention/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["TicClick <ya@ticclick.ch>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,6 +5,6 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "1.76.0"
+channel = "1.77.0"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -9,7 +9,7 @@ set -x
 # Checks all tests, lints etc.
 # Basically does what the CI does.
 
-cargo +1.76.0 install --quiet typos-cli
+cargo +1.77.0 install --quiet typos-cli
 
 export RUSTFLAGS="-D warnings"
 export RUSTDOCFLAGS="-D warnings" # https://github.com/emilk/egui/pull/1454

--- a/scripts/clippy_wasm/clippy.toml
+++ b/scripts/clippy_wasm/clippy.toml
@@ -6,7 +6,7 @@
 # -----------------------------------------------------------------------------
 # Section identical to the root clippy.toml:
 
-msrv = "1.76"
+msrv = "1.77"
 
 allow-unwrap-in-tests = true
 

--- a/tests/test_egui_extras_compilation/Cargo.toml
+++ b/tests/test_egui_extras_compilation/Cargo.toml
@@ -3,7 +3,7 @@ name = "test_egui_extras_compilation"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/tests/test_inline_glow_paint/Cargo.toml
+++ b/tests/test_inline_glow_paint/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/tests/test_size_pass/Cargo.toml
+++ b/tests/test_size_pass/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/tests/test_ui_stack/Cargo.toml
+++ b/tests/test_ui_stack/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Antoine Beyeler <abeyeler@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]

--- a/tests/test_viewports/Cargo.toml
+++ b/tests/test_viewports/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["konkitoman"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 publish = false
 
 [lints]


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [X] I have followed the instructions in the PR template

I am preparing a separate PR that adds support for JXL with `jxl-oxide`, which is unlikely to be added to the `image` crate anytime soon (more context will be provided in that PR).

`jxl-oxide` makes use of the [`array::each_mut`](https://doc.rust-lang.org/stable/std/primitive.array.html#method.each_mut) API which was stabilized in 1.77, which is the motivation for this MSRV bump.

Rust 1.77 was officially released to stable on 21 March, 2024.