### PR TITLE
Use RUSTUP_TOOLCHAIN=stable for rust-analyzer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,7 +33,11 @@
         "--all-features",
     ],
     "rust-analyzer.showUnlinkedFileNotification": false,
-
+    "rust-analyzer.cargo.extraEnv": {
+        // rust-analyzer is only guaranteed to support the latest stable version of Rust. Use it instead of whatever is
+        // specified in rust-toolchain.
+        "RUSTUP_TOOLCHAIN": "stable"
+    },
     // Uncomment the following options and restart rust-analyzer to get it to check code behind `cfg(target_arch=wasm32)`.
     // Don't forget to put it in a comment again before committing.
     // "rust-analyzer.cargo.target": "wasm32-unknown-unknown",


### PR DESCRIPTION
* Resolves #5760

Overrides the toolchain used in rust-analyzer to `stable`, as [suggested by rustup](https://rust-analyzer.github.io/book/installation.html#rust-standard-library).
