### PR TITLE
Prevent panic when copying text outside of a secure context

### DIFF
--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -174,6 +174,13 @@ fn set_cursor_icon(cursor: egui::CursorIcon) -> Option<()> {
 /// Set the clipboard text.
 fn set_clipboard_text(s: &str) {
     if let Some(window) = web_sys::window() {
+        if !window.is_secure_context() {
+            log::error!(
+                "Clipboard is not available because we are not in a secure context. \
+                See https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts"
+            );
+            return;
+        }
         let promise = window.navigator().clipboard().write_text(s);
         let future = wasm_bindgen_futures::JsFuture::from(promise);
         let future = async move {

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1439,6 +1439,10 @@ impl Context {
     ///
     /// Empty strings are ignored.
     ///
+    /// Note that in wasm applications, the clipboard is only accessible in secure contexts (e.g.,
+    /// HTTPS or localhost). If this method is used outside of a secure context, it will log an
+    /// error and do nothing. See <https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts>.
+    ///
     /// Equivalent to:
     /// ```
     /// # let ctx = egui::Context::default();


### PR DESCRIPTION
* Closes <https://github.com/emilk/egui/issues/5293>
* [x] I have followed the instructions in the PR template
