### PR TITLE
Allow opening multiple popups

### DIFF
--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -519,7 +519,7 @@ impl<'a> Popup<'a> {
                             _ => mem.open_popup(id),
                         }
                     } else {
-                        mem.close_popup();
+                        mem.close_popup(id);
                     }
                 }
                 Some(SetOpenCommand::Toggle) => {
@@ -599,7 +599,7 @@ impl<'a> Popup<'a> {
             }
             OpenKind::Memory { .. } => {
                 if should_close {
-                    ctx.memory_mut(|mem| mem.close_popup());
+                    ctx.memory_mut(|mem| mem.close_popup(id));
                 }
             }
         }

--- a/crates/egui/src/widgets/color_picker.rs
+++ b/crates/egui/src/widgets/color_picker.rs
@@ -521,7 +521,7 @@ pub fn color_edit_button_hsva(ui: &mut Ui, hsva: &mut Hsva, alpha: Alpha) -> Res
         if !button_response.clicked()
             && (ui.input(|i| i.key_pressed(Key::Escape)) || area_response.clicked_elsewhere())
         {
-            ui.memory_mut(|mem| mem.close_popup());
+            ui.memory_mut(|mem| mem.close_popup(popup_id));
         }
     }
 


### PR DESCRIPTION
* Closes #4607 
* [x] I have followed the instructions in the PR template

While this kinda works, it's still missing some kind of unified popup close behaviour handling, like in the menu. So maybe we need a similar PopupState or something to properly support nested popups.
(Right now, having a popup with CloseOnClickOutside and a nested popup, the outer popup will close or not depending on whether the click on the child popup was inside or outside of the bounds of the original popup)