### PR TITLE
Group created values in IdTypeMap by a shared Id that can later be used to remove them in bulk.

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -956,6 +956,24 @@ impl Context {
         self.write(move |ctx| writer(&mut ctx.memory.data))
     }
 
+    /// Sets the `data_id` used to create new elements in the [`IdTypeMap`].
+    /// This id can later be used to remove all temporary data created for the part of the ui created inside the closure.
+    pub fn push_data_id<R>(
+        &self,
+        context_id: impl Into<Id>,
+        closure: impl FnOnce(&Self) -> R,
+    ) -> R {
+        let context_id = context_id.into();
+        let old_id = self.data_mut(|data_map| {
+            let old_id = data_map.get_current_data_id();
+            data_map.set_current_data_id(context_id);
+            old_id
+        });
+        let result = closure(self);
+        self.data_mut(|data_map| data_map.set_current_data_id(old_id));
+        result
+    }
+
     /// Read-write access to [`GraphicLayers`], where painted [`crate::Shape`]s are written to.
     #[inline]
     pub fn graphics_mut<R>(&self, writer: impl FnOnce(&mut GraphicLayers) -> R) -> R {

--- a/crates/egui/src/util/id_type_map.rs
+++ b/crates/egui/src/util/id_type_map.rs
@@ -78,6 +78,7 @@ type Serializer = fn(&Box<dyn Any + 'static + Send + Sync>) -> Option<String>;
 enum Element {
     /// A value, maybe serializable.
     Value {
+        data_id: Id,
         /// The actual value.
         value: Box<dyn Any + 'static + Send + Sync>,
 
@@ -98,11 +99,13 @@ impl Clone for Element {
     fn clone(&self) -> Self {
         match &self {
             Self::Value {
+                data_id,
                 value,
                 clone_fn,
                 #[cfg(feature = "persistence")]
                 serialize_fn,
             } => Self::Value {
+                data_id: *data_id,
                 value: clone_fn(value),
                 clone_fn: *clone_fn,
                 #[cfg(feature = "persistence")]
@@ -138,8 +141,9 @@ impl std::fmt::Debug for Element {
 impl Element {
     /// Create a value that won't be persisted.
     #[inline]
-    pub(crate) fn new_temp<T: 'static + Any + Clone + Send + Sync>(t: T) -> Self {
+    pub(crate) fn new_temp<T: 'static + Any + Clone + Send + Sync>(t: T, data_id: Id) -> Self {
         Self::Value {
+            data_id,
             value: Box::new(t),
             clone_fn: |x| {
                 let x = x.downcast_ref::<T>().unwrap(); // This unwrap will never panic, because we always construct this type using this `new` function and because we return &mut reference only with this type `T`, so type cannot change.
@@ -152,8 +156,9 @@ impl Element {
 
     /// Create a value that will be persisted.
     #[inline]
-    pub(crate) fn new_persisted<T: SerializableAny>(t: T) -> Self {
+    pub(crate) fn new_persisted<T: SerializableAny>(t: T, data_id: Id) -> Self {
         Self::Value {
+            data_id,
             value: Box::new(t),
             clone_fn: |x| {
                 let x = x.downcast_ref::<T>().unwrap(); // This unwrap will never panic, because we always construct this type using this `new` function and because we return &mut reference only with this type `T`, so type cannot change.
@@ -198,13 +203,13 @@ impl Element {
         insert_with: impl FnOnce() -> T,
     ) -> &mut T {
         match self {
-            Self::Value { value, .. } => {
+            Self::Value { value, data_id, .. } => {
                 if !value.is::<T>() {
-                    *self = Self::new_temp(insert_with());
+                    *self = Self::new_temp(insert_with(), *data_id);
                 }
             }
             Self::Serialized(_) => {
-                *self = Self::new_temp(insert_with());
+                *self = Self::new_temp(insert_with(), Id::NULL);
             }
         }
 
@@ -220,20 +225,23 @@ impl Element {
         insert_with: impl FnOnce() -> T,
     ) -> &mut T {
         match self {
-            Self::Value { value, .. } => {
+            Self::Value { value, data_id, .. } => {
                 if !value.is::<T>() {
-                    *self = Self::new_persisted(insert_with());
+                    *self = Self::new_persisted(insert_with(), *data_id);
                 }
             }
 
             #[cfg(feature = "persistence")]
             Self::Serialized(SerializedElement { ron, .. }) => {
-                *self = Self::new_persisted(from_ron_str::<T>(ron).unwrap_or_else(insert_with));
+                *self = Self::new_persisted(
+                    from_ron_str::<T>(ron).unwrap_or_else(insert_with),
+                    Id::NULL,
+                );
             }
 
             #[cfg(not(feature = "persistence"))]
             Self::Serialized(_) => {
-                *self = Self::new_persisted(insert_with());
+                *self = Self::new_persisted(insert_with(), Id::NULL);
             }
         }
 
@@ -249,7 +257,7 @@ impl Element {
 
             #[cfg(feature = "persistence")]
             Self::Serialized(SerializedElement { ron, .. }) => {
-                *self = Self::new_persisted(from_ron_str::<T>(ron)?);
+                *self = Self::new_persisted(from_ron_str::<T>(ron)?, Id::NULL);
 
                 match self {
                     Self::Value { value, .. } => value.downcast_mut(),
@@ -351,6 +359,8 @@ use crate::Id;
 pub struct IdTypeMap {
     map: nohash_hasher::IntMap<u64, Element>,
 
+    current_data_id: Id,
+
     max_bytes_per_type: usize,
 }
 
@@ -358,24 +368,47 @@ impl Default for IdTypeMap {
     fn default() -> Self {
         Self {
             map: Default::default(),
+            current_data_id: Id::NULL,
             max_bytes_per_type: 256 * 1024,
         }
     }
 }
 
 impl IdTypeMap {
+    /// Get the current data id used to insert new elements
+    #[inline]
+    pub fn get_current_data_id(&self) -> Id {
+        self.current_data_id
+    }
+
+    /// Set the current data id used to insert new elements
+    #[inline]
+    pub fn set_current_data_id(&mut self, data_id: impl Into<Id>) {
+        self.current_data_id = data_id.into();
+    }
+
+    /// Removes all temp elements that were created with the given context id.
+    pub fn remove_all_with_data_id(&mut self, data_id_to_remove: Id) {
+        self.map.retain(|_, element| match element {
+            Element::Value { data_id, .. } => *data_id != data_id_to_remove,
+            Element::Serialized(_) => true,
+        });
+    }
+
     /// Insert a value that will not be persisted.
     #[inline]
     pub fn insert_temp<T: 'static + Any + Clone + Send + Sync>(&mut self, id: Id, value: T) {
         let hash = hash(TypeId::of::<T>(), id);
-        self.map.insert(hash, Element::new_temp(value));
+        self.map
+            .insert(hash, Element::new_temp(value, self.current_data_id));
     }
 
     /// Insert a value that will be persisted next time you start the app.
     #[inline]
     pub fn insert_persisted<T: SerializableAny>(&mut self, id: Id, value: T) {
         let hash = hash(TypeId::of::<T>(), id);
-        self.map.insert(hash, Element::new_persisted(value));
+        self.map
+            .insert(hash, Element::new_persisted(value, self.current_data_id));
     }
 
     /// Read a value without trying to deserialize a persisted value.
@@ -438,7 +471,7 @@ impl IdTypeMap {
         use std::collections::hash_map::Entry;
         match self.map.entry(hash) {
             Entry::Vacant(vacant) => vacant
-                .insert(Element::new_temp(insert_with()))
+                .insert(Element::new_temp(insert_with(), self.current_data_id))
                 .get_mut_temp()
                 .unwrap(), // this unwrap will never panic, because we insert correct type right now
             Entry::Occupied(occupied) => {
@@ -456,7 +489,7 @@ impl IdTypeMap {
         use std::collections::hash_map::Entry;
         match self.map.entry(hash) {
             Entry::Vacant(vacant) => vacant
-                .insert(Element::new_persisted(insert_with()))
+                .insert(Element::new_persisted(insert_with(), self.current_data_id))
                 .get_mut_persisted()
                 .unwrap(), // this unwrap will never panic, because we insert correct type right now
             Entry::Occupied(occupied) => occupied


### PR DESCRIPTION
Hello, 
this is my first PR to this repository.

I hope it meets your requirements on how a PR is supposed to be filed.

It is a small change that allows me to remove temporary values stored in the TypeIdMap created by a part of the ui that is obsolete.

What is the problem?
I have a very generic UI that changes drastically based on data/state and user actions. 
It is impossible for me to uniquely id many of my widgets that require an id. 
I have therefore opted to assign semi random id's together with the state.
This works great, however sometimes user action or data/state changes cause parts of the ui
to disappear and different stuff to be added. 
Over a long time this causes the TypeIdMap to bloat with temporary values.
To print the count I used
```rust
  ctx.data_mut(|m | {
      println!("{}", m.len());
  });
```
In my update loop. This value never decreased. (Memory Leak)

How does this PR help me?
This pr adds a fn to Context that I can call to assign a id to all elements inserted
into the TypeIdMap during the execution of a closure. (Similar to ui::push_id)
The "group" id is determined at the time of insertion into the TypeIdMap.
During this closure I will update my UI. (For example update/create a nested left or right Panel and all elements in it).
This allows me to logically group my elements so that I can later remove all temporary values associated to the elements once
I desire them to become obsolete. 

What alternatives have I considered?
I was unable to individually remove all the elements from the TypeIdMap because 
I was not able to correctly deduce the TypeId which is part of the Key Hash.
Calling TypeIdMap::clear() is also not workable for me because it makes the entire UI jerk back to default settings,
undoing any resizing the user may have done to still relevant panels.

Naming/Bikeshedding
I am not at all attached to the function name "push_data_id" or the name "data_id" 
I gave this name group id explained above which is stored for every value in the TypeIdMap.
As you are probably aware naming things is not trivial. 
If you want me to change the name to something else then tell me and I will gladly change it.

Since this is quite a technical PR I don't think adding any screenshots provides value.
If you want me to make a simple app demonstrating my problem (by printing the number) and making a button that appears/disappears a panel each time with a new id then I can do so. But once again since this is a technical issue I think such an app would be boring to look at?

I would be delighted if this could be merged.

Sincerely
Alexander Schütz