### PR TITLE
Add `WidgetType::Image` and `Image::alt_text`

### DIFF
--- a/crates/egui/src/data/output.rs
+++ b/crates/egui/src/data/output.rs
@@ -673,6 +673,7 @@ impl WidgetInfo {
             WidgetType::DragValue => "drag value",
             WidgetType::ColorButton => "color button",
             WidgetType::ImageButton => "image button",
+            WidgetType::Image => "image",
             WidgetType::CollapsingHeader => "collapsing header",
             WidgetType::ProgressIndicator => "progress indicator",
             WidgetType::Window => "window",

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -664,7 +664,7 @@ pub enum WidgetType {
     ColorButton,
 
     ImageButton,
-    
+
     Image,
 
     CollapsingHeader,

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -664,6 +664,8 @@ pub enum WidgetType {
     ColorButton,
 
     ImageButton,
+    
+    Image,
 
     CollapsingHeader,
 

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -1017,6 +1017,7 @@ impl Response {
             WidgetType::Button | WidgetType::ImageButton | WidgetType::CollapsingHeader => {
                 Role::Button
             }
+            WidgetType::Image => Role::Image,
             WidgetType::Checkbox => Role::CheckBox,
             WidgetType::RadioButton => Role::RadioButton,
             WidgetType::RadioGroup => Role::RadioGroup,

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -290,8 +290,7 @@ impl Widget for Button<'_> {
         });
 
         if ui.is_rect_visible(rect) {
-            let style = ui.style().clone();
-            let visuals = style.interact(&response);
+            let visuals = ui.style().interact(&response);
 
             let (frame_expansion, frame_rounding, frame_fill, frame_stroke) = if selected {
                 let selection = ui.visuals().selection;

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -290,7 +290,8 @@ impl Widget for Button<'_> {
         });
 
         if ui.is_rect_visible(rect) {
-            let visuals = ui.style().interact(&response);
+            let style = ui.style().clone();
+            let visuals = style.interact(&response);
 
             let (frame_expansion, frame_rounding, frame_fill, frame_stroke) = if selected {
                 let selection = ui.visuals().selection;
@@ -344,6 +345,7 @@ impl Widget for Button<'_> {
                     image_rect,
                     image.show_loading_spinner,
                     &image_options,
+                    None,
                 );
                 response = widgets::image::texture_load_result_response(
                     &image.source(ui.ctx()),

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -6,7 +6,7 @@ use epaint::RectShape;
 use crate::{
     load::{Bytes, SizeHint, SizedTexture, TextureLoadResult, TexturePoll},
     pos2, Align2, Color32, Context, Id, Mesh, Painter, Rect, Response, Rounding, Sense, Shape,
-    Spinner, Stroke, TextStyle, TextureOptions, Ui, Vec2, Widget,
+    Spinner, Stroke, TextStyle, TextureOptions, Ui, Vec2, Widget, WidgetInfo, WidgetType,
 };
 
 /// A widget which displays an image.
@@ -363,6 +363,7 @@ impl<'a> Widget for Image<'a> {
         let ui_size = self.calc_size(ui.available_size(), original_image_size);
 
         let (rect, response) = ui.allocate_exact_size(ui_size, self.sense);
+        response.widget_info(|| WidgetInfo::new(WidgetType::Image));
         if ui.is_rect_visible(rect) {
             paint_texture_load_result(
                 ui,

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -8,8 +8,8 @@ use epaint::{
 
 use crate::{
     load::{Bytes, SizeHint, SizedTexture, TextureLoadResult, TexturePoll},
-    pos2, Align2, Color32, Context, Id, Mesh, Painter, Rect, Response, Rounding, Sense, Shape,
-    Spinner, Stroke, TextStyle, TextureOptions, Ui, Vec2, Widget, WidgetInfo, WidgetType,
+    pos2, Color32, Context, Id, Mesh, Painter, Rect, Response, Rounding, Sense, Shape, Spinner,
+    Stroke, TextStyle, TextureOptions, Ui, Vec2, Widget, WidgetInfo, WidgetType,
 };
 
 /// A widget which displays an image.
@@ -357,7 +357,7 @@ impl<'a> Image<'a> {
     /// # });
     /// ```
     #[inline]
-    pub fn paint_at(&self, ui: &mut Ui, rect: Rect) {
+    pub fn paint_at(&self, ui: &Ui, rect: Rect) {
         paint_texture_load_result(
             ui,
             &self.load_for_size(ui.ctx(), rect.size()),
@@ -614,7 +614,7 @@ impl<'a> ImageSource<'a> {
 }
 
 pub fn paint_texture_load_result(
-    ui: &mut Ui,
+    ui: &Ui,
     tlr: &TextureLoadResult,
     rect: Rect,
     show_loading_spinner: Option<bool>,
@@ -634,9 +634,11 @@ pub fn paint_texture_load_result(
         }
         Err(_) => {
             let font_id = TextStyle::Body.resolve(ui.style());
-            let mut job = LayoutJob::default();
-            job.wrap = TextWrapping::truncate_at_width(rect.width());
-            job.halign = Align::Center;
+            let mut job = LayoutJob {
+                wrap: TextWrapping::truncate_at_width(rect.width()),
+                halign: Align::Center,
+                ..Default::default()
+            };
             job.append(
                 "⚠",
                 0.0,

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -643,21 +643,13 @@ pub fn paint_texture_load_result(
             job.append(
                 "⚠",
                 0.0,
-                TextFormat {
-                    color: ui.visuals().error_fg_color,
-                    font_id: font_id.clone(),
-                    ..Default::default()
-                },
+                TextFormat::simple(font_id.clone(), ui.visuals().error_fg_color),
             );
             if let Some(alt) = alt {
                 job.append(
                     alt,
                     ui.spacing().item_spacing.x,
-                    TextFormat {
-                        color: ui.visuals().text_color(),
-                        font_id,
-                        ..Default::default()
-                    },
+                    TextFormat::simple(font_id, ui.visuals().text_color()),
                 );
             }
             let galley = ui.painter().layout_job(job);

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -263,6 +263,7 @@ impl<'a> Image<'a> {
 
     /// Set alt text for the image. This will be shown when the image fails to load.
     /// It will also be read to screen readers.
+    #[inline]
     pub fn alt_text(mut self, label: impl Into<String>) -> Self {
         self.alt_text = Some(label.into());
         self

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, sync::Arc, time::Duration};
 
-use emath::{Float as _, Rot2};
+use emath::{Align, Float as _, Rot2};
 use epaint::{
     text::{LayoutJob, TextFormat, TextWrapping},
     RectShape,
@@ -635,7 +635,8 @@ pub fn paint_texture_load_result(
         Err(_) => {
             let font_id = TextStyle::Body.resolve(ui.style());
             let mut job = LayoutJob::default();
-            job.wrap = TextWrapping::wrap_at_width(rect.width());
+            job.wrap = TextWrapping::truncate_at_width(rect.width());
+            job.halign = Align::Center;
             job.append(
                 "⚠",
                 0.0,
@@ -658,7 +659,7 @@ pub fn paint_texture_load_result(
             }
             let galley = ui.painter().layout_job(job);
             ui.painter().galley(
-                rect.center() - 0.5 * galley.size(),
+                rect.center() - Vec2::Y * galley.size().y * 0.5,
                 galley,
                 ui.visuals().text_color(),
             );

--- a/crates/egui/src/widgets/image_button.rs
+++ b/crates/egui/src/widgets/image_button.rs
@@ -11,6 +11,7 @@ pub struct ImageButton<'a> {
     sense: Sense,
     frame: bool,
     selected: bool,
+    alt_text: Option<String>,
 }
 
 impl<'a> ImageButton<'a> {
@@ -20,6 +21,7 @@ impl<'a> ImageButton<'a> {
             sense: Sense::click(),
             frame: true,
             selected: false,
+            alt_text: None,
         }
     }
 
@@ -87,7 +89,11 @@ impl<'a> Widget for ImageButton<'a> {
 
         let padded_size = image_size + 2.0 * padding;
         let (rect, response) = ui.allocate_exact_size(padded_size, self.sense);
-        response.widget_info(|| WidgetInfo::new(WidgetType::ImageButton));
+        response.widget_info(|| {
+            let mut info = WidgetInfo::new(WidgetType::ImageButton);
+            info.label = self.alt_text.clone();
+            info
+        });
 
         if ui.is_rect_visible(rect) {
             let (expansion, rounding, fill, stroke) = if self.selected {
@@ -121,7 +127,14 @@ impl<'a> Widget for ImageButton<'a> {
             // let image_rect = image_rect.expand2(expansion); // can make it blurry, so let's not
             let image_options = self.image.image_options().clone();
 
-            widgets::image::paint_texture_load_result(ui, &tlr, image_rect, None, &image_options);
+            widgets::image::paint_texture_load_result(
+                ui,
+                &tlr,
+                image_rect,
+                None,
+                &image_options,
+                self.alt_text.as_deref(),
+            );
 
             // Draw frame outline:
             ui.painter()

--- a/crates/egui_demo_app/src/apps/image_viewer.rs
+++ b/crates/egui_demo_app/src/apps/image_viewer.rs
@@ -14,6 +14,7 @@ pub struct ImageViewer {
     fit: ImageFit,
     maintain_aspect_ratio: bool,
     max_size: Vec2,
+    alt_text: String,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -44,6 +45,7 @@ impl Default for ImageViewer {
             fit: ImageFit::Fraction(Vec2::splat(1.0)),
             maintain_aspect_ratio: true,
             max_size: Vec2::splat(2048.0),
+            alt_text: "My Image".to_owned(),
         }
     }
 }
@@ -184,6 +186,11 @@ impl eframe::App for ImageViewer {
             ui.add_space(5.0);
             ui.label("Aspect ratio is maintained by scaling both sides as necessary");
             ui.checkbox(&mut self.maintain_aspect_ratio, "Maintain aspect ratio");
+            
+            // alt text
+            ui.add_space(5.0);
+            ui.label("Alt text");
+            ui.text_edit_singleline(&mut self.alt_text);
 
             // forget all images
             if ui.button("Forget all images").clicked() {
@@ -211,6 +218,9 @@ impl eframe::App for ImageViewer {
                 }
                 image = image.maintain_aspect_ratio(self.maintain_aspect_ratio);
                 image = image.max_size(self.max_size);
+                if !self.alt_text.is_empty() {
+                    image = image.alt_text(&self.alt_text);
+                }
 
                 ui.add_sized(ui.available_size(), image);
             });

--- a/crates/egui_demo_app/src/apps/image_viewer.rs
+++ b/crates/egui_demo_app/src/apps/image_viewer.rs
@@ -186,7 +186,7 @@ impl eframe::App for ImageViewer {
             ui.add_space(5.0);
             ui.label("Aspect ratio is maintained by scaling both sides as necessary");
             ui.checkbox(&mut self.maintain_aspect_ratio, "Maintain aspect ratio");
-            
+
             // alt text
             ui.add_space(5.0);
             ui.label("Alt text");

--- a/crates/egui_demo_lib/tests/snapshots/widget_gallery.png
+++ b/crates/egui_demo_lib/tests/snapshots/widget_gallery.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d122b1a995e691b5049c57d65c9f222a5f1639b1e4f6f96f91823444339693cc
-size 160540
+oid sha256:b3dc1bf9a59007a6ad0fb66a345d6cf272bd8bdcd26b10dbf411c1280e62b6fc
+size 158285

--- a/crates/egui_kittest/tests/regression_tests.rs
+++ b/crates/egui_kittest/tests/regression_tests.rs
@@ -1,4 +1,4 @@
-use egui::Button;
+use egui::{Button, Image, Vec2, Widget};
 use egui_kittest::{kittest::Queryable, Harness};
 
 #[test]
@@ -26,4 +26,20 @@ pub fn focus_should_skip_over_disabled_buttons() {
 
     let button_1 = harness.get_by_label("Button 1");
     assert!(button_1.is_focused());
+}
+
+#[test]
+fn image_failed() {
+    let mut harness = Harness::new_ui(|ui| {
+        Image::new("file://invalid/path")
+            .alt_text("I have an alt text")
+            .max_size(Vec2::new(100.0, 100.0))
+            .ui(ui);
+    });
+
+    harness.run();
+    harness.fit_contents();
+
+    #[cfg(all(feature = "wgpu", feature = "snapshot"))]
+    harness.wgpu_snapshot("image_snapshots");
 }

--- a/crates/egui_kittest/tests/snapshots/image_snapshots.png
+++ b/crates/egui_kittest/tests/snapshots/image_snapshots.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31faeb4e5f488b8bcee5e090accd326d7e43b264e81768ae7c1907e3b6d0f739
+size 2121


### PR DESCRIPTION
This adds `WidgetType::Image` and correctly sets it in the Image widget. This allows us to query for images in kittest tests and tells accesskit that a node is an image. 
It also adds `Image::alt_text` to set a text that will be shown if the image fails to load and will be read via screen readers. This also allows us to query images by label in kittest. 


* [x] I have followed the instructions in the PR template
