### PR TITLE
Improve hit-test of thin widgets, and widgets across layers

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2272,6 +2272,7 @@ impl Context {
         if self.style().debug.show_widget_hits {
             let hits = self.write(|ctx| ctx.viewport().hits.clone());
             let WidgetHits {
+                close: _,
                 contains_pointer,
                 click,
                 drag,

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -498,19 +498,8 @@ impl ContextImpl {
         viewport.this_pass.begin_pass(screen_rect);
 
         {
-            let area_order = self.memory.areas().order_map();
-
             let mut layers: Vec<LayerId> = viewport.prev_pass.widgets.layer_ids().collect();
-
-            layers.sort_by(|a, b| {
-                if a.order == b.order {
-                    // Maybe both are windows, so respect area order:
-                    area_order.get(a).cmp(&area_order.get(b))
-                } else {
-                    // comparing e.g. background to tooltips
-                    a.order.cmp(&b.order)
-                }
-            });
+            layers.sort_by(|&a, &b| self.memory.areas().compare_order(a, b));
 
             viewport.hits = if let Some(pos) = viewport.input.pointer.interact_pos() {
                 let interact_radius = self.memory.options.style().interaction.interact_radius;

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2235,7 +2235,8 @@ impl Context {
                     for id in contains_pointer {
                         let mut widget_text = format!("{id:?}");
                         if let Some(rect) = widget_rects.get(id) {
-                            widget_text += &format!(" {:?} {:?}", rect.rect, rect.sense);
+                            widget_text +=
+                                &format!(" {:?} {:?} {:?}", rect.layer_id, rect.rect, rect.sense);
                         }
                         if let Some(info) = widget_rects.info(id) {
                             widget_text += &format!(" {info:?}");
@@ -2261,12 +2262,17 @@ impl Context {
         if self.style().debug.show_widget_hits {
             let hits = self.write(|ctx| ctx.viewport().hits.clone());
             let WidgetHits {
-                close: _,
+                close,
                 contains_pointer,
                 click,
                 drag,
             } = hits;
 
+            if false {
+                for widget in &close {
+                    paint_widget(widget, "close", Color32::from_gray(70));
+                }
+            }
             if true {
                 for widget in &contains_pointer {
                     paint_widget(widget, "contains_pointer", Color32::BLUE);
@@ -3149,28 +3155,26 @@ impl Context {
                 self.memory_mut(|mem| *mem.areas_mut() = Default::default());
             }
         });
-        ui.indent("areas", |ui| {
-            ui.label("Visible areas, ordered back to front.");
-            ui.label("Hover to highlight");
+        ui.indent("layers", |ui| {
+            ui.label("Layers, ordered back to front.");
             let layers_ids: Vec<LayerId> = self.memory(|mem| mem.areas().order().to_vec());
             for layer_id in layers_ids {
-                let area = AreaState::load(self, layer_id.id);
-                if let Some(area) = area {
+                if let Some(area) = AreaState::load(self, layer_id.id) {
                     let is_visible = self.memory(|mem| mem.areas().is_visible(&layer_id));
                     if !is_visible {
                         continue;
                     }
                     let text = format!("{} - {:?}", layer_id.short_debug_format(), area.rect(),);
                     // TODO(emilk): `Sense::hover_highlight()`
-                    if ui
-                        .add(Label::new(RichText::new(text).monospace()).sense(Sense::click()))
-                        .hovered
-                        && is_visible
-                    {
+                    let response =
+                        ui.add(Label::new(RichText::new(text).monospace()).sense(Sense::click()));
+                    if response.hovered && is_visible {
                         ui.ctx()
                             .debug_painter()
                             .debug_rect(area.rect(), Color32::RED, "");
                     }
+                } else {
+                    ui.monospace(layer_id.short_debug_format());
                 }
             }
         });

--- a/crates/egui/src/hit_test.rs
+++ b/crates/egui/src/hit_test.rs
@@ -112,16 +112,16 @@ pub fn hit_test(
     // but if the pointer is at the edge of a layer, we might include widgets in
     // a layer behind it.
 
-    let mut allowed_layers: ahash::HashSet<LayerId> = Default::default();
+    let mut included_layers: ahash::HashSet<LayerId> = Default::default();
     for hit in close.iter().rev() {
-        allowed_layers.insert(hit.layer_id);
+        included_layers.insert(hit.layer_id);
         let hit_covers_search_area = contains_circle(hit.interact_rect, pos, search_radius);
         if hit_covers_search_area {
             break; // nothing behind this layer could ever be interacted with
         }
     }
 
-    close.retain(|hit| allowed_layers.contains(&hit.layer_id));
+    close.retain(|hit| included_layers.contains(&hit.layer_id));
 
     // If a widget is disabled, treat it as if it isn't sensing anything.
     // This simplifies the code in `hit_test_on_close` so it doesn't have to check

--- a/crates/egui/src/hit_test.rs
+++ b/crates/egui/src/hit_test.rs
@@ -128,7 +128,7 @@ pub fn hit_test(
 
     let mut hits = hit_test_on_close(&close, pos);
 
-    // Trandform back to local coordinates:
+    // Transform back to local coordinates:
     for wr in &mut hits.contains_pointer {
         *wr = wr.transform(
             layer_to_global

--- a/crates/egui/src/interaction.rs
+++ b/crates/egui/src/interaction.rs
@@ -264,9 +264,9 @@ pub(crate) fn interact(
         // but none below it (an interactive widget stops the hover search).
         //
         // To know when to stop we need to first know the order of the widgets,
-        // which luckily we have in the `WidgetRects`.
+        // which luckily we already have in `hits.close`.
 
-        let order = |id| widgets.order(id).map(|(_layer, order)| order); // we ignore the layer, since all widgets at this point is in the same layer
+        let order = |id| hits.close.iter().position(|w| w.id == id);
 
         let click_order = hits.click.and_then(|w| order(w.id)).unwrap_or(0);
         let drag_order = hits.drag.and_then(|w| order(w.id)).unwrap_or(0);

--- a/crates/egui/src/interaction.rs
+++ b/crates/egui/src/interaction.rs
@@ -249,7 +249,7 @@ pub(crate) fn interact(
             .copied()
             .collect()
     } else {
-        // We may be hovering a an interactive widget or two.
+        // We may be hovering an interactive widget or two.
         // We must also consider the case where non-interactive widgets
         // are _on top_ of an interactive widget.
         // For instance: a label in a draggable window.

--- a/crates/egui/src/layers.rs
+++ b/crates/egui/src/layers.rs
@@ -60,7 +60,7 @@ impl Order {
 
 /// An identifier for a paint layer.
 /// Also acts as an identifier for [`crate::Area`]:s.
-#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+#[derive(Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct LayerId {
     pub order: Order,
@@ -99,6 +99,13 @@ impl LayerId {
             self.order.short_debug_format(),
             self.id.short_debug_format()
         )
+    }
+}
+
+impl std::fmt::Debug for LayerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self { order, id } = self;
+        write!(f, "LayerId {{ {order:?} {id:?} }}")
     }
 }
 

--- a/crates/egui/src/widget_rect.rs
+++ b/crates/egui/src/widget_rect.rs
@@ -20,10 +20,10 @@ pub struct WidgetRect {
     /// What layer the widget is on.
     pub layer_id: LayerId,
 
-    /// The full widget rectangle.
+    /// The full widget rectangle, in local layer coordinates.
     pub rect: Rect,
 
-    /// Where the widget is.
+    /// Where the widget is, in local layer coordinates.
     ///
     /// This is after clipping with the parent ui clip rect.
     pub interact_rect: Rect,
@@ -40,6 +40,27 @@ pub struct WidgetRect {
 
     /// Is the widget enabled?
     pub enabled: bool,
+}
+
+impl WidgetRect {
+    pub fn transform(self, transform: emath::TSTransform) -> Self {
+        let Self {
+            id,
+            layer_id,
+            rect,
+            interact_rect,
+            sense,
+            enabled,
+        } = self;
+        Self {
+            id,
+            layer_id,
+            rect: transform * rect,
+            interact_rect: transform * interact_rect,
+            sense,
+            enabled,
+        }
+    }
 }
 
 /// Stores the [`WidgetRect`]s of all widgets generated during a single egui update/frame.


### PR DESCRIPTION
When there are multiple layers (e.g. with custom transforms) close to each other, the hit test code used to only consider widgets in the layer directly under the mouse. This can make it difficult to hit thin widgets just on the outside of a transform layer.

This PR fixes that.

It also prioritizes thin widgets, so that if there is both a thin widget and a thick widget under the mouse cursor, you will always hit the thin widgets, even if the thin widgets is layered behind the thick one. This makes it easier to hit thin resize-handles.

In theory this should allow us to make `resize_grab_radius_side` and `resize_grab_radius_corner` smaller in a future PR, if we want to.
