### PR TITLE
Improve error message when kittest fails

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
+/crates/egui_kittest @lucasmerlin
 /crates/egui-wgpu @Wumpf

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -426,7 +426,7 @@ mod tests {
 
             let result = harness.try_wgpu_snapshot_options(&format!("demos/{name}"), &options);
             if let Err(err) = result {
-                errors.push(err);
+                errors.push(err.to_string());
             }
         }
 

--- a/crates/egui_kittest/src/snapshot.rs
+++ b/crates/egui_kittest/src/snapshot.rs
@@ -95,26 +95,26 @@ impl Display for SnapshotError {
             Self::Diff { diff, diff_path } => {
                 write!(
                     f,
-                    "Image did not match snapshot. Diff: {diff}, {diff_path:?}"
+                    "Image did not match snapshot. Diff: {diff}, {diff_path:?}. Run `UPDATE_SNAPSHOTS=1 cargo test` to update the snapshots."
                 )
             }
             Self::OpenSnapshot { path, err } => match err {
                 ImageError::IoError(io) => match io.kind() {
                     ErrorKind::NotFound => {
-                        write!(f, "Missing snapshot: {path:?}")
+                        write!(f, "Missing snapshot: {path:?}. Run `UPDATE_SNAPSHOTS=1 cargo test` to update the snapshots.")
                     }
                     err => {
-                        write!(f, "Error reading snapshot: {err:?}\nAt: {path:?}")
+                        write!(f, "Error reading snapshot: {err:?}\nAt: {path:?}. Run `UPDATE_SNAPSHOTS=1 cargo test` to update the snapshots.")
                     }
                 },
                 err => {
-                    write!(f, "Error decoding snapshot: {err:?}\nAt: {path:?}")
+                    write!(f, "Error decoding snapshot: {err:?}\nAt: {path:?}. Run `UPDATE_SNAPSHOTS=1 cargo test` to update the snapshots.")
                 }
             },
             Self::SizeMismatch { expected, actual } => {
                 write!(
                     f,
-                    "Image size did not match snapshot. Expected: {expected:?}, Actual: {actual:?}"
+                    "Image size did not match snapshot. Expected: {expected:?}, Actual: {actual:?}. Run `UPDATE_SNAPSHOTS=1 cargo test` to update the snapshots."
                 )
             }
             Self::WriteSnapshot { path, err } => {

--- a/crates/egui_kittest/src/snapshot.rs
+++ b/crates/egui_kittest/src/snapshot.rs
@@ -95,6 +95,9 @@ pub enum SnapshotError {
     },
 }
 
+const HOW_TO_UPDATE_SCREENSHOTS: &str =
+    "Run `UPDATE_SNAPSHOTS=1 cargo test` to update the snapshots.";
+
 impl Display for SnapshotError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -105,20 +108,20 @@ impl Display for SnapshotError {
             } => {
                 write!(
                     f,
-                    "'{name}' Image did not match snapshot. Diff: {diff}, {diff_path:?}. Run `UPDATE_SNAPSHOTS=1 cargo test` to update the snapshots."
+                    "'{name}' Image did not match snapshot. Diff: {diff}, {diff_path:?}. {HOW_TO_UPDATE_SCREENSHOTS}"
                 )
             }
             Self::OpenSnapshot { path, err } => match err {
                 ImageError::IoError(io) => match io.kind() {
                     ErrorKind::NotFound => {
-                        write!(f, "Missing snapshot: {path:?}. Run `UPDATE_SNAPSHOTS=1 cargo test` to update the snapshots.")
+                        write!(f, "Missing snapshot: {path:?}. {HOW_TO_UPDATE_SCREENSHOTS}")
                     }
                     err => {
-                        write!(f, "Error reading snapshot: {err:?}\nAt: {path:?}. Run `UPDATE_SNAPSHOTS=1 cargo test` to update the snapshots.")
+                        write!(f, "Error reading snapshot: {err:?}\nAt: {path:?}. {HOW_TO_UPDATE_SCREENSHOTS}")
                     }
                 },
                 err => {
-                    write!(f, "Error decoding snapshot: {err:?}\nAt: {path:?}. Run `UPDATE_SNAPSHOTS=1 cargo test` to update the snapshots.")
+                    write!(f, "Error decoding snapshot: {err:?}\nAt: {path:?}. Make sure git-lfs is setup correctly. Read the instructions here: https://github.com/emilk/egui/blob/master/CONTRIBUTING.md#making-a-pr")
                 }
             },
             Self::SizeMismatch {
@@ -128,7 +131,7 @@ impl Display for SnapshotError {
             } => {
                 write!(
                     f,
-                    "'{name}' Image size did not match snapshot. Expected: {expected:?}, Actual: {actual:?}. Run `UPDATE_SNAPSHOTS=1 cargo test` to update the snapshots."
+                    "'{name}' Image size did not match snapshot. Expected: {expected:?}, Actual: {actual:?}. {HOW_TO_UPDATE_SCREENSHOTS}"
                 )
             }
             Self::WriteSnapshot { path, err } => {


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/5423

New output is actionable

```
failures:

---- demo::demo_app_windows::tests::demos_should_match_snapshot stdout ----
thread 'demo::demo_app_windows::tests::demos_should_match_snapshot' panicked at crates/egui_demo_lib/src/demo/demo_app_windows.rs:433:9:
Errors: [
    "'demos/Code Example' Image size did not match snapshot. Expected: (402, 574), Actual: (415, 574).
     Run `UPDATE_SNAPSHOTS=1 cargo test` to update the snapshots.",
]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    demo::demo_app_windows::tests::demos_should_match_snapshot
```