### PR TITLE
`RectShape`: add control over where the stoke goes

### DIFF
--- a/crates/egui/src/containers/frame.rs
+++ b/crates/egui/src/containers/frame.rs
@@ -423,7 +423,10 @@ impl Frame {
         let fill_rect = self.fill_rect(content_rect);
         let widget_rect = self.widget_rect(content_rect);
 
-        let frame_shape = Shape::Rect(epaint::RectShape::new(fill_rect, rounding, fill, stroke));
+        let frame_shape = Shape::Rect(
+            epaint::RectShape::new(fill_rect, rounding, fill, stroke)
+                .with_stroke_kind(epaint::StrokeKind::Outside),
+        );
 
         if shadow == Default::default() {
             frame_shape

--- a/crates/epaint/src/shape_transform.rs
+++ b/crates/epaint/src/shape_transform.rs
@@ -63,6 +63,7 @@ pub fn adjust_colors(
             rounding: _,
             fill,
             stroke,
+            stroke_kind: _,
             round_to_pixels: _,
             blur_width: _,
             brush: _,

--- a/crates/epaint/src/shape_transform.rs
+++ b/crates/epaint/src/shape_transform.rs
@@ -63,6 +63,7 @@ pub fn adjust_colors(
             rounding: _,
             fill,
             stroke,
+            round_to_pixels: _,
             blur_width: _,
             brush: _,
         }) => {

--- a/crates/epaint/src/shapes/rect_shape.rs
+++ b/crates/epaint/src/shapes/rect_shape.rs
@@ -22,6 +22,9 @@ pub struct RectShape {
     /// This means the [`Self::visual_bounding_rect`] is `rect.size() + 2.0 * stroke.width`.
     pub stroke: Stroke,
 
+    /// Is the stroke on the inside, outside, or centered on the rectangle?
+    pub stroke_kind: StrokeKind,
+
     /// Snap the rectangle to pixels?
     ///
     /// Rounding produces sharper rectangles.
@@ -72,6 +75,7 @@ impl RectShape {
             rounding: rounding.into(),
             fill: fill_color.into(),
             stroke: stroke.into(),
+            stroke_kind: StrokeKind::Outside,
             round_to_pixels: None,
             blur_width: 0.0,
             brush: Default::default(),
@@ -92,6 +96,13 @@ impl RectShape {
     pub fn stroke(rect: Rect, rounding: impl Into<Rounding>, stroke: impl Into<Stroke>) -> Self {
         let fill = Color32::TRANSPARENT;
         Self::new(rect, rounding, fill, stroke)
+    }
+
+    /// Set if the stroke is on the inside, outside, or centered on the rectangle.
+    #[inline]
+    pub fn with_stroke_kind(mut self, stroke_kind: StrokeKind) -> Self {
+        self.stroke_kind = stroke_kind;
+        self
     }
 
     /// Snap the rectangle to pixels?

--- a/crates/epaint/src/shapes/rect_shape.rs
+++ b/crates/epaint/src/shapes/rect_shape.rs
@@ -22,6 +22,15 @@ pub struct RectShape {
     /// This means the [`Self::visual_bounding_rect`] is `rect.size() + 2.0 * stroke.width`.
     pub stroke: Stroke,
 
+    /// Snap the rectangle to pixels?
+    ///
+    /// Rounding produces sharper rectangles.
+    /// It is the outside of the fill (=inside of the stroke)
+    /// that will be rounded to the physical pixel grid.
+    ///
+    /// If `None`, [`crate::TessellationOptions::round_rects_to_pixels`] will be used.
+    pub round_to_pixels: Option<bool>,
+
     /// If larger than zero, the edges of the rectangle
     /// (for both fill and stroke) will be blurred.
     ///
@@ -63,6 +72,7 @@ impl RectShape {
             rounding: rounding.into(),
             fill: fill_color.into(),
             stroke: stroke.into(),
+            round_to_pixels: None,
             blur_width: 0.0,
             brush: Default::default(),
         }
@@ -82,6 +92,19 @@ impl RectShape {
     pub fn stroke(rect: Rect, rounding: impl Into<Rounding>, stroke: impl Into<Stroke>) -> Self {
         let fill = Color32::TRANSPARENT;
         Self::new(rect, rounding, fill, stroke)
+    }
+
+    /// Snap the rectangle to pixels?
+    ///
+    /// Rounding produces sharper rectangles.
+    /// It is the outside of the fill (=inside of the stroke)
+    /// that will be rounded to the physical pixel grid.
+    ///
+    /// If `None`, [`crate::TessellationOptions::round_rects_to_pixels`] will be used.
+    #[inline]
+    pub fn with_round_to_pixels(mut self, round_to_pixels: bool) -> Self {
+        self.round_to_pixels = Some(round_to_pixels);
+        self
     }
 
     /// If larger than zero, the edges of the rectangle

--- a/crates/epaint/src/stroke.rs
+++ b/crates/epaint/src/stroke.rs
@@ -56,17 +56,17 @@ impl std::hash::Hash for Stroke {
 }
 
 /// Describes how the stroke of a shape should be painted.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum StrokeKind {
-    /// The stroke should be painted entirely outside of the shape
-    Outside,
-
     /// The stroke should be painted entirely inside of the shape
     Inside,
 
     /// The stroke should be painted right on the edge of the shape, half inside and half outside.
     Middle,
+
+    /// The stroke should be painted entirely outside of the shape
+    Outside,
 }
 
 impl Default for StrokeKind {

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -1676,9 +1676,12 @@ impl Tessellator {
             mut rounding,
             fill,
             stroke,
+            round_to_pixels,
             mut blur_width,
             ..
         } = *rect_shape;
+
+        let round_to_pixels = round_to_pixels.unwrap_or(self.options.round_rects_to_pixels);
 
         if self.options.coarse_tessellation_culling
             && !rect.expand(stroke.width).intersects(self.clip_rect)
@@ -1689,7 +1692,7 @@ impl Tessellator {
             return;
         }
 
-        if self.options.round_rects_to_pixels {
+        if round_to_pixels {
             // Since the stroke extends outside of the rectangle,
             // we can round the rectangle sides to the physical pixel edges,
             // and the filled rect will appear crisp, as will the inside of the stroke.

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -1669,8 +1669,8 @@ impl Tessellator {
     ///
     /// * `rect`: the rectangle to tessellate.
     /// * `out`: triangles are appended to this.
-    pub fn tessellate_rect(&mut self, rect: &RectShape, out: &mut Mesh) {
-        let brush = rect.brush.as_ref();
+    pub fn tessellate_rect(&mut self, rect_shape: &RectShape, out: &mut Mesh) {
+        let brush = rect_shape.brush.as_ref();
         let RectShape {
             mut rect,
             mut rounding,
@@ -1678,7 +1678,7 @@ impl Tessellator {
             stroke,
             mut blur_width,
             ..
-        } = *rect;
+        } = *rect_shape;
 
         if self.options.coarse_tessellation_culling
             && !rect.expand(stroke.width).intersects(self.clip_rect)

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -1688,9 +1688,6 @@ impl Tessellator {
         {
             return;
         }
-        if rect.is_negative() {
-            return;
-        }
 
         if round_to_pixels {
             // Since the stroke extends outside of the rectangle,
@@ -1739,7 +1736,7 @@ impl Tessellator {
         if rect.width() < 0.5 * self.feathering {
             // Very thin - approximate by a vertical line-segment:
             let line = [rect.center_top(), rect.center_bottom()];
-            if fill != Color32::TRANSPARENT {
+            if 0.0 < rect.width() && fill != Color32::TRANSPARENT {
                 self.tessellate_line_segment(line, Stroke::new(rect.width(), fill), out);
             }
             if !stroke.is_empty() {
@@ -1749,7 +1746,7 @@ impl Tessellator {
         } else if rect.height() < 0.5 * self.feathering {
             // Very thin - approximate by a horizontal line-segment:
             let line = [rect.left_center(), rect.right_center()];
-            if fill != Color32::TRANSPARENT {
+            if 0.0 < rect.height() && fill != Color32::TRANSPARENT {
                 self.tessellate_line_segment(line, Stroke::new(rect.height(), fill), out);
             }
             if !stroke.is_empty() {


### PR DESCRIPTION
Adds `RectShape::stroke_kind` so you can select if the stroke goes inside, outside, or is centered on the rectangle.

Also adds `RectShape::round_to_pixels` so you can override `TessellationOptions::round_rects_to_pixels`.