### PR TITLE
fix accidental change of FallbackEgl to PreferEgl

### DIFF
--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -943,7 +943,7 @@ impl GlutinWindowContext {
             // we might want to expose this option to users in the future. maybe using an env var or using native_options.
             //
             // The justification for FallbackEgl over PreferEgl is at https://github.com/emilk/egui/pull/2526#issuecomment-1400229576 .
-            .with_preference(glutin_winit::ApiPreference::PreferEgl)
+            .with_preference(glutin_winit::ApiPreference::FallbackEgl)
             .with_window_attributes(Some(egui_winit::create_winit_window_attributes(
                 egui_ctx,
                 event_loop,


### PR DESCRIPTION
I accidentally changed this in a previous commit when I meant to only change the comment above it.

https://github.com/emilk/egui/pull/5392#discussion_r1859383653