### PR TITLE
Fix: don't interact with `Area` outside its `constrain_rect`

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -467,7 +467,7 @@ impl Area {
                     id: interact_id,
                     layer_id,
                     rect: state.rect(),
-                    interact_rect: state.rect(),
+                    interact_rect: state.rect().intersect(constrain_rect),
                     sense,
                     enabled,
                 },


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->
* [x] I have followed the instructions in the PR template

This PR makes an area's interact rect intersect its constrain rect. This fixes an issue where masked areas would still intercept input.


Before:
![before](https://github.com/user-attachments/assets/6b790a04-8a15-44fe-a7ae-4adda189ecba)

After:
![after](https://github.com/user-attachments/assets/98010d89-e680-44cb-8717-faf31b0912d3)
