### PR TITLE
Add a `Slider::update_while_editing(bool)` API

### DIFF
--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -117,6 +117,7 @@ pub struct Slider<'a> {
     custom_parser: Option<NumParser<'a>>,
     trailing_fill: Option<bool>,
     handle_shape: Option<HandleShape>,
+    update_while_editing: bool,
 }
 
 impl<'a> Slider<'a> {
@@ -167,6 +168,7 @@ impl<'a> Slider<'a> {
             custom_parser: None,
             trailing_fill: None,
             handle_shape: None,
+            update_while_editing: true,
         }
     }
 
@@ -641,6 +643,16 @@ impl<'a> Slider<'a> {
         let normalized = normalized_from_value(value, self.range(), &self.spec);
         lerp(position_range, normalized as f32)
     }
+
+    /// Update the value on each key press when text-editing the value.
+    ///
+    /// Default: `true`.
+    /// If `false`, the value will only be updated when user presses enter or deselects the value.
+    #[inline]
+    pub fn update_while_editing(mut self, update: bool) -> Self {
+        self.update_while_editing = update;
+        self
+    }
 }
 
 impl Slider<'_> {
@@ -900,7 +912,8 @@ impl Slider<'_> {
                 .min_decimals(self.min_decimals)
                 .max_decimals_opt(self.max_decimals)
                 .suffix(self.suffix.clone())
-                .prefix(self.prefix.clone());
+                .prefix(self.prefix.clone())
+                .update_while_editing(self.update_while_editing);
 
             match self.clamping {
                 SliderClamping::Never => {}


### PR DESCRIPTION
* Closes #5976
* [x] I have followed the instructions in the PR template
  - The `scripts/check.sh` fails in `cargo-deny` because of a security vulnerability in `crossbeam-channel` but this is also present on `master`.

https://github.com/user-attachments/assets/a964c968-bb76-4e56-88e1-d1e3d51a401a
