### PR TITLE
Simplify kittest readme example

### DIFF
--- a/crates/egui_kittest/README.md
+++ b/crates/egui_kittest/README.md
@@ -12,13 +12,11 @@ use std::cell::RefCell;
 
 fn main() {
     let mut checked = false;
-    let app = |ctx: &Context| {
-        CentralPanel::default().show(ctx, |ui| {
-            ui.checkbox(&mut checked, "Check me!");
-        });
+    let app = |ui: &mut egui::Ui| {
+        ui.checkbox(&mut checked, "Check me!");
     };
 
-    let mut harness = Harness::builder().with_size(egui::Vec2::new(200.0, 100.0)).build(app);
+    let mut harness = Harness::new_ui(app);
     
     let checkbox = harness.get_by_label("Check me!");
     assert_eq!(checkbox.toggled(), Some(Toggled::False));
@@ -28,6 +26,9 @@ fn main() {
 
     let checkbox = harness.get_by_label("Check me!");
     assert_eq!(checkbox.toggled(), Some(Toggled::True));
+    
+    // Shrink the window size to the smallest size possible
+    harness.fit_contents();
 
     // You can even render the ui and do image snapshot tests
     #[cfg(all(feature = "wgpu", feature = "snapshot"))]

--- a/crates/egui_kittest/README.md
+++ b/crates/egui_kittest/README.md
@@ -4,11 +4,8 @@ Ui testing library for egui, based on [kittest](https://github.com/rerun-io/kitt
 
 ## Example usage
 ```rust
-use egui::accesskit::{Role, Toggled};
-use egui::{CentralPanel, Context, TextEdit, Vec2};
-use egui_kittest::Harness;
-use kittest::Queryable;
-use std::cell::RefCell;
+use egui::accesskit::Toggled;
+use egui_kittest::{Harness, kittest::Queryable};
 
 fn main() {
     let mut checked = false;

--- a/crates/egui_kittest/tests/snapshots/readme_example.png
+++ b/crates/egui_kittest/tests/snapshots/readme_example.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:36c1b432140456ea5cbb687076b1c910aea8b31affd33a0ece22218f60af2d6e
-size 2296
+oid sha256:31bd906040fcc356c19dc36036fbfd2a28dfcef54c7a073f584f4a9abddbdb4c
+size 1699


### PR DESCRIPTION
Updates the example using the new_ui function, and call fit_contents
- [x] I have followed the instructions in the PR template
