### PR TITLE
Only generate a paste command when pasted text is available.

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -772,9 +772,9 @@ impl State {
                         let contents = contents.replace("\r\n", "\n");
                         if !contents.is_empty() {
                             self.egui_input.events.push(egui::Event::Paste(contents));
+                            return;
                         }
                     }
-                    return;
                 }
             }
 


### PR DESCRIPTION
Not always a text is in the paste buffer.

IMO Cut/Copy/Paste shouldn't be part of the events - or at least have an opt_out. I've made desktop applications that have custom clipboard formats - and potentially can remap command keys.

So handling cut/copy/paste is a problem. (Remapping not really) 
Alternatively the paste system could be enhanced to support multiple formats - but with that fix I can just handle ctrl+v myself.

* [x ] I have followed the instructions in the PR template
