### PR TITLE
Add basic JXL image support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,16 +2201,18 @@ dependencies = [
 
 [[package]]
 name = "jxl-bitstream"
-version = "0.5.0-alpha.0"
-source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c84490d13b6303b007b63b6ffea9fa82ff5a4c33b0b2dc673e6f4556f11a2a1"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "jxl-coding"
-version = "0.5.0-alpha.0"
-source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7ffdab0c48e989f23a8bd6113d88bd243ae45c7871e90cfdcb6997eacbfb2"
 dependencies = [
  "jxl-bitstream",
  "tracing",
@@ -2219,7 +2221,8 @@ dependencies = [
 [[package]]
 name = "jxl-color"
 version = "0.9.0"
-source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4806c94be9e37c82e571684ad673af0a2e4049a74942c407034da6a087c4de7b"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
@@ -2232,7 +2235,8 @@ dependencies = [
 [[package]]
 name = "jxl-frame"
 version = "0.11.0"
-source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b5014aa075774dc44ef861d6ae5ca362980b64498ed2f464c25c660646a4c"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
@@ -2247,8 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "jxl-grid"
-version = "0.5.0"
-source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a28ba2734da33624db4b426b44750a7b1238e6cba65d27b7d84bf3cba7f507"
 dependencies = [
  "tracing",
 ]
@@ -2256,7 +2261,8 @@ dependencies = [
 [[package]]
 name = "jxl-image"
 version = "0.11.0"
-source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de3283303bb66b1742538f1a6947313596242598d6ddf325f301c2fbf01abd3"
 dependencies = [
  "jxl-bitstream",
  "jxl-color",
@@ -2268,7 +2274,8 @@ dependencies = [
 [[package]]
 name = "jxl-modular"
 version = "0.9.0"
-source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed6e144e58dc051182702ef4f3c78357c23e7df0164f60f69e0f267a8b59bd42"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
@@ -2281,7 +2288,8 @@ dependencies = [
 [[package]]
 name = "jxl-oxide"
 version = "0.10.0"
-source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336649ea025b9895ce1c9af694f75aa38ae5aed8c5da2019425381e32fbe19a"
 dependencies = [
  "bytemuck",
  "image",
@@ -2299,7 +2307,8 @@ dependencies = [
 [[package]]
 name = "jxl-oxide-common"
 version = "0.1.0"
-source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4efb65a6ef812eae1083e5d2d1a4358bd74cf7e08d112f6e939a40003a6a9920"
 dependencies = [
  "jxl-bitstream",
 ]
@@ -2307,7 +2316,8 @@ dependencies = [
 [[package]]
 name = "jxl-render"
 version = "0.10.0"
-source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685c13278d0ba6b522d7b0957bf9aa14b9f975b229ec582c2eec3fe89978ee93"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
@@ -2325,7 +2335,8 @@ dependencies = [
 [[package]]
 name = "jxl-threadpool"
 version = "0.1.1"
-source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d2860c68899a3c6266044fc26c6a0041e9f27145f58cc69b6eedc1b77f5ee13"
 dependencies = [
  "tracing",
 ]
@@ -2333,7 +2344,8 @@ dependencies = [
 [[package]]
 name = "jxl-vardct"
 version = "0.9.0"
-source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "737b4a65897907c644329c8a54e042cefdec2989e482698eea150d463e475fe5"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,6 +1328,7 @@ dependencies = [
  "ehttp",
  "enum-map",
  "image",
+ "jxl-oxide",
  "log",
  "mime_guess2",
  "puffin",
@@ -2196,6 +2197,151 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jxl-bitstream"
+version = "0.5.0-alpha.0"
+source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
+name = "jxl-coding"
+version = "0.5.0-alpha.0"
+source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+dependencies = [
+ "jxl-bitstream",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-color"
+version = "0.9.0"
+source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-grid",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-frame"
+version = "0.11.0"
+source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-grid",
+ "jxl-image",
+ "jxl-modular",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "jxl-vardct",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-grid"
+version = "0.5.0"
+source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
+name = "jxl-image"
+version = "0.11.0"
+source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-color",
+ "jxl-grid",
+ "jxl-oxide-common",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-modular"
+version = "0.9.0"
+source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-grid",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-oxide"
+version = "0.10.0"
+source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+dependencies = [
+ "bytemuck",
+ "image",
+ "jxl-bitstream",
+ "jxl-color",
+ "jxl-frame",
+ "jxl-grid",
+ "jxl-image",
+ "jxl-oxide-common",
+ "jxl-render",
+ "jxl-threadpool",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-oxide-common"
+version = "0.1.0"
+source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+dependencies = [
+ "jxl-bitstream",
+]
+
+[[package]]
+name = "jxl-render"
+version = "0.10.0"
+source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-color",
+ "jxl-frame",
+ "jxl-grid",
+ "jxl-image",
+ "jxl-modular",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "jxl-vardct",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-threadpool"
+version = "0.1.1"
+source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
+name = "jxl-vardct"
+version = "0.9.0"
+source = "git+https://github.com/tirr-c/jxl-oxide.git#229c223af49de96247a4e5548470ce2753912f3e"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-grid",
+ "jxl-modular",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ ahash = { version = "0.8.11", default-features = false, features = [
     "std",
 ] }
 backtrace = "0.3"
-bytemuck = "1.7.2"
+bytemuck = "1.19"
 criterion = { version = "0.5.1", default-features = false }
 dify = { version = "0.7", default-features = false }
 document-features = "0.2.10"

--- a/crates/egui_extras/Cargo.toml
+++ b/crates/egui_extras/Cargo.toml
@@ -30,8 +30,8 @@ rustdoc-args = ["--generate-link-to-definition"]
 [features]
 default = ["dep:mime_guess2"]
 
-## Shorthand for enabling the different types of image loaders (`file`, `http`, `image`, `svg`).
-all_loaders = ["file", "http", "image", "svg", "gif"]
+## Shorthand for enabling the different types of image loaders (`file`, `http`, `image`, `jxl`, `svg`, `gif`).
+all_loaders = ["file", "http", "image", "jxl", "svg", "gif"]
 
 ## Enable [`DatePickerButton`] widget.
 datepicker = ["chrono"]
@@ -52,6 +52,9 @@ http = ["dep:ehttp"]
 ## image = { version = "0.25", features = ["jpeg", "png"] } # Add the types you want support for
 ## ```
 image = ["dep:image"]
+
+## Support loading jxl images via jxl-oxide. Requires the [`image`](https://docs.rs/image) crate feature.
+jxl = ["dep:jxl-oxide", "image"]
 
 ## Enable profiling with the [`puffin`](https://docs.rs/puffin) crate.
 ##
@@ -104,6 +107,11 @@ syntect = { version = "5", optional = true, default-features = false, features =
 
 # svg feature
 resvg = { version = "0.37", optional = true, default-features = false }
+
+# jxl feature
+jxl-oxide = { version = "0.10", git = "https://github.com/tirr-c/jxl-oxide.git", optional = true, default-features = false, features = [
+  "image",
+] }
 
 # http feature
 ehttp = { version = "0.5", optional = true, default-features = false }

--- a/crates/egui_extras/Cargo.toml
+++ b/crates/egui_extras/Cargo.toml
@@ -109,7 +109,7 @@ syntect = { version = "5", optional = true, default-features = false, features =
 resvg = { version = "0.37", optional = true, default-features = false }
 
 # jxl feature
-jxl-oxide = { version = "0.10", git = "https://github.com/tirr-c/jxl-oxide.git", optional = true, default-features = false, features = [
+jxl-oxide = { version = "0.10", optional = true, default-features = false, features = [
   "image",
 ] }
 

--- a/crates/egui_extras/src/loaders.rs
+++ b/crates/egui_extras/src/loaders.rs
@@ -78,6 +78,12 @@ pub fn install_image_loaders(ctx: &egui::Context) {
         log::trace!("installed ImageCrateLoader");
     }
 
+    #[cfg(feature = "jxl")]
+    if !ctx.is_loader_installed(self::jxl_loader::JxlLoader::ID) {
+        ctx.add_image_loader(std::sync::Arc::new(self::jxl_loader::JxlLoader::default()));
+        log::trace!("installed JxlLoader");
+    }
+
     #[cfg(feature = "gif")]
     if !ctx.is_loader_installed(self::gif_loader::GifLoader::ID) {
         ctx.add_image_loader(std::sync::Arc::new(self::gif_loader::GifLoader::default()));
@@ -111,5 +117,7 @@ mod ehttp_loader;
 mod gif_loader;
 #[cfg(feature = "image")]
 mod image_loader;
+#[cfg(feature = "jxl")]
+mod jxl_loader;
 #[cfg(feature = "svg")]
 mod svg_loader;

--- a/crates/egui_extras/src/loaders/image_loader.rs
+++ b/crates/egui_extras/src/loaders/image_loader.rs
@@ -117,5 +117,6 @@ mod tests {
         assert!(is_supported_uri("http://test.gif"));
         assert!(is_supported_uri("file://test"));
         assert!(!is_supported_uri("test.svg"));
+        assert!(!is_supported_uri("test.jxl"));
     }
 }


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [X] I have followed the instructions in the PR template

### Blocked by:
- [x] https://github.com/emilk/egui/pull/5322 `jxl-oxide` makes use of the [`array::each_mut`](https://doc.rust-lang.org/stable/std/primitive.array.html#method.each_mut) API 
- [x] https://github.com/emilk/egui/pull/5324
- [x] [`jxl-oxide`](https://github.com/tirr-c/jxl-oxide) v0.10 --> Git source then needs to be replaced

### Rationale
The `image` crate maintainer has made it clear that they do not intend to support JXL at this time, and likely won't be in the future either, see: https://github.com/image-rs/image/issues/1979

For this reason, the `jxl-oxide` crate has just recently added support for the `image` crate format, see: https://github.com/tirr-c/jxl-oxide/issues/162

JXL is a leading format (with yes, much less adoption than others) including various features that make it a compelling option. ~~`jxl-oxide` is an appropriate crate choice as it has a history of being very well maintained, and (at least a couple months ago?) is the likely pickup for Chromium and Firefox support in the next year or so. I've lost the source on this one, but remember either the Chromium or Firefox devs officially stating they were unwilling to merge the C library in, but suggested continuing this rust port.~~ The eventual crate being worked on to be implemented in Chromium and Firefox is https://github.com/libjxl/jxl-rs, however, `jxl-oxide` is still receiving active updates.

This is also especially interesting to implement as it allows high quality jxl support through WASM, irrespective of browser jxl support (which is poor at the moment).

~~This PR is a draft until `jxl-oxide`'s v0.10 release, which adds built-in `image` crate compatibility. The other linked PRs should also come first.~~ v0.10 was released https://github.com/tirr-c/jxl-oxide/releases/tag/0.10.0

### Todo/Further Considerations

- [ ] https://github.com/emilk/egui/issues/5341 ~Possibly should await any further image crate support detection changes. JXL magic byte detection could be added if that is the route we want to go down.
- [ ] `jxl-oxide` uses rayon optionally to speed up decode. Is it fine leaving this feature for the caller to specify in their own Cargo.toml? (similar to how the `image` crate features are currently set up)
- [ ] Should this PR be expanded to include more JXL features? Or (more likely) worry about basic support for now, and do larger refactoring of image loaders in a new PR? (Multiple image formats support progressive decode)