### PR TITLE
Shrink size of `Shadow` by using `i8/u8` instead of `f32`

### DIFF
--- a/crates/egui/src/containers/frame.rs
+++ b/crates/egui/src/containers/frame.rs
@@ -76,7 +76,7 @@ pub struct Frame {
 #[test]
 fn frame_size() {
     assert_eq!(
-        std::mem::size_of::<Frame>(), 44,
+        std::mem::size_of::<Frame>(), 32,
         "Frame changed size! If it shrank - good! Update this test. If it grew - bad! Try to find a way to avoid it."
     );
     assert!(

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1293,9 +1293,9 @@ impl Visuals {
 
             window_rounding: Rounding::same(6),
             window_shadow: Shadow {
-                offset: vec2(10.0, 20.0),
-                blur: 15.0,
-                spread: 0.0,
+                offset: [10, 20],
+                blur: 15,
+                spread: 0,
                 color: Color32::from_black_alpha(96),
             },
             window_fill: Color32::from_gray(27),
@@ -1307,9 +1307,9 @@ impl Visuals {
             panel_fill: Color32::from_gray(27),
 
             popup_shadow: Shadow {
-                offset: vec2(6.0, 10.0),
-                blur: 8.0,
-                spread: 0.0,
+                offset: [6, 10],
+                blur: 8,
+                spread: 0,
                 color: Color32::from_black_alpha(96),
             },
 
@@ -1349,9 +1349,9 @@ impl Visuals {
             error_fg_color: Color32::from_rgb(255, 0, 0),  // red
 
             window_shadow: Shadow {
-                offset: vec2(10.0, 20.0),
-                blur: 15.0,
-                spread: 0.0,
+                offset: [10, 20],
+                blur: 15,
+                spread: 0,
                 color: Color32::from_black_alpha(25),
             },
             window_fill: Color32::from_gray(248),
@@ -1360,9 +1360,9 @@ impl Visuals {
             panel_fill: Color32::from_gray(248),
 
             popup_shadow: Shadow {
-                offset: vec2(6.0, 10.0),
-                blur: 8.0,
-                spread: 0.0,
+                offset: [6, 10],
+                blur: 8,
+                spread: 0,
                 color: Color32::from_black_alpha(25),
             },
 
@@ -2456,13 +2456,13 @@ impl Widget for &mut Shadow {
         ui.vertical(|ui| {
             crate::Grid::new("shadow_ui").show(ui, |ui| {
                 ui.add(
-                    DragValue::new(&mut offset.x)
+                    DragValue::new(&mut offset[0])
                         .speed(1.0)
                         .range(-100.0..=100.0)
                         .prefix("x: "),
                 );
                 ui.add(
-                    DragValue::new(&mut offset.y)
+                    DragValue::new(&mut offset[1])
                         .speed(1.0)
                         .range(-100.0..=100.0)
                         .prefix("y: "),

--- a/crates/egui_demo_lib/src/demo/frame_demo.rs
+++ b/crates/egui_demo_lib/src/demo/frame_demo.rs
@@ -12,9 +12,9 @@ impl Default for FrameDemo {
                 outer_margin: 24.0.into(),
                 rounding: 14.0.into(),
                 shadow: egui::Shadow {
-                    offset: [8.0, 12.0].into(),
-                    blur: 16.0,
-                    spread: 0.0,
+                    offset: [8, 12],
+                    blur: 16,
+                    spread: 0,
                     color: egui::Color32::from_black_alpha(180),
                 },
                 fill: egui::Color32::from_rgba_unmultiplied(97, 0, 255, 128),

--- a/crates/epaint/src/shadow.rs
+++ b/crates/epaint/src/shadow.rs
@@ -5,33 +5,41 @@ use crate::{Color32, Marginf, Rect, RectShape, Rounding, Vec2};
 /// Can be used for a rectangular shadow with a soft penumbra.
 ///
 /// Very similar to a box-shadow in CSS.
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Shadow {
     /// Move the shadow by this much.
     ///
     /// For instance, a value of `[1.0, 2.0]` will move the shadow 1 point to the right and 2 points down,
     /// causing a drop-shadow effect.
-    pub offset: Vec2,
+    pub offset: [i8; 2],
 
     /// The width of the blur, i.e. the width of the fuzzy penumbra.
     ///
-    /// A value of 0.0 means a sharp shadow.
-    pub blur: f32,
+    /// A value of 0 means a sharp shadow.
+    pub blur: u8,
 
     /// Expand the shadow in all directions by this much.
-    pub spread: f32,
+    pub spread: u8,
 
     /// Color of the opaque center of the shadow.
     pub color: Color32,
 }
 
+#[test]
+fn shadow_size() {
+    assert_eq!(
+        std::mem::size_of::<Shadow>(), 8,
+        "Shadow changed size! If it shrank - good! Update this test. If it grew - bad! Try to find a way to avoid it."
+    );
+}
+
 impl Shadow {
     /// No shadow at all.
     pub const NONE: Self = Self {
-        offset: Vec2::ZERO,
-        blur: 0.0,
-        spread: 0.0,
+        offset: [0, 0],
+        blur: 0,
+        spread: 0,
         color: Color32::TRANSPARENT,
     };
 
@@ -45,11 +53,14 @@ impl Shadow {
             spread,
             color,
         } = *self;
+        let [offset_x, offset_y] = offset;
 
-        let rect = rect.translate(offset).expand(spread);
-        let rounding = rounding.into() + Rounding::from(spread.abs());
+        let rect = rect
+            .translate(Vec2::new(offset_x as _, offset_y as _))
+            .expand(spread as _);
+        let rounding = rounding.into() + Rounding::from(spread);
 
-        RectShape::filled(rect, rounding, color).with_blur_width(blur)
+        RectShape::filled(rect, rounding, color).with_blur_width(blur as _)
     }
 
     /// How much larger than the parent rect are we in each direction?
@@ -60,11 +71,14 @@ impl Shadow {
             spread,
             color: _,
         } = *self;
+        let spread = spread as f32;
+        let blur = blur as f32;
+        let [offset_x, offset_y] = offset;
         Marginf {
-            left: spread + 0.5 * blur - offset.x,
-            right: spread + 0.5 * blur + offset.x,
-            top: spread + 0.5 * blur - offset.y,
-            bottom: spread + 0.5 * blur + offset.y,
+            left: spread + 0.5 * blur - offset_x as f32,
+            right: spread + 0.5 * blur + offset_x as f32,
+            top: spread + 0.5 * blur - offset_y as f32,
+            bottom: spread + 0.5 * blur + offset_y as f32,
         }
     }
 }


### PR DESCRIPTION
* Part of https://github.com/emilk/egui/issues/4019

