### PR TITLE
Fix`TextEdit` selection when placed in a `Scene`.

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -579,6 +579,8 @@ impl TextEdit<'_> {
 
         if interactive {
             if let Some(pointer_pos) = ui.ctx().pointer_interact_pos() {
+                // Transform the pointer position from global coordinates to ui layer local coordinates.
+                // This is important if the TextEdit has a Scene parent.
                 let from_global = ui
                     .ctx()
                     .layer_transform_from_global(ui.layer_id())

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -579,6 +579,12 @@ impl TextEdit<'_> {
 
         if interactive {
             if let Some(pointer_pos) = ui.ctx().pointer_interact_pos() {
+                let from_global = ui
+                    .ctx()
+                    .layer_transform_from_global(ui.layer_id())
+                    .unwrap_or_default();
+                let pointer_pos = from_global.mul_pos(pointer_pos);
+
                 if response.hovered() && text.is_mutable() {
                     ui.output_mut(|o| o.mutable_text_under_cursor = true);
                 }

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -578,15 +578,7 @@ impl TextEdit<'_> {
         let painter = ui.painter_at(text_clip_rect.expand(1.0)); // expand to avoid clipping cursor
 
         if interactive {
-            if let Some(pointer_pos) = ui.ctx().pointer_interact_pos() {
-                // Transform the pointer position from global coordinates to ui layer local coordinates.
-                // This is important if the TextEdit has a Scene parent.
-                let from_global = ui
-                    .ctx()
-                    .layer_transform_from_global(ui.layer_id())
-                    .unwrap_or_default();
-                let pointer_pos = from_global.mul_pos(pointer_pos);
-
+            if let Some(pointer_pos) = response.interact_pointer_pos() {
                 if response.hovered() && text.is_mutable() {
                     ui.output_mut(|o| o.mutable_text_under_cursor = true);
                 }


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/5789
* [x] I have followed the instructions in the PR template

While this change fixes the TextEdit specific issue, I'm worried that the underlying problem is more fundamental and could show up in other widgets, and I'm wondering if there's a more general solution? 