### PR TITLE
add Label::show_tooltip_when_elided

### DIFF
--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -30,6 +30,7 @@ pub struct Label {
     sense: Option<Sense>,
     selectable: Option<bool>,
     halign: Option<Align>,
+    show_tooltip_when_elided: bool,
 }
 
 impl Label {
@@ -40,6 +41,7 @@ impl Label {
             sense: None,
             selectable: None,
             halign: None,
+            show_tooltip_when_elided: true,
         }
     }
 
@@ -114,6 +116,23 @@ impl Label {
     #[inline]
     pub fn sense(mut self, sense: Sense) -> Self {
         self.sense = Some(sense);
+        self
+    }
+
+    /// Show the full text when hovered, if the text was elided.
+    ///
+    /// By default, this is true.
+    ///
+    /// ```
+    /// # use egui::{Label, Sense};
+    /// # egui::__run_test_ui(|ui| {
+    /// ui.add(Label::new("some text").show_tooltip_when_elided(false))
+    ///     .on_hover_text("completely different text");
+    /// # });
+    /// ```
+    #[inline]
+    pub fn show_tooltip_when_elided(mut self, show: bool) -> Self {
+        self.show_tooltip_when_elided = show;
         self
     }
 }
@@ -247,13 +266,14 @@ impl Widget for Label {
         let interactive = self.sense.is_some_and(|sense| sense != Sense::hover());
 
         let selectable = self.selectable;
+        let show_tooltip_when_elided = self.show_tooltip_when_elided;
 
         let (galley_pos, galley, mut response) = self.layout_in_ui(ui);
         response
             .widget_info(|| WidgetInfo::labeled(WidgetType::Label, ui.is_enabled(), galley.text()));
 
         if ui.is_rect_visible(response.rect) {
-            if galley.elided {
+            if show_tooltip_when_elided && galley.elided {
                 // Show the full (non-elided) text on hover:
                 response = response.on_hover_text(galley.text());
             }


### PR DESCRIPTION
fixes #5708

Allows the user to disable the automatic tooltip when a Label is elided

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes <https://github.com/emilk/egui/issues/5708>
* [x] I have followed the instructions in the PR template
