### PR TITLE
Fix: Ignoring Characters with ALT Key

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -800,7 +800,9 @@ impl State {
                 // contain some data even when the key is released.
                 let is_cmd = self.egui_input.modifiers.ctrl
                     || self.egui_input.modifiers.command
-                    || self.egui_input.modifiers.mac_cmd;
+                    || self.egui_input.modifiers.mac_cmd
+                    || (self.egui_ctx.os() == egui::os::OperatingSystem::Windows
+                        && self.egui_input.modifiers.alt);
                 if pressed && !is_cmd {
                     self.egui_input
                         .events


### PR DESCRIPTION
Fix: Ignoring Characters with ALT Key

When you press the ALT key and a character at the same time, the character is ignored.

* Related #5338
* Related #5347

On Windows, this is correct for `ALT`.
If you don't want to handle `ALT` on Windows, you might want to close this.
