### PR TITLE
Support wgpu-tracing with same mechanism as wgpu examples

### DIFF
--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -159,10 +159,11 @@ impl RenderState {
                     );
                 }
 
+                let trace_path = std::env::var("WGPU_TRACE");
                 let (device, queue) = {
                     crate::profile_scope!("request_device");
                     adapter
-                        .request_device(&(*device_descriptor)(&adapter), None)
+                        .request_device(&(*device_descriptor)(&adapter), trace_path.ok().as_ref().map(std::path::Path::new))
                         .await?
                 };
 


### PR DESCRIPTION
Gets the WGPU_TRACE env variable and gives it as an optional argument
to request_device. Same mechanism as the wgpu-examples:

https://github.com/gfx-rs/wgpu/blob/11b51693d3dc883b55b5ec0e30c340e43e6fac50/examples/src/framework.rs#L316
