### PR TITLE
Save state on suspend on Android

### DIFF
--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -371,7 +371,7 @@ impl<'app> WinitApp for GlowWinitApp<'app> {
         if let Some(running) = self.running.as_mut() {
             profiling::function_scope!();
 
-            // This is because of the "save on suspend" logic on Android. Once the application is suspended, there is no window associated to it, which was causing panics when `.window().expect()` was used.
+            // This is used because of the "save on suspend" logic on Android. Once the application is suspended, there is no window associated to it, which was causing panics when `.window().expect()` was used.
             let window_opt = running.glutin.borrow().window_opt(ViewportId::ROOT);
 
             running.integration.save(

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -373,6 +373,11 @@ impl<'app> WinitApp for GlowWinitApp<'app> {
 
             // This is used because of the "save on suspend" logic on Android. Once the application is suspended, there is no window associated to it, which was causing panics when `.window().expect()` was used.
             let window_opt = running.glutin.borrow().window_opt(ViewportId::ROOT);
+            if window_opt.is_some() {
+                log::debug!("Saving application state with a window");
+            } else {
+                log::debug!("Saving application state without a window");
+            }
 
             running.integration.save(
                 running.app.as_mut(),

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -379,10 +379,9 @@ impl<'app> WinitApp for GlowWinitApp<'app> {
                 log::debug!("Saving application state without a window");
             }
 
-            running.integration.save(
-                running.app.as_mut(),
-                window_opt.as_deref(),
-            );
+            running
+                .integration
+                .save(running.app.as_mut(), window_opt.as_deref());
         }
     }
 
@@ -1241,13 +1240,12 @@ impl GlutinWindowContext {
     }
 
     fn window_opt(&self, viewport_id: ViewportId) -> Option<Arc<Window>> {
-        self.viewport(viewport_id)
-            .window
-            .clone()
+        self.viewport(viewport_id).window.clone()
     }
 
     fn window(&self, viewport_id: ViewportId) -> Arc<Window> {
-        self.window_opt(viewport_id).expect("winit window doesn't exist")
+        self.window_opt(viewport_id)
+            .expect("winit window doesn't exist")
     }
 
     fn resize(&mut self, viewport_id: ViewportId, physical_size: winit::dpi::PhysicalSize<u32>) {

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -89,6 +89,7 @@ impl<T: WinitApp> WinitAppWrapper<T> {
         event_result: Result<EventResult>,
     ) {
         let mut exit = false;
+        let mut save = false;
 
         log::trace!("event_result: {event_result:?}");
 
@@ -126,6 +127,10 @@ impl<T: WinitApp> WinitAppWrapper<T> {
                     );
                     Ok(event_result)
                 }
+                EventResult::Save => {
+                    save = true;
+                    Ok(event_result)
+                }
                 EventResult::Exit => {
                     exit = true;
                     Ok(event_result)
@@ -138,6 +143,11 @@ impl<T: WinitApp> WinitAppWrapper<T> {
             exit = true;
             self.return_result = Err(err);
         };
+
+        if save {
+            log::debug!("Received an EventResult::Save - saving app state");
+            self.winit_app.save();
+        }
 
         if exit {
             if self.run_and_return {

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -516,7 +516,7 @@ impl<'app> WgpuWinitRunning<'app> {
     fn save_and_destroy(&mut self) {
         profiling::function_scope!();
 
-        self.save(false);        
+        self.save(false);
 
         #[cfg(feature = "glow")]
         self.app.on_exit(None);

--- a/crates/eframe/src/native/winit_integration.rs
+++ b/crates/eframe/src/native/winit_integration.rs
@@ -70,6 +70,8 @@ pub trait WinitApp {
 
     fn window_id_from_viewport_id(&self, id: ViewportId) -> Option<WindowId>;
 
+    fn save(&mut self);
+
     fn save_and_destroy(&mut self);
 
     fn run_ui_and_paint(
@@ -118,6 +120,9 @@ pub enum EventResult {
     RepaintNext(WindowId),
 
     RepaintAt(WindowId, Instant),
+
+    /// Causes a save of the client state when the persistence feature is enabled.
+    Save,
 
     Exit,
 }

--- a/crates/eframe/src/native/winit_integration.rs
+++ b/crates/eframe/src/native/winit_integration.rs
@@ -122,7 +122,7 @@ pub enum EventResult {
     RepaintAt(WindowId, Instant),
 
     /// Causes a save of the client state when the persistence feature is enabled.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Not used outside of Android
     Save,
 
     Exit,

--- a/crates/eframe/src/native/winit_integration.rs
+++ b/crates/eframe/src/native/winit_integration.rs
@@ -122,6 +122,7 @@ pub enum EventResult {
     RepaintAt(WindowId, Instant),
 
     /// Causes a save of the client state when the persistence feature is enabled.
+    #[allow(dead_code)]
     Save,
 
     Exit,


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

This pull request fixes a subset of #5492 by saving the application state when the `suspended` event is received on Android. This way, even if the user exits the app and closes it manually right after changing some state, it will be saved since `suspended` gets fired when the app is exited. It does not fix the `on_exit` function not being fired - this seems to be a winit bug (the `exiting` function in the winit application handler trait is not called on exit). Once it gets fixed, it may be possible to remove logic introduced by this PR (however, I am not sure how it would handle the app being killed by the system when in the background, that would have to be tested).

I've tested the logic by:
 * Leaving from the app to the home screen, then killing it from the "recent apps" menu
 * Leaving from the app to the "recent apps" menu and killing it
 * Restarting the device while the app was running

In all of these instances, the state was saved (the last one being a pleasant surprise). It was tested on the repository mentioned in #5492 with my forked repository as the source for eframe (I unfortunately am not able to test it in a larger project of mine due to dependence on "3rd party" egui libraries (like egui_notify) which do not compile along with the master branch of eframe (different versions of egui), but I believe it should work in the same manner in all scenarios). Tests were conducted on a Galaxy Tab S8 running Android 14, One UI 6.1.1.

CI passed on my fork.

* [x] I have followed the instructions in the PR template
