### PR TITLE
Fix bug in pointer movement detection

### DIFF
--- a/crates/egui/src/input_state/mod.rs
+++ b/crates/egui/src/input_state/mod.rs
@@ -932,6 +932,7 @@ impl PointerState {
                             press_origin.distance(pos) > self.input_options.max_click_dist;
                     }
 
+                    self.last_move_time = time;
                     self.pointer_events.push(PointerEvent::Moved(pos));
                 }
                 Event::PointerButton {


### PR DESCRIPTION
Fix: Popups do not appear in certain situations.

* Closes #5080
* Related #5107

The root cause is that `last_move_time` is not updated in certain situations (slow situations?).
