### PR TITLE
Avoid infinite extension of ColorTest inside a Window

### DIFF
--- a/crates/egui_demo_lib/src/rendering_test.rs
+++ b/crates/egui_demo_lib/src/rendering_test.rs
@@ -437,7 +437,7 @@ fn pixel_test_strokes(ui: &mut Ui) {
         let thickness_points = thickness_pixels / pixels_per_point;
         let num_squares = (pixels_per_point * 10.0).round().max(10.0) as u32;
         let size_pixels = vec2(ui.min_size().x, num_squares as f32 + thickness_pixels * 2.0);
-        let size_points = size_pixels / pixels_per_point + Vec2::splat(2.0);
+        let size_points = size_pixels / pixels_per_point;
         let (response, painter) = ui.allocate_painter(size_points, Sense::hover());
 
         let mut cursor_pixel = Pos2::new(


### PR DESCRIPTION
Current implementation of ColorTest infinitely expand horizontally at each redraw if included in a Window.

The effect can be see replacing the Panel in the ColorTestApp::update with a Window:
```
egui::CentralPanel::default().show(ctx, |ui| {
   egui::Window::new("Colors").vscroll(true).show(ctx, |ui| {
   if frame.is_web() {
      ui.label(
         "NOTE: Some old browsers stuck on WebGL1 without sRGB support will not pass the color test.",
      );
      ui.separator();
   }
   egui::ScrollArea::both().auto_shrink(false).show(ui, |ui| {
      self.color_test.ui(ui);
   });
   self.color_test.ui(ui);
});
```

The cause is the is the _pixel_test_strokes_ function that, at each redraw, tries to expand the target rectangle of 2.0 points in each direction.