### PR TITLE
Use `TextBuffer` for `layouter` in `TextEdit` instead of `&str`

### DIFF
--- a/crates/egui/src/widgets/text_edit/text_buffer.rs
+++ b/crates/egui/src/widgets/text_edit/text_buffer.rs
@@ -172,6 +172,39 @@ pub trait TextBuffer {
             self.delete_selected(&CCursorRange::two(min, max))
         }
     }
+
+    /// Returns a unique identifier for the implementing type.
+    ///
+    /// This is useful for downcasting from this trait to the implementing type.
+    /// Here is an example usage:
+    /// ```
+    /// use egui::TextBuffer;
+    /// use std::any::TypeId;
+    ///
+    /// struct ExampleBuffer {}
+    ///
+    /// impl TextBuffer for ExampleBuffer {
+    ///     fn is_mutable(&self) -> bool { unimplemented!() }
+    ///     fn as_str(&self) -> &str { unimplemented!() }
+    ///     fn insert_text(&mut self, text: &str, char_index: usize) -> usize { unimplemented!() }
+    ///     fn delete_char_range(&mut self, char_range: std::ops::Range<usize>) { unimplemented!() }
+    ///
+    ///     // Implement it like the following:
+    ///     fn type_id(&self) -> TypeId {
+    ///         TypeId::of::<Self>()
+    ///     }
+    /// }
+    ///
+    /// // Example downcast:
+    /// pub fn downcast_example(buffer: &dyn TextBuffer) -> Option<&ExampleBuffer> {
+    ///     if buffer.type_id() == TypeId::of::<ExampleBuffer>() {
+    ///         unsafe { Some(&*(buffer as *const dyn TextBuffer as *const ExampleBuffer)) }
+    ///     } else {
+    ///         None
+    ///     }
+    /// }
+    /// ```
+    fn type_id(&self) -> std::any::TypeId;
 }
 
 impl TextBuffer for String {
@@ -218,6 +251,10 @@ impl TextBuffer for String {
     fn take(&mut self) -> String {
         std::mem::take(self)
     }
+
+    fn type_id(&self) -> std::any::TypeId {
+        std::any::TypeId::of::<Self>()
+    }
 }
 
 impl TextBuffer for Cow<'_, str> {
@@ -248,6 +285,10 @@ impl TextBuffer for Cow<'_, str> {
     fn take(&mut self) -> String {
         std::mem::take(self).into_owned()
     }
+
+    fn type_id(&self) -> std::any::TypeId {
+        std::any::TypeId::of::<Cow<'_, str>>()
+    }
 }
 
 /// Immutable view of a `&str`!
@@ -265,4 +306,8 @@ impl TextBuffer for &str {
     }
 
     fn delete_char_range(&mut self, _ch_range: Range<usize>) {}
+
+    fn type_id(&self) -> std::any::TypeId {
+        std::any::TypeId::of::<&str>()
+    }
 }

--- a/crates/egui_demo_lib/src/demo/code_editor.rs
+++ b/crates/egui_demo_lib/src/demo/code_editor.rs
@@ -76,12 +76,12 @@ impl crate::View for CodeEditor {
             });
         });
 
-        let mut layouter = |ui: &egui::Ui, string: &str, wrap_width: f32| {
+        let mut layouter = |ui: &egui::Ui, buf: &dyn egui::TextBuffer, wrap_width: f32| {
             let mut layout_job = egui_extras::syntax_highlighting::highlight(
                 ui.ctx(),
                 ui.style(),
                 &theme,
-                string,
+                buf.as_str(),
                 language,
             );
             layout_job.wrap.max_width = wrap_width;

--- a/crates/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/crates/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -80,8 +80,8 @@ impl EasyMarkEditor {
         } = self;
 
         let response = if self.highlight_editor {
-            let mut layouter = |ui: &egui::Ui, easymark: &str, wrap_width: f32| {
-                let mut layout_job = highlighter.highlight(ui.style(), easymark);
+            let mut layouter = |ui: &egui::Ui, easymark: &dyn TextBuffer, wrap_width: f32| {
+                let mut layout_job = highlighter.highlight(ui.style(), easymark.as_str());
                 layout_job.wrap.max_width = wrap_width;
                 ui.fonts(|f| f.layout_job(layout_job))
             };


### PR DESCRIPTION
This change allows `layouter` to use the `TextBuffer` instead of `&str` in the closure. It is necessary when layout decisions depend on more than just the raw string content, such as metadata stored in the concrete type implementing `TextBuffer`.

In [our use case](https://github.com/damus-io/notedeck/pull/723), we needed this to support mention highlighting when a user selects a mention. Since mentions can contain spaces, determining mention boundaries from the `&str` alone is impossible. Instead, we use the `TextBuffer` implementation to retrieve the correct bounds.

See the video below for a demonstration:

https://github.com/user-attachments/assets/3cba2906-5546-4b52-b728-1da9c56a83e1


# Breaking change

This PR introduces a breaking change to the `layouter` function in `TextEdit`.

Previous API:
```rust
pub fn layouter(mut self, layouter: &'t mut dyn FnMut(&Ui, &str, f32) -> Arc<Galley>) -> Self
```

New API:
```rust
pub fn layouter(mut self, layouter: &'t mut dyn FnMut(&Ui, &dyn TextBuffer, f32) -> Arc<Galley>) -> Self
```


## Impact on Existing Code

• Any existing usage of `layouter` will **no longer compile**.
• Callers must update their closures to use `&dyn TextBuffer` instead of `&str`.

## Migration Guide

Before:
```rust
let mut layouter = |ui: &Ui, text: &str, wrap_width: f32| {
    let layout_job = my_highlighter(text);
    layout_job.wrap.max_width = wrap_width;
    ui.fonts(|f| f.layout_job(layout_job))
};
```

After:
```rust
let mut layouter = |ui: &Ui, text: &dyn TextBuffer, wrap_width: f32| {
    let layout_job = my_highlighter(text.as_str());
    layout_job.wrap.max_width = wrap_width;
    ui.fonts(|f| f.layout_job(layout_job))
};
```

---

* There is not an issue for this change.
* [x]  I have followed the instructions in the PR template