### PR TITLE
Fix CI failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,7 +2262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3334,9 +3334,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
  "log",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,7 +2262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/crates/egui/tests/regression_tests.rs
+++ b/crates/egui/tests/regression_tests.rs
@@ -13,18 +13,18 @@ pub fn focus_should_skip_over_disabled_buttons() {
     harness.press_key(egui::Key::Tab);
     harness.run();
 
-    let button_1 = harness.get_by_name("Button 1");
+    let button_1 = harness.get_by_label("Button 1");
     assert!(button_1.is_focused());
 
     harness.press_key(egui::Key::Tab);
     harness.run();
 
-    let button_3 = harness.get_by_name("Button 3");
+    let button_3 = harness.get_by_label("Button 3");
     assert!(button_3.is_focused());
 
     harness.press_key(egui::Key::Tab);
     harness.run();
 
-    let button_1 = harness.get_by_name("Button 1");
+    let button_1 = harness.get_by_label("Button 1");
     assert!(button_1.is_focused());
 }


### PR DESCRIPTION
Fixes the RUSTSEC-2024-0399 issue with rustls and the errors in the regression test
See:
https://rustsec.org/advisories/RUSTSEC-2024-0399.html
https://github.com/rustls/rustls/issues/2227

This also fixes the cargo deny runs which are currently failing

* [x] I have followed the instructions in the PR template
