### PR TITLE
Add button benchmark

### DIFF
--- a/crates/egui_demo_lib/README.md
+++ b/crates/egui_demo_lib/README.md
@@ -26,4 +26,7 @@ cargo bench -p egui_demo_lib "benchmark name"
 
 # Profile benchmarks with cargo-flamegraph (--root flag is necessary for MacOS)
 CARGO_PROFILE_BENCH_DEBUG=true cargo flamegraph --bench benchmark --root -p egui_demo_lib  -- --bench "benchmark name"
+
+# Profile with cargo-instruments
+CARGO_PROFILE_BENCH_DEBUG=true cargo instruments --profile bench --bench benchmark -p egui_demo_lib -t time -- --bench "benchmark name" 
 ```

--- a/crates/egui_demo_lib/README.md
+++ b/crates/egui_demo_lib/README.md
@@ -14,3 +14,16 @@ The demo library is a separate crate for three reasons:
 * To remove the amount of code in `egui` proper.
 * To make it easy for 3rd party egui integrations to use it for tests.
   - See for instance https://github.com/not-fl3/egui-miniquad/blob/master/examples/demo.rs
+
+This crate also contains benchmarks for egui. 
+Run them with 
+```bash
+# Run all benchmarks
+cargo bench -p egui_demo_lib 
+
+# Run a single benchmark
+cargo bench -p egui_demo_lib "benchmark name"
+
+# Profile benchmarks with cargo-flamegraph (--root flag is necessary for MacOS)
+CARGO_PROFILE_BENCH_DEBUG=true cargo flamegraph --bench benchmark --root -p egui_demo_lib  -- --bench "benchmark name"
+```

--- a/crates/egui_demo_lib/benches/benchmark.rs
+++ b/crates/egui_demo_lib/benches/benchmark.rs
@@ -111,7 +111,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 group.bench_function("button image right text", |b| {
                     b.iter_batched_ref(
                         || ui.new_child(UiBuilder::new()),
-                        |ui| ui.add(Button::image_and_text(image, "Hello World")),
+                        |ui| {
+                            ui.add(Button::image_and_text(image, "Hello World").right_text("⏵"));
+                        },
                         BatchSize::LargeInput,
                     )
                 });

--- a/crates/egui_demo_lib/benches/benchmark.rs
+++ b/crates/egui_demo_lib/benches/benchmark.rs
@@ -3,7 +3,8 @@ use std::fmt::Write as _;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 
 use egui::epaint::TextShape;
-use egui::{Button, UiBuilder};
+use egui::load::SizedTexture;
+use egui::{Button, TextureId, UiBuilder, Vec2};
 use egui_demo_lib::LOREM_IPSUM_LONG;
 use rand::Rng as _;
 
@@ -84,6 +85,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let _ = ctx.run(RawInput::default(), |ctx| {
             egui::CentralPanel::default().show(ctx, |ui| {
                 let mut group = c.benchmark_group("button");
+
+                // To ensure we have a valid image, let's use the font texture. The size
+                // shouldn't be important for this benchmark.
+                let image = SizedTexture::new(TextureId::default(), Vec2::splat(16.0));
+
                 group.bench_function("button", |b| {
                     b.iter_batched_ref(
                         || ui.new_child(UiBuilder::new()),
@@ -97,7 +103,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                     b.iter_batched_ref(
                         || ui.new_child(UiBuilder::new()),
                         |ui| {
-                            ui.add(Button::image_and_text("some-image.png", "Hello World"));
+                            ui.add(Button::image_and_text(image, "Hello World"));
                         },
                         BatchSize::LargeInput,
                     )
@@ -105,7 +111,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 group.bench_function("button image right text", |b| {
                     b.iter_batched_ref(
                         || ui.new_child(UiBuilder::new()),
-                        |ui| ui.add(Button::image_and_text("some-image.png", "Hello World")),
+                        |ui| ui.add(Button::image_and_text(image, "Hello World")),
                         BatchSize::LargeInput,
                     )
                 });


### PR DESCRIPTION
This helped me benchmark the atomic layout (#5830) changes.

I also realized that the label benchmark wasn't testing the painting, since the buttons at some point will be placed outside the screen_rect, meaning it won't be painted.

This fixes it by benching the label in a child ui.

The `label &str` benchmark went from 483 ns to 535 ns with these changes.

EDIT:

I fixed another benchmark problem, since the benchmark would show the same widget millions of times for a single frame, the WidgetRects hashmap would get huge, causing each iteration to slow down a bit more and causing the benchmark to have unreliable results.

With this the `label &str` benchmark went from 535ns to 298ns. Also the `label format!` benchmark now takes almost the same time (302 ns). Before, it was a lot slower since it reused the same Context which already had millions of widget ids.

