### PR TITLE
refactor mime type support detection in image loader to allow for deferred handling and appended encoding info

### DIFF
--- a/crates/egui_extras/src/loaders/image_loader.rs
+++ b/crates/egui_extras/src/loaders/image_loader.rs
@@ -35,11 +35,21 @@ fn is_supported_uri(uri: &str) -> bool {
 }
 
 fn is_supported_mime(mime: &str) -> bool {
-    // This is the default mime type for binary files, so this might actually be a valid image,
-    // let's relay on image's format guessing
-    if mime == "application/octet-stream" {
-        return true;
+    // some mime types e.g. reflect binary files or mark the content as a download, which
+    // may be a valid image or not, in this case, defer the decision on the format guessing
+    // or the image crate and return true here
+    let mimes_to_defer = [
+        "application/octet-stream",
+        "application/x-msdownload",
+        "application/force-download",
+    ];
+    for m in &mimes_to_defer {
+        // use contains instead of direct equality, as e.g. encoding info might be appended
+        if mime.contains(m) {
+            return true;
+        }
     }
+
     // Uses only the enabled image crate features
     ImageFormat::all()
         .filter(ImageFormat::reading_enabled)


### PR DESCRIPTION
as recommended by @lucasmerlin in #5679

* Closes #5679
* [x] I have followed the instructions in the PR template
