### PR TITLE
`copied_text` function maintained in `copy_text()` until deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1230,7 +1230,7 @@ egui_extras::install_image_loaders(egui_ctx);
 * [Tweaked the default visuals style](https://github.com/emilk/egui/pull/450).
 * Plot: Renamed `Curve` to `Line`.
 * `TopPanel::top` is now `TopBottomPanel::top`.
-* `SidePanel::left` no longest takes the default width by argument, but by a builder call.
+* `SidePanel::left` no longer takes the default width by argument, but by a builder call.
 * `SidePanel::left` is resizable by default.
 
 ### 🐛 Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1230,7 +1230,7 @@ egui_extras::install_image_loaders(egui_ctx);
 * [Tweaked the default visuals style](https://github.com/emilk/egui/pull/450).
 * Plot: Renamed `Curve` to `Line`.
 * `TopPanel::top` is now `TopBottomPanel::top`.
-* `SidePanel::left` no longet takes the default width by argument, but by a builder call.
+* `SidePanel::left` no longest takes the default width by argument, but by a builder call.
 * `SidePanel::left` is resizable by default.
 
 ### 🐛 Fixed

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1443,6 +1443,7 @@ impl Context {
     /// HTTPS or localhost). If this method is used outside of a secure context, it will log an
     /// error and do nothing. See <https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts>.
     pub fn copy_text(&self, text: String) {
+        self.output_mut(|o| o.copied_text = text.clone());
         self.send_cmd(crate::OutputCommand::CopyText(text));
     }
 


### PR DESCRIPTION
My opinion is that it would be better to keep the current `copied_text` without deprecating it, rather than creating a new function to identify or modify the content on the clipboard.

at least until `copied_text` is removed, the `copy_text()` function should continue to use `copied_text` in the same way it currently does.
