### PR TITLE
Add `Ui::close` and `Response::should_close`

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -556,7 +556,8 @@ impl Prepared {
             .ui_stack_info(UiStackInfo::new(self.kind))
             .layer_id(self.layer_id)
             .max_rect(max_rect)
-            .layout(self.layout);
+            .layout(self.layout)
+            .closable();
 
         if !self.enabled {
             ui_builder = ui_builder.disabled();
@@ -610,6 +611,12 @@ impl Prepared {
         let final_rect = state.rect();
         response.rect = final_rect;
         response.interact_rect = final_rect;
+
+        // TODO(lucasmerlin): Can the area response be based on Ui::response? Then this won't be needed
+        // Bubble up the close event
+        if content_ui.should_close() {
+            response.set_close();
+        }
 
         ctx.memory_mut(|m| m.areas_mut().set_state(layer_id, state));
 

--- a/crates/egui/src/containers/close_tag.rs
+++ b/crates/egui/src/containers/close_tag.rs
@@ -7,10 +7,13 @@ pub struct ClosableTag {
 
 impl ClosableTag {
     pub const NAME: &'static str = "egui_close_tag";
+
+    /// Set close to `true`
     pub fn set_close(&self) {
         self.close.store(true, std::sync::atomic::Ordering::Relaxed);
     }
 
+    /// Returns `true` if [`ClosableTag::set_close`] has been called.
     pub fn should_close(&self) -> bool {
         self.close.load(std::sync::atomic::Ordering::Relaxed)
     }

--- a/crates/egui/src/containers/close_tag.rs
+++ b/crates/egui/src/containers/close_tag.rs
@@ -1,0 +1,17 @@
+use std::sync::atomic::AtomicBool;
+
+#[derive(Debug, Default)]
+pub struct ClosableTag {
+    pub close: AtomicBool,
+}
+
+impl ClosableTag {
+    pub const NAME: &'static str = "egui_close_tag";
+    pub fn set_close(&self) {
+        self.close.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn should_close(&self) -> bool {
+        self.close.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}

--- a/crates/egui/src/containers/mod.rs
+++ b/crates/egui/src/containers/mod.rs
@@ -3,6 +3,7 @@
 //! For instance, a [`Frame`] adds a frame and background to some contained UI.
 
 pub(crate) mod area;
+pub mod close_tag;
 pub mod collapsing_header;
 mod combo_box;
 pub mod frame;

--- a/crates/egui/src/containers/modal.rs
+++ b/crates/egui/src/containers/modal.rs
@@ -150,7 +150,10 @@ impl<T> ModalResponse<T> {
         let escape_clicked =
             || ctx.input_mut(|i| i.consume_key(crate::Modifiers::NONE, crate::Key::Escape));
 
+        let ui_close_called = self.response.should_close();
+
         self.backdrop_response.clicked()
+            || ui_close_called
             || (self.is_top_modal && !self.any_popup_open && escape_clicked())
     }
 }

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -542,7 +542,9 @@ impl<'a> Popup<'a> {
                 PopupCloseBehavior::IgnoreClicks => false,
             };
 
-            should_close || ctx.input(|i| i.key_pressed(Key::Escape))
+            should_close
+                || ctx.input(|i| i.key_pressed(Key::Escape))
+                || response.response.should_close()
         };
 
         match open_kind {

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -434,7 +434,7 @@ impl Window<'_> {
     ) -> Option<InnerResponse<Option<R>>> {
         let Window {
             title,
-            open,
+            mut open,
             area,
             frame,
             resize,
@@ -634,7 +634,12 @@ impl Window<'_> {
                     title_bar.ui(
                         &mut area_content_ui,
                         &content_response,
-                        open,
+                        // TODO: I feel stupid, is there some better way to pass the &mut open
+                        // without moving it?
+                        match &mut open {
+                            None => None,
+                            Some(open) => Some(open),
+                        },
                         &mut collapsing,
                         collapsible,
                     );
@@ -649,6 +654,12 @@ impl Window<'_> {
         };
 
         let full_response = area.end(ctx, area_content_ui);
+
+        if full_response.should_close() {
+            if let Some(open) = open {
+                *open = false;
+            }
+        }
 
         let inner_response = InnerResponse {
             inner: content_inner,

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -634,7 +634,7 @@ impl Window<'_> {
                     title_bar.ui(
                         &mut area_content_ui,
                         &content_response,
-                        // TODO: I feel stupid, is there some better way to pass the &mut open
+                        // TODO(lucas): I feel stupid, is there some better way to pass the &mut open
                         // without moving it?
                         match &mut open {
                             None => None,

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -634,12 +634,7 @@ impl Window<'_> {
                     title_bar.ui(
                         &mut area_content_ui,
                         &content_response,
-                        // TODO(lucas): I feel stupid, is there some better way to pass the &mut open
-                        // without moving it?
-                        match &mut open {
-                            None => None,
-                            Some(open) => Some(open),
-                        },
+                        open.as_deref_mut(),
                         &mut collapsing,
                         collapsible,
                     );

--- a/crates/egui/src/gui_zoom.rs
+++ b/crates/egui/src/gui_zoom.rs
@@ -88,7 +88,7 @@ pub fn zoom_menu_buttons(ui: &mut Ui) {
         .clicked()
     {
         zoom_in(ui.ctx());
-        ui.close_menu();
+        ui.close();
     }
 
     if ui
@@ -99,7 +99,7 @@ pub fn zoom_menu_buttons(ui: &mut Ui) {
         .clicked()
     {
         zoom_out(ui.ctx());
-        ui.close_menu();
+        ui.close();
     }
 
     if ui
@@ -110,6 +110,6 @@ pub fn zoom_menu_buttons(ui: &mut Ui) {
         .clicked()
     {
         ui.ctx().set_zoom_factor(1.0);
-        ui.close_menu();
+        ui.close();
     }
 }

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -364,7 +364,10 @@ impl MenuRoot {
             let menu_state = self.menu_state.read();
 
             let escape_pressed = button.ctx.input(|i| i.key_pressed(Key::Escape));
-            if menu_state.response.is_close() || escape_pressed {
+            if menu_state.response.is_close()
+                || escape_pressed
+                || inner_response.response.should_close()
+            {
                 return (MenuResponse::Close, Some(inner_response));
             }
         }
@@ -667,6 +670,9 @@ impl MenuState {
     ) -> Option<R> {
         let (sub_response, response) = self.submenu(id).map(|sub| {
             let inner_response = menu_popup(ctx, parent_layer, sub, id, add_contents);
+            if inner_response.response.should_close() {
+                sub.write().close();
+            }
             (sub.read().response, inner_response.inner)
         })?;
         self.cascade_close_response(sub_response);

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -133,6 +133,9 @@ bitflags::bitflags! {
         /// Note that this can be `true` even if the user did not interact with the widget,
         /// for instance if an existing slider value was clamped to the given range.
         const CHANGED = 1<<11;
+
+        /// Should this container be closed?
+        const CLOSE = 1<<12;
     }
 }
 
@@ -526,6 +529,14 @@ impl Response {
     #[inline(always)]
     pub fn mark_changed(&mut self) {
         self.flags.set(Flags::CHANGED, true);
+    }
+
+    pub fn should_close(&self) -> bool {
+        self.flags.contains(Flags::CLOSE)
+    }
+
+    pub fn set_close(&mut self) {
+        self.flags.set(Flags::CLOSE, true);
     }
 
     /// Show this UI if the widget was hovered (i.e. a tooltip).

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -920,13 +920,13 @@ impl Response {
     /// let response = ui.add(Label::new("Right-click me!").sense(Sense::click()));
     /// response.context_menu(|ui| {
     ///     if ui.button("Close the menu").clicked() {
-    ///         ui.close_menu();
+    ///         ui.close();
     ///     }
     /// });
     /// # });
     /// ```
     ///
-    /// See also: [`Ui::menu_button`] and [`Ui::close_menu`].
+    /// See also: [`Ui::menu_button`] and [`Ui::close`].
     pub fn context_menu(&self, add_contents: impl FnOnce(&mut Ui)) -> Option<InnerResponse<()>> {
         menu::context_menu(self, add_contents)
     }

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -531,10 +531,17 @@ impl Response {
         self.flags.set(Flags::CHANGED, true);
     }
 
+    /// Should the container be closed?
+    ///
+    /// Will e.g. be set by calling [`Ui::close`] in a child [`Ui`] or by calling
+    /// [`Self::set_close`].
     pub fn should_close(&self) -> bool {
         self.flags.contains(Flags::CLOSE)
     }
 
+    /// Set the [`Flags::CLOSE`] flag.
+    ///
+    /// Can be used to e.g. signal that a container should be closed.
     pub fn set_close(&mut self) {
         self.flags.set(Flags::CLOSE, true);
     }

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -764,62 +764,6 @@ impl Ui {
     pub fn is_rect_visible(&self, rect: Rect) -> bool {
         self.is_visible() && rect.intersects(self.clip_rect())
     }
-
-    /// Find and close the first closable parent.
-    /// Use [`UiBuilder::closable`] to make a [`Ui`] closable.
-    /// You can then use [`Ui::should_close`] to check if it should be closed.
-    ///
-    /// This is implemented for all egui containers, e.g. [`crate::Popup`], [`crate::Modal`],
-    /// [`crate::Area`], [`crate::Window`], [`crate::CollapsingHeader`], etc.
-    ///
-    /// What exactly happens when you close a container depends on the container implementation.
-    /// [`crate::Area`] e.g. will return true from it's [`Response::should_close`] method.
-    ///
-    /// If you want to close a specific kind of container, use [`Ui::close_kind`] instead.
-    pub fn close(&self) {
-        let tag = self.stack.iter().find_map(|stack| {
-            stack
-                .info
-                .tags
-                .get_downcast::<ClosableTag>(ClosableTag::NAME)
-        });
-        if let Some(tag) = tag {
-            tag.set_close();
-        } else {
-            warn!("Tried to close a Ui that has no ClosableTag in its stack.");
-        }
-    }
-
-    /// Find and close the first closable parent of a specific [`UiKind`].
-    /// This is useful if you want to e.g. close a [`crate::Window`]. Since it contains a
-    /// `Collapsible`, [`Ui::close`] would close the `Collapsible` instead.
-    /// You can close the [`crate::Window`] by calling `ui.close_kind(UiKind::Window)`.
-    pub fn close_kind(&self, ui_kind: UiKind) {
-        let tag = self
-            .stack
-            .iter()
-            .filter(|stack| stack.info.kind == Some(ui_kind))
-            .find_map(|stack| {
-                stack
-                    .info
-                    .tags
-                    .get_downcast::<ClosableTag>(ClosableTag::NAME)
-            });
-        if let Some(tag) = tag {
-            tag.set_close();
-        } else {
-            warn!("Tried to close a Ui that has no ClosableTag in its stack.");
-        }
-    }
-
-    /// Was [`Ui::close`] called on this [`Ui`] or any of its children?
-    pub fn should_close(&self) -> bool {
-        self.stack
-            .info
-            .tags
-            .get_downcast(ClosableTag::NAME)
-            .is_some_and(|tag: &ClosableTag| tag.should_close())
-    }
 }
 
 /// # Helpers for accessing the underlying [`Context`].
@@ -1230,6 +1174,65 @@ impl Ui {
     /// use [`Self::response`] instead.
     pub fn ui_contains_pointer(&self) -> bool {
         self.rect_contains_pointer(self.min_rect())
+    }
+
+    /// Find and close the first closable parent.
+    /// Use [`UiBuilder::closable`] to make a [`Ui`] closable.
+    /// You can then use [`Ui::should_close`] to check if it should be closed.
+    ///
+    /// This is implemented for all egui containers, e.g. [`crate::Popup`], [`crate::Modal`],
+    /// [`crate::Area`], [`crate::Window`], [`crate::CollapsingHeader`], etc.
+    ///
+    /// What exactly happens when you close a container depends on the container implementation.
+    /// [`crate::Area`] e.g. will return true from it's [`Response::should_close`] method.
+    ///
+    /// If you want to close a specific kind of container, use [`Ui::close_kind`] instead.
+    pub fn close(&self) {
+        let tag = self.stack.iter().find_map(|stack| {
+            stack
+                .info
+                .tags
+                .get_downcast::<ClosableTag>(ClosableTag::NAME)
+        });
+        if let Some(tag) = tag {
+            tag.set_close();
+        } else {
+            warn!("Tried to close a Ui that has no ClosableTag in its stack.");
+        }
+    }
+
+    /// Find and close the first closable parent of a specific [`UiKind`].
+    /// This is useful if you want to e.g. close a [`crate::Window`]. Since it contains a
+    /// `Collapsible`, [`Ui::close`] would close the `Collapsible` instead.
+    /// You can close the [`crate::Window`] by calling `ui.close_kind(UiKind::Window)`.
+    pub fn close_kind(&self, ui_kind: UiKind) {
+        let tag = self
+            .stack
+            .iter()
+            .filter(|stack| stack.info.kind == Some(ui_kind))
+            .find_map(|stack| {
+                stack
+                    .info
+                    .tags
+                    .get_downcast::<ClosableTag>(ClosableTag::NAME)
+            });
+        if let Some(tag) = tag {
+            tag.set_close();
+        } else {
+            warn!("Tried to close a Ui that has no ClosableTag in its stack.");
+        }
+    }
+
+    /// Was [`Ui::close`] called on this [`Ui`] or any of its children?
+    /// Only works if the [`Ui`] was created with [`UiBuilder::closable`].
+    ///
+    /// You can also check via this [`Ui`]'s [`Response::should_close`].
+    pub fn should_close(&self) -> bool {
+        self.stack
+            .info
+            .tags
+            .get_downcast(ClosableTag::NAME)
+            .is_some_and(|tag: &ClosableTag| tag.should_close())
     }
 }
 

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -3,7 +3,6 @@
 
 use emath::GuiRounding as _;
 use epaint::mutex::RwLock;
-use log::warn;
 use std::{any::Any, hash::Hash, sync::Arc};
 
 use crate::close_tag::ClosableTag;
@@ -1197,7 +1196,8 @@ impl Ui {
         if let Some(tag) = tag {
             tag.set_close();
         } else {
-            warn!("Tried to close a Ui that has no ClosableTag in its stack.");
+            #[cfg(feature = "log")]
+            log::warn!("Tried to close a Ui that has no ClosableTag in its stack.");
         }
     }
 
@@ -1219,7 +1219,8 @@ impl Ui {
         if let Some(tag) = tag {
             tag.set_close();
         } else {
-            warn!("Tried to close a Ui that has no ClosableTag in its stack.");
+            #[cfg(feature = "log")]
+            log::warn!("Tried to close a Ui that has no ClosableTag in its stack.");
         }
     }
 

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1198,7 +1198,7 @@ impl Ui {
             tag.set_close();
         } else {
             #[cfg(feature = "log")]
-            log::warn!("Tried to close a Ui that has no ClosableTag in its stack.");
+            log::warn!("Called ui.close() on a Ui that has no closable parent.");
         }
     }
 
@@ -1222,7 +1222,7 @@ impl Ui {
             tag.set_close();
         } else {
             #[cfg(feature = "log")]
-            log::warn!("Tried to close a Ui that has no ClosableTag in its stack.");
+            log::warn!("Called ui.close_kind({ui_kind:?}) on ui with no such closable parent.");
         }
     }
 

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2988,14 +2988,14 @@ impl Ui {
     /// ui.menu_button("My menu", |ui| {
     ///     ui.menu_button("My sub-menu", |ui| {
     ///         if ui.button("Close the menu").clicked() {
-    ///             ui.close_menu();
+    ///             ui.close();
     ///         }
     ///     });
     /// });
     /// # });
     /// ```
     ///
-    /// See also: [`Self::close_menu`] and [`Response::context_menu`].
+    /// See also: [`Self::close`] and [`Response::context_menu`].
     pub fn menu_button<R>(
         &mut self,
         title: impl Into<WidgetText>,
@@ -3019,7 +3019,7 @@ impl Ui {
     /// ui.menu_image_button(title, img, |ui| {
     ///     ui.menu_button("My sub-menu", |ui| {
     ///         if ui.button("Close the menu").clicked() {
-    ///             ui.close_menu();
+    ///             ui.close();
     ///         }
     ///     });
     /// });
@@ -3027,7 +3027,7 @@ impl Ui {
     /// ```
     ///
     ///
-    /// See also: [`Self::close_menu`] and [`Response::context_menu`].
+    /// See also: [`Self::close`] and [`Response::context_menu`].
     #[inline]
     pub fn menu_image_button<'a, R>(
         &mut self,
@@ -3053,14 +3053,14 @@ impl Ui {
     /// ui.menu_image_text_button(img, title, |ui| {
     ///     ui.menu_button("My sub-menu", |ui| {
     ///         if ui.button("Close the menu").clicked() {
-    ///             ui.close_menu();
+    ///             ui.close();
     ///         }
     ///     });
     /// });
     /// # });
     /// ```
     ///
-    /// See also: [`Self::close_menu`] and [`Response::context_menu`].
+    /// See also: [`Self::close`] and [`Response::context_menu`].
     #[inline]
     pub fn menu_image_text_button<'a, R>(
         &mut self,

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1176,6 +1176,7 @@ impl Ui {
     }
 
     /// Find and close the first closable parent.
+    ///
     /// Use [`UiBuilder::closable`] to make a [`Ui`] closable.
     /// You can then use [`Ui::should_close`] to check if it should be closed.
     ///
@@ -1202,6 +1203,7 @@ impl Ui {
     }
 
     /// Find and close the first closable parent of a specific [`UiKind`].
+    ///
     /// This is useful if you want to e.g. close a [`crate::Window`]. Since it contains a
     /// `Collapsible`, [`Ui::close`] would close the `Collapsible` instead.
     /// You can close the [`crate::Window`] by calling `ui.close_kind(UiKind::Window)`.
@@ -2970,9 +2972,9 @@ impl Ui {
     /// Close the menu we are in (including submenus), if any.
     ///
     /// See also: [`Self::menu_button`] and [`Response::context_menu`].
-    #[deprecated = "Use `ui.close()` instead"]
+    #[deprecated = "Use `ui.close()` or `ui.close_kind(UiKind::Menu)` instead"]
     pub fn close_menu(&self) {
-        self.close();
+        self.close_kind(UiKind::Menu);
     }
 
     pub(crate) fn set_menu_state(&mut self, menu_state: Option<Arc<RwLock<MenuState>>>) {

--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -125,6 +125,7 @@ impl UiBuilder {
     }
 
     /// Set if you want sense clicks and/or drags. Default is [`Sense::hover`].
+    ///
     /// The sense will be registered below the Senses of any widgets contained in this [`Ui`], so
     /// if the user clicks a button contained within this [`Ui`], that button will receive the click
     /// instead.
@@ -137,6 +138,7 @@ impl UiBuilder {
     }
 
     /// Make this [`Ui`] closable.
+    ///
     /// Calling [`Ui::close`] in a child [`Ui`] will mark this [`Ui`] for closing.
     /// After [`Ui::close`] was called, [`Ui::should_close`] and [`crate::Response::should_close`] will
     /// return `true` (for this frame).

--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -1,9 +1,9 @@
 use std::{hash::Hash, sync::Arc};
 
-use crate::{Id, LayerId, Layout, Rect, Sense, Style, UiStackInfo};
-
+use crate::close_tag::ClosableTag;
 #[allow(unused_imports)] // Used for doclinks
 use crate::Ui;
+use crate::{Id, LayerId, Layout, Rect, Sense, Style, UiStackInfo};
 
 /// Build a [`Ui`] as the child of another [`Ui`].
 ///
@@ -133,6 +133,13 @@ impl UiBuilder {
     #[inline]
     pub fn sense(mut self, sense: Sense) -> Self {
         self.sense = Some(sense);
+        self
+    }
+
+    pub fn closable(mut self) -> Self {
+        self.ui_stack_info
+            .tags
+            .insert(ClosableTag::NAME, Some(Arc::new(ClosableTag::default())));
         self
     }
 }

--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -136,6 +136,13 @@ impl UiBuilder {
         self
     }
 
+    /// Make this [`Ui`] closable.
+    /// Calling [`Ui::close`] in a child [`Ui`] will mark this [`Ui`] for closing.
+    /// After [`Ui::close`] was called, [`Ui::should_close`] and [`Response::should_close`] will
+    /// return `true` (for this frame).
+    ///
+    /// This works by adding a [`ClosableTag`] to the [`UiStackInfo`].
+    #[inline]
     pub fn closable(mut self) -> Self {
         self.ui_stack_info
             .tags

--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -138,7 +138,7 @@ impl UiBuilder {
 
     /// Make this [`Ui`] closable.
     /// Calling [`Ui::close`] in a child [`Ui`] will mark this [`Ui`] for closing.
-    /// After [`Ui::close`] was called, [`Ui::should_close`] and [`Response::should_close`] will
+    /// After [`Ui::close`] was called, [`Ui::should_close`] and [`crate::Response::should_close`] will
     /// return `true` (for this frame).
     ///
     /// This works by adding a [`ClosableTag`] to the [`UiStackInfo`].

--- a/crates/egui/src/ui_stack.rs
+++ b/crates/egui/src/ui_stack.rs
@@ -53,6 +53,9 @@ pub enum UiKind {
 
     /// An [`crate::Area`] that is not of any other kind.
     GenericArea,
+
+    /// A collapsible container, e.g. a [`crate::CollapsingHeader`].
+    Collapsible,
 }
 
 impl UiKind {
@@ -81,6 +84,7 @@ impl UiKind {
             | Self::Frame
             | Self::ScrollArea
             | Self::Resize
+            | Self::Collapsible
             | Self::TableCell => false,
 
             Self::Window

--- a/crates/egui_demo_app/src/backend_panel.rs
+++ b/crates/egui_demo_app/src/backend_panel.rs
@@ -333,7 +333,7 @@ fn integration_ui(ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
                     .send_viewport_cmd(egui::ViewportCommand::InnerSize(size));
                 ui.ctx()
                     .send_viewport_cmd(egui::ViewportCommand::Fullscreen(false));
-                ui.close_menu();
+                ui.close();
             }
         });
     }

--- a/crates/egui_demo_app/src/wrap_app.rs
+++ b/crates/egui_demo_app/src/wrap_app.rs
@@ -384,12 +384,12 @@ impl WrapApp {
                 .clicked()
             {
                 ui.ctx().memory_mut(|mem| *mem = Default::default());
-                ui.close_menu();
+                ui.close();
             }
 
             if ui.button("Reset everything").clicked() {
                 *cmd = Command::ResetEverything;
-                ui.close_menu();
+                ui.close();
             }
         });
     }

--- a/crates/egui_demo_lib/src/demo/context_menu.rs
+++ b/crates/egui_demo_lib/src/demo/context_menu.rs
@@ -59,25 +59,25 @@ impl ContextMenus {
         ui.set_max_width(200.0); // To make sure we wrap long text
 
         if ui.button("Open…").clicked() {
-            ui.close_menu();
+            ui.close();
         }
         ui.menu_button("SubMenu", |ui| {
             ui.menu_button("SubMenu", |ui| {
                 if ui.button("Open…").clicked() {
-                    ui.close_menu();
+                    ui.close();
                 }
                 let _ = ui.button("Item");
                 ui.menu_button("Recursive", Self::nested_menus)
             });
             ui.menu_button("SubMenu", |ui| {
                 if ui.button("Open…").clicked() {
-                    ui.close_menu();
+                    ui.close();
                 }
                 let _ = ui.button("Item");
             });
             let _ = ui.button("Item");
             if ui.button("Open…").clicked() {
-                ui.close_menu();
+                ui.close();
             }
         });
         ui.menu_button("SubMenu", |ui| {
@@ -86,7 +86,7 @@ impl ContextMenus {
             let _ = ui.button("Item3");
             let _ = ui.button("Item4");
             if ui.button("Open…").clicked() {
-                ui.close_menu();
+                ui.close();
             }
         });
         let _ = ui.button("Very long text for this item that should be wrapped");

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -234,7 +234,7 @@ impl DemoWindows {
                     ui.set_style(ui.ctx().style()); // ignore the "menu" style set by `menu_button`.
                     self.demo_list_ui(ui);
                     if ui.ui_contains_pointer() && ui.input(|i| i.pointer.any_click()) {
-                        ui.close_menu();
+                        ui.close();
                     }
                 });
 
@@ -345,7 +345,7 @@ fn file_menu_button(ui: &mut Ui) {
             .clicked()
         {
             ui.ctx().memory_mut(|mem| mem.reset_areas());
-            ui.close_menu();
+            ui.close();
         }
 
         if ui
@@ -357,7 +357,7 @@ fn file_menu_button(ui: &mut Ui) {
             .clicked()
         {
             ui.ctx().memory_mut(|mem| *mem = Default::default());
-            ui.close_menu();
+            ui.close();
         }
     });
 }

--- a/crates/egui_demo_lib/src/demo/modals.rs
+++ b/crates/egui_demo_lib/src/demo/modals.rs
@@ -96,7 +96,9 @@ impl crate::View for Modals {
                             *save_modal_open = true;
                         }
                         if ui.button("Cancel").clicked() {
-                            *user_modal_open = false;
+                            // You can call `ui.close()` to close the modal.
+                            // (This causes the current modals `should_close` to return true)
+                            ui.close();
                         }
                     },
                 );
@@ -123,7 +125,7 @@ impl crate::View for Modals {
                         }
 
                         if ui.button("No Thanks").clicked() {
-                            *save_modal_open = false;
+                            ui.close();
                         }
                     },
                 );

--- a/crates/egui_demo_lib/src/demo/popups.rs
+++ b/crates/egui_demo_lib/src/demo/popups.rs
@@ -153,6 +153,10 @@ impl crate::View for PopupsDemo {
             .show(|ui| {
                 _ = ui.button("Menu item 1");
                 _ = ui.button("Menu item 2");
+
+                if ui.button("I always close the menu").clicked() {
+                    ui.close();
+                }
             });
 
         self.apply_options(Popup::context_menu(&response).id(Id::new("context_menu")))

--- a/crates/egui_demo_lib/src/demo/window_options.rs
+++ b/crates/egui_demo_lib/src/demo/window_options.rs
@@ -1,4 +1,4 @@
-use egui::Vec2b;
+use egui::{UiKind, Vec2b};
 
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -149,6 +149,16 @@ impl crate::View for WindowOptions {
                 self.disabled_time = ui.input(|i| i.time);
             }
             egui::reset_button(ui, self, "Reset");
+            if ui
+                .button("Close")
+                .on_hover_text("You can collapse / close Windows via Ui::close")
+                .clicked()
+            {
+                // Calling close would close the collapsible within the window
+                // ui.close();
+                // Instead, we close the window itself
+                ui.close_kind(UiKind::Window);
+            }
             ui.add(crate::egui_github_link_file!());
         });
     }

--- a/crates/egui_demo_lib/tests/snapshots/demos/Window Options.png
+++ b/crates/egui_demo_lib/tests/snapshots/demos/Window Options.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3411a4a8939b7e731c9c1a6331921b0ac905f4e3e86a51af70bdb38d9446f5e1
-size 35193
+oid sha256:e67b1e676ff994cb9557939db3dca5ddd15c69d167afd96c0957a2a3b75c0fd8
+size 36007


### PR DESCRIPTION
This adds a generic way of telling containers to close from their child `Ui`s.

* Part of #5727 
* [x] I have followed the instructions in the PR template
