### PR TITLE
Make frame delay on screenshots consistently one frame on web as well

### DIFF
--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -1056,7 +1056,7 @@ pub enum ViewportCommand {
     /// Enable mouse pass-through: mouse clicks pass through the window, used for non-interactable overlays.
     MousePassthrough(bool),
 
-    /// Take a screenshot.
+    /// Take a screenshot of the next frame after this.
     ///
     /// The results are returned in [`crate::Event::Screenshot`].
     Screenshot(crate::UserData),


### PR DESCRIPTION
Native is already delayed by a frame because it calls `handle_viewport_output` -> `egui_winit::process_viewport_commands` after drawing. On web however, we process input including viewport commands separately from drawing.
This adds an arbitrary frame delay mechanism for web and then uses this with 1 frame delay always