### PR TITLE
Add script to update local snapshots from CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,9 @@ Browse through [`ARCHITECTURE.md`](ARCHITECTURE.md) to get a sense of how all pi
 You can test your code locally by running `./scripts/check.sh`.
 There are snapshots test that might need to be updated.
 Run the tests with `UPDATE_SNAPSHOTS=true cargo test --workspace --all-features` to update all of them.
+If CI keeps complaining about snapshots (which could happen if you don't use MacOS, snapshots in CI are currently
+rendered with MacOS), you can instead run `./scripts/update_snapshots_from_ci.sh` to update all snapshots from the
+last CI run of your PR.
 For more info about the tests see [egui_kittest](./crates/egui_kittest/README.md).
 Snapshots and other big files are stored with git lfs. See [Working with lfs](#working-with-lfs) for more info.
 If you see an `InvalidSignature` error when running snapshot tests, it's probably a problem related to git-lfs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,11 +34,11 @@ Browse through [`ARCHITECTURE.md`](ARCHITECTURE.md) to get a sense of how all pi
 You can test your code locally by running `./scripts/check.sh`.
 There are snapshots test that might need to be updated.
 Run the tests with `UPDATE_SNAPSHOTS=true cargo test --workspace --all-features` to update all of them.
-If CI keeps complaining about snapshots (which could happen if you don't use MacOS, snapshots in CI are currently
-rendered with MacOS), you can instead run `./scripts/update_snapshots_from_ci.sh` to update all snapshots from the
-last CI run of your PR.
+If CI keeps complaining about snapshots (which could happen if you don't use macOS, snapshots in CI are currently
+rendered with macOS), you can instead run `./scripts/update_snapshots_from_ci.sh` to update your local snapshots from 
+the last CI run of your PR (which will download the `test_results` artefact).
 For more info about the tests see [egui_kittest](./crates/egui_kittest/README.md).
-Snapshots and other big files are stored with git lfs. See [Working with lfs](#working-with-lfs) for more info.
+Snapshots and other big files are stored with git lfs. See [Working with git lfs](#working-with-git-lfs) for more info.
 If you see an `InvalidSignature` error when running snapshot tests, it's probably a problem related to git-lfs.
 
 When you have something that works, open a draft PR. You may get some helpful feedback early!

--- a/scripts/update_snapshots_from_ci.sh
+++ b/scripts/update_snapshots_from_ci.sh
@@ -3,9 +3,11 @@
 # and replaces your existing snapshots with the new ones.
 # Make sure you have the gh cli installed and authenticated before running this script.
 
+set -eu
+
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-RUN_ID=$(gh run list --json databaseId --branch "$BRANCH" -q '.[0].databaseId')
+RUN_ID=$(gh run list --branch "$BRANCH" --workflow "Rust" --json databaseId -q '.[0].databaseId')
 
 ECHO "Downloading test results from run $RUN_ID from branch $BRANCH"
 

--- a/scripts/update_snapshots_from_ci.sh
+++ b/scripts/update_snapshots_from_ci.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# This script searches for the last CI run with your branch name, downloads the test_results artefact
+# and replaces your existing snapshots with the new ones.
+# Make sure you have the gh cli installed and authenticated before running this script.
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+RUN_ID=$(gh run list --json databaseId --branch "$BRANCH" -q '.[0].databaseId')
+
+ECHO "Downloading test results from run $RUN_ID from branch $BRANCH"
+
+# remove any existing .new.png that might have been left behind
+find . -type d -path "*/tests/snapshots*" | while read dir; do
+    find "$dir" -type f -name "*.new.png" | while read file; do
+        rm "$file"
+    done
+done
+
+
+gh run download "$RUN_ID" --name "test-results" --dir tmp_artefacts
+
+# move the snapshots to the correct location, overwriting the existing ones
+rsync -a tmp_artefacts/ .
+
+rm -r tmp_artefacts
+
+# rename the .new.png files to .png
+find . -type d -path "*/tests/snapshots*" | while read dir; do
+    find "$dir" -type f -name "*.new.png" | while read file; do
+        mv -f "$file" "${file%.new.png}.png"
+    done
+done
+
+echo "Done!"


### PR DESCRIPTION
It seems like the thresholds are too low for all tests to pass when snapshots are generated from windows / linux. We need a better solution to this problem, but in the meantime this script should allow contributors to update their snapshots by downloading them from the last CI run.
