### PR TITLE
Make force_set_min_rect public

### DIFF
--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -877,7 +877,7 @@ impl Ui {
     }
 
     /// Used for animation, kind of hacky
-    pub(crate) fn force_set_min_rect(&mut self, min_rect: Rect) {
+    pub fn force_set_min_rect(&mut self, min_rect: Rect) {
         self.placer.force_set_min_rect(min_rect);
     }
 


### PR DESCRIPTION
I want to implement my own collapsing header based on the existing collapsing header. To do this, I need access to the function force_set_min_rect public