### PR TITLE
Update failing snapshot tests

### DIFF
--- a/crates/egui_demo_lib/tests/snapshots/rendering_test/dpi_1.00.png
+++ b/crates/egui_demo_lib/tests/snapshots/rendering_test/dpi_1.00.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5a1f0d0759458017127d93278b89278af20fdc57c7747652ac6554f24cc708f2
-size 552939
+oid sha256:9f6cf5b14056522d06f0cb1e56bafd7e5ab7a9033eb358748d43d748bb0ceef1
+size 553177

--- a/crates/egui_demo_lib/tests/snapshots/rendering_test/dpi_1.25.png
+++ b/crates/egui_demo_lib/tests/snapshots/rendering_test/dpi_1.25.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7948ced20e3f62b8356fc978ca7b12f8522b7c15716409cc661c0ebd2f12047f
-size 770062
+oid sha256:fd3bd1f64995db34a14dbc860ae8b8e269073ed7b8f10d10ce8f99b613cfc999
+size 769357

--- a/crates/egui_demo_lib/tests/snapshots/rendering_test/dpi_1.50.png
+++ b/crates/egui_demo_lib/tests/snapshots/rendering_test/dpi_1.50.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:334f52bfee27f9c467de739696fd7ce7c48ec9013e315dc4b2e61eee58f11287
-size 907997
+oid sha256:f12e6145f3a1c3fda6dede3daeb0e52ed2bffb35531d823133224a477798a14a
+size 907800

--- a/crates/egui_demo_lib/tests/snapshots/rendering_test/dpi_1.67.png
+++ b/crates/egui_demo_lib/tests/snapshots/rendering_test/dpi_1.67.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d31f018cdabf92966b5636d9aef7f11ef1a0383884867e819e7ec99c0474e872
-size 1025013
+oid sha256:05bdcfd2c34b6d7badede14f5495dce34e5e9cfe421314f40dcea15e9f865736
+size 1024735

--- a/crates/egui_demo_lib/tests/snapshots/rendering_test/dpi_1.75.png
+++ b/crates/egui_demo_lib/tests/snapshots/rendering_test/dpi_1.75.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e18f7ddadd53e16d04f191268747f244c98d0ea0f4cb9c0ea299f5da7affbc58
-size 1139723
+oid sha256:8365c89f6b823f01464a9310bab7717bf25305b335cdeecf21711c7dca9f053f
+size 1140082

--- a/crates/egui_demo_lib/tests/snapshots/rendering_test/dpi_2.00.png
+++ b/crates/egui_demo_lib/tests/snapshots/rendering_test/dpi_2.00.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:09a49cb9da7269bec6eef30c46a0bc85df6538d6e31dc0d0ff2758dbee45f3d8
-size 1291804
+oid sha256:b38021057ec6b5bb39c41bd4afaf5e9ff38687216d52d5bba8cbf7b6fdfe9a4f
+size 1291518


### PR DESCRIPTION
For some reason the pipeline in https://github.com/emilk/egui/pull/5698 succeeded even though the snapshots should have been updated. This updates the snapshots.
