### PR TITLE
Mark all keys as up if the app loses focus

### DIFF
--- a/crates/egui/src/input_state/mod.rs
+++ b/crates/egui/src/input_state/mod.rs
@@ -362,6 +362,14 @@ impl InputState {
                 Event::Zoom(factor) => {
                     zoom_factor_delta *= *factor;
                 }
+                Event::WindowFocused(false) => {
+                    // Example: pressing `Cmd+S` brings up a save-dialog (e.g. using rfd),
+                    // but we get no key-up event for the `S` key (in winit).
+                    // This leads to `S` being mistakenly marked as down when we switch back to the app.
+                    // So we take the safe route and just clear all the keys and modifiers when
+                    // the app loses focus.
+                    keys_down.clear();
+                }
                 _ => {}
             }
         }


### PR DESCRIPTION
In Rerun, pressing `Cmd+S` brings up a save dialog using `rfd`, but we get not key-up event for the `S` key (in winit).
This leads to `S` being mistakenly marked as down when we switch back to the app.

This PR takes the safe route and marks all keys as up when an egui app loses focus.

* Tested with https://github.com/rerun-io/rerun/pull/9103