### PR TITLE
Set hint_text in WidgetInfo

### DIFF
--- a/crates/egui/src/data/output.rs
+++ b/crates/egui/src/data/output.rs
@@ -539,6 +539,9 @@ pub struct WidgetInfo {
 
     /// Selected range of characters in [`Self::current_text_value`].
     pub text_selection: Option<std::ops::RangeInclusive<usize>>,
+
+    /// The hint text for text edit fields.
+    pub hint_text: Option<String>,
 }
 
 impl std::fmt::Debug for WidgetInfo {
@@ -552,6 +555,7 @@ impl std::fmt::Debug for WidgetInfo {
             selected,
             value,
             text_selection,
+            hint_text,
         } = self;
 
         let mut s = f.debug_struct("WidgetInfo");
@@ -580,6 +584,9 @@ impl std::fmt::Debug for WidgetInfo {
         if let Some(text_selection) = text_selection {
             s.field("text_selection", text_selection);
         }
+        if let Some(hint_text) = hint_text {
+            s.field("hint_text", hint_text);
+        }
 
         s.finish()
     }
@@ -596,6 +603,7 @@ impl WidgetInfo {
             selected: None,
             value: None,
             text_selection: None,
+            hint_text: None,
         }
     }
 
@@ -643,9 +651,11 @@ impl WidgetInfo {
         enabled: bool,
         prev_text_value: impl ToString,
         text_value: impl ToString,
+        hint_text: impl ToString,
     ) -> Self {
         let text_value = text_value.to_string();
         let prev_text_value = prev_text_value.to_string();
+        let hint_text = hint_text.to_string();
         let prev_text_value = if text_value == prev_text_value {
             None
         } else {
@@ -655,6 +665,7 @@ impl WidgetInfo {
             enabled,
             current_text_value: Some(text_value),
             prev_text_value,
+            hint_text: Some(hint_text),
             ..Self::new(WidgetType::TextEdit)
         }
     }
@@ -684,6 +695,7 @@ impl WidgetInfo {
             selected,
             value,
             text_selection: _,
+            hint_text: _,
         } = self;
 
         // TODO(emilk): localization

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -1059,6 +1059,9 @@ impl Response {
             // Indeterminate state
             builder.set_toggled(Toggled::Mixed);
         }
+        if let Some(hint_text) = info.hint_text {
+            builder.set_placeholder(hint_text);
+        }
     }
 
     /// Associate a label with a control for accessibility.

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -505,6 +505,7 @@ impl TextEdit<'_> {
             .unwrap_or_else(|| ui.visuals().widgets.inactive.text_color());
 
         let prev_text = text.as_str().to_owned();
+        let hint_text_str = hint_text.text().to_owned();
 
         let font_id = font_selection.resolve(ui.style());
         let row_height = ui.fonts(|f| f.row_height(&font_id));
@@ -807,6 +808,7 @@ impl TextEdit<'_> {
                     ui.is_enabled(),
                     mask_if_password(password, prev_text.as_str()),
                     mask_if_password(password, text.as_str()),
+                    hint_text_str.as_str(),
                 )
             });
         } else if selection_changed {
@@ -825,6 +827,7 @@ impl TextEdit<'_> {
                     ui.is_enabled(),
                     mask_if_password(password, prev_text.as_str()),
                     mask_if_password(password, text.as_str()),
+                    hint_text_str.as_str(),
                 )
             });
         }


### PR DESCRIPTION
The placeholder in kittest is currently not set for TextEdit Fields.
This resolves it 

* [x] I have followed the instructions in the PR template
