### PR TITLE
Split wayland x11 features into renderer specific variants

### DIFF
--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -124,6 +124,11 @@ x11-glow = [
   "glutin-winit?/glx",
 ]
 
+## For backwards compatibility
+wayland = ["wayland-glow"]
+x11 = ["x11-glow"]
+
+
 ## If set, eframe will look for the env-var `EFRAME_SCREENSHOT_TO` and write a screenshot to that location, and then quit.
 ## This is used to generate images for examples.
 __screenshot = []

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -35,10 +35,10 @@ default = [
   "accesskit",
   "default_fonts",
   "glow",
-  "wayland",                                      # Required for Linux support (including CI!)
+  "wayland-glow",                                 # Required for Linux support (including CI!)
   "web_screen_reader",
   "winit/default",
-  "x11",
+  "x11-glow",
   "egui-wgpu?/fragile-send-sync-non-atomic-wasm",
 ]
 
@@ -71,12 +71,15 @@ persistence = [
   "serde",
 ]
 
-## Enables wayland support and fixes clipboard issue.
-##
-## If you are compiling for Linux (or want to test on a CI system using Linux), you should enable this feature.
-wayland = [
-  "egui-winit/wayland",
-  "egui-wgpu?/wayland",
+## Enables basic wayland windowing support (renderer-agnostic)
+wayland-base = ["egui-winit/wayland"]
+
+## Enables wayland support with wgpu renderer
+wayland-wgpu = ["wayland-base", "egui-wgpu?/wayland"]
+
+## Enables wayland support with glow renderer
+wayland-glow = [
+  "wayland-base",
   "egui_glow?/wayland",
   "glutin?/wayland",
   "glutin-winit?/wayland",
@@ -105,10 +108,15 @@ web_screen_reader = [
 ## you can configure this at run-time with [`NativeOptions::wgpu_options`].
 wgpu = ["dep:wgpu", "dep:egui-wgpu", "dep:pollster"]
 
-## Enables compiling for x11.
-x11 = [
-  "egui-winit/x11",
-  "egui-wgpu?/x11",
+## Enables basic X11 windowing support (renderer-agnostic)
+x11-base = ["egui-winit/x11"]
+
+## Enables X11 support with wgpu renderer
+x11-wgpu = ["x11-base", "egui-wgpu?/x11"]
+
+## Enables X11 support with glow renderer
+x11-glow = [
+  "x11-base",
   "egui_glow?/x11",
   "glutin?/x11",
   "glutin?/glx",


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes <https://github.com/emilk/egui/issues/6770>
* [X] I have followed the instructions in the PR template

This PR splits the `wayland` and `x11` features into `wayland-wgpu`, `wayland-glow`, `x11-wgpu` and `x11-glow` so that when using one renderer you, won't have to compile crates relevant to the other renderer.

I kept the `wayland` and `x11` features for backwards compatibility, that are just aliases to `wayland-glow` and `x11-glow`, but I understand if it would be better to remove these features to remove complexity.


I have ran the `check.sh` file and got the following error, and I don't really know why, but I don't think it's related to this PR:
```
error: test failed, to rerun pass `-p egui_demo_lib --lib`

Caused by:
  process didn't exit successfully: `/home/lucas/Desktop/egui/target/debug/deps/egui_demo_lib-156f2e69448b8740` (signal: 11, SIGSEGV: invalid memory reference)
```
I tested every other test besides `egui_demo_lib` and it passed all of them.
