### PR TITLE
fixed order of assignments in available_from_cursor_max_rect

### DIFF
--- a/crates/egui/src/layout.rs
+++ b/crates/egui/src/layout.rs
@@ -466,28 +466,28 @@ impl Layout {
 
         match self.main_dir {
             Direction::LeftToRight => {
-                avail.min.x = cursor.min.x;
                 avail.max.x = avail.max.x.max(cursor.min.x);
                 avail.max.x = avail.max.x.max(avail.min.x);
+                avail.min.x = cursor.min.x;
                 avail.max.y = avail.max.y.max(avail.min.y);
             }
             Direction::RightToLeft => {
-                avail.max.x = cursor.max.x;
                 avail.min.x = avail.min.x.min(cursor.max.x);
                 avail.min.x = avail.min.x.min(avail.max.x);
+                avail.max.x = cursor.max.x;
                 avail.max.y = avail.max.y.max(avail.min.y);
             }
             Direction::TopDown => {
-                avail.min.y = cursor.min.y;
                 avail.max.y = avail.max.y.max(cursor.min.y);
-                avail.max.x = avail.max.x.max(avail.min.x);
                 avail.max.y = avail.max.y.max(avail.min.y);
+                avail.min.y = cursor.min.y;
+                avail.max.x = avail.max.x.max(avail.min.x);
             }
             Direction::BottomUp => {
-                avail.max.y = cursor.max.y;
                 avail.min.y = avail.min.y.min(cursor.max.y);
-                avail.max.x = avail.max.x.max(avail.min.x);
                 avail.min.y = avail.min.y.min(avail.max.y);
+                avail.max.y = cursor.max.y;
+                avail.max.x = avail.max.x.max(avail.min.x);
             }
         }
 


### PR DESCRIPTION
I changed the order of assignments in available_from_cursor_max_rect so that the same value is not checked twice in the min or max calls. 
I am not sure if this fixes anything or if the extra assignment can be removed. 

I also find it kinda weird that the match arms always leave one part of the "avail" rect untouched, but assign another twice. Is that just for formatting or is it a bug?
