### PR TITLE
Create gray -> grey doc aliases

### DIFF
--- a/crates/ecolor/src/color32.rs
+++ b/crates/ecolor/src/color32.rs
@@ -43,8 +43,11 @@ impl Color32 {
 
     pub const TRANSPARENT: Self = Self::from_rgba_premultiplied(0, 0, 0, 0);
     pub const BLACK: Self = Self::from_rgb(0, 0, 0);
+    #[doc(alias = "DARK_GREY")]
     pub const DARK_GRAY: Self = Self::from_rgb(96, 96, 96);
+    #[doc(alias = "GREY")]
     pub const GRAY: Self = Self::from_rgb(160, 160, 160);
+    #[doc(alias = "LIGHT_GREY")]
     pub const LIGHT_GRAY: Self = Self::from_rgb(220, 220, 220);
     pub const WHITE: Self = Self::from_rgb(255, 255, 255);
 
@@ -128,6 +131,7 @@ impl Color32 {
         }
     }
 
+    #[doc(alias = "from_grey")]
     #[inline]
     pub const fn from_gray(l: u8) -> Self {
         Self([l, l, l, 255])

--- a/crates/ecolor/src/rgba.rs
+++ b/crates/ecolor/src/rgba.rs
@@ -91,6 +91,7 @@ impl Rgba {
         Self([r, g, b, 1.0])
     }
 
+    #[doc(alias = "from_grey")]
     #[inline]
     pub const fn from_gray(l: f32) -> Self {
         Self([l, l, l, 1.0])

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1014,8 +1014,8 @@ impl Visuals {
         self.widgets.noninteractive.weak_bg_fill
     }
 
-    #[doc(alias = "grey_out")]
     /// Returned a "grayed out" version of the given color.
+    #[doc(alias = "grey_out")]
     #[inline(always)]
     pub fn gray_out(&self, color: Color32) -> Color32 {
         crate::ecolor::tint_color_towards(color, self.fade_out_to_color())

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1014,6 +1014,7 @@ impl Visuals {
         self.widgets.noninteractive.weak_bg_fill
     }
 
+    #[doc(alias = "grey_out")]
     /// Returned a "grayed out" version of the given color.
     #[inline(always)]
     pub fn gray_out(&self, color: Color32) -> Color32 {

--- a/crates/epaint/src/image.rs
+++ b/crates/epaint/src/image.rs
@@ -124,6 +124,7 @@ impl ColorImage {
     /// Create a [`ColorImage`] from iterator over flat opaque gray data.
     ///
     /// Panics if `size[0] * size[1] != gray_iter.len()`.
+    #[doc(alias = "from_grey_iter")]
     pub fn from_gray_iter(size: [usize; 2], gray_iter: impl Iterator<Item = u8>) -> Self {
         let pixels: Vec<_> = gray_iter.map(Color32::from_gray).collect();
         assert_eq!(size[0] * size[1], pixels.len());


### PR DESCRIPTION
As someone who uses "grey" instead of "gray", it is annoying that my autocomplete can never find any of the "gray" color related things, so this adds doc aliases for that.

* [x] I have followed the instructions in the PR template
