### PR TITLE
Fix Cargo-Machete Workflow

### DIFF
--- a/.github/workflows/cargo_machete.yml
+++ b/.github/workflows/cargo_machete.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Machete
-        run: cargo install cargo-machete --locked && cargo machete
+        run: cargo install cargo-machete && cargo machete

--- a/.github/workflows/cargo_machete.yml
+++ b/.github/workflows/cargo_machete.yml
@@ -6,6 +6,9 @@ jobs:
   cargo-machete:
     runs-on: ubuntu-latest
     steps:
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.85
       - name: Machete install
         run: cargo install cargo-machete
       - name: Checkout

--- a/.github/workflows/cargo_machete.yml
+++ b/.github/workflows/cargo_machete.yml
@@ -6,7 +6,10 @@ jobs:
   cargo-machete:
     runs-on: ubuntu-latest
     steps:
+      - name: Machete install
+        run: cargo install cargo-machete
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Machete
-        run: cargo install cargo-machete && cargo machete
+      - name: Machete Check
+        run: cargo machete
+      

--- a/.github/workflows/cargo_machete.yml
+++ b/.github/workflows/cargo_machete.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           toolchain: 1.85
       - name: Machete install
-        run: cargo install cargo-machete
+        run: cargo install cargo-machete --locked
       - name: Checkout
         uses: actions/checkout@v4
       - name: Machete Check


### PR DESCRIPTION
As cargo machete now uses rust edition2024 we cannot use the older rust version - we need to install the newest on the runner

* [ ] I have followed the instructions in the PR template
