### PR TITLE
forward x11 and wayland features to glutin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,8 +78,8 @@ criterion = { version = "0.5.1", default-features = false }
 dify = { version = "0.7", default-features = false }
 document-features = "0.2.10"
 glow = "0.14"
-glutin = "0.32.0"
-glutin-winit = "0.5.0"
+glutin = { version = "0.32.0", default-features = false }
+glutin-winit = { version = "0.5.0", default-features = false }
 home = "0.5.9"
 image = { version = "0.25", default-features = false }
 kittest = { git = "https://github.com/rerun-io/kittest", version = "0.1", branch = "main" }

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -85,7 +85,7 @@ puffin = [
 ]
 
 ## Enables wayland support and fixes clipboard issue.
-wayland = ["egui-winit/wayland", "egui-wgpu?/wayland", "egui_glow?/wayland"]
+wayland = ["egui-winit/wayland", "egui-wgpu?/wayland", "egui_glow?/wayland", "glutin?/wayland", "glutin-winit?/wayland"]
 
 ## Enable screen reader support (requires `ctx.options_mut(|o| o.screen_reader = true);`) on web.
 ##
@@ -111,7 +111,7 @@ web_screen_reader = [
 wgpu = ["dep:wgpu", "dep:egui-wgpu", "dep:pollster"]
 
 ## Enables compiling for x11.
-x11 = ["egui-winit/x11", "egui-wgpu?/x11", "egui_glow?/x11"]
+x11 = ["egui-winit/x11", "egui-wgpu?/x11", "egui_glow?/x11", "glutin?/x11", "glutin?/glx", "glutin-winit?/x11", "glutin-winit?/glx"]
 
 ## If set, eframe will look for the env-var `EFRAME_SCREENSHOT_TO` and write a screenshot to that location, and then quit.
 ## This is used to generate images for examples.
@@ -154,10 +154,8 @@ egui-wgpu = { workspace = true, optional = true, features = [
 ] } # if wgpu is used, use it with winit
 pollster = { workspace = true, optional = true } # needed for wgpu
 
-# we can expose these to user so that they can select which backends they want to enable to avoid compiling useless deps.
-# this can be done at the same time we expose x11/wayland features of winit crate.
-glutin = { workspace = true, optional = true }
-glutin-winit = { workspace = true, optional = true }
+glutin = { workspace = true, optional = true, default-features = false, features = ["egl", "wgl"] }
+glutin-winit = { workspace = true, optional = true, default-features = false, features = ["egl", "wgl"] }
 home = { workspace = true, optional = true }
 puffin = { workspace = true, optional = true }
 wgpu = { workspace = true, optional = true, features = [

--- a/crates/egui_glow/Cargo.toml
+++ b/crates/egui_glow/Cargo.toml
@@ -78,8 +78,8 @@ wasm-bindgen.workspace = true
 
 
 [dev-dependencies]
-glutin.workspace = true       # examples/pure_glow
-glutin-winit.workspace = true
+glutin = { workspace = true, default-features = true }       # examples/pure_glow
+glutin-winit = { workspace = true, default-features = true }
 
 [[example]]
 name = "pure_glow"


### PR DESCRIPTION
eframe has features for selecting between x11 and wayland. eframe does not forward the features to glutin. This makes glutin always compile with both backends enabled. This change forwards the feature. This allows users of egui to compile less dependencies when they only need one of x11, wayland.

To understand this change, read the glutin Cargo.toml [1] and the glutin build.rs [2]. You always have to enable glutin's glx feature with the x11 feature. The other default features (egl, wgl) stay enabled. This is intentional so that everything continues to work as before. We could further minimize when egl and wgl are enabled, but that is not part of this change. There is little reason to do so because those feature already only add dependencies when you compile glutin for the right platform (for example wgl on windows).

[1] https://github.com/rust-windowing/glutin/blob/v0.32.1/glutin/Cargo.toml
[2] https://github.com/rust-windowing/glutin/blob/v0.32.1/glutin/build.rs