### PR TITLE
Make text background rects pixel-sharp

### DIFF
--- a/crates/egui_demo_lib/tests/snapshots/rendering_test/dpi_1.50.png
+++ b/crates/egui_demo_lib/tests/snapshots/rendering_test/dpi_1.50.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e6f394c2beb51d95edaf8c7ddc9ff62d3f95913ea88a3840245b6bacf8b850cc
+oid sha256:334f52bfee27f9c467de739696fd7ce7c48ec9013e315dc4b2e61eee58f11287
 size 907997

--- a/crates/egui_extras/src/syntax_highlighting.rs
+++ b/crates/egui_extras/src/syntax_highlighting.rs
@@ -33,6 +33,7 @@ pub fn highlight(
     // performing it at a separate thread (ctx, ctx.style()) can be used and when ui is available
     // (ui.ctx(), ui.style()) can be used
 
+    #[allow(non_local_definitions)]
     impl egui::cache::ComputerMut<(&egui::FontId, &CodeTheme, &str, &str), LayoutJob> for Highlighter {
         fn compute(
             &mut self,

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -715,7 +715,7 @@ fn tessellate_row(
     mesh.reserve_vertices(row.glyphs.len() * 4);
 
     if format_summary.any_background {
-        add_row_backgrounds(job, row, &mut mesh);
+        add_row_backgrounds(point_scale, job, row, &mut mesh);
     }
 
     let glyph_index_start = mesh.indices.len();
@@ -753,7 +753,7 @@ fn tessellate_row(
 
 /// Create background for glyphs that have them.
 /// Creates as few rectangular regions as possible.
-fn add_row_backgrounds(job: &LayoutJob, row: &Row, mesh: &mut Mesh) {
+fn add_row_backgrounds(point_scale: PointScale, job: &LayoutJob, row: &Row, mesh: &mut Mesh) {
     if row.glyphs.is_empty() {
         return;
     }
@@ -762,6 +762,7 @@ fn add_row_backgrounds(job: &LayoutJob, row: &Row, mesh: &mut Mesh) {
         if let Some((color, start_rect, expand)) = start {
             let rect = Rect::from_min_max(start_rect.left_top(), pos2(stop_x, start_rect.bottom()));
             let rect = rect.expand(expand);
+            let rect = rect.round_to_pixels(point_scale.pixels_per_point());
             mesh.add_colored_rect(rect, color);
         }
     };


### PR DESCRIPTION
Small visual teak: make sure the background text color is pixel-aligned.