### PR TITLE
Rework interal Modal drawing to better use the the provided Area, allowing for draggable Modals. 

### DIFF
--- a/crates/egui/src/containers/modal.rs
+++ b/crates/egui/src/containers/modal.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Area, Color32, Context, Frame, Id, InnerResponse, Order, Response, Sense, Ui, UiBuilder, UiKind,
+    Area, Color32, Context, Frame, Id, InnerResponse, Order, Response, Sense, Ui, UiKind,
+    WidgetRect,
 };
 use emath::{Align2, Vec2};
 
@@ -33,14 +34,33 @@ impl Modal {
     /// Returns an area customized for a modal.
     ///
     /// Makes these changes to the default area:
-    /// - sense: hover
+    /// - sense: hover + click + drag
     /// - anchor: center
     /// - order: foreground
+    ///
+    /// Consider the notes at [`Modal::area`] for more information.
     pub fn default_area(id: Id) -> Area {
         Area::new(id)
             .kind(UiKind::Modal)
-            .sense(Sense::hover())
+            .sense(Sense::HOVER | Sense::DRAG | Sense::CLICK)
             .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
+            .order(Order::Foreground)
+            .interactable(true)
+    }
+
+    /// Returns an area customized to make a modal draggable.
+    ///
+    /// Makes these changes to the default area:
+    /// - sense: hover + click + drag
+    /// - pivot: center
+    /// - order: foreground
+    ///
+    /// Consider the notes at [`Modal::area`] for more information.
+    pub fn draggable_area(id: Id) -> Area {
+        Area::new(id)
+            .kind(UiKind::Modal)
+            .sense(Sense::HOVER | Sense::DRAG | Sense::CLICK)
+            .pivot(Align2::CENTER_CENTER)
             .order(Order::Foreground)
             .interactable(true)
     }
@@ -66,6 +86,14 @@ impl Modal {
     /// Set the area of the modal.
     ///
     /// Default is [`Modal::default_area`].
+    ///
+    /// If the modal should be draggable, consider using [`Modal::draggable_area`] instead.
+    ///
+    /// If you want to provide a custom area, make sure it senses [`Sense::CLICK`] and [`Sense::DRAG`].
+    /// Otherwise the background backdrop might catch events meant for the content of the modal.
+    ///
+    /// Also, if the Area satisfies [`Area::is_movable`], the Modal will ignore the stored position and re-center it on modal re-open.
+    /// This is affected by [`Area::pivot`], which [`Modal::draggable_area`] sets to [`Align2::CENTER_CENTER`].
     #[inline]
     pub fn area(mut self, area: Area) -> Self {
         self.area = area;
@@ -75,7 +103,7 @@ impl Modal {
     /// Show the modal.
     pub fn show<T>(self, ctx: &Context, content: impl FnOnce(&mut Ui) -> T) -> ModalResponse<T> {
         let Self {
-            area,
+            mut area,
             backdrop_color,
             frame,
         } = self;
@@ -87,28 +115,36 @@ impl Modal {
                 mem.any_popup_open(),
             )
         });
-        let InnerResponse {
-            inner: (inner, backdrop_response),
-            response,
-        } = area.show(ctx, |ui| {
-            let bg_rect = ui.ctx().screen_rect();
-            let bg_sense = Sense::CLICK | Sense::DRAG;
-            let mut backdrop = ui.new_child(UiBuilder::new().sense(bg_sense).max_rect(bg_rect));
-            backdrop.set_min_size(bg_rect.size());
+
+        // The backdrop response is responsible for checking for click through etc.
+        // It needs to be drawn before everything else, so we can use it to block clicks.
+        // Thus, we manually add the widget.
+        let bg_rect = ctx.screen_rect();
+        let bg_sense = Sense::CLICK | Sense::DRAG;
+        let backdrop_response = ctx.create_widget(
+            WidgetRect {
+                id: area.id.with("background rect"),
+                layer_id: area.layer(),
+                rect: bg_rect,
+                interact_rect: bg_rect,
+                sense: bg_sense,
+                enabled: true,
+            },
+            true,
+        );
+
+        // Should the area be movable, and we are (re-)opening it, try to center it.
+        if area.is_movable() && !ctx.memory(|mem| mem.areas().visible_last_frame(&area.layer())) {
+            area = area.current_pos(ctx.screen_rect().center());
+        }
+
+        let InnerResponse { inner, response } = area.show(ctx, |ui| {
+            // The backdrop still needs painting.
             ui.painter().rect_filled(bg_rect, 0.0, backdrop_color);
-            let backdrop_response = backdrop.response();
 
+            // We are handling the area sensing already, so we can jow just create and show the frame.
             let frame = frame.unwrap_or_else(|| Frame::popup(ui.style()));
-
-            // We need the extra scope with the sense since frame can't have a sense and since we
-            // need to prevent the clicks from passing through to the backdrop.
-            let inner = ui
-                .scope_builder(UiBuilder::new().sense(Sense::CLICK | Sense::DRAG), |ui| {
-                    frame.show(ui, content).inner
-                })
-                .inner;
-
-            (inner, backdrop_response)
+            frame.show(ui, content).inner
         });
 
         ModalResponse {

--- a/crates/egui_demo_lib/src/demo/modals.rs
+++ b/crates/egui_demo_lib/src/demo/modals.rs
@@ -6,6 +6,7 @@ pub struct Modals {
     user_modal_open: bool,
     save_modal_open: bool,
     save_progress: Option<f32>,
+    drag_modal_open: bool,
 
     role: &'static str,
     name: String,
@@ -16,6 +17,7 @@ impl Default for Modals {
         Self {
             user_modal_open: false,
             save_modal_open: false,
+            drag_modal_open: false,
             save_progress: None,
             role: Self::ROLES[0],
             name: "John Doe".to_owned(),
@@ -48,6 +50,7 @@ impl crate::View for Modals {
             user_modal_open,
             save_modal_open,
             save_progress,
+            drag_modal_open,
             role,
             name,
         } = self;
@@ -59,6 +62,10 @@ impl crate::View for Modals {
 
             if ui.button("Open Save Modal").clicked() {
                 *save_modal_open = true;
+            }
+
+            if ui.button("Draggable Modal").clicked() {
+                *drag_modal_open = true;
             }
         });
 
@@ -152,6 +159,34 @@ impl crate::View for Modals {
                     ui.ctx().request_repaint();
                 }
             });
+        }
+
+        if *drag_modal_open {
+            let id = Id::new("Modal D");
+
+            // It is tempting to do this:
+            // let area = Modal::default_area(id).movable(true);
+            // However the default area sets anchors, and thus movable will not work.
+            // Instead, use Modal::draggable_area instead.
+            let modal = Modal::new(id)
+                .area(Modal::draggable_area(id))
+                .show(ui.ctx(), |ui| {
+                    egui::Resize::default()
+                        .with_stroke(false)
+                        .min_size([125.0, 225.0])
+                        .max_size(ui.ctx().screen_rect().size())
+                        .show(ui, |ui| {
+                            ui.vertical_centered(|ui| {
+                                ui.add_space(25.0);
+                                ui.heading("You should be able to drag me around!");
+                                ui.add_space(125.0);
+                            });
+                        });
+                });
+
+            if modal.should_close() {
+                *drag_modal_open = false;
+            }
         }
 
         ui.vertical_centered(|ui| {

--- a/crates/egui_demo_lib/tests/snapshots/demos/Modals.png
+++ b/crates/egui_demo_lib/tests/snapshots/demos/Modals.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2f467edf4a84c8a98d96f168d843edb201ad2ee067dcd9d8d9ea214a02a41b1f
-size 32182
+oid sha256:edabb8f21c8cb79fe4be2d83d215803dcdd58435df372076a7703896d18960aa
+size 34393

--- a/crates/egui_demo_lib/tests/snapshots/modals_1.png
+++ b/crates/egui_demo_lib/tests/snapshots/modals_1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e954bf915d562abc69269cd10a4df8fbd0e5603929e6446fefa694099e2494a4
-size 47542
+oid sha256:7d12074ba6cee5594d6f926070cef2bb397407c1c3df26259ed7476fb59a6cb8
+size 49600

--- a/crates/egui_demo_lib/tests/snapshots/modals_2.png
+++ b/crates/egui_demo_lib/tests/snapshots/modals_2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c7bd1a65b6c33eff2fe17f7af2dd731a03658abc2419f8722c0e9395b26fdef
-size 47515
+oid sha256:fe0ce71079e295c3cca563152fb3226d27f19f526b3a9b13132078d0ec05743a
+size 49304

--- a/crates/egui_demo_lib/tests/snapshots/modals_3.png
+++ b/crates/egui_demo_lib/tests/snapshots/modals_3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e89cd220a925150384b9f9987b178036ffacfe29cdb36ed688205524dbb731fd
-size 43803
+oid sha256:89a4e7b3645b5507755a341241a9c5481846491cd9ed28bb453f8e75bdedbf3a
+size 45327

--- a/crates/egui_demo_lib/tests/snapshots/modals_backdrop_should_prevent_focusing_lower_area.png
+++ b/crates/egui_demo_lib/tests/snapshots/modals_backdrop_should_prevent_focusing_lower_area.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b71da58f5c0178517f9e0cc97753a0a5d1653cc5d094b5a35ffe050499bcd569
-size 43679
+oid sha256:6436ceca0186172d5ab912edd55ba8dfc827c0bcfd8654477bcfeac83946049a
+size 45477

--- a/crates/egui_demo_lib/tests/snapshots/modals_drag_1.png
+++ b/crates/egui_demo_lib/tests/snapshots/modals_drag_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0cc3473d8b0a9aad8d569534481a72bf99dac90ac3ad2b6b333b87c0ccd7ec3
+size 49419

--- a/crates/egui_demo_lib/tests/snapshots/modals_drag_2.png
+++ b/crates/egui_demo_lib/tests/snapshots/modals_drag_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15fcfc297dd0345fa7eb4b713262850ab253ec4c9431bb98ce122dd008394a22
+size 49768

--- a/crates/egui_demo_lib/tests/snapshots/modals_drag_3.png
+++ b/crates/egui_demo_lib/tests/snapshots/modals_drag_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b565961ffb0adfe36b4bee4e4305aad5f31b5a6e1d33fcc04e1729253c6be88
+size 45652


### PR DESCRIPTION
Rework modal drawing to better use provided Area
When creating a modal with a custom Area that is `Area::is_movable`, i
would expect to be able to drag it around.

However, that is not the case.

Modal, in rough terms, currently does the following:
 * Enter the area using `Area::show()`
 * Draw the backdrop and get its reponse
 * Create a child ui to stop events from going to the backdrop, as that
   might cause clicks inside the frame below to close the modal.
 * Draw the frame, and in it the user content.

The main issue this creates is that drawing the backdrop after entering
the area via `Area::show()` captures the events before they hit the
area, and thus a moveable area cannot be dragged - it does not see any
events to itself in the first place.

Instead, i have modified `Modal::show` to do the following
 * Create the backdrop response using `Context::create_widget`.
 * Then enter the area.
 * Draw the frame, and then the user content.

Note that the child ui is now not required anymore, since as long as the
Area senses click and drag, it eats those events now.

I was then left with two issues:
  * Modal::default_area() cannot ever become a draggable thing (even if
    setting movable to true), as it is anchored, and i cannot reset the
    anchor.
  * If i create a custom Area to be moved around, it is not centered
    anymore, as without an anchor it will just get a auto-position.

The solution for the first problem is that i have
  * Added documentation to `Modal::area` and `Modal::default_area`
  * Added a new function, `Modal::draggable_area`, to give a quick area
    that can be dragged around and behaves as expected.

The second problem is a bit trickier. Will a user want an arbirtrary
position for the modal? If yes, i expect they would set fixed_position,
right? If thats the case, there is no harm in re-centering the modal
every time it is first shown. I query that using the areas id and
`Memory::areas().visible_last_frame()` and it appears to be working
reasonably well.

If its however expected that the user will use `default_pos`,
currently that will "break" (as in, defaukt_pos gets ignored) as i have not find a way to query it in `Modals` code if
`default_pos` was set. Of course that is just an added function to
`Area` away, but i didn't want to expand the scope of this.

But for now i think this solution is a sufficient compromise.

Finally, i have also added code to the egui demo lib to demonstrate a draggable
and resizable modal. 

All this results in the following: 

https://github.com/user-attachments/assets/552c687f-3801-4f8c-9e23-a1dad1d1414a

CI build on my fork went through, i have updated the tests as well and played around with it quite a bit. 

In any case, i hope it helps! 

~mkalte 


<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [x] I have followed the instructions in the PR template
