### PR TITLE
Add `Color32::CYAN` and `Color32::MAGENTA`

### DIFF
--- a/crates/ecolor/src/color32.rs
+++ b/crates/ecolor/src/color32.rs
@@ -56,7 +56,10 @@ impl Color32 {
     pub const RED: Self = Self::from_rgb(255, 0, 0);
     pub const LIGHT_RED: Self = Self::from_rgb(255, 128, 128);
 
+    pub const CYAN: Self = Self::from_rgb(0, 255, 255);
+    pub const MAGENTA: Self = Self::from_rgb(255, 0, 255);
     pub const YELLOW: Self = Self::from_rgb(255, 255, 0);
+
     pub const ORANGE: Self = Self::from_rgb(255, 165, 0);
     pub const LIGHT_YELLOW: Self = Self::from_rgb(255, 255, 0xE0);
     pub const KHAKI: Self = Self::from_rgb(240, 230, 140);


### PR DESCRIPTION
I often find myself reaching out for these two colors so I figured I'd just add the constants next to `YELLOW` to have CMYK