### PR TITLE
Area positioning

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -9,6 +9,102 @@ use crate::{
     Response, Sense, Ui, UiBuilder, UiKind, UiStackInfo, Vec2, WidgetRect, WidgetWithState,
 };
 
+/// Area positioning.
+///
+/// Handles the rather complex question: Where to put an area.
+#[derive(Copy, Clone, Debug)]
+pub enum AreaPosition {
+    /// The area is at this exact position and cannot be moved. This takes [`Area::pivot`] into account.
+    Fixed(Pos2),
+
+    /// The area is in the screen rect. This will anchor the point specified with [`Area::pivot`].
+    Anchored {
+        /// Where exactly to anchor the area.
+        anchor: Align2,
+
+        /// An offset from the anchor position
+        offset: Vec2,
+    },
+
+    /// The area is movable, i.g. for windows.
+    Moveable {
+        /// When the area is first shown or its position is reset, where will it be put?
+        initial_position: InitialAreaPosition,
+
+        /// When re-showing the area after it was not visible, will the position be reset to `initial_position`?
+        reset_position_on_open: bool,
+
+        /// When not `None`, this will put the area to the position, without generally disabling movability.
+        current_position_override: Option<Pos2>,
+    },
+}
+
+impl AreaPosition {
+    // A fixed position
+    pub fn fixed(pos: impl Into<Pos2>) -> Self {
+        Self::Fixed(pos.into())
+    }
+
+    /// An anchored position
+    pub fn anchored(anchor: impl Into<Align2>, offset: impl Into<Vec2>) -> Self {
+        Self::Anchored {
+            anchor: anchor.into(),
+            offset: offset.into(),
+        }
+    }
+
+    /// A moveable position that starts centered
+    pub fn moveable_centered(reset_position_on_open: bool) -> Self {
+        Self::Moveable {
+            initial_position: InitialAreaPosition::Centered,
+            reset_position_on_open,
+            current_position_override: None,
+        }
+    }
+
+    /// A moveable position that starts centered
+    pub fn moveable_automatic(reset_position_on_open: bool) -> Self {
+        Self::Moveable {
+            initial_position: InitialAreaPosition::Automatic,
+            reset_position_on_open,
+            current_position_override: None,
+        }
+    }
+
+    /// A moveable position with a default
+    pub fn moveable_default(default_pos: impl Into<Pos2>, reset_position_on_open: bool) -> Self {
+        Self::Moveable {
+            initial_position: InitialAreaPosition::Position(default_pos.into()),
+            reset_position_on_open,
+            current_position_override: None,
+        }
+    }
+}
+
+impl Default for AreaPosition {
+    fn default() -> Self {
+        Self::Moveable {
+            initial_position: Default::default(),
+            reset_position_on_open: false,
+            current_position_override: None,
+        }
+    }
+}
+
+/// When opening a moveable the Area for the first time, where will it be placed
+#[derive(Copy, Clone, Default, Debug)]
+pub enum InitialAreaPosition {
+    /// Use the automatic positioning, looking for a good space on screen.
+    #[default]
+    Automatic,
+
+    /// Put the Area in the center of the context
+    Centered,
+
+    /// Put the area at a position. This will take [`Area::pivot`] into consideration.
+    Position(Pos2),
+}
+
 /// State of an [`Area`] that is persisted between frames.
 ///
 /// Areas back [`crate::Window`]s and other floating containers,
@@ -108,17 +204,14 @@ pub struct Area {
     pub(crate) id: Id,
     info: UiStackInfo,
     sense: Option<Sense>,
-    movable: bool,
     interactable: bool,
     enabled: bool,
     constrain: bool,
     constrain_rect: Option<Rect>,
     order: Order,
-    default_pos: Option<Pos2>,
+    position: AreaPosition,
     default_size: Vec2,
     pivot: Align2,
-    anchor: Option<(Align2, Vec2)>,
-    new_pos: Option<Pos2>,
     fade_in: bool,
     layout: Layout,
 }
@@ -134,17 +227,14 @@ impl Area {
             id,
             info: UiStackInfo::new(UiKind::GenericArea),
             sense: None,
-            movable: true,
             interactable: true,
             constrain: true,
             constrain_rect: None,
             enabled: true,
+            position: Default::default(),
             order: Order::Middle,
-            default_pos: None,
             default_size: Vec2::NAN,
-            new_pos: None,
             pivot: Align2::LEFT_TOP,
-            anchor: None,
             fade_in: true,
             layout: Layout::default(),
         }
@@ -191,11 +281,28 @@ impl Area {
         self
     }
 
+    #[inline]
+    pub fn position(mut self, position: AreaPosition) -> Self {
+        self.position = position;
+        self
+    }
+
+    pub fn get_position(&self) -> AreaPosition {
+        self.position
+    }
+
     /// Moveable by dragging the area?
+    ///
+    /// Setting this to false if the area is not moveable does nothing.
+    /// Same as setting it to true if the area positioning is already movable.
+    ///
+    /// In case the area is set to a moveable positioning mode, and you set this to false, the area will default to anchoring in the center.
     #[inline]
     pub fn movable(mut self, movable: bool) -> Self {
-        self.movable = movable;
-        self.interactable |= movable;
+        if !movable && self.is_movable() {
+            self.position = AreaPosition::anchored(Align2::CENTER_CENTER, [0.0, 0.0]);
+        }
+
         self
     }
 
@@ -204,7 +311,7 @@ impl Area {
     }
 
     pub fn is_movable(&self) -> bool {
-        self.movable && self.enabled
+        matches!(self.position, AreaPosition::Moveable { .. }) && self.enabled
     }
 
     /// If false, clicks goes straight through to what is behind us.
@@ -215,7 +322,6 @@ impl Area {
     #[inline]
     pub fn interactable(mut self, interactable: bool) -> Self {
         self.interactable = interactable;
-        self.movable &= interactable;
         self
     }
 
@@ -235,9 +341,22 @@ impl Area {
         self
     }
 
+    /// If the area is already movable, this will set the initial position to be [`InitialAreaPosition::Position(default_pos)`]
+    /// If not, it will make the area movable, and set the default position.
     #[inline]
     pub fn default_pos(mut self, default_pos: impl Into<Pos2>) -> Self {
-        self.default_pos = Some(default_pos.into());
+        self.position = match self.position {
+            AreaPosition::Moveable {
+                reset_position_on_open,
+                current_position_override,
+                initial_position: _initial_position,
+            } => AreaPosition::Moveable {
+                initial_position: InitialAreaPosition::Position(default_pos.into()),
+                reset_position_on_open,
+                current_position_override,
+            },
+            _ => AreaPosition::moveable_default(default_pos, false),
+        };
         self
     }
 
@@ -273,8 +392,7 @@ impl Area {
     /// Positions the window and prevents it from being moved
     #[inline]
     pub fn fixed_pos(mut self, fixed_pos: impl Into<Pos2>) -> Self {
-        self.new_pos = Some(fixed_pos.into());
-        self.movable = false;
+        self.position = AreaPosition::fixed(fixed_pos);
         self
     }
 
@@ -310,10 +428,20 @@ impl Area {
         self
     }
 
-    /// Positions the window but you can still move it.
+    /// Put the area at a position.
+    /// If the position is anchored, this will do nothing.
+    /// If the current position is movable, this will override movement input.
+    /// Finally, if the position is fixed, this is the same as calling [`Area::fixed_pos`]
     #[inline]
     pub fn current_pos(mut self, current_pos: impl Into<Pos2>) -> Self {
-        self.new_pos = Some(current_pos.into());
+        match &mut self.position {
+            AreaPosition::Fixed(pos) => *pos = current_pos.into(),
+            AreaPosition::Anchored { .. } => {}
+            AreaPosition::Moveable {
+                current_position_override,
+                ..
+            } => *current_position_override = Some(current_pos.into()),
+        }
         self
     }
 
@@ -330,15 +458,14 @@ impl Area {
     /// It is an error to set both an anchor and a position.
     #[inline]
     pub fn anchor(mut self, align: Align2, offset: impl Into<Vec2>) -> Self {
-        self.anchor = Some((align, offset.into()));
-        self.movable(false)
+        self.position = AreaPosition::anchored(align, offset);
+        self
     }
 
     pub(crate) fn get_pivot(&self) -> Align2 {
-        if let Some((pivot, _)) = self.anchor {
-            pivot
-        } else {
-            Align2::LEFT_TOP
+        match self.position {
+            AreaPosition::Anchored { anchor, .. } => anchor,
+            _ => self.pivot,
         }
     }
 
@@ -393,19 +520,18 @@ impl Area {
     }
 
     pub(crate) fn begin(self, ctx: &Context) -> Prepared {
+        let movable = self.is_movable();
+
         let Self {
             id,
             info,
             sense,
-            movable,
             order,
             interactable,
             enabled,
-            default_pos,
+            position,
             default_size,
-            new_pos,
             pivot,
-            anchor,
             constrain,
             constrain_rect,
             fade_in,
@@ -427,12 +553,7 @@ impl Area {
         });
         state.pivot = pivot;
         state.interactable = interactable;
-        if let Some(new_pos) = new_pos {
-            state.pivot_pos = Some(new_pos);
-        }
-        state.pivot_pos.get_or_insert_with(|| {
-            default_pos.unwrap_or_else(|| automatic_area_position(ctx, layer_id))
-        });
+
         state.interactable = interactable;
 
         let size = *state.size.get_or_insert_with(|| {
@@ -463,14 +584,40 @@ impl Area {
             state.last_became_visible_at = Some(ctx.input(|i| i.time));
         }
 
-        if let Some((anchor, offset)) = anchor {
-            state.set_left_top_pos(
-                anchor
-                    .align_size_within_rect(size, constrain_rect)
-                    .left_top()
-                    + offset,
-            );
-        }
+        match position {
+            AreaPosition::Fixed(pos) => state.pivot_pos = Some(pos),
+            AreaPosition::Anchored { anchor, offset } => {
+                state.set_left_top_pos(
+                    anchor
+                        .align_size_within_rect(size, constrain_rect)
+                        .left_top()
+                        + offset,
+                );
+            }
+            AreaPosition::Moveable {
+                initial_position,
+                reset_position_on_open,
+                current_position_override,
+            } => {
+                if let Some(override_pos) = current_position_override {
+                    state.pivot_pos = Some(override_pos);
+                } else {
+                    // If we are shown for the first time ever, or we reset the position on re-open, set a new position.
+                    if reset_position_on_open && !visible_last_frame {
+                        state.pivot_pos = None;
+                    }
+                    state
+                        .pivot_pos
+                        .get_or_insert_with(|| match initial_position {
+                            InitialAreaPosition::Automatic => {
+                                automatic_area_position(ctx, layer_id)
+                            }
+                            InitialAreaPosition::Centered => ctx.screen_rect().center(),
+                            InitialAreaPosition::Position(default_pos) => default_pos,
+                        });
+                }
+            }
+        };
 
         // interact right away to prevent frame-delay
         let mut move_response = {

--- a/crates/egui/src/containers/mod.rs
+++ b/crates/egui/src/containers/mod.rs
@@ -20,7 +20,7 @@ mod tooltip;
 pub(crate) mod window;
 
 pub use {
-    area::{Area, AreaState},
+    area::{Area, AreaPosition, AreaState, InitialAreaPosition},
     collapsing_header::{CollapsingHeader, CollapsingResponse},
     combo_box::*,
     frame::Frame,

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -205,6 +205,13 @@ impl<'open> Window<'open> {
         self
     }
 
+    /// Set the [`AreaPosition`] of this window
+    #[inline]
+    pub fn position(mut self, position: AreaPosition) -> Self {
+        self.area = self.area.position(position);
+        self
+    }
+
     /// Set current position of the window.
     /// If the window is movable it is up to you to keep track of where it moved to!
     #[inline]

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -536,6 +536,7 @@ impl ContextImpl {
                 size: Some(screen_rect.size()),
                 interactable: true,
                 last_became_visible_at: None,
+                last_was_sizing_pass: false,
             },
         );
 

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -102,6 +102,7 @@ impl Default for DemoGroups {
                 Box::<super::tests::ManualLayoutTest>::default(),
                 Box::<super::tests::TessellationTest>::default(),
                 Box::<super::tests::WindowResizeTest>::default(),
+                Box::<super::tests::WindowPositionTest>::default(),
             ]),
         }
     }

--- a/crates/egui_demo_lib/src/demo/tests/mod.rs
+++ b/crates/egui_demo_lib/src/demo/tests/mod.rs
@@ -7,6 +7,7 @@ mod input_test;
 mod layout_test;
 mod manual_layout_test;
 mod tessellation_test;
+mod window_position_test;
 mod window_resize_test;
 
 pub use clipboard_test::ClipboardTest;
@@ -18,4 +19,5 @@ pub use input_test::InputTest;
 pub use layout_test::LayoutTest;
 pub use manual_layout_test::ManualLayoutTest;
 pub use tessellation_test::TessellationTest;
+pub use window_position_test::WindowPositionTest;
 pub use window_resize_test::WindowResizeTest;

--- a/crates/egui_demo_lib/src/demo/tests/window_position_test.rs
+++ b/crates/egui_demo_lib/src/demo/tests/window_position_test.rs
@@ -1,0 +1,67 @@
+use egui::{Align2, AreaPosition, Vec2, Vec2b};
+
+#[derive(Default)]
+pub struct WindowPositionTest {
+    open_with_offset: bool,
+    standard_window: bool,
+    opens_in_center: bool,
+}
+
+impl crate::Demo for WindowPositionTest {
+    fn name(&self) -> &'static str {
+        "Window Position Test"
+    }
+
+    fn show(&mut self, ctx: &egui::Context, open: &mut bool) {
+        use egui::Window;
+
+        let main_window = Window::new("Window/Area position demo and test")
+            .resizable(false)
+            .open(open)
+            .auto_sized()
+            .anchor(Align2::LEFT_TOP, [0.0, 0.0])
+            .show(ctx, |ui| {
+                ui.label("Areas have a big varity of ways to be positioned.");
+                ui.label("And since Windows are based on Areas, this applies to them as well.");
+                ui.label("Here are a bunch of examples on what can be done.");
+                ui.checkbox(&mut self.standard_window, "A standard window");
+                ui.checkbox(
+                    &mut self.opens_in_center,
+                    "A window that always opens in the center of the screen",
+                );
+                ui.checkbox(&mut self.open_with_offset, "Anchored, with offset");
+            });
+
+        self.standard_window &= *open;
+        Window::new("Standard window")
+            .open(&mut self.standard_window)
+            .show(ctx, |ui| {
+                ui.label("This is just a standard window");
+            });
+
+        self.opens_in_center &= *open;
+        Window::new("Opens centered")
+            .open(&mut self.opens_in_center)
+            .position(AreaPosition::moveable_centered(true))
+            .show(ctx, |ui| {
+                ui.label("This is almost a standard window");
+                ui.label("It differs in that it will always open in the center, centered");
+            });
+
+        let offset = Vec2::Y
+            * main_window
+                .map(|resp| resp.response.rect.height())
+                .unwrap_or_default()
+            + ctx.style().spacing.item_spacing;
+        self.open_with_offset &= *open;
+        Window::new("Anchored Top Left, but with an offset")
+            .open(&mut self.open_with_offset)
+            .min_size([125.0, 125.0])
+            .resizable(Vec2b::TRUE)
+            .anchor(Align2::LEFT_TOP, offset)
+            .show(ctx, |ui| {
+                ui.label("This window is still anchored top left.");
+                ui.label("It is also offset, and you can resize it.");
+            });
+    }
+}


### PR DESCRIPTION
When i did the quick implementation for movable modals for https://github.com/emilk/egui/pull/6749 @lucasmerlin [pointed out that](https://github.com/emilk/egui/pull/6749#discussion_r2044142830) that just forcibly recentering a modal if it is movable is a bit odd. 

It would be nicer if this was an inherent property of Areas. 

This is a surprisingly small change set, considering the wide impact it has, so i went with a pr directly, instead of an issue. 

Investigating this, i figured  that some area is quite Stateful in its positioning. 

Instead of keeping default_pos, new_pos, anchor as seperate entities, i have implemented its internal position using a new enum, `AreaPosition`, that now encodes the different types of position an area can have. 
  * Is it at a fixed position?
  * Is it anchored somewhere? 
  * Is it moveable? 
    - If it is indeed movable, what is its initial position? 

I have also quickly thrown together a demo, that i will expand on with test cases. 

The way it is done now is that all the old builder methods still exist and behave the same, though the colliding states (setting area movable while an anchor is set, for example) now overwrite each other. In practice this should not change anything, i think? 

Things that are still to-do before this can be merged in the first place:  
-  [ ] Anchored windows are currently not resizable, though they should be
-  [ ] Investigate how pivot affected anchors before, and mirror this behavior correctly 
-  [ ] Investigate how pivot affected auto position before, and mirror that behavior correctly. 
-  [ ] Clean up the demo, and the comments of the builder methods 
-  [ ] `Area::get_pivot` previously only reported TOP_LEFT; or if set, the anchor. Was that correct? - im now reporting the pivot instead. Needs trying out. 

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->
