### PR TITLE
Fix: Ignoring Characters with ALT Key

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -799,6 +799,7 @@ impl State {
                 // Also make sure the key is pressed (not released). On Linux, text might
                 // contain some data even when the key is released.
                 let is_cmd = self.egui_input.modifiers.ctrl
+                    || self.egui_input.modifiers.alt
                     || self.egui_input.modifiers.command
                     || self.egui_input.modifiers.mac_cmd;
                 if pressed && !is_cmd {


### PR DESCRIPTION
Fix: Ignoring Characters with ALT Key

When you press the ALT key and a character at the same time, the character is ignored.

* Closes #5338
