### PR TITLE
Wgpu resources are no longer wrapped in `Arc` (since they are now `Clone`)

### DIFF
--- a/crates/egui-wgpu/src/setup.rs
+++ b/crates/egui-wgpu/src/setup.rs
@@ -45,7 +45,7 @@ impl WgpuSetup {
     ///
     /// Does *not* store the wgpu instance, so calling this repeatedly may
     /// create a new instance every time!
-    pub async fn new_instance(&self) -> Arc<wgpu::Instance> {
+    pub async fn new_instance(&self) -> wgpu::Instance {
         match self {
             Self::CreateNew(create_new) => {
                 #[allow(unused_mut)]
@@ -65,12 +65,8 @@ impl WgpuSetup {
                 }
 
                 log::debug!("Creating wgpu instance with backends {:?}", backends);
-
-                #[allow(clippy::arc_with_non_send_sync)]
-                Arc::new(
-                    wgpu::util::new_instance_with_webgpu_detection(&create_new.instance_descriptor)
-                        .await,
-                )
+                wgpu::util::new_instance_with_webgpu_detection(&create_new.instance_descriptor)
+                    .await
             }
             Self::Existing(existing) => existing.instance.clone(),
         }
@@ -93,9 +89,8 @@ impl From<WgpuSetupExisting> for WgpuSetup {
 ///
 /// This can be used for fully custom adapter selection.
 /// If available, `wgpu::Surface` is passed to allow checking for surface compatibility.
-// TODO(gfx-rs/wgpu#6665): Remove layer of `Arc` here.
 pub type NativeAdapterSelectorMethod = Arc<
-    dyn Fn(&[Arc<wgpu::Adapter>], Option<&wgpu::Surface<'_>>) -> Result<Arc<wgpu::Adapter>, String>
+    dyn Fn(&[wgpu::Adapter], Option<&wgpu::Surface<'_>>) -> Result<wgpu::Adapter, String>
         + Send
         + Sync,
 >;
@@ -215,8 +210,8 @@ impl Default for WgpuSetupCreateNew {
 /// Used for [`WgpuSetup::Existing`].
 #[derive(Clone)]
 pub struct WgpuSetupExisting {
-    pub instance: Arc<wgpu::Instance>,
-    pub adapter: Arc<wgpu::Adapter>,
-    pub device: Arc<wgpu::Device>,
-    pub queue: Arc<wgpu::Queue>,
+    pub instance: wgpu::Instance,
+    pub adapter: wgpu::Adapter,
+    pub device: wgpu::Device,
+    pub queue: wgpu::Queue,
 }

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -27,7 +27,7 @@ pub struct Painter {
     depth_format: Option<wgpu::TextureFormat>,
     screen_capture_state: Option<CaptureState>,
 
-    instance: Arc<wgpu::Instance>,
+    instance: wgpu::Instance,
     render_state: Option<RenderState>,
 
     // Per viewport/window:

--- a/crates/egui_kittest/src/builder.rs
+++ b/crates/egui_kittest/src/builder.rs
@@ -1,5 +1,4 @@
 use crate::app_kind::AppKind;
-use crate::wgpu::WgpuTestRenderer;
 use crate::{Harness, LazyRenderer, TestRenderer};
 use egui::{Pos2, Rect, Vec2};
 use std::marker::PhantomData;
@@ -78,13 +77,13 @@ impl<State> HarnessBuilder<State> {
     /// This sets up a [`WgpuTestRenderer`] with the default setup.
     #[cfg(feature = "wgpu")]
     pub fn wgpu(self) -> Self {
-        self.renderer(WgpuTestRenderer::default())
+        self.renderer(crate::wgpu::WgpuTestRenderer::default())
     }
 
     /// Enable wgpu rendering with the given setup.
     #[cfg(feature = "wgpu")]
     pub fn wgpu_setup(self, setup: egui_wgpu::WgpuSetup) -> Self {
-        self.renderer(WgpuTestRenderer::from_setup(setup))
+        self.renderer(crate::wgpu::WgpuTestRenderer::from_setup(setup))
     }
 
     /// Create a new Harness with the given app closure and a state.

--- a/crates/egui_kittest/src/builder.rs
+++ b/crates/egui_kittest/src/builder.rs
@@ -74,7 +74,7 @@ impl<State> HarnessBuilder<State> {
 
     /// Enable wgpu rendering with a default setup suitable for testing.
     ///
-    /// This sets up a [`WgpuTestRenderer`] with the default setup.
+    /// This sets up a [`crate::wgpu::WgpuTestRenderer`] with the default setup.
     #[cfg(feature = "wgpu")]
     pub fn wgpu(self) -> Self {
         self.renderer(crate::wgpu::WgpuTestRenderer::default())

--- a/crates/egui_kittest/src/lib.rs
+++ b/crates/egui_kittest/src/lib.rs
@@ -402,6 +402,7 @@ impl<'a, State> Harness<'a, State> {
     ///
     /// # Errors
     /// Returns an error if the rendering fails.
+    #[cfg(any(feature = "wgpu", feature = "snapshot"))]
     pub fn render(&mut self) -> Result<image::RgbaImage, String> {
         self.renderer.render(&self.ctx, &self.output)
     }

--- a/crates/egui_kittest/src/renderer.rs
+++ b/crates/egui_kittest/src/renderer.rs
@@ -1,5 +1,4 @@
-use egui::{Context, FullOutput, TexturesDelta};
-use image::RgbaImage;
+use egui::TexturesDelta;
 
 pub trait TestRenderer {
     /// We use this to pass the glow / wgpu render state to [`eframe::Frame`].
@@ -13,7 +12,12 @@ pub trait TestRenderer {
     ///
     /// # Errors
     /// Returns an error if the rendering fails.
-    fn render(&mut self, ctx: &Context, output: &FullOutput) -> Result<RgbaImage, String>;
+    #[cfg(any(feature = "wgpu", feature = "snapshot"))]
+    fn render(
+        &mut self,
+        ctx: &egui::Context,
+        output: &egui::FullOutput,
+    ) -> Result<image::RgbaImage, String>;
 }
 
 /// A lazy renderer that initializes the renderer on the first render call.
@@ -58,7 +62,12 @@ impl TestRenderer for LazyRenderer {
         }
     }
 
-    fn render(&mut self, ctx: &Context, output: &FullOutput) -> Result<RgbaImage, String> {
+    #[cfg(any(feature = "wgpu", feature = "snapshot"))]
+    fn render(
+        &mut self,
+        ctx: &egui::Context,
+        output: &egui::FullOutput,
+    ) -> Result<image::RgbaImage, String> {
         match self {
             Self::Uninitialized {
                 texture_ops,


### PR DESCRIPTION
* Follow-up to https://github.com/emilk/egui/pull/5610

Wgpu 24 makes most of its interface `Clone`. Which means we no longer have to wrap everything in `Arc`! \o/