### PR TITLE
Serialize window maximized state in `WindowSettings`

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1824,6 +1824,9 @@ pub fn apply_viewport_builder_to_window(
             let pos = PhysicalPosition::new(pixels_per_point * pos.x, pixels_per_point * pos.y);
             window.set_outer_position(pos);
         }
+        if let Some(maximized) = builder.maximized {
+            window.set_maximized(maximized);
+        }
     }
 }
 

--- a/crates/egui-winit/src/window_settings.rs
+++ b/crates/egui-winit/src/window_settings.rs
@@ -13,6 +13,8 @@ pub struct WindowSettings {
 
     fullscreen: bool,
 
+    maximized: bool,
+
     /// Inner size of window in logical pixels
     inner_size_points: Option<egui::Vec2>,
 }
@@ -38,6 +40,7 @@ impl WindowSettings {
             outer_position_pixels,
 
             fullscreen: window.fullscreen().is_some(),
+            maximized: window.is_maximized(),
 
             inner_size_points: Some(egui::vec2(
                 inner_size_points.width,
@@ -80,7 +83,8 @@ impl WindowSettings {
         if let Some(inner_size_points) = self.inner_size_points {
             viewport_builder = viewport_builder
                 .with_inner_size(inner_size_points)
-                .with_fullscreen(self.fullscreen);
+                .with_fullscreen(self.fullscreen)
+                .with_maximized(self.maximized);
         }
 
         viewport_builder


### PR DESCRIPTION
A user of my Windows application reported a papercut where the application restores its size on next load, but does not restore its maximized state. This PR fixes that.

To test, I patched https://github.com/emilk/eframe_template to use my local code since I knew that template saves/restores window data. Testing methodology was to simply `cargo run`, maximize the application, then close the application. `cargo run` again and the application should start maximized.

Closes #1517.

* [x] I have followed the instructions in the PR template
* * This is mostly true, I had difficulties running `./scripts/check.sh` for some reason. Possibly a bad Python version?
