### PR TITLE
Use sRGBA unaware textures, and let the GPU interpolate in sRGB space.

### DIFF
--- a/crates/egui-wgpu/src/egui.wgsl
+++ b/crates/egui-wgpu/src/egui.wgsl
@@ -97,9 +97,11 @@ fn vs_main(
 
 @fragment
 fn fs_main_linear_framebuffer(in: VertexOutput) -> @location(0) vec4<f32> {
-    // We always have an sRGB aware texture at the moment.
-    let tex_linear = textureSample(r_tex_color, r_tex_sampler, in.tex_coord);
-    let tex_gamma = gamma_from_linear_rgba(tex_linear);
+    // We use sRGB unware textures, and store (premultiplied) sRGB values.
+    // Hence any interpolation done by the GPU will be in gamma space.
+    // Note: Because we store premultiplied alpha, we can't rely on sRGB aware
+    // textures that convert "sRGB -> linear RGB" before interpolating.
+    let tex_gamma = textureSample(r_tex_color, r_tex_sampler, in.tex_coord);
     var out_color_gamma = in.color * tex_gamma;
     // Dither the float color down to eight bits to reduce banding.
     // This step is optional for egui backends.
@@ -115,9 +117,11 @@ fn fs_main_linear_framebuffer(in: VertexOutput) -> @location(0) vec4<f32> {
 
 @fragment
 fn fs_main_gamma_framebuffer(in: VertexOutput) -> @location(0) vec4<f32> {
-    // We always have an sRGB aware texture at the moment.
-    let tex_linear = textureSample(r_tex_color, r_tex_sampler, in.tex_coord);
-    let tex_gamma = gamma_from_linear_rgba(tex_linear);
+    // We use sRGB unware textures, and store (premultiplied) sRGB values.
+    // Hence any interpolation done by the GPU will be in gamma space.
+    // Note: Because we store premultiplied alpha, we can't rely on sRGB aware
+    // textures that convert "sRGB -> linear RGB" before interpolating.
+    let tex_gamma = textureSample(r_tex_color, r_tex_sampler, in.tex_coord);
     var out_color_gamma = in.color * tex_gamma;
     // Dither the float color down to eight bits to reduce banding.
     // This step is optional for egui backends.

--- a/crates/egui-wgpu/src/renderer.rs
+++ b/crates/egui-wgpu/src/renderer.rs
@@ -638,9 +638,9 @@ impl Renderer {
                     mip_level_count: 1,
                     sample_count: 1,
                     dimension: wgpu::TextureDimension::D2,
-                    format: wgpu::TextureFormat::Rgba8UnormSrgb, // Minspec for wgpu WebGL emulation is WebGL2, so this should always be supported.
+                    format: wgpu::TextureFormat::Rgba8Unorm,
                     usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-                    view_formats: &[wgpu::TextureFormat::Rgba8UnormSrgb],
+                    view_formats: &[wgpu::TextureFormat::Rgba8Unorm],
                 })
             };
             let origin = wgpu::Origin3d::ZERO;


### PR DESCRIPTION
This is one potential fix to the issues we are seeing around GPU texture interpolation of semi-transparent values. 

Note that this intentionally switches texture interpolation from linear to gamma. One one hand this makes interpolation more consistent with how it is done everywhere else in egui (vertex blending, and cpu computations). On the other hand it breaks a current assumption (see the screenshot from the rendering demo app). 

If linear texture interpolation is not necessary, I think this is our best option, and I want to put it forward for discussion. See below for alternatives. 

## More

**Alternatives that allow for linear blending:**
- Use sRGB aware textures, but **do not** premultiply the stored values.
  - This will open us up to interpolation artifacts due to interpolating in non-premultiplied spaces (i.e color bleeding) and is hence undesirable.
- Use sRGB unaware textures, and **do not** store sRGB values, but linear ones instead.
  - We will loose the precision gains that gamma encoding in u8 gives us. Still, if linear texture interpolation is strictly desired, this is our best option, perhaps in combination with a higher precision linear texture format. 

**Missing: **
- If these changes are acceptable I'll update the PR with matching changes to the glow backend. 

## Related:

* https://github.com/emilk/egui/pull/5824
* Closes https://github.com/emilk/egui/issues/5810
* [x] I have followed the instructions in the PR template


