### PR TITLE
Raise MSRV to 1.84

### DIFF
--- a/.github/workflows/deploy_web_demo.yml
+++ b/.github/workflows/deploy_web_demo.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           profile: minimal
           target: wasm32-unknown-unknown
-          toolchain: 1.81.0
+          toolchain: 1.84.0
           override: true
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/preview_build.yml
+++ b/.github/workflows/preview_build.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.81.0
+          toolchain: 1.84.0
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,7 +5,7 @@ name: Rust
 env:
   RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
-  NIGHTLY_VERSION: nightly-2024-09-11
+  NIGHTLY_VERSION: nightly-2025-04-22
 
 jobs:
   fmt-crank-check-test:
@@ -18,7 +18,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.81.0
+          toolchain: 1.84.0
 
       - name: Install packages (Linux)
         if: runner.os == 'Linux'
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.81.0
+          toolchain: 1.84.0
           targets: wasm32-unknown-unknown
 
       - run: sudo apt-get update && sudo apt-get install libgtk-3-dev libatk1.0-dev
@@ -155,7 +155,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          rust-version: "1.81.0"
+          rust-version: "1.84.0"
           log-level: error
           command: check
           arguments: --target  ${{ matrix.target }}
@@ -170,7 +170,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.81.0
+          toolchain: 1.84.0
           targets: aarch64-linux-android
 
       - name: Set up cargo cache
@@ -189,7 +189,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.81.0
+          toolchain: 1.84.0
           targets: aarch64-apple-ios
 
       - name: Set up cargo cache
@@ -208,7 +208,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.81.0
+          toolchain: 1.84.0
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
@@ -232,7 +232,7 @@ jobs:
           lfs: true
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.81.0
+          toolchain: 1.84.0
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 [workspace.package]
 edition = "2021"
 license = "MIT OR Apache-2.0"
-rust-version = "1.81"
+rust-version = "1.84"
 version = "0.31.1"
 
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,7 +3,7 @@
 # -----------------------------------------------------------------------------
 # Section identical to scripts/clippy_wasm/clippy.toml:
 
-msrv = "1.81"
+msrv = "1.84"
 
 allow-unwrap-in-tests = true
 

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -3,7 +3,7 @@
 //! Try the live web demo: <https://www.egui.rs/#demo>. Read more about egui at <https://github.com/emilk/egui>.
 //!
 //! `egui` is in heavy development, with each new version having breaking changes.
-//! You need to have rust 1.81.0 or later to use `egui`.
+//! You need to have rust 1.84.0 or later to use `egui`.
 //!
 //! To quickly get started with egui, you can take a look at [`eframe_template`](https://github.com/emilk/eframe_template)
 //! which uses [`eframe`](https://docs.rs/eframe).

--- a/examples/confirm_exit/Cargo.toml
+++ b/examples/confirm_exit/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/examples/custom_3d_glow/Cargo.toml
+++ b/examples/custom_3d_glow/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/examples/custom_font/Cargo.toml
+++ b/examples/custom_font/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/examples/custom_font_style/Cargo.toml
+++ b/examples/custom_font_style/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["tami5 <kkharji@proton.me>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/examples/custom_keypad/Cargo.toml
+++ b/examples/custom_keypad/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Varphone Wong <varphone@qq.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/examples/custom_style/Cargo.toml
+++ b/examples/custom_style/Cargo.toml
@@ -3,7 +3,7 @@ name = "custom_style"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/examples/custom_window_frame/Cargo.toml
+++ b/examples/custom_window_frame/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/examples/file_dialog/Cargo.toml
+++ b/examples/file_dialog/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/examples/hello_android/Cargo.toml
+++ b/examples/hello_android/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 # `unsafe_code` is required for `#[no_mangle]`, disable workspace lints to workaround lint error.

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/examples/hello_world_par/Cargo.toml
+++ b/examples/hello_world_par/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Maxim Osipenko <maxim1999max@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/examples/hello_world_simple/Cargo.toml
+++ b/examples/hello_world_simple/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/examples/images/Cargo.toml
+++ b/examples/images/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Jan Procházka <github.com/jprochazk>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/examples/keyboard_events/Cargo.toml
+++ b/examples/keyboard_events/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Jose Palazon <jose@palako.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/examples/multiple_viewports/Cargo.toml
+++ b/examples/multiple_viewports/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/examples/puffin_profiler/Cargo.toml
+++ b/examples/puffin_profiler/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [package.metadata.cargo-machete]

--- a/examples/screenshot/Cargo.toml
+++ b/examples/screenshot/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/examples/serial_windows/Cargo.toml
+++ b/examples/serial_windows/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/examples/user_attention/Cargo.toml
+++ b/examples/user_attention/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["TicClick <ya@ticclick.ch>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,6 +5,6 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "1.81.0"
+channel = "1.84.0"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -9,7 +9,7 @@ set -x
 # Checks all tests, lints etc.
 # Basically does what the CI does.
 
-# cargo +1.81.0 install --quiet typos-cli
+# cargo +1.84.0 install --quiet typos-cli
 
 export RUSTFLAGS="-D warnings"
 export RUSTDOCFLAGS="-D warnings" # https://github.com/emilk/egui/pull/1454

--- a/scripts/clippy_wasm/clippy.toml
+++ b/scripts/clippy_wasm/clippy.toml
@@ -6,7 +6,7 @@
 # -----------------------------------------------------------------------------
 # Section identical to the root clippy.toml:
 
-msrv = "1.81"
+msrv = "1.84"
 
 allow-unwrap-in-tests = true
 

--- a/tests/test_egui_extras_compilation/Cargo.toml
+++ b/tests/test_egui_extras_compilation/Cargo.toml
@@ -3,7 +3,7 @@ name = "test_egui_extras_compilation"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/tests/test_inline_glow_paint/Cargo.toml
+++ b/tests/test_inline_glow_paint/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/tests/test_size_pass/Cargo.toml
+++ b/tests/test_size_pass/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/tests/test_ui_stack/Cargo.toml
+++ b/tests/test_ui_stack/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Antoine Beyeler <abeyeler@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]

--- a/tests/test_viewports/Cargo.toml
+++ b/tests/test_viewports/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["konkitoman"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lints]


### PR DESCRIPTION
Prerequisite of https://github.com/emilk/egui/pull/6744.
See: https://github.com/gfx-rs/wgpu/pull/7218, https://github.com/gfx-rs/wgpu/pull/7425

Please be aware that Rust 1.84 enables some (more) WASM extensions by default, and ships with an `std` built with them enabled: https://blog.rust-lang.org/2024/09/24/webassembly-targets-change-in-default-target-features/
According to `rustc +1.84 --print=cfg --target wasm32-unknown-unknown`, these are: `multivalue`, `mutable-globals`, `reference-types`, and `sign-ext`.
(c.f. `rustc +1.84 --print=cfg --target wasm32-unknown-unknown -C target-cpu=mvp` enabling none.)
For reference: https://webassembly.org/features/

----

If support is desired for ancient/esoteric browsers that don't have these implemented, there are two ways to get around this:
 - Target `wasm32v1-none` instead, but that's a `no-std` target, and I suppose a lot of dependencies don't work that way (e.g. https://github.com/gfx-rs/wgpu/issues/6826)
 - Using the `-Ctarget-cpu=mvp`  and `-Zbuild-std=panic_abort,std` flags, and the `RUSTC_BOOTSTRAP=1` escape hatch to allow using the latter with non-`nightly` toolchains - until https://github.com/rust-lang/wg-cargo-std-aware is stabilized. (For reference: https://github.com/ruffle-rs/ruffle/pull/18528/files#diff-fb2896d189d77b35ace9a079c1ba9b55777d16e0f11ce79f776475a451b1825a)

I don't think either of these is particularly advantageous, so I suggest just accepting that browsers will have to have some extensions implemented to run `egui`.