### PR TITLE
Fix typo in comment in `containers/scene.rs`

### DIFF
--- a/crates/egui/src/containers/scene.rs
+++ b/crates/egui/src/containers/scene.rs
@@ -118,7 +118,7 @@ impl Scene {
         }
 
         if !scene_rect_was_good {
-            // Auto-reset if the trsnsformation goes bad somehow (or started bad).
+            // Auto-reset if the transformation goes bad somehow (or started bad).
             *scene_rect = inner_rect;
         }
 


### PR DESCRIPTION
There was a typo in one of the comments in the file, so I fixed it :).