### PR TITLE
Fix image_loader for animated image types

### DIFF
--- a/crates/egui_extras/src/loaders/image_loader.rs
+++ b/crates/egui_extras/src/loaders/image_loader.rs
@@ -1,5 +1,6 @@
 use ahash::HashMap;
 use egui::{
+    decode_animated_image_uri,
     load::{BytesPoll, ImageLoadResult, ImageLoader, ImagePoll, LoadError, SizeHint},
     mutex::Mutex,
     ColorImage,
@@ -57,6 +58,7 @@ impl ImageLoader for ImageCrateLoader {
         // 1. URI extension (only done for files)
         // 2. Mime from `BytesPoll::Ready`
         // 3. image::guess_format (used internally by image::load_from_memory)
+        let uri = decode_animated_image_uri(uri).map_or(uri, |(uri, _frame_index)| uri);
 
         // (1)
         if uri.starts_with("file://") && !is_supported_uri(uri) {

--- a/crates/egui_extras/src/loaders/image_loader.rs
+++ b/crates/egui_extras/src/loaders/image_loader.rs
@@ -58,6 +58,10 @@ impl ImageLoader for ImageCrateLoader {
         // 1. URI extension (only done for files)
         // 2. Mime from `BytesPoll::Ready`
         // 3. image::guess_format (used internally by image::load_from_memory)
+
+        // TODO(lucasmerlin): Egui currently changes all URIs for webp and gif files to include
+        // the frame index (#0), which breaks if the animated image loader is disabled.
+        // We work around this by removing the frame index from the URI here
         let uri = decode_animated_image_uri(uri).map_or(uri, |(uri, _frame_index)| uri);
 
         // (1)


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

Hi, after upgrading to 0.31.0 all of my beautiful static webp images started failing to load. I use the image_loader to load those via the `image` crate.

I noticed that with 0.31.0 there are additions to how animated image types are handled with frames and such. And with those changes the frame index is attached to the uri at the end. This was problematic for the image_loader, because it wasn't updated to handle that frame tag at the end of the uri, so when looking up the bytes, it would fail to match the uri in the bytes cache (the bytes were being saved without the frame index, but attempting to be fetched _with_ the frame index).

This fixes the image_loader for me with webp & gif. They don't load the animations, but I think that is because I don't have the custom image_loader set up so I'm not worried about that for myself. I'm not sure if that part is problematic in general, or if its just the way I have my features set up.

You can recreate the issue on master by swapping out the dependency features in the `images` example like this:
```
# egui_extras = { workspace = true, features = ["default", "all_loaders"] }
# env_logger = { version = "0.10", default-features = false, features = [
#   "auto-color",
#   "humantime",
# ] }
# image = { workspace = true, features = ["jpeg", "png"] }
egui_extras = { workspace = true, features = ["image", "svg"] }
env_logger = { version = "0.10", default-features = false, features = [
  "auto-color",
  "humantime",
] }
image = { workspace = true, features = ["jpeg", "png", "webp", "gif"] }
```

* [x] I have followed the instructions in the PR template
