### PR TITLE
Double Slider Widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ NOTE: this is just the changelog for the core `egui` crate. [`eframe`](crates/ef
 This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
+# Unreleased
+* Added double slider widget
 
 ## 0.29.1 - 2024-10-01 - Bug fixes
 * Remove debug-assert triggered by `with_layer_id/dnd_drag_source` [#5191](https://github.com/emilk/egui/pull/5191) by [@emilk](https://github.com/emilk)

--- a/crates/egui/src/widgets/double_slider.rs
+++ b/crates/egui/src/widgets/double_slider.rs
@@ -122,7 +122,7 @@ impl<'a> Widget for DoubleSlider<'a> {
         // calculate height
         let height = 2.0 * self.control_point_radius + 2.0 * OFFSET;
 
-        let (response, painter) =
+        let (mut response, painter) =
             ui.allocate_painter(Vec2::new(self.width, height), Sense::hover());
         let mut left_edge = response.rect.left_center();
         left_edge.x += self.control_point_radius;
@@ -151,6 +151,10 @@ impl<'a> Widget for DoubleSlider<'a> {
             let point_rect = Rect::from_center_size(point_in_screen, size);
             let point_id = response.id.with(0);
             let point_response = ui.interact(point_rect, point_id, Sense::drag());
+
+            if point_response.dragged() {
+                response.mark_changed();
+            }
 
             // handle logic
             *self.left_slider += self.x_to_val(point_response.drag_delta().x);
@@ -185,6 +189,10 @@ impl<'a> Widget for DoubleSlider<'a> {
             let point_rect = Rect::from_center_size(point_in_screen, size);
             let point_id = response.id.with(1);
             let point_response = ui.interact(point_rect, point_id, Sense::drag());
+
+            if point_response.dragged() {
+                response.mark_changed();
+            }
 
             // handle logic
             *self.right_slider += self.x_to_val(point_response.drag_delta().x);

--- a/crates/egui/src/widgets/double_slider.rs
+++ b/crates/egui/src/widgets/double_slider.rs
@@ -1,9 +1,8 @@
-use std::ops::RangeInclusive;
 use crate::emath;
 use crate::emath::{Pos2, Rect, Vec2};
 use crate::epaint::{CircleShape, Color32, PathShape, Shape, Stroke};
 use crate::{Sense, Ui, Widget};
-
+use std::ops::RangeInclusive;
 
 // offset for stroke highlight
 const OFFSET: f32 = 2.0;
@@ -22,7 +21,11 @@ pub struct DoubleSlider<'a> {
 }
 
 impl<'a> DoubleSlider<'a> {
-    pub fn new(lower_value: &'a mut f32, upper_value: &'a mut f32, range: RangeInclusive<f32>) -> Self {
+    pub fn new(
+        lower_value: &'a mut f32,
+        upper_value: &'a mut f32,
+        range: RangeInclusive<f32>,
+    ) -> Self {
         DoubleSlider {
             left_slider: lower_value,
             right_slider: upper_value,
@@ -85,19 +88,23 @@ impl<'a> DoubleSlider<'a> {
         self
     }
 
-
     fn to_coord(&self, num: f32) -> f32 {
-        (self.width - 2.0 * self.control_point_radius - 2.0 * OFFSET) / (self.range.end() - self.range.start()) * (num - self.range.start())
-            + self.control_point_radius + OFFSET
+        (self.width - 2.0 * self.control_point_radius - 2.0 * OFFSET)
+            / (self.range.end() - self.range.start())
+            * (num - self.range.start())
+            + self.control_point_radius
+            + OFFSET
     }
 
     fn from_coord(&self, x: f32) -> f32 {
-        (self.range.end() - self.range.start()) / (self.width - 2.0 * self.control_point_radius - 2.0 * OFFSET) * x
+        (self.range.end() - self.range.start())
+            / (self.width - 2.0 * self.control_point_radius - 2.0 * OFFSET)
+            * x
     }
 }
 
 impl<'a> Widget for DoubleSlider<'a> {
-    fn ui(self: Self, ui: &mut Ui) -> crate::Response {
+    fn ui(self, ui: &mut Ui) -> crate::Response {
         let height = 2.0 * self.control_point_radius + 2.0 * OFFSET;
 
         let (response, painter) =
@@ -107,7 +114,10 @@ impl<'a> Widget for DoubleSlider<'a> {
         let mut right_edge = response.rect.right_center();
         right_edge.x -= self.control_point_radius;
 
-        painter.add(PathShape::line(vec![left_edge, right_edge], Stroke::new(self.stroke.width, self.color)));
+        painter.add(PathShape::line(
+            vec![left_edge, right_edge],
+            Stroke::new(self.stroke.width, self.color),
+        ));
 
         let to_screen = emath::RectTransform::from_to(
             Rect::from_min_size(Pos2::ZERO, response.rect.size()),
@@ -116,17 +126,24 @@ impl<'a> Widget for DoubleSlider<'a> {
 
         let lower_bound = {
             let size = Vec2::splat(2.0 * self.control_point_radius);
-            let point_in_screen = to_screen.transform_pos(Pos2 { x: self.to_coord(*self.left_slider), y: self.control_point_radius + OFFSET });
+            let point_in_screen = to_screen.transform_pos(Pos2 {
+                x: self.to_coord(*self.left_slider),
+                y: self.control_point_radius + OFFSET,
+            });
             let point_rect = Rect::from_center_size(point_in_screen, size);
             let point_id = response.id.with(0);
             let point_response = ui.interact(point_rect, point_id, Sense::drag());
 
             *self.left_slider += self.from_coord(point_response.drag_delta().x);
             if *self.right_slider < *self.left_slider + self.separation_distance {
-                *self.right_slider = *self.left_slider + self.separation_distance
+                *self.right_slider = *self.left_slider + self.separation_distance;
             }
-            *self.right_slider = self.right_slider.clamp(*self.range.start(), *self.range.end());
-            *self.left_slider = self.left_slider.clamp(*self.range.start(), *self.range.end());
+            *self.right_slider = self
+                .right_slider
+                .clamp(*self.range.start(), *self.range.end());
+            *self.left_slider = self
+                .left_slider
+                .clamp(*self.range.start(), *self.range.end());
 
             let stroke = ui.style().interact(&point_response).fg_stroke;
 
@@ -140,17 +157,24 @@ impl<'a> Widget for DoubleSlider<'a> {
 
         let upper_bound = {
             let size = Vec2::splat(2.0 * self.control_point_radius);
-            let point_in_screen = to_screen.transform_pos(Pos2 { x: self.to_coord(*self.right_slider), y: self.control_point_radius + OFFSET });
+            let point_in_screen = to_screen.transform_pos(Pos2 {
+                x: self.to_coord(*self.right_slider),
+                y: self.control_point_radius + OFFSET,
+            });
             let point_rect = Rect::from_center_size(point_in_screen, size);
             let point_id = response.id.with(1);
             let point_response = ui.interact(point_rect, point_id, Sense::drag());
 
             *self.right_slider += self.from_coord(point_response.drag_delta().x);
             if *self.left_slider > *self.right_slider - self.separation_distance {
-                *self.left_slider = *self.right_slider - self.separation_distance
+                *self.left_slider = *self.right_slider - self.separation_distance;
             }
-            *self.right_slider = self.right_slider.clamp(*self.range.start(), *self.range.end());
-            *self.left_slider = self.left_slider.clamp(*self.range.start(), *self.range.end());
+            *self.right_slider = self
+                .right_slider
+                .clamp(*self.range.start(), *self.range.end());
+            *self.left_slider = self
+                .left_slider
+                .clamp(*self.range.start(), *self.range.end());
 
             let stroke = ui.style().interact(&point_response).fg_stroke;
 
@@ -162,12 +186,19 @@ impl<'a> Widget for DoubleSlider<'a> {
             }
         };
 
-
-        let points_in_screen: Vec<Pos2> = [self.to_coord(*self
-            .left_slider), self.to_coord(*self.right_slider)]
-            .iter()
-            .map(|p| to_screen * Pos2 { x: *p, y: self.control_point_radius + OFFSET })
-            .collect();
+        let points_in_screen: Vec<Pos2> = [
+            self.to_coord(*self.left_slider),
+            self.to_coord(*self.right_slider),
+        ]
+        .iter()
+        .map(|p| {
+            to_screen
+                * Pos2 {
+                    x: *p,
+                    y: self.control_point_radius + OFFSET,
+                }
+        })
+        .collect();
 
         painter.add(PathShape::line(points_in_screen, self.stroke));
         painter.extend([Shape::Circle(lower_bound), Shape::Circle(upper_bound)]);

--- a/crates/egui/src/widgets/double_slider.rs
+++ b/crates/egui/src/widgets/double_slider.rs
@@ -1,4 +1,3 @@
-use crate::emath;
 use crate::emath::{Pos2, Rect, Vec2};
 use crate::epaint::{CircleShape, Color32, PathShape, Shape, Stroke};
 use crate::{Sense, Ui, Widget};
@@ -7,6 +6,21 @@ use std::ops::RangeInclusive;
 // offset for stroke highlight
 const OFFSET: f32 = 2.0;
 
+/// Control two numbers with a double slider.
+///
+/// The slider range defines the values you get when pulling the slider to the far edges.
+///
+/// The range can include any numbers, and go from low-to-high or from high-to-low.
+///
+///
+/// ```
+/// # egui::__run_test_ui(|ui| {
+/// # let mut my_f32: f32 = 0.0;
+/// # let mut my_other_f32: f32 = 0.0;
+/// ui.add(egui::DoubleSlider::new(&mut my_f32,&mut my_other_f32, 0.0..=100.0));
+/// # });
+/// ```
+///
 #[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct DoubleSlider<'a> {
     left_slider: &'a mut f32,
@@ -39,64 +53,64 @@ impl<'a> DoubleSlider<'a> {
         }
     }
 
-    #[allow(dead_code)]
     /// Set the primary width for the slider.
+    #[inline]
     pub fn width(mut self, width: f32) -> Self {
         self.width = width;
         self
     }
 
-    #[allow(dead_code)]
     /// Set the separation distance for the two sliders.
+    #[inline]
     pub fn separation_distance(mut self, separation_distance: f32) -> Self {
         self.separation_distance = separation_distance;
         self
     }
 
-    #[allow(dead_code)]
     /// Set the primary color for the slider.
+    #[inline]
     pub fn color(mut self, color: Color32) -> Self {
         self.color = color;
         self
     }
 
-    #[allow(dead_code)]
     /// Set the stroke for the main line.
+    #[inline]
     pub fn stroke(mut self, stroke: Stroke) -> Self {
         self.stroke = stroke;
         self
     }
 
-    #[allow(dead_code)]
     /// Set the color fill for the slider cursor.
+    #[inline]
     pub fn cursor_fill(mut self, cursor_fill: Color32) -> Self {
         self.cursor_fill = cursor_fill;
         self
     }
 
-    #[allow(dead_code)]
     /// Set the auxiliary stroke.
+    #[inline]
     pub fn aux_stroke(mut self, aux_stroke: Stroke) -> Self {
         self.stroke = aux_stroke;
         self
     }
 
-    #[allow(dead_code)]
     /// Set the control point radius
+    #[inline]
     pub fn control_point_radius(mut self, control_point_radius: f32) -> Self {
         self.control_point_radius = control_point_radius;
         self
     }
 
-    fn to_coord(&self, num: f32) -> f32 {
+    fn val_to_x(&self, val: f32) -> f32 {
         (self.width - 2.0 * self.control_point_radius - 2.0 * OFFSET)
             / (self.range.end() - self.range.start())
-            * (num - self.range.start())
+            * (val - self.range.start())
             + self.control_point_radius
             + OFFSET
     }
 
-    fn from_coord(&self, x: f32) -> f32 {
+    fn x_to_val(&self, x: f32) -> f32 {
         (self.range.end() - self.range.start())
             / (self.width - 2.0 * self.control_point_radius - 2.0 * OFFSET)
             * x
@@ -105,6 +119,7 @@ impl<'a> DoubleSlider<'a> {
 
 impl<'a> Widget for DoubleSlider<'a> {
     fn ui(self, ui: &mut Ui) -> crate::Response {
+        // calculate height
         let height = 2.0 * self.control_point_radius + 2.0 * OFFSET;
 
         let (response, painter) =
@@ -114,6 +129,7 @@ impl<'a> Widget for DoubleSlider<'a> {
         let mut right_edge = response.rect.right_center();
         right_edge.x -= self.control_point_radius;
 
+        // draw the line
         painter.add(PathShape::line(
             vec![left_edge, right_edge],
             Stroke::new(self.stroke.width, self.color),
@@ -124,17 +140,20 @@ impl<'a> Widget for DoubleSlider<'a> {
             response.rect,
         );
 
+        // handle lower bound
         let lower_bound = {
+            // get the control point
             let size = Vec2::splat(2.0 * self.control_point_radius);
             let point_in_screen = to_screen.transform_pos(Pos2 {
-                x: self.to_coord(*self.left_slider),
+                x: self.val_to_x(*self.left_slider),
                 y: self.control_point_radius + OFFSET,
             });
             let point_rect = Rect::from_center_size(point_in_screen, size);
             let point_id = response.id.with(0);
             let point_response = ui.interact(point_rect, point_id, Sense::drag());
 
-            *self.left_slider += self.from_coord(point_response.drag_delta().x);
+            // handle logic
+            *self.left_slider += self.x_to_val(point_response.drag_delta().x);
             if *self.right_slider < *self.left_slider + self.separation_distance {
                 *self.right_slider = *self.left_slider + self.separation_distance;
             }
@@ -155,17 +174,20 @@ impl<'a> Widget for DoubleSlider<'a> {
             }
         };
 
+        // handle upper bound
         let upper_bound = {
+            // get the control point
             let size = Vec2::splat(2.0 * self.control_point_radius);
             let point_in_screen = to_screen.transform_pos(Pos2 {
-                x: self.to_coord(*self.right_slider),
+                x: self.val_to_x(*self.right_slider),
                 y: self.control_point_radius + OFFSET,
             });
             let point_rect = Rect::from_center_size(point_in_screen, size);
             let point_id = response.id.with(1);
             let point_response = ui.interact(point_rect, point_id, Sense::drag());
 
-            *self.right_slider += self.from_coord(point_response.drag_delta().x);
+            // handle logic
+            *self.right_slider += self.x_to_val(point_response.drag_delta().x);
             if *self.left_slider > *self.right_slider - self.separation_distance {
                 *self.left_slider = *self.right_slider - self.separation_distance;
             }
@@ -187,8 +209,8 @@ impl<'a> Widget for DoubleSlider<'a> {
         };
 
         let points_in_screen: Vec<Pos2> = [
-            self.to_coord(*self.left_slider),
-            self.to_coord(*self.right_slider),
+            self.val_to_x(*self.left_slider),
+            self.val_to_x(*self.right_slider),
         ]
         .iter()
         .map(|p| {
@@ -200,7 +222,9 @@ impl<'a> Widget for DoubleSlider<'a> {
         })
         .collect();
 
+        // draw line between points
         painter.add(PathShape::line(points_in_screen, self.stroke));
+        // draw control points
         painter.extend([Shape::Circle(lower_bound), Shape::Circle(upper_bound)]);
 
         response

--- a/crates/egui/src/widgets/double_slider.rs
+++ b/crates/egui/src/widgets/double_slider.rs
@@ -1,0 +1,177 @@
+use std::ops::RangeInclusive;
+use crate::emath;
+use crate::emath::{Pos2, Rect, Vec2};
+use crate::epaint::{CircleShape, Color32, PathShape, Shape, Stroke};
+use crate::{Sense, Ui, Widget};
+
+
+// offset for stroke highlight
+const OFFSET: f32 = 2.0;
+
+#[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
+pub struct DoubleSlider<'a> {
+    left_slider: &'a mut f32,
+    right_slider: &'a mut f32,
+    separation_distance: f32,
+    control_point_radius: f32,
+    width: f32,
+    color: Color32,
+    cursor_fill: Color32,
+    stroke: Stroke,
+    range: RangeInclusive<f32>,
+}
+
+impl<'a> DoubleSlider<'a> {
+    pub fn new(lower_value: &'a mut f32, upper_value: &'a mut f32, range: RangeInclusive<f32>) -> Self {
+        DoubleSlider {
+            left_slider: lower_value,
+            right_slider: upper_value,
+            separation_distance: 75.0,
+            control_point_radius: 7.0,
+            width: 100.0,
+            cursor_fill: Color32::DARK_GRAY,
+            color: Color32::DARK_GRAY,
+            stroke: Stroke::new(7.0, Color32::RED.linear_multiply(0.5)),
+            range,
+        }
+    }
+
+    #[allow(dead_code)]
+    /// Set the primary width for the slider.
+    pub fn width(mut self, width: f32) -> Self {
+        self.width = width;
+        self
+    }
+
+    #[allow(dead_code)]
+    /// Set the separation distance for the two sliders.
+    pub fn separation_distance(mut self, separation_distance: f32) -> Self {
+        self.separation_distance = separation_distance;
+        self
+    }
+
+    #[allow(dead_code)]
+    /// Set the primary color for the slider.
+    pub fn color(mut self, color: Color32) -> Self {
+        self.color = color;
+        self
+    }
+
+    #[allow(dead_code)]
+    /// Set the stroke for the main line.
+    pub fn stroke(mut self, stroke: Stroke) -> Self {
+        self.stroke = stroke;
+        self
+    }
+
+    #[allow(dead_code)]
+    /// Set the color fill for the slider cursor.
+    pub fn cursor_fill(mut self, cursor_fill: Color32) -> Self {
+        self.cursor_fill = cursor_fill;
+        self
+    }
+
+    #[allow(dead_code)]
+    /// Set the auxiliary stroke.
+    pub fn aux_stroke(mut self, aux_stroke: Stroke) -> Self {
+        self.stroke = aux_stroke;
+        self
+    }
+
+    #[allow(dead_code)]
+    /// Set the control point radius
+    pub fn control_point_radius(mut self, control_point_radius: f32) -> Self {
+        self.control_point_radius = control_point_radius;
+        self
+    }
+
+
+    fn to_coord(&self, num: f32) -> f32 {
+        (self.width - 2.0 * self.control_point_radius - 2.0 * OFFSET) / (self.range.end() - self.range.start()) * (num - self.range.start())
+            + self.control_point_radius + OFFSET
+    }
+
+    fn from_coord(&self, x: f32) -> f32 {
+        (self.range.end() - self.range.start()) / (self.width - 2.0 * self.control_point_radius - 2.0 * OFFSET) * x
+    }
+}
+
+impl<'a> Widget for DoubleSlider<'a> {
+    fn ui(self: Self, ui: &mut Ui) -> crate::Response {
+        let height = 2.0 * self.control_point_radius + 2.0 * OFFSET;
+
+        let (response, painter) =
+            ui.allocate_painter(Vec2::new(self.width, height), Sense::hover());
+        let mut left_edge = response.rect.left_center();
+        left_edge.x += self.control_point_radius;
+        let mut right_edge = response.rect.right_center();
+        right_edge.x -= self.control_point_radius;
+
+        painter.add(PathShape::line(vec![left_edge, right_edge], Stroke::new(self.stroke.width, self.color)));
+
+        let to_screen = emath::RectTransform::from_to(
+            Rect::from_min_size(Pos2::ZERO, response.rect.size()),
+            response.rect,
+        );
+
+        let lower_bound = {
+            let size = Vec2::splat(2.0 * self.control_point_radius);
+            let point_in_screen = to_screen.transform_pos(Pos2 { x: self.to_coord(*self.left_slider), y: self.control_point_radius + OFFSET });
+            let point_rect = Rect::from_center_size(point_in_screen, size);
+            let point_id = response.id.with(0);
+            let point_response = ui.interact(point_rect, point_id, Sense::drag());
+
+            *self.left_slider += self.from_coord(point_response.drag_delta().x);
+            if *self.right_slider < *self.left_slider + self.separation_distance {
+                *self.right_slider = *self.left_slider + self.separation_distance
+            }
+            *self.right_slider = self.right_slider.clamp(*self.range.start(), *self.range.end());
+            *self.left_slider = self.left_slider.clamp(*self.range.start(), *self.range.end());
+
+            let stroke = ui.style().interact(&point_response).fg_stroke;
+
+            CircleShape {
+                center: point_in_screen,
+                radius: self.control_point_radius,
+                fill: self.cursor_fill,
+                stroke,
+            }
+        };
+
+        let upper_bound = {
+            let size = Vec2::splat(2.0 * self.control_point_radius);
+            let point_in_screen = to_screen.transform_pos(Pos2 { x: self.to_coord(*self.right_slider), y: self.control_point_radius + OFFSET });
+            let point_rect = Rect::from_center_size(point_in_screen, size);
+            let point_id = response.id.with(1);
+            let point_response = ui.interact(point_rect, point_id, Sense::drag());
+
+            *self.right_slider += self.from_coord(point_response.drag_delta().x);
+            if *self.left_slider > *self.right_slider - self.separation_distance {
+                *self.left_slider = *self.right_slider - self.separation_distance
+            }
+            *self.right_slider = self.right_slider.clamp(*self.range.start(), *self.range.end());
+            *self.left_slider = self.left_slider.clamp(*self.range.start(), *self.range.end());
+
+            let stroke = ui.style().interact(&point_response).fg_stroke;
+
+            CircleShape {
+                center: point_in_screen,
+                radius: self.control_point_radius,
+                fill: self.cursor_fill,
+                stroke,
+            }
+        };
+
+
+        let points_in_screen: Vec<Pos2> = [self.to_coord(*self
+            .left_slider), self.to_coord(*self.right_slider)]
+            .iter()
+            .map(|p| to_screen * Pos2 { x: *p, y: self.control_point_radius + OFFSET })
+            .collect();
+
+        painter.add(PathShape::line(points_in_screen, self.stroke));
+        painter.extend([Shape::Circle(lower_bound), Shape::Circle(upper_bound)]);
+
+        response
+    }
+}

--- a/crates/egui/src/widgets/mod.rs
+++ b/crates/egui/src/widgets/mod.rs
@@ -9,6 +9,7 @@ use crate::{epaint, Response, Ui};
 mod button;
 mod checkbox;
 pub mod color_picker;
+mod double_slider;
 pub(crate) mod drag_value;
 mod hyperlink;
 mod image;
@@ -21,11 +22,11 @@ mod separator;
 mod slider;
 mod spinner;
 pub mod text_edit;
-mod double_slider;
 
 pub use self::{
     button::Button,
     checkbox::Checkbox,
+    double_slider::DoubleSlider,
     drag_value::DragValue,
     hyperlink::{Hyperlink, Link},
     image::{
@@ -39,7 +40,6 @@ pub use self::{
     selected_label::SelectableLabel,
     separator::Separator,
     slider::{Slider, SliderClamping, SliderOrientation},
-    double_slider::DoubleSlider,
     spinner::Spinner,
     text_edit::{TextBuffer, TextEdit},
 };

--- a/crates/egui/src/widgets/mod.rs
+++ b/crates/egui/src/widgets/mod.rs
@@ -21,6 +21,7 @@ mod separator;
 mod slider;
 mod spinner;
 pub mod text_edit;
+mod double_slider;
 
 pub use self::{
     button::Button,
@@ -38,6 +39,7 @@ pub use self::{
     selected_label::SelectableLabel,
     separator::Separator,
     slider::{Slider, SliderClamping, SliderOrientation},
+    double_slider::DoubleSlider,
     spinner::Spinner,
     text_edit::{TextBuffer, TextEdit},
 };

--- a/crates/egui_demo_lib/src/demo/widget_gallery.rs
+++ b/crates/egui_demo_lib/src/demo/widget_gallery.rs
@@ -15,6 +15,7 @@ pub struct WidgetGallery {
     opacity: f32,
     radio: Enum,
     scalar: f32,
+    scalar_2: f32,
     string: String,
     color: egui::Color32,
     animate_progress_bar: bool,
@@ -33,6 +34,7 @@ impl Default for WidgetGallery {
             boolean: false,
             radio: Enum::First,
             scalar: 42.0,
+            scalar_2: 52.0,
             string: Default::default(),
             color: egui::Color32::LIGHT_BLUE.linear_multiply(0.5),
             animate_progress_bar: false,
@@ -94,7 +96,7 @@ impl crate::View for WidgetGallery {
                         .speed(0.01)
                         .range(0.0..=1.0),
                 ) | ui.label("Opacity"))
-                .on_hover_text("Reduce this value to make widgets semi-transparent");
+                    .on_hover_text("Reduce this value to make widgets semi-transparent");
             }
         });
 
@@ -119,6 +121,7 @@ impl WidgetGallery {
             boolean,
             radio,
             scalar,
+            scalar_2,
             string,
             color,
             animate_progress_bar,
@@ -187,6 +190,10 @@ impl WidgetGallery {
 
         ui.add(doc_link_label("Slider", "Slider"));
         ui.add(egui::Slider::new(scalar, 0.0..=360.0).suffix("°"));
+        ui.end_row();
+
+        ui.add(doc_link_label("Double Slider", "Double Slider"));
+        ui.add(egui::DoubleSlider::new(scalar, scalar_2, 0.0..=360.0));
         ui.end_row();
 
         ui.add(doc_link_label("DragValue", "DragValue"));

--- a/crates/egui_demo_lib/src/demo/widget_gallery.rs
+++ b/crates/egui_demo_lib/src/demo/widget_gallery.rs
@@ -96,7 +96,7 @@ impl crate::View for WidgetGallery {
                         .speed(0.01)
                         .range(0.0..=1.0),
                 ) | ui.label("Opacity"))
-                    .on_hover_text("Reduce this value to make widgets semi-transparent");
+                .on_hover_text("Reduce this value to make widgets semi-transparent");
             }
         });
 


### PR DESCRIPTION
This addresses the request for a double handed slider #2006 . I also updated the widget gallery and the demo app.
* [X] I have followed the instructions in the PR template

The widget is currently only working with `f32`. It is also not yet as neatly integrated into the ui-style as `egui::Slider`, there is no Value display yet and no text, suffix options.

Features:
- dragging the two sliders.
- pushing the next slider when they touch (`separation_distance` is configurable)

<img width="348" alt="Bildschirmfoto 2024-10-30 um 22 50 40" src="https://github.com/user-attachments/assets/7bb53c99-8ba0-4c8e-bd4c-e609c9abb252">