### PR TITLE
Debug kittest tests with eframe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,6 +1363,7 @@ version = "0.29.1"
 dependencies = [
  "dify",
  "document-features",
+ "eframe",
  "egui",
  "egui-wgpu",
  "egui_kittest",

--- a/crates/egui_kittest/Cargo.toml
+++ b/crates/egui_kittest/Cargo.toml
@@ -22,10 +22,15 @@ wgpu = ["dep:egui-wgpu", "dep:pollster", "dep:image"]
 # Adds a dify-based image snapshot utility.
 snapshot = ["dep:dify", "dep:image", "image/png"]
 
+# Allows debugging tests via eframe.
+run_with_eframe = ["dep:eframe"]
+
+default = ["eframe?/wgpu"]
 
 [dependencies]
 kittest.workspace = true
 egui = { workspace = true, features = ["accesskit"] }
+eframe = { workspace = true, features = ["accesskit"], optional = true }
 
 # wgpu dependencies
 egui-wgpu = { workspace = true, optional = true }

--- a/crates/egui_kittest/src/lib.rs
+++ b/crates/egui_kittest/src/lib.rs
@@ -12,6 +12,8 @@ mod snapshot;
 pub use snapshot::*;
 use std::fmt::{Debug, Formatter};
 mod app_kind;
+#[cfg(feature = "run_with_eframe")]
+mod run_with_eframe;
 #[cfg(feature = "wgpu")]
 mod texture_to_image;
 #[cfg(feature = "wgpu")]
@@ -23,7 +25,7 @@ use std::mem;
 use crate::app_kind::AppKind;
 use crate::event::EventState;
 pub use builder::*;
-use egui::{Pos2, Rect, TexturesDelta, Vec2, ViewportId};
+use egui::{Pos2, Rect, TexturesDelta, Vec2, ViewportBuilder, ViewportId};
 use kittest::{Node, Queryable};
 
 /// The test Harness. This contains everything needed to run the test.
@@ -267,6 +269,19 @@ impl<'a, State> Harness<'a, State> {
             repeat: false,
             physical_key: None,
         });
+    }
+
+    #[cfg(feature = "run_with_eframe")]
+    pub fn run_with_eframe(&mut self) {
+        let native_options = eframe::NativeOptions {
+            viewport: ViewportBuilder::default().with_inner_size(self.ctx.screen_rect().size()),
+            ..Default::default()
+        };
+        eframe::run_native(
+            "egui_debug",
+            native_options,
+            Box::new(|cc| Ok(Box::new(self))),
+        );
     }
 }
 

--- a/crates/egui_kittest/src/run_with_eframe.rs
+++ b/crates/egui_kittest/src/run_with_eframe.rs
@@ -1,0 +1,13 @@
+use crate::Harness;
+use eframe::Frame;
+use egui::Context;
+
+impl<'a, State> eframe::App for &mut Harness<'a, State> {
+    fn update(&mut self, ctx: &Context, frame: &mut Frame) {
+        self.app.run(ctx, &mut self.state, false);
+    }
+
+    fn persist_egui_memory(&self) -> bool {
+        false
+    }
+}

--- a/crates/egui_kittest/tests/tests.rs
+++ b/crates/egui_kittest/tests/tests.rs
@@ -10,5 +10,7 @@ fn test_shrink() {
 
     harness.fit_contents();
 
+    harness.run_with_eframe();
+
     harness.wgpu_snapshot("test_shrink");
 }


### PR DESCRIPTION
It would be nice to have some way to debug kittest tests by running them with eframe. I gave this a try but ran into the problem that tests usually aren't run on the main thread. 

It could be possible to solve this via https://github.com/emilk/eterm (but we'd need to update it to work with current egui)

See also: https://github.com/rerun-io/rerun/pull/8248#discussion_r1863191027

* [x] I have followed the instructions in the PR template
