### PR TITLE
Make `Grid` take full width when `Self::num_columns` is `Some`

### DIFF
--- a/crates/egui/src/grid.rs
+++ b/crates/egui/src/grid.rs
@@ -251,7 +251,11 @@ impl GridLayout {
         let size = Vec2::new(self.prev_state.full_width(self.spacing.x), height);
         let rect = Rect::from_min_size(cursor.min, size);
         let rect = rect.expand2(0.5 * self.spacing.y * Vec2::Y);
-        let rect = rect.expand2(2.0 * Vec2::X); // HACK: just looks better with some spacing on the sides
+        let mut rect = rect.expand2(2.0 * Vec2::X); // HACK: just looks better with some spacing on the sides
+
+        if self.num_columns.is_some() {
+            rect.set_width(cursor.width())
+        }
 
         painter.rect_filled(rect, 2.0, row_color);
     }

--- a/crates/egui/src/grid.rs
+++ b/crates/egui/src/grid.rs
@@ -254,7 +254,7 @@ impl GridLayout {
         let mut rect = rect.expand2(2.0 * Vec2::X); // HACK: just looks better with some spacing on the sides
 
         if self.num_columns.is_some() {
-            rect.set_width(cursor.width())
+            rect.set_width(cursor.width());
         }
 
         painter.rect_filled(rect, 2.0, row_color);


### PR DESCRIPTION
Hello!
**This is a PR to address ticket #3928. This PR would close the issue.**
I've made grid stripes take up the full width available to the Grid when Grid::num_rows is_some(). 
This change is being made to match the documentation, which states that: `Setting this will allow the last column to expand to take up the rest of the space of the parent` [(Link to comment)](https://docs.rs/egui/latest/egui/struct.Grid.html#method.num_columns)

```diff
    fn paint_row(&self, cursor: &Rect, painter: &Painter) {
        // ...
-       let rect = rect.expand2(2.0 * Vec2::X); // HACK: just looks better with some spacing on the sides
+       let mut rect = rect.expand2(2.0 * Vec2::X); // HACK: just looks better with some spacing on the sides
+
+       if self.num_columns.is_some() {
+          rect.set_width(cursor.width())
+       }

        painter.rect_filled(rect, 2.0, row_color);
    }
```
![image](https://github.com/user-attachments/assets/ee8b04c1-3150-43fc-8278-1b33742d07f5)

I'm a first time contributor to this repo, and I'm honestly not too familiar with how it works, so if there are any issues with this, please let me know and I'll investigate it ASAP!