### PR TITLE
Fix vector normalization in epaint/tessellator/add_line_loop.

### DIFF
--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -470,7 +470,7 @@ impl Path {
                 self.add_point(points[i], n1c / n1c.length_sq());
             } else {
                 // miter join
-                self.add_point(points[i], normal / length_sq);
+                self.add_point(points[i], normal.normalized());
             }
 
             n0 = n1;


### PR DESCRIPTION
In epaint/tessellator/add_line_loop normal vectors of added points were not normalized correctly, they were divided by length squared, what caused their length to explode for some points close together.

Before:
![before](https://github.com/user-attachments/assets/58ad3714-6417-4aad-9b58-beaafa137982)

After:
![after](https://github.com/user-attachments/assets/1ff51b58-276f-4e29-aa30-86a06c717bee)

* [x] I have followed the instructions in the PR template
