### PR TITLE
Update web-sys min version to 0.3.73

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ thiserror = "1.0.37"
 type-map = "0.5.0"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-web-sys = "0.3.70"
+web-sys = "0.3.73"
 web-time = "1.1.0" # Timekeeping for native and web
 wgpu = { version = "24.0.0", default-features = false }
 windows-sys = "0.59"


### PR DESCRIPTION
This should prevent compilation errors (which I ran into) where eframe tries to use HtmlElement::set_autofocus(), which doesn't exist until 0.3.73.

```
error[E0599]: no method named `set_autofocus` found for struct `HtmlElement` in the current scope
  --> C:\Users\wareya\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\eframe-0.31.1\src\web\text_agent.rs:24:15
   |
24 |         input.set_autofocus(true)?;
   |               ^^^^^^^^^^^^^
   |
help: there is a method `set_onfocus` with a similar name
   |
24 |         input.set_onfocus(true)?;
   |               ~~~~~~~~~~~
```

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [x] I have followed the instructions in the PR template
