### PR TITLE
Add `SnapshotResults` struct to egui_kittest

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   fmt-crank-check-test:
-    name: Format + check + test
+    name: Format + check
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -223,7 +223,7 @@ jobs:
 
   tests:
     name: Run tests
-    # We run the tests on macOS because it will run with a actual GPU
+    # We run the tests on macOS because it will run with an actual GPU
     runs-on: macos-latest
 
     steps:

--- a/crates/egui/src/painter.rs
+++ b/crates/egui/src/painter.rs
@@ -435,7 +435,6 @@ impl Painter {
         self.add(RectShape::filled(rect, rounding, fill_color))
     }
 
-    /// The stroke extends _outside_ the [`Rect`].
     pub fn rect_stroke(
         &self,
         rect: Rect,

--- a/crates/egui_demo_app/tests/test_demo_app.rs
+++ b/crates/egui_demo_app/tests/test_demo_app.rs
@@ -71,6 +71,4 @@ fn test_demo_app() {
 
         results.add(harness.try_snapshot(&anchor.to_string()));
     }
-
-    results.unwrap();
 }

--- a/crates/egui_demo_app/tests/test_demo_app.rs
+++ b/crates/egui_demo_app/tests/test_demo_app.rs
@@ -2,6 +2,7 @@ use egui::accesskit::Role;
 use egui::Vec2;
 use egui_demo_app::{Anchor, WrapApp};
 use egui_kittest::kittest::Queryable;
+use egui_kittest::SnapshotResults;
 
 #[test]
 fn test_demo_app() {
@@ -27,7 +28,7 @@ fn test_demo_app() {
         "Expected to find the Custom3d app.",
     );
 
-    let mut results = vec![];
+    let mut results = SnapshotResults::new();
 
     for (name, anchor) in apps {
         harness.get_by_role_and_label(Role::Button, name).click();
@@ -68,12 +69,8 @@ fn test_demo_app() {
         // Can't use Harness::run because fractal clock keeps requesting repaints
         harness.run_steps(2);
 
-        if let Err(e) = harness.try_snapshot(&anchor.to_string()) {
-            results.push(e);
-        }
+        results.add(harness.try_snapshot(&anchor.to_string()));
     }
 
-    if let Some(error) = results.first() {
-        panic!("{error}");
-    }
+    results.unwrap();
 }

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -365,13 +365,13 @@ mod tests {
     use crate::{demo::demo_app_windows::DemoGroups, Demo};
     use egui::Vec2;
     use egui_kittest::kittest::Queryable;
-    use egui_kittest::{Harness, SnapshotOptions};
+    use egui_kittest::{Harness, SnapshotOptions, SnapshotResults};
 
     #[test]
     fn demos_should_match_snapshot() {
         let demos = DemoGroups::default().demos;
 
-        let mut errors = Vec::new();
+        let mut results = SnapshotResults::new();
 
         for mut demo in demos.demos {
             // Widget Gallery needs to be customized (to set a specific date) and has its own test
@@ -405,12 +405,9 @@ mod tests {
                 options.threshold = 2.1;
             }
 
-            let result = harness.try_snapshot_options(&format!("demos/{name}"), &options);
-            if let Err(err) = result {
-                errors.push(err.to_string());
-            }
+            results.add(harness.try_snapshot_options(&format!("demos/{name}"), &options));
         }
 
-        assert!(errors.is_empty(), "Errors: {errors:#?}");
+        results.unwrap();
     }
 }

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -407,7 +407,5 @@ mod tests {
 
             results.add(harness.try_snapshot_options(&format!("demos/{name}"), &options));
         }
-
-        results.unwrap();
     }
 }

--- a/crates/egui_demo_lib/src/demo/modals.rs
+++ b/crates/egui_demo_lib/src/demo/modals.rs
@@ -165,7 +165,7 @@ mod tests {
     use egui::accesskit::Role;
     use egui::Key;
     use egui_kittest::kittest::Queryable;
-    use egui_kittest::Harness;
+    use egui_kittest::{Harness, SnapshotResults};
 
     #[test]
     fn clicking_escape_when_popup_open_should_not_close_modal() {
@@ -233,22 +233,20 @@ mod tests {
             initial_state,
         );
 
-        let mut results = Vec::new();
+        let mut results = SnapshotResults::new();
 
         harness.run();
-        results.push(harness.try_snapshot("modals_1"));
+        results.add(harness.try_snapshot("modals_1"));
 
         harness.get_by_label("Save").click();
         harness.run_ok();
-        results.push(harness.try_snapshot("modals_2"));
+        results.add(harness.try_snapshot("modals_2"));
 
         harness.get_by_label("Yes Please").click();
         harness.run_ok();
-        results.push(harness.try_snapshot("modals_3"));
+        results.add(harness.try_snapshot("modals_3"));
 
-        for result in results {
-            result.unwrap();
-        }
+        results.unwrap();
     }
 
     // This tests whether the backdrop actually prevents interaction with lower layers.

--- a/crates/egui_demo_lib/src/demo/modals.rs
+++ b/crates/egui_demo_lib/src/demo/modals.rs
@@ -245,8 +245,6 @@ mod tests {
         harness.get_by_label("Yes Please").click();
         harness.run_ok();
         results.add(harness.try_snapshot("modals_3"));
-
-        results.unwrap();
     }
 
     // This tests whether the backdrop actually prevents interaction with lower layers.

--- a/crates/egui_demo_lib/src/demo/widget_gallery.rs
+++ b/crates/egui_demo_lib/src/demo/widget_gallery.rs
@@ -23,6 +23,7 @@ pub struct WidgetGallery {
     #[cfg_attr(feature = "serde", serde(skip))]
     date: Option<chrono::NaiveDate>,
 
+    #[cfg(feature = "chrono")]
     with_date_button: bool,
 }
 

--- a/crates/egui_demo_lib/src/rendering_test.rs
+++ b/crates/egui_demo_lib/src/rendering_test.rs
@@ -688,10 +688,11 @@ fn mul_color_gamma(left: Color32, right: Color32) -> Color32 {
 mod tests {
     use crate::ColorTest;
     use egui_kittest::kittest::Queryable as _;
+    use egui_kittest::SnapshotResults;
 
     #[test]
     pub fn rendering_test() {
-        let mut errors = vec![];
+        let mut results = SnapshotResults::new();
         for dpi in [1.0, 1.25, 1.5, 1.75, 1.6666667, 2.0] {
             let mut color_test = ColorTest::default();
             let mut harness = egui_kittest::Harness::builder()
@@ -708,12 +709,9 @@ mod tests {
 
             harness.fit_contents();
 
-            let result = harness.try_snapshot(&format!("rendering_test/dpi_{dpi:.2}"));
-            if let Err(err) = result {
-                errors.push(err);
-            }
+            results.add(harness.try_snapshot(&format!("rendering_test/dpi_{dpi:.2}")));
         }
 
-        assert!(errors.is_empty(), "Errors: {errors:#?}");
+        results.unwrap();
     }
 }

--- a/crates/egui_demo_lib/src/rendering_test.rs
+++ b/crates/egui_demo_lib/src/rendering_test.rs
@@ -711,7 +711,5 @@ mod tests {
 
             results.add(harness.try_snapshot(&format!("rendering_test/dpi_{dpi:.2}")));
         }
-
-        results.unwrap();
     }
 }

--- a/crates/egui_kittest/src/snapshot.rs
+++ b/crates/egui_kittest/src/snapshot.rs
@@ -503,12 +503,13 @@ impl<State> Harness<'_, State> {
 /// // Call add for each snapshot in your test
 /// results.add(harness.try_snapshot("my_test"));
 ///
-/// // At the end of the test, fail if there are any errors
-/// results.unwrap();
+/// // If there are any errors, SnapshotResults will panic once dropped.
 /// ```
 ///
 /// # Panics
 /// Panics if there are any errors when dropped (this way it is impossible to forget to call `unwrap`).
+/// If you don't want to panic, you can use [`SnapshotResults::into_result`] or [`SnapshotResults::into_inner`].
+/// If you want to panic early, you can use [`SnapshotResults::unwrap`].
 #[derive(Debug, Default)]
 pub struct SnapshotResults {
     errors: Vec<SnapshotError>,

--- a/crates/egui_kittest/src/snapshot.rs
+++ b/crates/egui_kittest/src/snapshot.rs
@@ -562,6 +562,7 @@ impl SnapshotResults {
 
     /// Panics if there are any errors, displaying each.
     #[allow(clippy::unused_self)]
+    #[track_caller]
     pub fn unwrap(self) {
         // Panic is handled in drop
     }
@@ -574,11 +575,15 @@ impl From<SnapshotResults> for Vec<SnapshotError> {
 }
 
 impl Drop for SnapshotResults {
+    #[track_caller]
     fn drop(&mut self) {
         // Don't panic if we are already panicking (the test probably failed for another reason)
         if std::thread::panicking() {
             return;
         }
-        assert!(!self.has_errors(), "{}", self);
+        #[allow(clippy::manual_assert)]
+        if self.has_errors() {
+            panic!("{}", self);
+        }
     }
 }

--- a/crates/egui_kittest/tests/regression_tests.rs
+++ b/crates/egui_kittest/tests/regression_tests.rs
@@ -87,6 +87,4 @@ fn test_combobox() {
 
     // Popup should be closed now
     assert!(harness.query_by_label("Item 2").is_none());
-
-    results.unwrap();
 }

--- a/crates/egui_kittest/tests/regression_tests.rs
+++ b/crates/egui_kittest/tests/regression_tests.rs
@@ -1,6 +1,6 @@
 use egui::accesskit::Role;
 use egui::{Button, ComboBox, Image, Vec2, Widget};
-use egui_kittest::{kittest::Queryable, Harness};
+use egui_kittest::{kittest::Queryable, Harness, SnapshotResults};
 
 #[test]
 pub fn focus_should_skip_over_disabled_buttons() {
@@ -64,10 +64,10 @@ fn test_combobox() {
 
     harness.run();
 
-    let mut results = vec![];
+    let mut results = SnapshotResults::new();
 
     #[cfg(all(feature = "wgpu", feature = "snapshot"))]
-    results.push(harness.try_snapshot("combobox_closed"));
+    results.add(harness.try_snapshot("combobox_closed"));
 
     let combobox = harness.get_by_role_and_label(Role::ComboBox, "Select Something");
     combobox.click();
@@ -75,7 +75,7 @@ fn test_combobox() {
     harness.run();
 
     #[cfg(all(feature = "wgpu", feature = "snapshot"))]
-    results.push(harness.try_snapshot("combobox_opened"));
+    results.add(harness.try_snapshot("combobox_opened"));
 
     let item_2 = harness.get_by_role_and_label(Role::Button, "Item 2");
     // Node::click doesn't close the popup, so we use simulate_click
@@ -88,9 +88,5 @@ fn test_combobox() {
     // Popup should be closed now
     assert!(harness.query_by_label("Item 2").is_none());
 
-    for result in results {
-        if let Err(err) = result {
-            panic!("{}", err);
-        }
-    }
+    results.unwrap();
 }

--- a/crates/egui_kittest/tests/tests.rs
+++ b/crates/egui_kittest/tests/tests.rs
@@ -1,4 +1,4 @@
-use egui_kittest::Harness;
+use egui_kittest::{Harness, SnapshotResults};
 
 #[test]
 fn test_shrink() {
@@ -10,6 +10,8 @@ fn test_shrink() {
 
     harness.fit_contents();
 
+    let mut results = SnapshotResults::new();
+
     #[cfg(all(feature = "snapshot", feature = "wgpu"))]
-    harness.snapshot("test_shrink");
+    results.add(harness.try_snapshot("test_shrink"));
 }


### PR DESCRIPTION
I got annoyed by all the slightly different variations of "collect snapshot results and unwrap them at the end of test" I've written, so I added a struct to make this nice and simple.

One controversial thing: It panics when dropped. I wanted to ensure people cannot forget to unwrap the results at the end, and this was the best thing I could come up with. I don't think this is possible via clippy lint or something like that.

* [x] I have followed the instructions in the PR template
