### PR TITLE
egui: Add `collapsed` and `default_collapsed` to Window for programatically collapsing it

### DIFF
--- a/crates/egui/src/containers/collapsing_header.rs
+++ b/crates/egui/src/containers/collapsing_header.rs
@@ -58,12 +58,24 @@ impl CollapsingState {
         })
     }
 
+    pub fn load_with_default_collapsed(ctx: &Context, id: Id, default_collapsed: bool) -> Self {
+        Self::load_with_default_open(ctx, id, !default_collapsed)
+    }
+
     pub fn is_open(&self) -> bool {
         self.state.open
     }
 
     pub fn set_open(&mut self, open: bool) {
         self.state.open = open;
+    }
+
+    pub fn is_collapsed(&self) -> bool {
+        !self.state.open
+    }
+
+    pub fn set_collapsed(&mut self, collapsed: bool) {
+        self.state.open = !collapsed;
     }
 
     pub fn toggle(&mut self, ui: &Ui) {

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -299,8 +299,8 @@ impl<'open, 'collapsed> Window<'open, 'collapsed> {
         self
     }
 
-    #[inline]
     /// Set initial collapsed state of the window
+    #[inline]
     pub fn default_collapsed(mut self, default_collapsed: bool) -> Self {
         self.default_collapsed = default_collapsed;
         self
@@ -486,8 +486,11 @@ impl Window<'_, '_> {
         let area_id = area.id;
         let area_layer_id = area.layer();
         let resize_id = area_id.with("resize");
-        let mut collapsing =
-            CollapsingState::load_with_default_collapsed(ctx, area_id.with("collapsing"), default_collapsed);
+        let mut collapsing = CollapsingState::load_with_default_collapsed(
+            ctx,
+            area_id.with("collapsing"),
+            default_collapsed,
+        );
 
         let is_collapsed = with_title_bar && !collapsing.is_open();
         let possible = PossibleInteractions::new(&area, &resize, is_collapsed);
@@ -1327,7 +1330,7 @@ impl TitleBar {
             collapsing.toggle(ui);
 
             if let Some(collapsed) = collapsed.as_mut() {
-                **collapsed = collapsing.is_collapsed()
+                **collapsed = collapsing.is_collapsed();
             }
         }
     }


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

In summary, this PR:
- introduces `collapsed(&self, collapsed: &mut bool)` to window which can be used to explicitly collapse a window. It will, similar to the `open` function, set the `collapsed` boolean according to the internal state when it is changed by the default collapse button / double click on title and explicitly set it to the provided value if changed
- introduces `default_collapsed` which does what old `default_open` did - sets default collapsed state
- marks `default_open` as deprecated since it was miss-labeled imo, should have been called `default_collapse`. The `open` word in the `Window` is related to the open/close button on the window and got mixed up with the collapsed state. I would also be fine if the `open` function was renamed, though this seemed like the smallest change.
- Closes #358 

This PR does not redesign the window API to handle `events` like #4835, but rather implements it using the same API as the current `open` API  

---


* I have run `./scripts/check.sh` (edit: though I apparently misinterpreted the output. It should show errors in red xD didn't read) and `cargo test` in `crates/egui` as well as used and verified the new API works how we want for our application
* [X] I have followed the instructions in the PR template
