### PR TITLE
[egui_extra] Allow loading multi-mime formats using the image_loader

### DIFF
--- a/crates/egui_extras/src/loaders/image_loader.rs
+++ b/crates/egui_extras/src/loaders/image_loader.rs
@@ -29,10 +29,7 @@ fn is_supported_uri(uri: &str) -> bool {
     };
 
     // Uses only the enabled image crate features
-    ImageFormat::all()
-        .filter(ImageFormat::reading_enabled)
-        .flat_map(ImageFormat::extensions_str)
-        .any(|format_ext| ext == *format_ext)
+    ImageFormat::from_extension(ext).is_some_and(|format| format.reading_enabled())
 }
 
 fn is_supported_mime(mime: &str) -> bool {
@@ -42,10 +39,7 @@ fn is_supported_mime(mime: &str) -> bool {
         return true;
     }
     // Uses only the enabled image crate features
-    ImageFormat::all()
-        .filter(ImageFormat::reading_enabled)
-        .map(|fmt| fmt.to_mime_type())
-        .any(|format_mime| mime == format_mime)
+    ImageFormat::from_mime_type(mime).is_some_and(|format| format.reading_enabled())
 }
 
 impl ImageLoader for ImageCrateLoader {


### PR DESCRIPTION
Hi ! 

I'm using egui and egui_extra to build a demo tool for a crate I'm building. In this crate I load favicons from a lot of websites, and I have some failures on some .ico files. After tracking this thing down, I guess there is two issues (kinda), in the image crate, 'image/vnd.microsoft.icon' isn't recognized as the valid mime for an ico image (I created a [PR](https://github.com/image-rs/image/pull/2434)), and the code to detect if a given mime type is compatible with the image crate decoders in this crate do not support multi-mime type formats.

[ImageFormat::to_mime_type](https://github.com/image-rs/image/blob/85f2412d552ddd2f576e16d023fd352589f4c605/src/image.rs#L216C12-L216C24) is only returning one mime for a given format (which is fine), we compare the result of this method to guess if the format is valid/enabled. Retriveing the correct format using [ImageFormat::from_mime_type](https://github.com/image-rs/image/blob/85f2412d552ddd2f576e16d023fd352589f4c605/src/image.rs#L166) would allow more mime to be considered valid since multiple mime can match the same format.

The same applies to the extension detection, which I also modified to stay consistent

Thanks
