### PR TITLE
Add screenshot support for eframe web

### DIFF
--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -655,7 +655,6 @@ impl<'app> WgpuWinitRunning<'app> {
                 true
             }
         });
-        let screenshot_requested = !screenshot_commands.is_empty();
         let vsync_secs = painter.paint_and_update_textures(
             viewport_id,
             pixels_per_point,

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -185,6 +185,7 @@ impl<'app> WgpuWinitApp<'app> {
 
         #[allow(unsafe_code, unused_mut, unused_unsafe)]
         let mut painter = egui_wgpu::winit::Painter::new(
+            egui_ctx.clone(),
             self.native_options.wgpu_options.clone(),
             self.native_options.multisampling.max(1) as _,
             egui_wgpu::depth_format_from_bits(
@@ -593,6 +594,8 @@ impl<'app> WgpuWinitRunning<'app> {
                 .map(|(id, viewport)| (*id, viewport.info.clone()))
                 .collect();
 
+            painter.handle_screenshots(&mut raw_input.events);
+
             (viewport_ui_cb, raw_input)
         };
 
@@ -653,36 +656,14 @@ impl<'app> WgpuWinitRunning<'app> {
             }
         });
         let screenshot_requested = !screenshot_commands.is_empty();
-        let (vsync_secs, screenshot) = painter.paint_and_update_textures(
+        let vsync_secs = painter.paint_and_update_textures(
             viewport_id,
             pixels_per_point,
             app.clear_color(&egui_ctx.style().visuals),
             &clipped_primitives,
             &textures_delta,
-            screenshot_requested,
+            screenshot_commands,
         );
-        match (screenshot_requested, screenshot) {
-            (false, None) => {}
-            (true, Some(screenshot)) => {
-                let screenshot = Arc::new(screenshot);
-                for user_data in screenshot_commands {
-                    egui_winit
-                        .egui_input_mut()
-                        .events
-                        .push(egui::Event::Screenshot {
-                            viewport_id,
-                            user_data,
-                            image: screenshot.clone(),
-                        });
-                }
-            }
-            (true, None) => {
-                log::error!("Bug in egui_wgpu: screenshot requested, but no screenshot was taken");
-            }
-            (false, Some(_)) => {
-                log::warn!("Bug in egui_wgpu: Got screenshot without requesting it");
-            }
-        }
 
         for action in viewport.actions_requested.drain() {
             match action {
@@ -1024,7 +1005,7 @@ fn render_immediate_viewport(
         [0.0, 0.0, 0.0, 0.0],
         &clipped_primitives,
         &textures_delta,
-        false,
+        vec![],
     );
 
     egui_winit.handle_platform_output(window, platform_output);

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -1,7 +1,5 @@
-use egui::{TexturesDelta, UserData, ViewportCommand, ViewportId};
-use js_sys::Reflect::is_extensible;
+use egui::{TexturesDelta, UserData, ViewportCommand};
 use std::mem;
-use std::sync::Arc;
 
 use crate::{epi, App};
 

--- a/crates/eframe/src/web/web_painter.rs
+++ b/crates/eframe/src/web/web_painter.rs
@@ -1,3 +1,4 @@
+use egui::{Event, UserData};
 use wasm_bindgen::JsValue;
 
 /// Renderer for a browser canvas.
@@ -22,8 +23,10 @@ pub(crate) trait WebPainter {
         clipped_primitives: &[egui::ClippedPrimitive],
         pixels_per_point: f32,
         textures_delta: &egui::TexturesDelta,
-        capture: bool,
-    ) -> Result<Option<egui::ColorImage>, JsValue>;
+        capture: Vec<UserData>,
+    ) -> Result<(), JsValue>;
+
+    fn handle_screenshots(&mut self, events: &mut Vec<Event>);
 
     /// Destroy all resources.
     fn destroy(&mut self);

--- a/crates/eframe/src/web/web_painter.rs
+++ b/crates/eframe/src/web/web_painter.rs
@@ -22,7 +22,8 @@ pub(crate) trait WebPainter {
         clipped_primitives: &[egui::ClippedPrimitive],
         pixels_per_point: f32,
         textures_delta: &egui::TexturesDelta,
-    ) -> Result<(), JsValue>;
+        capture: bool,
+    ) -> Result<Option<egui::ColorImage>, JsValue>;
 
     /// Destroy all resources.
     fn destroy(&mut self);

--- a/crates/eframe/src/web/web_painter.rs
+++ b/crates/eframe/src/web/web_painter.rs
@@ -17,6 +17,8 @@ pub(crate) trait WebPainter {
     fn max_texture_side(&self) -> usize;
 
     /// Update all internal textures and paint gui.
+    /// When `capture` isn't empty, the rendered screen should be captured.
+    /// Once the screenshot is ready, the screenshot should be returned via [`Self::handle_screenshots`].
     fn paint_and_update_textures(
         &mut self,
         clear_color: [f32; 4],

--- a/crates/eframe/src/web/web_painter_glow.rs
+++ b/crates/eframe/src/web/web_painter_glow.rs
@@ -1,8 +1,8 @@
+use egui::UserData;
+use egui_glow::glow;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
 use web_sys::HtmlCanvasElement;
-
-use egui_glow::glow;
 
 use crate::{WebGlContextOption, WebOptions};
 
@@ -46,8 +46,8 @@ impl WebPainter for WebPainterGlow {
         clipped_primitives: &[egui::ClippedPrimitive],
         pixels_per_point: f32,
         textures_delta: &egui::TexturesDelta,
-        capture: bool,
-    ) -> Result<Option<egui::ColorImage>, JsValue> {
+        capture: Vec<UserData>,
+    ) -> Result<(), JsValue> {
         let canvas_dimension = [self.canvas.width(), self.canvas.height()];
 
         for (id, image_delta) in &textures_delta.set {

--- a/crates/eframe/src/web/web_painter_glow.rs
+++ b/crates/eframe/src/web/web_painter_glow.rs
@@ -46,7 +46,8 @@ impl WebPainter for WebPainterGlow {
         clipped_primitives: &[egui::ClippedPrimitive],
         pixels_per_point: f32,
         textures_delta: &egui::TexturesDelta,
-    ) -> Result<(), JsValue> {
+        capture: bool,
+    ) -> Result<Option<egui::ColorImage>, JsValue> {
         let canvas_dimension = [self.canvas.width(), self.canvas.height()];
 
         for (id, image_delta) in &textures_delta.set {
@@ -61,7 +62,7 @@ impl WebPainter for WebPainterGlow {
             self.painter.free_texture(id);
         }
 
-        Ok(())
+        Ok(None)
     }
 
     fn destroy(&mut self) {

--- a/crates/eframe/src/web/web_painter_glow.rs
+++ b/crates/eframe/src/web/web_painter_glow.rs
@@ -1,5 +1,6 @@
-use egui::UserData;
+use egui::{Event, UserData, ViewportId};
 use egui_glow::glow;
+use std::sync::Arc;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
 use web_sys::HtmlCanvasElement;
@@ -11,6 +12,7 @@ use super::web_painter::WebPainter;
 pub(crate) struct WebPainterGlow {
     canvas: HtmlCanvasElement,
     painter: egui_glow::Painter,
+    screenshots: Vec<(egui::ColorImage, Vec<UserData>)>,
 }
 
 impl WebPainterGlow {
@@ -18,7 +20,11 @@ impl WebPainterGlow {
         self.painter.gl()
     }
 
-    pub async fn new(canvas: HtmlCanvasElement, options: &WebOptions) -> Result<Self, String> {
+    pub async fn new(
+        _ctx: egui::Context,
+        canvas: HtmlCanvasElement,
+        options: &WebOptions,
+    ) -> Result<Self, String> {
         let (gl, shader_prefix) =
             init_glow_context_from_canvas(&canvas, options.webgl_context_option)?;
         #[allow(clippy::arc_with_non_send_sync)]
@@ -27,7 +33,11 @@ impl WebPainterGlow {
         let painter = egui_glow::Painter::new(gl, shader_prefix, None, options.dithering)
             .map_err(|err| format!("Error starting glow painter: {err}"))?;
 
-        Ok(Self { canvas, painter })
+        Ok(Self {
+            canvas,
+            painter,
+            screenshots: Vec::new(),
+        })
     }
 }
 
@@ -58,15 +68,33 @@ impl WebPainter for WebPainterGlow {
         self.painter
             .paint_primitives(canvas_dimension, pixels_per_point, clipped_primitives);
 
+        if !capture.is_empty() {
+            let image = self.painter.read_screen_rgba(canvas_dimension);
+            self.screenshots.push((image, capture));
+        }
+
         for &id in &textures_delta.free {
             self.painter.free_texture(id);
         }
 
-        Ok(None)
+        Ok(())
     }
 
     fn destroy(&mut self) {
         self.painter.destroy();
+    }
+
+    fn handle_screenshots(&mut self, events: &mut Vec<Event>) {
+        for (image, data) in self.screenshots.drain(..) {
+            let image = Arc::new(image);
+            for data in data {
+                events.push(Event::Screenshot {
+                    viewport_id: ViewportId::default(),
+                    image: image.clone(),
+                    user_data: data,
+                });
+            }
+        }
     }
 }
 

--- a/crates/eframe/src/web/web_painter_wgpu.rs
+++ b/crates/eframe/src/web/web_painter_wgpu.rs
@@ -138,6 +138,7 @@ impl WebPainterWgpu {
         // It would be more efficient to reuse the Buffer, e.g. via some kind of ring buffer, but
         // for most screenshot use cases this should be fine. When taking many screenshots (e.g. for a video)
         // it might make sense to revisit this and implement a more efficient solution.
+        #[allow(clippy::arc_with_non_send_sync)]
         let buffer = Arc::new(render_state.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("egui_screen_capture_buffer"),
             size: (screen_capture_state.padding.padded_bytes_per_row

--- a/crates/eframe/src/web/web_painter_wgpu.rs
+++ b/crates/eframe/src/web/web_painter_wgpu.rs
@@ -2,7 +2,7 @@ use std::sync::{mpsc, Arc};
 
 use super::web_painter::WebPainter;
 use crate::epaint::ColorImage;
-use crate::{epaint, WebOptions};
+use crate::WebOptions;
 use egui::{Event, UserData, ViewportId};
 use egui_wgpu::capture::CaptureState;
 use egui_wgpu::{RenderState, SurfaceErrorAction, WgpuSetup};

--- a/crates/eframe/src/web/web_painter_wgpu.rs
+++ b/crates/eframe/src/web/web_painter_wgpu.rs
@@ -1,7 +1,6 @@
-use std::sync::{mpsc, Arc};
+use std::sync::Arc;
 
 use super::web_painter::WebPainter;
-use crate::epaint::ColorImage;
 use crate::WebOptions;
 use egui::{Event, UserData, ViewportId};
 use egui_wgpu::capture::{capture_channel, CaptureReceiver, CaptureSender, CaptureState};

--- a/crates/eframe/src/web/web_painter_wgpu.rs
+++ b/crates/eframe/src/web/web_painter_wgpu.rs
@@ -330,9 +330,8 @@ impl WebPainter for WebPainterWgpu {
 
         if capture {
             if let Some(capture_state) = &mut self.screen_capture_state {
-                CaptureState::read_screen_rgba(
+                capture_state.read_screen_rgba(
                     self.ctx.clone(),
-                    capture_state,
                     render_state,
                     frame.as_ref(),
                     capture_data,

--- a/crates/egui-wgpu/src/blit.wgsl
+++ b/crates/egui-wgpu/src/blit.wgsl
@@ -1,0 +1,52 @@
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) tex_coords: vec2<f32>,
+};
+
+// meant to be called with 3 vertex indices: 0, 1, 2
+// draws one large triangle over the clip space like this:
+// (the asterisks represent the clip space bounds)
+//-1,1           1,1
+// ---------------------------------
+// |              *              .
+// |              *           .
+// |              *        .
+// |              *      .
+// |              *    .
+// |              * .
+// |***************
+// |            . 1,-1
+// |          .
+// |       .
+// |     .
+// |   .
+// |.
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
+    var result: VertexOutput;
+    let x = i32(vertex_index) / 2;
+    let y = i32(vertex_index) & 1;
+    let tc = vec2<f32>(
+        f32(x) * 2.0,
+        f32(y) * 2.0
+    );
+    result.position = vec4<f32>(
+        tc.x * 2.0 - 1.0,
+        1.0 - tc.y * 2.0,
+        0.0, 1.0
+    );
+    result.tex_coords = tc;
+    return result;
+}
+
+@group(0)
+@binding(0)
+var r_color: texture_2d<f32>;
+@group(0)
+@binding(1)
+var r_sampler: sampler;
+
+@fragment
+fn fs_main(vertex: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(r_color, r_sampler, vertex.tex_coords);
+}

--- a/crates/egui-wgpu/src/capture.rs
+++ b/crates/egui-wgpu/src/capture.rs
@@ -184,6 +184,7 @@ impl CaptureState {
         tx: CaptureSender,
         viewport_id: ViewportId,
     ) {
+        #[allow(clippy::arc_with_non_send_sync)]
         let buffer = Arc::new(buffer);
         let buffer_clone = buffer.clone();
         let buffer_slice = buffer_clone.slice(..);

--- a/crates/egui-wgpu/src/capture.rs
+++ b/crates/egui-wgpu/src/capture.rs
@@ -62,7 +62,7 @@ impl CaptureState {
         });
 
         let (texture, padding, bind_group) =
-            Self::recreate_texture(device, surface_texture, &sampler, &bind_group_layout);
+            Self::create_texture(device, surface_texture, &sampler, &bind_group_layout);
 
         Self {
             padding,
@@ -74,7 +74,7 @@ impl CaptureState {
         }
     }
 
-    fn recreate_texture(
+    fn create_texture(
         device: &wgpu::Device,
         surface_texture: &wgpu::Texture,
         sampler: &Sampler,
@@ -118,7 +118,7 @@ impl CaptureState {
     /// Updates the [`CaptureState`] if the size of the surface texture has changed
     pub fn update(&mut self, device: &wgpu::Device, texture: &wgpu::Texture) {
         if self.texture.size() != texture.size() {
-            let (new_texture, padding, bind_group) = Self::recreate_texture(
+            let (new_texture, padding, bind_group) = Self::create_texture(
                 device,
                 texture,
                 &self.sampler,

--- a/crates/egui-wgpu/src/capture.rs
+++ b/crates/egui-wgpu/src/capture.rs
@@ -1,0 +1,251 @@
+use crate::RenderState;
+use egui::UserData;
+use epaint::ColorImage;
+use std::sync::{mpsc, Arc};
+use wgpu::{MultisampleState, StoreOp};
+
+/// A texture and a buffer for reading the rendered frame back to the cpu.
+/// The texture is required since [`wgpu::TextureUsages::COPY_DST`] is not an allowed
+/// flag for the surface texture on all platforms. This means that anytime we want to
+/// capture the frame, we first render it to this texture, and then we can copy it to
+/// both the surface texture and the buffer, from where we can pull it back to the cpu.
+pub struct CaptureState {
+    pub texture: wgpu::Texture,
+    padding: BufferPadding,
+    pipeline: wgpu::RenderPipeline,
+    bind_group: wgpu::BindGroup,
+}
+
+impl CaptureState {
+    pub fn new(device: &Arc<wgpu::Device>, surface_texture: &wgpu::Texture) -> Self {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("egui_screen_capture_texture"),
+            size: surface_texture.size(),
+            mip_level_count: surface_texture.mip_level_count(),
+            sample_count: surface_texture.sample_count(),
+            dimension: surface_texture.dimension(),
+            format: surface_texture.format(),
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+
+        let padding = BufferPadding::new(surface_texture.width());
+
+        let shader = device.create_shader_module(wgpu::include_wgsl!("blit.wgsl"));
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("blit"),
+            layout: None,
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                compilation_options: Default::default(),
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                compilation_options: Default::default(),
+                targets: &[Some(surface_texture.format().into())],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        let bind_group_layout = pipeline.get_bind_group_layout(0);
+
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("mip"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Nearest,
+            ..Default::default()
+        });
+
+        let view = texture.create_view(&Default::default());
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&sampler),
+                },
+            ],
+            label: None,
+        });
+
+        Self {
+            texture,
+            padding,
+            pipeline,
+            bind_group,
+        }
+    }
+
+    // CaptureState only needs to be updated when the size of the two textures don't match, and we want to
+    // capture a frame
+    pub fn update_capture_state(
+        screen_capture_state: &mut Option<CaptureState>,
+        surface_texture: &wgpu::SurfaceTexture,
+        render_state: &RenderState,
+    ) {
+        let surface_texture = &surface_texture.texture;
+        match screen_capture_state {
+            Some(capture_state) => {
+                if capture_state.texture.size() != surface_texture.size() {
+                    *capture_state = CaptureState::new(&render_state.device, surface_texture);
+                }
+            }
+            None => {
+                *screen_capture_state =
+                    Some(CaptureState::new(&render_state.device, surface_texture));
+            }
+        }
+    }
+
+    // Handles copying from the CaptureState texture to the surface texture and the cpu
+    pub fn read_screen_rgba(
+        ctx: egui::Context,
+        screen_capture_state: &mut CaptureState,
+        render_state: &RenderState,
+        output_frame: Option<&wgpu::SurfaceTexture>,
+        data: Vec<UserData>,
+        tx: mpsc::Sender<(Vec<UserData>, ColorImage)>,
+    ) {
+        // It would be more efficient to reuse the Buffer, e.g. via some kind of ring buffer, but
+        // for most screenshot use cases this should be fine. When taking many screenshots (e.g. for a video)
+        // it might make sense to revisit this and implement a more efficient solution.
+        #[allow(clippy::arc_with_non_send_sync)]
+        let buffer = Arc::new(render_state.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("egui_screen_capture_buffer"),
+            size: (screen_capture_state.padding.padded_bytes_per_row
+                * screen_capture_state.texture.height()) as u64,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        }));
+        let padding = screen_capture_state.padding;
+        let tex = &mut screen_capture_state.texture;
+
+        let device = &render_state.device;
+        let queue = &render_state.queue;
+
+        let tex_extent = tex.size();
+
+        let mut encoder = device.create_command_encoder(&Default::default());
+        encoder.copy_texture_to_buffer(
+            tex.as_image_copy(),
+            wgpu::ImageCopyBuffer {
+                buffer: &buffer,
+                layout: wgpu::ImageDataLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padding.padded_bytes_per_row),
+                    rows_per_image: None,
+                },
+            },
+            tex_extent,
+        );
+
+        if let Some(texture) = output_frame {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("blit"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &texture.texture.create_view(&Default::default()),
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                occlusion_query_set: None,
+                timestamp_writes: None,
+            });
+
+            pass.set_pipeline(&screen_capture_state.pipeline);
+            pass.set_bind_group(0, &screen_capture_state.bind_group, &[]);
+            pass.draw(0..3, 0..1);
+        }
+
+        let id = queue.submit(Some(encoder.finish()));
+        let buffer_clone = buffer.clone();
+        let buffer_slice = buffer_clone.slice(..);
+        let format = tex.format();
+        buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+            if let Err(err) = result {
+                log::error!("Failed to map buffer for reading: {:?}", err);
+                return;
+            }
+            let to_rgba = match format {
+                wgpu::TextureFormat::Rgba8Unorm => [0, 1, 2, 3],
+                wgpu::TextureFormat::Bgra8Unorm => [2, 1, 0, 3],
+                _ => {
+                    log::error!("Screen can't be captured unless the surface format is Rgba8Unorm or Bgra8Unorm. Current surface format is {:?}", format);
+                    return;
+                }
+            };
+            let buffer_slice = buffer.slice(..);
+
+            let mut pixels = Vec::with_capacity((tex_extent.width * tex_extent.height) as usize);
+            for padded_row in buffer_slice
+                .get_mapped_range()
+                .chunks(padding.padded_bytes_per_row as usize)
+            {
+                let row = &padded_row[..padding.unpadded_bytes_per_row as usize];
+                for color in row.chunks(4) {
+                    pixels.push(epaint::Color32::from_rgba_premultiplied(
+                        color[to_rgba[0]],
+                        color[to_rgba[1]],
+                        color[to_rgba[2]],
+                        color[to_rgba[3]],
+                    ));
+                }
+            }
+            buffer.unmap();
+
+            tx.send((
+                data,
+                ColorImage {
+                    size: [tex_extent.width as usize, tex_extent.height as usize],
+                    pixels,
+                },
+            )).ok();
+            ctx.request_repaint();
+        });
+        device.poll(wgpu::Maintain::WaitForSubmissionIndex(id));
+    }
+}
+
+#[derive(Copy, Clone)]
+struct BufferPadding {
+    unpadded_bytes_per_row: u32,
+    padded_bytes_per_row: u32,
+}
+
+impl BufferPadding {
+    fn new(width: u32) -> Self {
+        let bytes_per_pixel = std::mem::size_of::<u32>() as u32;
+        let unpadded_bytes_per_row = width * bytes_per_pixel;
+        let padded_bytes_per_row =
+            wgpu::util::align_to(unpadded_bytes_per_row, wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
+        Self {
+            unpadded_bytes_per_row,
+            padded_bytes_per_row,
+        }
+    }
+}

--- a/crates/egui-wgpu/src/capture.rs
+++ b/crates/egui-wgpu/src/capture.rs
@@ -178,24 +178,26 @@ impl CaptureState {
             tex_extent,
         );
 
-        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-            label: Some("blit"),
-            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                view: &output_frame.texture.create_view(&Default::default()),
-                resolve_target: None,
-                ops: wgpu::Operations {
-                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                    store: StoreOp::Store,
-                },
-            })],
-            depth_stencil_attachment: None,
-            occlusion_query_set: None,
-            timestamp_writes: None,
-        });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("blit"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &output_frame.texture.create_view(&Default::default()),
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                occlusion_query_set: None,
+                timestamp_writes: None,
+            });
 
-        pass.set_pipeline(&self.pipeline);
-        pass.set_bind_group(0, &self.bind_group, &[]);
-        pass.draw(0..3, 0..1);
+            pass.set_pipeline(&self.pipeline);
+            pass.set_bind_group(0, &self.bind_group, &[]);
+            pass.draw(0..3, 0..1);
+        }
 
         let id = queue.submit(Some(encoder.finish()));
         let buffer_clone = buffer.clone();

--- a/crates/egui-wgpu/src/capture.rs
+++ b/crates/egui-wgpu/src/capture.rs
@@ -1,8 +1,7 @@
-use crate::RenderState;
 use egui::{UserData, ViewportId};
 use epaint::ColorImage;
 use std::sync::{mpsc, Arc};
-use wgpu::{BindGroupLayout, MultisampleState, Sampler, StoreOp};
+use wgpu::{BindGroupLayout, MultisampleState, StoreOp};
 
 /// A texture and a buffer for reading the rendered frame back to the cpu.
 /// The texture is required since [`wgpu::TextureUsages::COPY_SRC`] is not an allowed
@@ -16,7 +15,6 @@ pub struct CaptureState {
     pub texture: wgpu::Texture,
     pipeline: wgpu::RenderPipeline,
     bind_group: wgpu::BindGroup,
-    buffer: Option<wgpu::Buffer>,
 }
 
 pub type CaptureReceiver = mpsc::Receiver<(ViewportId, Vec<UserData>, ColorImage)>;
@@ -62,7 +60,6 @@ impl CaptureState {
             texture,
             pipeline,
             bind_group,
-            buffer: None,
         }
     }
 

--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -26,6 +26,7 @@ mod renderer;
 pub use renderer::*;
 use wgpu::{Adapter, Device, Instance, Queue};
 
+pub mod capture;
 /// Module for painting [`egui`](https://github.com/emilk/egui) with [`wgpu`] on [`winit`].
 #[cfg(feature = "winit")]
 pub mod winit;

--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -26,7 +26,9 @@ mod renderer;
 pub use renderer::*;
 use wgpu::{Adapter, Device, Instance, Queue};
 
+/// Helpers for capturing screenshots of the UI.
 pub mod capture;
+
 /// Module for painting [`egui`](https://github.com/emilk/egui) with [`wgpu`] on [`winit`].
 #[cfg(feature = "winit")]
 pub mod winit;

--- a/crates/egui-wgpu/src/texture_copy.wgsl
+++ b/crates/egui-wgpu/src/texture_copy.wgsl
@@ -1,7 +1,12 @@
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
-    @location(0) tex_coords: vec2<f32>,
 };
+
+var<private> positions: array<vec2f, 3> = array<vec2f, 3>(
+    vec2f(-1.0, -3.0),
+    vec2f(-1.0, 1.0),
+    vec2f(3.0, 1.0)
+);
 
 // meant to be called with 3 vertex indices: 0, 1, 2
 // draws one large triangle over the clip space like this:
@@ -24,29 +29,15 @@ struct VertexOutput {
 @vertex
 fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
     var result: VertexOutput;
-    let x = i32(vertex_index) / 2;
-    let y = i32(vertex_index) & 1;
-    let tc = vec2<f32>(
-        f32(x) * 2.0,
-        f32(y) * 2.0
-    );
-    result.position = vec4<f32>(
-        tc.x * 2.0 - 1.0,
-        1.0 - tc.y * 2.0,
-        0.0, 1.0
-    );
-    result.tex_coords = tc;
+    result.position = vec4f(positions[vertex_index], 0.0, 1.0);
     return result;
 }
 
 @group(0)
 @binding(0)
 var r_color: texture_2d<f32>;
-@group(0)
-@binding(1)
-var r_sampler: sampler;
 
 @fragment
 fn fs_main(vertex: VertexOutput) -> @location(0) vec4<f32> {
-    return textureSample(r_color, r_sampler, vertex.tex_coords);
+    return textureLoad(r_color, vec2i(vertex.position.xy), 0);
 }

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -417,7 +417,7 @@ impl Painter {
         }
     }
 
-    // CaptureState only needs to be updated when the size of the two textures don't match and we want to
+    // CaptureState only needs to be updated when the size of the two textures don't match, and we want to
     // capture a frame
     fn update_capture_state(
         screen_capture_state: &mut Option<CaptureState>,

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -527,11 +527,7 @@ impl Painter {
             self.screen_capture_state
                 .as_mut()
                 .and_then(|screen_capture_state| {
-                    CaptureState::read_screen_rgba_blocking(
-                        screen_capture_state,
-                        render_state,
-                        &output_frame,
-                    )
+                    screen_capture_state.read_screen_rgba_blocking(render_state, &output_frame)
                 })
         } else {
             None

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -362,7 +362,7 @@ impl Painter {
     /// The approximate number of seconds spent on vsync-waiting (if any),
     /// and the captures captured screenshot if it was requested.
     ///
-    /// If capture_data isn't empty, a screenshot will be captured.
+    /// If `capture_data` isn't empty, a screenshot will be captured.
     pub fn paint_and_update_textures(
         &mut self,
         viewport_id: ViewportId,
@@ -563,7 +563,7 @@ impl Painter {
     }
 
     /// Call this at the beginning of each frame to receive the requested screenshots.
-    pub fn handle_screenshots(&mut self, events: &mut Vec<Event>) {
+    pub fn handle_screenshots(&self, events: &mut Vec<Event>) {
         for (viewport_id, user_data, screenshot) in self.capture_rx.try_iter() {
             let screenshot = Arc::new(screenshot);
             for data in user_data {

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -4,8 +4,6 @@
 use crate::capture::{capture_channel, CaptureReceiver, CaptureSender, CaptureState};
 use crate::{renderer, RenderState, SurfaceErrorAction, WgpuConfiguration};
 use egui::{Context, Event, UserData, ViewportId, ViewportIdMap, ViewportIdSet};
-use epaint::ColorImage;
-use std::sync::mpsc;
 use std::{num::NonZeroU32, sync::Arc};
 
 struct SurfaceState {

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -38,6 +38,7 @@ impl Default for Demos {
             Box::<super::painting::Painting>::default(),
             Box::<super::pan_zoom::PanZoom>::default(),
             Box::<super::panels::Panels>::default(),
+            Box::<super::screenshot::Screenshot>::default(),
             Box::<super::scrolling::Scrolling>::default(),
             Box::<super::sliders::Sliders>::default(),
             Box::<super::strip_demo::StripDemo>::default(),

--- a/crates/egui_demo_lib/src/demo/mod.rs
+++ b/crates/egui_demo_lib/src/demo/mod.rs
@@ -24,6 +24,7 @@ pub mod painting;
 pub mod pan_zoom;
 pub mod panels;
 pub mod password;
+pub mod screenshot;
 pub mod scrolling;
 pub mod sliders;
 pub mod strip_demo;

--- a/crates/egui_demo_lib/src/demo/screenshot.rs
+++ b/crates/egui_demo_lib/src/demo/screenshot.rs
@@ -11,7 +11,7 @@ pub struct Screenshot {
 
 impl crate::Demo for Screenshot {
     fn name(&self) -> &'static str {
-        "📸 Screenshot"
+        "📷 Screenshot"
     }
 
     fn show(&mut self, ctx: &egui::Context, open: &mut bool) {
@@ -41,7 +41,7 @@ impl crate::View for Screenshot {
         });
 
         ui.horizontal_top(|ui| {
-            if ui.button("📸 Take Screenshot").clicked() {
+            if ui.button("📷 Take Screenshot").clicked() {
                 ui.ctx()
                     .send_viewport_cmd(ViewportCommand::Screenshot(UserData::default()));
             }

--- a/crates/egui_demo_lib/src/demo/screenshot.rs
+++ b/crates/egui_demo_lib/src/demo/screenshot.rs
@@ -1,6 +1,4 @@
-use egui::{
-    Frame, Image, ImageSource, Label, RichText, Sense, UiBuilder, UserData, ViewportCommand, Widget,
-};
+use egui::{Image, UserData, ViewportCommand, Widget};
 use std::sync::Arc;
 
 /// Showcase [`egui::Ui::response`].

--- a/crates/egui_demo_lib/src/demo/screenshot.rs
+++ b/crates/egui_demo_lib/src/demo/screenshot.rs
@@ -1,0 +1,72 @@
+use egui::{
+    Frame, Image, ImageSource, Label, RichText, Sense, UiBuilder, UserData, ViewportCommand, Widget,
+};
+use std::sync::Arc;
+
+/// Showcase [`egui::Ui::response`].
+#[derive(PartialEq, Eq, Default)]
+pub struct Screenshot {
+    image: Option<(Arc<egui::ColorImage>, egui::TextureHandle)>,
+}
+
+impl crate::Demo for Screenshot {
+    fn name(&self) -> &'static str {
+        "📸 Screenshot"
+    }
+
+    fn show(&mut self, ctx: &egui::Context, open: &mut bool) {
+        egui::Window::new(self.name())
+            .open(open)
+            .resizable(false)
+            .default_width(250.0)
+            .show(ctx, |ui| {
+                use crate::View as _;
+                self.ui(ui);
+            });
+    }
+}
+
+impl crate::View for Screenshot {
+    fn ui(&mut self, ui: &mut egui::Ui) {
+        ui.set_width(300.0);
+        ui.vertical_centered(|ui| {
+            ui.add(crate::egui_github_link_file!());
+        });
+
+        ui.horizontal_wrapped(|ui| {
+            ui.spacing_mut().item_spacing.x = 0.0;
+            ui.label("This demo showcases how to take screenshots via ");
+            ui.code("ViewportCommand::Screenshot");
+            ui.label(".");
+        });
+
+        ui.horizontal_top(|ui| {
+            if ui.button("📸 Take Screenshot").clicked() {
+                ui.ctx()
+                    .send_viewport_cmd(ViewportCommand::Screenshot(UserData::default()));
+            }
+        });
+
+        let image = ui.ctx().input(|i| {
+            i.events.iter().find_map(|e| {
+                let egui::Event::Screenshot { image, .. } = e else {
+                    return None;
+                };
+                Some(image.clone())
+            })
+        });
+
+        if let Some(image) = image {
+            self.image = Some((
+                image.clone(),
+                ui.ctx()
+                    .load_texture("screenshot_demo", image, Default::default()),
+            ));
+        }
+
+        if let Some((_, texture)) = &self.image {
+            Image::new(texture).shrink_to_fit().ui(ui);
+        } else {
+        }
+    }
+}

--- a/crates/egui_demo_lib/src/demo/screenshot.rs
+++ b/crates/egui_demo_lib/src/demo/screenshot.rs
@@ -67,6 +67,13 @@ impl crate::View for Screenshot {
         if let Some((_, texture)) = &self.image {
             Image::new(texture).shrink_to_fit().ui(ui);
         } else {
+            ui.group(|ui| {
+                ui.set_width(ui.available_width());
+                ui.set_height(100.0);
+                ui.centered_and_justified(|ui| {
+                    ui.label("No screenshot taken yet.");
+                });
+            });
         }
     }
 }

--- a/crates/egui_demo_lib/src/demo/screenshot.rs
+++ b/crates/egui_demo_lib/src/demo/screenshot.rs
@@ -1,7 +1,7 @@
 use egui::{Image, UserData, ViewportCommand, Widget};
 use std::sync::Arc;
 
-/// Showcase [`egui::Ui::response`].
+/// Showcase [`ViewportCommand::Screenshot`].
 #[derive(PartialEq, Eq, Default)]
 pub struct Screenshot {
     image: Option<(Arc<egui::ColorImage>, egui::TextureHandle)>,
@@ -46,12 +46,16 @@ impl crate::View for Screenshot {
         });
 
         let image = ui.ctx().input(|i| {
-            i.events.iter().find_map(|e| {
-                let egui::Event::Screenshot { image, .. } = e else {
-                    return None;
-                };
-                Some(image.clone())
-            })
+            i.events
+                .iter()
+                .filter_map(|e| {
+                    if let egui::Event::Screenshot { image, .. } = e {
+                        Some(image.clone())
+                    } else {
+                        None
+                    }
+                })
+                .last()
         });
 
         if let Some(image) = image {

--- a/crates/egui_demo_lib/src/demo/screenshot.rs
+++ b/crates/egui_demo_lib/src/demo/screenshot.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 #[derive(PartialEq, Eq, Default)]
 pub struct Screenshot {
     image: Option<(Arc<egui::ColorImage>, egui::TextureHandle)>,
+    continuous: bool,
 }
 
 impl crate::Demo for Screenshot {
@@ -39,7 +40,9 @@ impl crate::View for Screenshot {
         });
 
         ui.horizontal_top(|ui| {
-            if ui.button("📷 Take Screenshot").clicked() {
+            let capture = ui.button("📷 Take Screenshot").clicked();
+            ui.checkbox(&mut self.continuous, "Capture continuously");
+            if capture || self.continuous {
                 ui.ctx()
                     .send_viewport_cmd(ViewportCommand::Screenshot(UserData::default()));
             }

--- a/crates/egui_demo_lib/tests/snapshots/demos/Screenshot.png
+++ b/crates/egui_demo_lib/tests/snapshots/demos/Screenshot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86f72b0e6801f7d772bf6d9df42d0e74cd4295e715c823f65fe4d2fd6da3f1db
+size 20977

--- a/crates/egui_demo_lib/tests/snapshots/demos/Screenshot.png
+++ b/crates/egui_demo_lib/tests/snapshots/demos/Screenshot.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:86f72b0e6801f7d772bf6d9df42d0e74cd4295e715c823f65fe4d2fd6da3f1db
-size 20977
+oid sha256:579a7a66f86ade628e9f469b0014e9010aa56312ad5bd1e8de2faaae7e0d1af6
+size 23770


### PR DESCRIPTION
This implements web support for taking screenshots in an eframe app (and adds a nice demo).
It also updates the native screenshot implementation to work with the wgpu gl backend. 

The wgpu implementation is quite different than the native one because we can't block to wait for the screenshot result, so instead I use a channel to pass the result to a future frame asynchronously.  

* Closes <https://github.com/emilk/egui/issues/5425>
* [x] I have followed the instructions in the PR template

https://github.com/user-attachments/assets/67cad40b-0384-431d-96a3-075cc3cb98fb

