### PR TITLE
Deprecate `Ui::allocate_new_ui` in favor of `Ui::scope_builder`

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -776,7 +776,7 @@ impl ScrollArea {
 
             let rect = Rect::from_x_y_ranges(ui.max_rect().x_range(), y_min..=y_max);
 
-            ui.allocate_new_ui(UiBuilder::new().max_rect(rect), |viewport_ui| {
+            ui.scope_builder(UiBuilder::new().max_rect(rect), |viewport_ui| {
                 viewport_ui.skip_ahead_auto_ids(min_row); // Make sure we get consistent IDs.
                 add_contents(viewport_ui, min_row..max_row)
             })

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -1217,7 +1217,7 @@ impl TitleBar {
             let button_rect = Rect::from_center_size(button_center, button_size);
             let button_rect = button_rect.round_ui();
 
-            ui.allocate_new_ui(UiBuilder::new().max_rect(button_rect), |ui| {
+            ui.scope_builder(UiBuilder::new().max_rect(button_rect), |ui| {
                 collapsing.show_default_button_with_size(ui, button_size);
             });
         }

--- a/crates/egui/src/grid.rs
+++ b/crates/egui/src/grid.rs
@@ -456,7 +456,7 @@ impl Grid {
             ui_builder = ui_builder.sizing_pass().invisible();
         }
 
-        ui.allocate_new_ui(ui_builder, |ui| {
+        ui.scope_builder(ui_builder, |ui| {
             ui.horizontal(|ui| {
                 let is_color = color_picker.is_some();
                 let grid = GridLayout {

--- a/examples/custom_window_frame/src/main.rs
+++ b/examples/custom_window_frame/src/main.rs
@@ -114,7 +114,7 @@ fn title_bar_ui(ui: &mut egui::Ui, title_bar_rect: eframe::epaint::Rect, title: 
         ui.ctx().send_viewport_cmd(ViewportCommand::StartDrag);
     }
 
-    ui.allocate_new_ui(
+    ui.scope_builder(
         UiBuilder::new()
             .max_rect(title_bar_rect)
             .layout(egui::Layout::right_to_left(egui::Align::Center)),


### PR DESCRIPTION
They had the same signature and slightly different implementations, now it's streamlined
