### PR TITLE
Use correct minimum version of `profiling` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ log = { version = "0.4", features = ["std"] }
 nohash-hasher = "0.2"
 parking_lot = "0.12"
 pollster = "0.4"
-profiling = { version = "1.0", default-features = false }
+profiling = { version = "1.0.16", default-features = false }
 puffin = "0.19"
 puffin_http = "0.16"
 raw-window-handle = "0.6.0"


### PR DESCRIPTION
We need profiling::function_scope which was introduced in 1.0.16, so this is the minimum required version
* Closes <https://github.com/emilk/egui/issues/5491>
* [x] I have followed the instructions in the PR template
