### PR TITLE
Allocate TextEdit's extra size on the side depending on the layout direction

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -727,10 +727,32 @@ impl<'t> TextEdit<'t> {
             // if there's a ScrollArea, it can properly scroll to the cursor.
             let extra_size = galley.size() - rect.size();
             if extra_size.x > 0.0 || extra_size.y > 0.0 {
-                ui.allocate_rect(
-                    Rect::from_min_size(outer_rect.max, extra_size),
-                    Sense::hover(),
-                );
+                match ui.layout().main_dir() {
+                    crate::Direction::LeftToRight | crate::Direction::TopDown => {
+                        ui.allocate_rect(
+                            Rect::from_min_size(outer_rect.max, extra_size),
+                            Sense::hover(),
+                        );
+                    }
+                    crate::Direction::RightToLeft => {
+                        ui.allocate_rect(
+                            Rect::from_min_size(
+                                emath::pos2(outer_rect.min.x - extra_size.x, outer_rect.max.y),
+                                extra_size,
+                            ),
+                            Sense::hover(),
+                        );
+                    }
+                    crate::Direction::BottomUp => {
+                        ui.allocate_rect(
+                            Rect::from_min_size(
+                                emath::pos2(outer_rect.min.x, outer_rect.max.y - extra_size.y),
+                                extra_size,
+                            ),
+                            Sense::hover(),
+                        );
+                    }
+                }
             }
 
             painter.galley(galley_pos, galley.clone(), text_color);


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

TextEdit sometimes allocates extra space if text changes and no longer fits into previously allocated Rect.
It also can happen when rounding error occurs. In this case extra space is extra small.

If extra space is needed, `Ui::allocate_rect` is used to carve that space from placer.
However it always allocated extra space on the bottom-right from the rect placer returned initially.
This works well on Left-to-Right and Top-to-bottom layouts.
However in case it's Right-to-Left, `Ui::allocate_rect` updates placer's cursor and puts it to the right side of the initially allocated rect. And next widget is then placed over the TextEdit.

This is hard to notice usually.
However I have scaling that can cause rounding errors, so 0.0003 units of extra space is allocated each frame. Making next widget to overlap the TextEdit almost entirely.

This changes makes extra space allocation aware of the layout main direction and it picks most appropriate side of the widget for the extra space.

* Closes <https://github.com/emilk/egui/issues/5546>
* [x] I have followed the instructions in the PR template
