### PR TITLE
Fix cargo machete

### DIFF
--- a/.github/workflows/cargo_machete.yml
+++ b/.github/workflows/cargo_machete.yml
@@ -9,4 +9,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Machete
-        uses: bnjbvr/cargo-machete@main
+        run: cargo install cargo-machete --locked && cargo machete


### PR DESCRIPTION
* [x] I have followed the instructions in the PR template

cargo machete depends on cargo-platform which seems to bumped it's msrv. Installing via --locked should fix this for now. I think it's fine to do this manually instead of using the cargo action since it's so simple and the action we used basically did the same (without --locked)