### PR TITLE
Web: Fix incorrect scale when moving to screen with new DPI

### DIFF
--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -211,6 +211,7 @@ percent-encoding = "2.1"
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
 web-sys = { workspace = true, features = [
+  "AddEventListenerOptions",
   "BinaryType",
   "Blob",
   "BlobPropertyBag",

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -59,7 +59,7 @@ impl AppRunner {
 
         egui_ctx.options_mut(|o| {
             // On web by default egui follows the zoom factor of the browser,
-            // and lets the browser handle the zoom shortscuts.
+            // and lets the browser handle the zoom shortcuts.
             // A user can still zoom egui separately by calling [`egui::Context::set_zoom_factor`].
             o.zoom_with_keyboard = false;
             o.zoom_factor = 1.0;
@@ -218,11 +218,13 @@ impl AppRunner {
 
         if super::DEBUG_RESIZE {
             log::info!(
-                "egui running at canvas size: {}x{} points, DPR: {}, zoom_factor: {}",
-                canvas_size.x,
-                canvas_size.y,
+                "egui running at canvas size: {}x{}, DPR: {}, zoom_factor: {}. egui size: {}x{} points",
+                self.canvas().width(),
+                self.canvas().height(),
                 super::native_pixels_per_point(),
                 self.egui_ctx.zoom_factor(),
+                canvas_size.x,
+                canvas_size.y,
             );
         }
 

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -216,6 +216,16 @@ impl AppRunner {
         let canvas_size = super::canvas_size_in_points(self.canvas(), self.egui_ctx());
         let mut raw_input = self.input.new_frame(canvas_size);
 
+        if super::DEBUG_RESIZE {
+            log::info!(
+                "egui running at canvas size: {}x{} points, DPR: {}, zoom_factor: {}",
+                canvas_size.x,
+                canvas_size.y,
+                super::native_pixels_per_point(),
+                self.egui_ctx.zoom_factor(),
+            );
+        }
+
         self.app.raw_input_hook(&self.egui_ctx, &mut raw_input);
 
         let full_output = self.egui_ctx.run(raw_input, |egui_ctx| {

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -393,10 +393,14 @@ fn install_dpr_change_event(web_runner: &WebRunner) -> Result<(), JsValue> {
     let original_dpr = native_pixels_per_point();
 
     let window = web_sys::window().unwrap();
-    let media_query_list = window
-        .match_media(&format!("(resolution: {original_dpr}dppx)"))
-        .unwrap()
-        .unwrap();
+    let Some(media_query_list) =
+        window.match_media(&format!("(resolution: {original_dpr}dppx)"))?
+    else {
+        log::error!(
+            "Failed to create MediaQueryList: eframe won't be able to detect changes in DPR"
+        );
+        return Ok(());
+    };
 
     let closure = move |_: web_sys::Event, app_runner: &mut AppRunner, web_runner: &WebRunner| {
         let new_dpr = native_pixels_per_point();

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -155,7 +155,10 @@ fn canvas_content_rect(canvas: &web_sys::HtmlCanvasElement) -> egui::Rect {
 }
 
 fn canvas_size_in_points(canvas: &web_sys::HtmlCanvasElement, ctx: &egui::Context) -> egui::Vec2 {
-    let pixels_per_point = ctx.pixels_per_point();
+    // ctx.pixels_per_point can be outdated
+
+    let pixels_per_point = ctx.zoom_factor() * native_pixels_per_point();
+
     egui::vec2(
         canvas.width() as f32 / pixels_per_point,
         canvas.height() as f32 / pixels_per_point,

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -51,6 +51,9 @@ use input::{
 
 // ----------------------------------------------------------------------------
 
+/// Debug browser resizing?
+const DEBUG_RESIZE: bool = false;
+
 pub(crate) fn string_from_js_value(value: &JsValue) -> String {
     value.as_string().unwrap_or_else(|| format!("{value:#?}"))
 }

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -52,7 +52,7 @@ use input::{
 // ----------------------------------------------------------------------------
 
 /// Debug browser resizing?
-const DEBUG_RESIZE: bool = true; // TODO: revert
+const DEBUG_RESIZE: bool = false;
 
 pub(crate) fn string_from_js_value(value: &JsValue) -> String {
     value.as_string().unwrap_or_else(|| format!("{value:#?}"))
@@ -361,7 +361,5 @@ pub fn percent_decode(s: &str) -> String {
 
 /// Are we running inside the Safari browser?
 pub fn is_safari_browser() -> bool {
-    web_sys::window()
-        .map(|window| window.has_own_property(&JsValue::from("safari")))
-        .unwrap_or(false)
+    web_sys::window().is_some_and(|window| window.has_own_property(&JsValue::from("safari")))
 }

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -52,7 +52,7 @@ use input::{
 // ----------------------------------------------------------------------------
 
 /// Debug browser resizing?
-const DEBUG_RESIZE: bool = false;
+const DEBUG_RESIZE: bool = true; // TODO: revert
 
 pub(crate) fn string_from_js_value(value: &JsValue) -> String {
     value.as_string().unwrap_or_else(|| format!("{value:#?}"))
@@ -357,4 +357,11 @@ pub fn percent_decode(s: &str) -> String {
     percent_encoding::percent_decode_str(s)
         .decode_utf8_lossy()
         .to_string()
+}
+
+/// Are we running inside the Safari browser?
+pub fn is_safari_browser() -> bool {
+    web_sys::window()
+        .map(|window| window.has_own_property(&JsValue::from("safari")))
+        .unwrap_or(false)
 }

--- a/crates/eframe/src/web/web_runner.rs
+++ b/crates/eframe/src/web/web_runner.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use wasm_bindgen::prelude::*;
 
-use crate::{epi, web::DEBUG_RESIZE, App};
+use crate::{epi, App};
 
 use super::{
     events::{self, ResizeObserverContext},
@@ -191,7 +191,7 @@ impl WebRunner {
         target: &web_sys::EventTarget,
         event_name: &'static str,
         options: &web_sys::AddEventListenerOptions,
-        mut closure: impl FnMut(E, &mut AppRunner, &WebRunner) + 'static,
+        mut closure: impl FnMut(E, &mut AppRunner, &Self) + 'static,
     ) -> Result<(), wasm_bindgen::JsValue> {
         let web_runner = self.clone();
 


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/5246

Tested on
* [x] Chromium
* [x] Firefox
* [x] Safari

On Chromium and Firefox we get one annoying frame with the wrong size, which can mess up the layout of egui apps, but this PR is still a huge improvement, and I don't want to spend more time on this right now.