### PR TITLE
Update to winit 0.30.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4536,7 +4536,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4834,9 +4834,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winit"
-version = "0.30.5"
+version = "0.30.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be9e76a1f1077e04a411f0b989cbd3c93339e1771cb41e71ac4aee95bfd2c67"
+checksum = "dba50bc8ef4b6f1a75c9274fb95aa9a8f63fbc66c56f391bd85cf68d51e7b1a3"
 dependencies = [
  "ahash",
  "android-activity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ web-sys = "0.3.70"
 web-time = "1.1.0" # Timekeeping for native and web
 wgpu = { version = "23.0.0", default-features = false }
 windows-sys = "0.59"
-winit = { version = "0.30.5", default-features = false }
+winit = { version = "0.30.7", default-features = false }
 
 [workspace.lints.rust]
 unsafe_code = "deny"


### PR DESCRIPTION
Fixes wrong cursor on Mac, among other things:

https://github.com/rust-windowing/winit/releases/tag/v0.30.6