### PR TITLE
egui_kittest: write `.old.png` files when updating images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/target_wasm
 **/tests/snapshots/**/*.diff.png
 **/tests/snapshots/**/*.new.png
+**/tests/snapshots/**/*.old.png
 /.*.json
 /.vscode
 /media/*


### PR DESCRIPTION
After running `UPDATE_SNAPSHOTS=1 cargo test --all-features` I want to compare before/after images before committing them. Now I can!