### PR TITLE
Keep `copied_text`

### DIFF
--- a/crates/egui/src/data/output.rs
+++ b/crates/egui/src/data/output.rs
@@ -123,7 +123,6 @@ pub struct PlatformOutput {
     /// }
     /// # });
     /// ```
-    #[deprecated = "Use `Context::copy_text` instead"]
     pub copied_text: String,
 
     /// Events that may be useful to e.g. a screen reader.


### PR DESCRIPTION
It's better to keep `copied_text` without deprecating it.
because there are cases where its content needs to be immediately retrieved and modified.
