### PR TITLE
Drag-and-drop: keep cursor set by user, if any

### DIFF
--- a/crates/egui/src/drag_and_drop.rs
+++ b/crates/egui/src/drag_and_drop.rs
@@ -57,7 +57,13 @@ impl DragAndDrop {
             if abort_dnd_due_to_mouse_release {
                 Self::clear_payload(ctx);
             } else {
-                ctx.set_cursor_icon(CursorIcon::Grabbing);
+                // We set the cursor icon only if its default, as the user code might have
+                // explicitly set it already.
+                ctx.output_mut(|o| {
+                    if o.cursor_icon == CursorIcon::Default {
+                        o.cursor_icon = CursorIcon::Grabbing;
+                    }
+                });
             }
         }
     }


### PR DESCRIPTION
We used to always set the cursor to `Grabbing` when a drag and drop payload is set, but this shadows user code trying to set an alternative cursor (e.g. `NoDrop`). This PR no only change the cursor to `Grabbing` if is way previously set to `Default`.