### PR TITLE
`pub mod gui_rounding` in emath

### DIFF
--- a/crates/emath/src/lib.rs
+++ b/crates/emath/src/lib.rs
@@ -27,7 +27,7 @@ use std::ops::{Add, Div, Mul, RangeInclusive, Sub};
 
 pub mod align;
 pub mod easing;
-mod gui_rounding;
+pub mod gui_rounding;
 mod history;
 mod numeric;
 mod ordered_float;


### PR DESCRIPTION
`pub mod gui_rounding` in emath

This is needed for convenience in other places.
