### PR TITLE
Add `epaint::Brush` for controlling `RectShape` texturing

### DIFF
--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -9,7 +9,7 @@ use epaint::{
 use crate::{
     load::{Bytes, SizeHint, SizedTexture, TextureLoadResult, TexturePoll},
     pos2, Color32, Context, Id, Mesh, Painter, Rect, Response, Rounding, Sense, Shape, Spinner,
-    Stroke, TextStyle, TextureOptions, Ui, Vec2, Widget, WidgetInfo, WidgetType,
+    TextStyle, TextureOptions, Ui, Vec2, Widget, WidgetInfo, WidgetType,
 };
 
 /// A widget which displays an image.
@@ -822,15 +822,10 @@ pub fn paint_texture_at(
             painter.add(Shape::mesh(mesh));
         }
         None => {
-            painter.add(RectShape {
-                rect,
-                rounding: options.rounding,
-                fill: options.tint,
-                stroke: Stroke::NONE,
-                blur_width: 0.0,
-                fill_texture_id: texture.id,
-                uv: options.uv,
-            });
+            painter.add(
+                RectShape::filled(rect, options.rounding, options.tint)
+                    .with_texture(texture.id, options.uv),
+            );
         }
     }
 }

--- a/crates/epaint/src/brush.rs
+++ b/crates/epaint/src/brush.rs
@@ -1,0 +1,19 @@
+use crate::{Rect, TextureId};
+
+/// Controls texturing of a [`crate::RectShape`].
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct Brush {
+    /// If the rect should be filled with a texture, which one?
+    ///
+    /// The texture is multiplied with [`crate::RectShape::fill`].
+    pub fill_texture_id: TextureId,
+
+    /// What UV coordinates to use for the texture?
+    ///
+    /// To display a texture, set [`Self::fill_texture_id`],
+    /// and set this to `Rect::from_min_max(pos2(0.0, 0.0), pos2(1.0, 1.0))`.
+    ///
+    /// Use [`Rect::ZERO`] to turn off texturing.
+    pub uv: Rect,
+}

--- a/crates/epaint/src/lib.rs
+++ b/crates/epaint/src/lib.rs
@@ -23,6 +23,7 @@
 #![allow(clippy::float_cmp)]
 #![allow(clippy::manual_range_contains)]
 
+mod brush;
 pub mod color;
 pub mod image;
 mod margin;
@@ -44,6 +45,7 @@ pub mod util;
 mod viewport;
 
 pub use self::{
+    brush::Brush,
     color::ColorMode,
     image::{ColorImage, FontImage, ImageData, ImageDelta},
     margin::Margin,

--- a/crates/epaint/src/shape_transform.rs
+++ b/crates/epaint/src/shape_transform.rs
@@ -64,8 +64,7 @@ pub fn adjust_colors(
             fill,
             stroke,
             blur_width: _,
-            fill_texture_id: _,
-            uv: _,
+            brush: _,
         }) => {
             adjust_color(fill);
             adjust_color(&mut stroke.color);

--- a/crates/epaint/src/shape_transform.rs
+++ b/crates/epaint/src/shape_transform.rs
@@ -86,7 +86,7 @@ pub fn adjust_colors(
             }
 
             if !galley.is_empty() {
-                let galley = std::sync::Arc::make_mut(galley);
+                let galley = Arc::make_mut(galley);
                 for row in &mut galley.rows {
                     for vertex in &mut row.visuals.mesh.vertices {
                         adjust_color(&mut vertex.color);
@@ -95,11 +95,13 @@ pub fn adjust_colors(
             }
         }
 
-        Shape::Mesh(Mesh {
-            indices: _,
-            vertices,
-            texture_id: _,
-        }) => {
+        Shape::Mesh(mesh) => {
+            let Mesh {
+                indices: _,
+                vertices,
+                texture_id: _,
+            } = Arc::make_mut(mesh);
+
             for v in vertices {
                 adjust_color(&mut v.color);
             }

--- a/crates/epaint/src/shapes/rect_shape.rs
+++ b/crates/epaint/src/shapes/rect_shape.rs
@@ -97,6 +97,7 @@ impl RectShape {
     }
 
     /// Set the texture to use when painting this rectangle, if any.
+    #[inline]
     pub fn with_texture(mut self, fill_texture_id: TextureId, uv: Rect) -> Self {
         self.brush = Some(Arc::new(Brush {
             fill_texture_id,

--- a/crates/epaint/src/shapes/rect_shape.rs
+++ b/crates/epaint/src/shapes/rect_shape.rs
@@ -42,6 +42,14 @@ pub struct RectShape {
     pub uv: Rect,
 }
 
+#[test]
+fn rect_shape_size() {
+    assert_eq!(
+        std::mem::size_of::<RectShape>(), 72,
+        "RectShape changed size! If it shrank - good! Update this test. If it grew - bad! Try to find a way to avoid it."
+    );
+}
+
 impl RectShape {
     /// The stroke extends _outside_ the [`Rect`].
     #[inline]

--- a/crates/epaint/src/shapes/shape.rs
+++ b/crates/epaint/src/shapes/shape.rs
@@ -69,6 +69,14 @@ pub enum Shape {
 }
 
 #[test]
+fn shape_size() {
+    assert_eq!(
+        std::mem::size_of::<Shape>(), 72,
+        "Shape changed size! If it shrank - good! Update this test. If it grew - bad! Try to find a way to avoid it."
+    );
+}
+
+#[test]
 fn shape_impl_send_sync() {
     fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<Shape>();

--- a/crates/epaint/src/shapes/shape.rs
+++ b/crates/epaint/src/shapes/shape.rs
@@ -377,7 +377,7 @@ impl Shape {
         if let Self::Mesh(mesh) = self {
             mesh.texture_id
         } else if let Self::Rect(rect_shape) = self {
-            rect_shape.fill_texture_id
+            rect_shape.fill_texture_id()
         } else {
             crate::TextureId::default()
         }

--- a/crates/epaint/src/shapes/shape.rs
+++ b/crates/epaint/src/shapes/shape.rs
@@ -56,7 +56,9 @@ pub enum Shape {
     /// A general triangle mesh.
     ///
     /// Can be used to display images.
-    Mesh(Mesh),
+    ///
+    /// Wrapped in an [`Arc`] to minimize the size of [`Shape`].
+    Mesh(Arc<Mesh>),
 
     /// A quadratic [Bézier Curve](https://en.wikipedia.org/wiki/B%C3%A9zier_curve).
     QuadraticBezier(QuadraticBezierShape),
@@ -71,8 +73,12 @@ pub enum Shape {
 #[test]
 fn shape_size() {
     assert_eq!(
-        std::mem::size_of::<Shape>(), 72,
+        std::mem::size_of::<Shape>(), 64,
         "Shape changed size! If it shrank - good! Update this test. If it grew - bad! Try to find a way to avoid it."
+    );
+    assert!(
+        std::mem::size_of::<Shape>() <= 64,
+        "Shape is getting way too big!"
     );
 }
 
@@ -92,6 +98,13 @@ impl From<Vec<Self>> for Shape {
 impl From<Mesh> for Shape {
     #[inline(always)]
     fn from(mesh: Mesh) -> Self {
+        Self::Mesh(mesh.into())
+    }
+}
+
+impl From<Arc<Mesh>> for Shape {
+    #[inline(always)]
+    fn from(mesh: Arc<Mesh>) -> Self {
         Self::Mesh(mesh)
     }
 }
@@ -322,7 +335,8 @@ impl Shape {
     }
 
     #[inline]
-    pub fn mesh(mesh: Mesh) -> Self {
+    pub fn mesh(mesh: impl Into<Arc<Mesh>>) -> Self {
+        let mesh = mesh.into();
         debug_assert!(mesh.is_valid());
         Self::Mesh(mesh)
     }
@@ -454,7 +468,7 @@ impl Shape {
                 galley.rect = transform.scaling * galley.rect;
             }
             Self::Mesh(mesh) => {
-                mesh.transform(transform);
+                Arc::make_mut(mesh).transform(transform);
             }
             Self::QuadraticBezier(bezier_shape) => {
                 bezier_shape.points[0] = transform * bezier_shape.points[0];

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -1693,14 +1693,14 @@ impl Tessellator {
     /// * `rect`: the rectangle to tessellate.
     /// * `out`: triangles are appended to this.
     pub fn tessellate_rect(&mut self, rect: &RectShape, out: &mut Mesh) {
+        let brush = rect.brush.as_ref();
         let RectShape {
             mut rect,
             mut rounding,
             fill,
             stroke,
             mut blur_width,
-            fill_texture_id,
-            uv,
+            ..
         } = *rect;
 
         if self.options.coarse_tessellation_culling
@@ -1775,7 +1775,11 @@ impl Tessellator {
             path.add_line_loop(&self.scratchpad_points);
             let path_stroke = PathStroke::from(stroke).outside();
 
-            if uv.is_positive() {
+            if let Some(brush) = brush {
+                let crate::Brush {
+                    fill_texture_id,
+                    uv,
+                } = **brush;
                 // Textured
                 let uv_from_pos = |p: Pos2| {
                     pos2(

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -1406,7 +1406,7 @@ impl Tessellator {
                     return;
                 }
 
-                out.append(mesh);
+                out.append_ref(&mesh);
             }
             Shape::LineSegment { points, stroke } => {
                 self.tessellate_line_segment(points, stroke, out);
@@ -2177,7 +2177,7 @@ impl Tessellator {
 
         profiling::scope!("distribute results", tessellated.len().to_string());
         for (index, mesh) in tessellated {
-            shapes[index].shape = Shape::Mesh(mesh);
+            shapes[index].shape = Shape::Mesh(mesh.into());
         }
     }
 


### PR DESCRIPTION
Also wraps `Shape::Mesh` in an `Arc`.

No new features, but decreases size of `Shape` from 72 bytes to 64.