### PR TITLE
Add image loading/creating/displaying example.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2227,6 +2227,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "image_loading_and_creating"
+version = "0.1.0"
+dependencies = [
+ "eframe",
+ "egui_extras",
+ "env_logger",
+ "url",
+]
+
+[[package]]
 name = "images"
 version = "0.1.0"
 dependencies = [

--- a/examples/image_loading_and_creating/Cargo.toml
+++ b/examples/image_loading_and_creating/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "image_loading_and_creating"
+version = "0.1.0"
+authors = ["Dominic Clifton <me@dominicclifton.name>"]
+license = "MIT OR Apache-2.0"
+edition = "2021"
+rust-version = "1.81"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+eframe = { workspace = true, features = [
+    "default",
+    "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
+] }
+
+# For image support:
+egui_extras = { workspace = true, features = ["file", "image", "all_loaders"] }
+
+env_logger = { version = "0.10", default-features = false, features = [
+    "auto-color",
+    "humantime",
+] }
+url = "2.5.4"

--- a/examples/image_loading_and_creating/src/main.rs
+++ b/examples/image_loading_and_creating/src/main.rs
@@ -79,6 +79,7 @@ impl ImageApp {
                         }
                     };
 
+                    ctx.tex_manager().write().retain(texture.id);
                     Some((url.to_string(), TextureHandle::new(ctx.tex_manager(), texture.id)))
                 }
 
@@ -108,15 +109,9 @@ impl ImageApp {
     }
     
     fn forget_existing_image(&mut self, ctx: &Context) {
-        if let Some((uri, existing_texture)) = self.texture.take() {
-            // this causes a panic "Tried freeing texture Managed(1) which is not allocated"
-            //ctx.forget_image(uri.as_str());
-            
-            // this causes a panic "Tried freeing texture Managed(1) which is not allocated"
-            //ctx.tex_manager().write().free(exising_texture.id());
-            
-            // this causes a panic when the program exits "Tried freeing texture Managed(1) which is not allocated"
-            //mem::forget(existing_texture);
+        if let Some((uri, _existing_texture)) = self.texture.take() {
+            // forget the image so that the image is loaded from disk again.
+            ctx.forget_image(uri.as_str());
         }
     }
 

--- a/examples/image_loading_and_creating/src/main.rs
+++ b/examples/image_loading_and_creating/src/main.rs
@@ -4,7 +4,7 @@
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::thread;
+use std::{mem, thread};
 use std::time::Duration;
 use eframe::egui;
 use eframe::egui::{Color32, ColorImage, Context, Image, ImageData, ImageSource, SizeHint, TextureHandle, TextureOptions};
@@ -108,12 +108,15 @@ impl ImageApp {
     }
     
     fn forget_existing_image(&mut self, ctx: &Context) {
-        if let Some((uri, exising_texture)) = self.texture.take() {
+        if let Some((uri, existing_texture)) = self.texture.take() {
             // this causes a panic "Tried freeing texture Managed(1) which is not allocated"
-            // ctx.forget_image(uri.as_str());
+            //ctx.forget_image(uri.as_str());
             
             // this causes a panic "Tried freeing texture Managed(1) which is not allocated"
-            // ctx.tex_manager().write().free(exising_texture.id());
+            //ctx.tex_manager().write().free(exising_texture.id());
+            
+            // this causes a panic when the program exits "Tried freeing texture Managed(1) which is not allocated"
+            //mem::forget(existing_texture);
         }
     }
 

--- a/examples/image_loading_and_creating/src/main.rs
+++ b/examples/image_loading_and_creating/src/main.rs
@@ -1,0 +1,160 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
+#![allow(rustdoc::missing_crate_level_docs)] // it's an example
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+use eframe::egui;
+use eframe::egui::{Color32, ColorImage, Context, Image, ImageData, ImageSource, SizeHint, TextureHandle, TextureOptions};
+use eframe::egui::load::{SizedTexture, TexturePoll};
+use url::Url;
+
+fn main() -> eframe::Result {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([640.0, 480.0]),
+        ..Default::default()
+    };
+    eframe::run_native(
+        "Image loading and creating",
+        options,
+        Box::new(|cc| {
+            // This gives us image support:
+            egui_extras::install_image_loaders(&cc.egui_ctx);
+
+            Ok(Box::<ImageApp>::default())
+        }),
+    )
+}
+
+struct ImageApp {
+    texture: Option<TextureHandle>,
+    path: String,
+    worker: Option<thread::JoinHandle<Option<TextureHandle>>>,
+}
+
+impl Default for ImageApp {
+    fn default() -> Self {
+        Self {
+            texture: None,
+            path: "crates/egui/assets/ferris.png".to_string(),
+            worker: None,
+        }
+    }
+}
+
+impl ImageApp {
+    fn load_image(&mut self, ctx: &Context) {
+        self.texture = None;
+        
+        let ctx = ctx.clone();
+        let path = PathBuf::from(self.path.as_str());
+
+        let handle = std::thread::Builder::new()
+            .name("load_image".to_string())
+            .spawn(move || {
+
+                fn load_image_from_file_using_egui_extras(ctx: &Context, path: &Path) -> Option<TextureHandle> {
+                    // Attempt to load the image
+                    let absolute_path = path.canonicalize().ok()?;
+                    println!("Loading image from {:?}", absolute_path);
+                    let url = Url::from_file_path(absolute_path).unwrap();
+                    println!("uri: {}", url);
+
+
+                    let texture = loop {
+                        let poll = ctx.try_load_texture(url.as_str(), TextureOptions::default(), SizeHint::default()).ok()?;
+                        match poll {
+                            TexturePoll::Pending { .. } => {
+                                println!("Waiting for image load");
+                                thread::sleep(Duration::from_millis(100));
+                            }
+                            TexturePoll::Ready { texture } => {
+                                println!("Loaded");
+                                break texture;
+                            }
+                        }
+                    };
+
+                    Some(TextureHandle::new(ctx.tex_manager(), texture.id))
+                }
+
+                let result = load_image_from_file_using_egui_extras(&ctx.clone(), &path);
+
+                ctx.request_repaint();
+
+                result
+            });
+
+            self.worker = Some(handle.unwrap())
+    }
+
+    fn generate_image(&mut self, ctx: &Context) {
+        self.texture = None;
+
+        let image_data: ImageData = ImageData::Color(Arc::new(ColorImage::new([100, 100], Color32::RED)));
+
+        let texture_handle = ctx.load_texture(
+            "generated-image",
+            image_data,
+            Default::default()
+        );
+
+        self.texture = Some(texture_handle);
+    }
+}
+
+impl eframe::App for ImageApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        
+        if self.worker.is_some() && self.worker.as_ref().unwrap().is_finished() {
+            let worker = self.worker.take().unwrap();
+            
+            match worker.join() {
+                Ok(result) => {
+                    self.texture = result;
+                }
+                Err(_) => {
+                    println!("Failed to load image")
+                }
+            }
+            
+        }
+        
+        egui::CentralPanel::default().show(ctx, |ui| {
+
+            ui.label("this example demonstrates how to render an image that is either loaded from the filesystem or generated programmatically");
+            
+            ui.horizontal(|ui| {
+                ui.label("path");
+                ui.text_edit_singleline(&mut self.path);
+                if ui.button("Load").clicked() {
+                    self.load_image(ctx);
+                }
+
+            });
+
+            ui.horizontal(|ui| {
+                if ui.button("Generate").clicked() {
+                    self.generate_image(ctx);
+                }
+                ui.label("(no files are touched when generating image)");
+            });
+
+            egui::Frame::new().show(ui, |ui| {
+                match &self.texture {
+                    Some(texture_handle) => {
+                        let image_source = ImageSource::Texture(SizedTexture::from_handle(&texture_handle));
+                        let image = Image::new(image_source);
+
+                        ui.add_sized(ui.available_size(), image);
+                    }
+                    None => {
+                        ui.label("Click 'Load' or 'Generate'");
+                    }
+                }
+            });
+        });
+    }
+}


### PR DESCRIPTION
While learning egui I faced a number of issues with the image API which I documented here:

https://github.com/emilk/egui/issues/3291#issuecomment-2669545952

This PR gives other users an idea of how to have a UI that shows either a loaded image or a generated image and serves as a talking point for potential API improvements.

Screenshots:

UI before any interaction:
![image](https://github.com/user-attachments/assets/47889b47-c54a-459f-ba1c-60fcb02d707c)

UI after clicking 'generate':
![image](https://github.com/user-attachments/assets/65147592-13dc-4702-9788-e7f2dc2f027b)

UI after clicking 'load':
![image](https://github.com/user-attachments/assets/9ee179c2-b437-4818-b942-32965c278050)

* [x] I have followed the instructions in the PR template
