### PR TITLE
Align `available_rect` docs with the new reality after #4590

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2549,10 +2549,7 @@ impl Context {
         self.input(|i| i.screen_rect()).round_ui()
     }
 
-    /// How much space is still available after panels has been added.
-    ///
-    /// This is the "background" area, what egui doesn't cover with panels (but may cover with windows).
-    /// This is also the area to which windows are constrained.
+    /// How much space is still available after panels have been added.
     pub fn available_rect(&self) -> Rect {
         self.pass_state(|s| s.available_rect()).round_ui()
     }

--- a/crates/egui/src/pass_state.rs
+++ b/crates/egui/src/pass_state.rs
@@ -303,8 +303,6 @@ impl PassState {
     }
 
     /// How much space is still available after panels has been added.
-    /// This is the "background" area, what egui doesn't cover with panels (but may cover with windows).
-    /// This is also the area to which windows are constrained.
     pub(crate) fn available_rect(&self) -> Rect {
         debug_assert!(
             self.available_rect.is_finite(),

--- a/crates/egui/src/pass_state.rs
+++ b/crates/egui/src/pass_state.rs
@@ -202,7 +202,6 @@ pub struct PassState {
 
     /// Starts off as the `screen_rect`, shrinks as panels are added.
     /// The [`crate::CentralPanel`] does not change this.
-    /// This is the area available to Window's.
     pub available_rect: Rect,
 
     /// Starts off as the `screen_rect`, shrinks as panels are added.


### PR DESCRIPTION
...as after #4590, `Window`/`Area` is not constrained within it.