### PR TITLE
CI: Install wasm-opt 123 from the GitHub release of Binaryen

### DIFF
--- a/.github/workflows/deploy_web_demo.yml
+++ b/.github/workflows/deploy_web_demo.yml
@@ -46,9 +46,12 @@ jobs:
         with:
           prefix-key: "web-demo-"
 
-      - name: "Install wasmopt / binaryen"
-        run: |
-          sudo apt-get update && sudo apt-get install binaryen
+      - name: Install wasm-opt
+        uses: sigoden/install-binary@v1
+        with:
+          repo: WebAssembly/binaryen
+          tag: version_123
+          name: wasm-opt
 
       - run: |
           scripts/build_demo_web.sh --release

--- a/.github/workflows/preview_build.yml
+++ b/.github/workflows/preview_build.yml
@@ -25,9 +25,12 @@ jobs:
         with:
           prefix-key: "pr-preview-"
 
-      - name: "Install wasmopt / binaryen"
-        run: |
-          sudo apt-get update && sudo apt-get install binaryen
+      - name: Install wasm-opt
+        uses: sigoden/install-binary@v1
+        with:
+          repo: WebAssembly/binaryen
+          tag: version_123
+          name: wasm-opt
 
       - run: |
           scripts/build_demo_web.sh --release


### PR DESCRIPTION
Prerequisite of https://github.com/emilk/egui/pull/6848.