### PR TITLE
Clarify platform-specific details for `Viewport`s

### DIFF
--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -214,11 +214,17 @@ pub struct ViewportInfo {
     /// The inner rectangle of the native window, in monitor space and ui points scale.
     ///
     /// This is the content rectangle of the viewport.
+    ///
+    /// Note that on Android / Wayland, this will always be `None` since getting the
+    /// position of the window is not possible.
     pub inner_rect: Option<Rect>,
 
     /// The outer rectangle of the native window, in monitor space and ui points scale.
     ///
     /// This is the content rectangle plus decoration chrome.
+    ///
+    /// Note that on Android / Wayland, this will always be `None` since getting the
+    /// position of the window is not possible.
     pub outer_rect: Option<Rect>,
 
     /// Are we minimized?

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -543,6 +543,16 @@ impl ViewportBuilder {
 
     /// The initial "outer" position of the window,
     /// i.e. where the top-left corner of the frame/chrome should be.
+    ///
+    /// ## Platform-specific:
+    ///
+    /// - **iOS:** Can only be called on the main thread. Sets the top left coordinates of the
+    ///   window in the screen space coordinate system.
+    /// - **Web:** Sets the top-left coordinates relative to the viewport. Doesn't account for CSS
+    ///   [`transform`].
+    /// - **Android / Wayland:** Unsupported.
+    ///
+    /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
     #[inline]
     pub fn with_position(mut self, pos: impl Into<Pos2>) -> Self {
         self.position = Some(pos.into());


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

On Wayland (and android apparently) it is not possible for applications to position their windows or request the window position (for some reason). This is not specified in the documentation.

proof: [`winit::set_outer_position`], [`winit::outer_position`], [`winit::inner_position`] all specify that Android / Wayland are not supported.

[`winit::set_outer_position`]: https://docs.rs/winit/latest/winit/window/struct.Window.html#method.set_outer_position
[`winit::outer_position`]: https://docs.rs/winit/latest/winit/window/struct.Window.html#method.outer_position
[`winit::inner_position`]: https://docs.rs/winit/latest/winit/window/struct.Window.html#method.inner_position

* Maybe closes #4469
* the lack of support makes me sad. I believe this makes some items in #3556 impossible. Oh well!