### PR TITLE
Always compute pointer position with current zoom

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -587,11 +587,11 @@ impl State {
         window: &Window,
         pos_in_pixels: winit::dpi::PhysicalPosition<f64>,
     ) {
-        let pixels_per_point = pixels_per_point(&self.egui_ctx, window);
+        let scale_factor = window.scale_factor() as f32;
 
         let pos_in_points = egui::pos2(
-            pos_in_pixels.x as f32 / pixels_per_point,
-            pos_in_pixels.y as f32 / pixels_per_point,
+            pos_in_pixels.x as f32 / scale_factor,
+            pos_in_pixels.y as f32 / scale_factor,
         );
         self.pointer_pos_in_points = Some(pos_in_points);
 


### PR DESCRIPTION
This addresses out-of-date pointer positions during changing zoom factors by performing the same zoom-based scaling per-frame when the current zoom factor is known, rather than baking in the zoom factor during the most recent pointer move.

Before:

[Screencast from 2024-11-16 04:09:08 PM.webm](https://github.com/user-attachments/assets/36976437-d79e-4d71-a9e9-ca7aca9d88a7)

After:

[Screencast from 2024-11-16 04:13:54 PM.webm](https://github.com/user-attachments/assets/aecfa5b1-7242-49ac-85c9-42e35002b6b3)

See https://github.com/emilk/egui/issues/5379 for discussion and more details

* Closes https://github.com/emilk/egui/issues/5379
* [x] I have followed the instructions in the PR template
