### PR TITLE
Move magic margin numbers in Frame into Style, and make Separator's spacing inherit from item_spacing 

### DIFF
--- a/crates/egui/src/containers/frame.rs
+++ b/crates/egui/src/containers/frame.rs
@@ -193,7 +193,9 @@ impl Frame {
     }
 
     pub fn central_panel(style: &Style) -> Self {
-        Self::new().inner_margin(style.spacing.central_panel_margin).fill(style.visuals.panel_fill)
+        Self::new()
+            .inner_margin(style.spacing.central_panel_margin)
+            .fill(style.visuals.panel_fill)
     }
 
     pub fn window(style: &Style) -> Self {

--- a/crates/egui/src/containers/frame.rs
+++ b/crates/egui/src/containers/frame.rs
@@ -181,19 +181,19 @@ impl Frame {
     /// For when you want to group a few widgets together within a frame.
     pub fn group(style: &Style) -> Self {
         Self::new()
-            .inner_margin(6)
+            .inner_margin(style.spacing.group_margin)
             .corner_radius(style.visuals.widgets.noninteractive.corner_radius)
             .stroke(style.visuals.widgets.noninteractive.bg_stroke)
     }
 
     pub fn side_top_panel(style: &Style) -> Self {
         Self::new()
-            .inner_margin(Margin::symmetric(8, 2))
+            .inner_margin(style.spacing.side_top_panel_margin)
             .fill(style.visuals.panel_fill)
     }
 
     pub fn central_panel(style: &Style) -> Self {
-        Self::new().inner_margin(8).fill(style.visuals.panel_fill)
+        Self::new().inner_margin(style.spacing.central_panel_margin).fill(style.visuals.panel_fill)
     }
 
     pub fn window(style: &Style) -> Self {
@@ -229,7 +229,7 @@ impl Frame {
     /// and in dark mode this will be very dark.
     pub fn canvas(style: &Style) -> Self {
         Self::new()
-            .inner_margin(2)
+            .inner_margin(style.spacing.canvas_margin)
             .corner_radius(style.visuals.widgets.noninteractive.corner_radius)
             .fill(style.visuals.extreme_bg_color)
             .stroke(style.visuals.window_stroke())

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -399,13 +399,13 @@ pub struct Spacing {
     /// Horizontal and vertical margins within a menu frame.
     pub menu_margin: Margin,
 
-    /// Horizontal and vertical margins within a SidePanel or TopBottomPanel
+    /// Horizontal and vertical margins within a `SidePanel` or `TopBottomPanel`
     pub side_top_panel_margin: Margin,
 
-    /// Horizontal and vertical margins within a CentralPanel
+    /// Horizontal and vertical margins within a `CentralPanel`
     pub central_panel_margin: Margin,
 
-    /// Horizontal and vertical margins within a canvas frame
+    /// Horizontal and vertical margins within a canvas `Frame`
     pub canvas_margin: Margin,
 
     /// Indent collapsing regions etc by this much.

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -390,11 +390,23 @@ pub struct Spacing {
     /// Horizontal and vertical margins within a window frame.
     pub window_margin: Margin,
 
+    /// Horizontal and vertical margins within a group frame.
+    pub group_margin: Margin,
+
     /// Button size is text size plus this on each side
     pub button_padding: Vec2,
 
     /// Horizontal and vertical margins within a menu frame.
     pub menu_margin: Margin,
+
+    /// Horizontal and vertical margins within a SidePanel or TopBottomPanel
+    pub side_top_panel_margin: Margin,
+
+    /// Horizontal and vertical margins within a CentralPanel
+    pub central_panel_margin: Margin,
+
+    /// Horizontal and vertical margins within a canvas frame
+    pub canvas_margin: Margin,
 
     /// Indent collapsing regions etc by this much.
     pub indent: f32,
@@ -1291,7 +1303,11 @@ impl Default for Spacing {
         Self {
             item_spacing: vec2(8.0, 3.0),
             window_margin: Margin::same(6),
+            group_margin: Margin::same(6),
             menu_margin: Margin::same(6),
+            side_top_panel_margin: Margin::symmetric(8, 2),
+            central_panel_margin: Margin::same(8),
+            canvas_margin: Margin::same(2),
             button_padding: vec2(4.0, 1.0),
             indent: 18.0, // match checkbox/radio-button with `button_padding.x + icon_width + icon_spacing`
             interact_size: vec2(40.0, 18.0),
@@ -1726,8 +1742,12 @@ impl Spacing {
         let Self {
             item_spacing,
             window_margin,
+            group_margin,
             menu_margin,
             button_padding,
+            canvas_margin,
+            central_panel_margin,
+            side_top_panel_margin,
             indent,
             interact_size,
             slider_width,
@@ -1759,8 +1779,24 @@ impl Spacing {
                 ui.add(window_margin);
                 ui.end_row();
 
+                ui.label("Group margin");
+                ui.add(group_margin);
+                ui.end_row();
+
                 ui.label("Menu margin");
                 ui.add(menu_margin);
+                ui.end_row();
+
+                ui.label("Canvas frame margin");
+                ui.add(canvas_margin);
+                ui.end_row();
+
+                ui.label("SidePanel and TopBottomPanel margin");
+                ui.add(side_top_panel_margin);
+                ui.end_row();
+
+                ui.label("CentralPanel margin");
+                ui.add(central_panel_margin);
                 ui.end_row();
 
                 ui.label("Button padding");

--- a/crates/egui/src/widgets/separator.rs
+++ b/crates/egui/src/widgets/separator.rs
@@ -13,7 +13,8 @@ use crate::{vec2, Response, Sense, Ui, Vec2, Widget};
 /// ```
 #[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct Separator {
-    spacing: f32,
+    /// None if inheriting from Spacing::item_spacing()
+    spacing: Option<f32>,
     grow: f32,
     is_horizontal_line: Option<bool>,
 }
@@ -21,7 +22,7 @@ pub struct Separator {
 impl Default for Separator {
     fn default() -> Self {
         Self {
-            spacing: 6.0,
+            spacing: None,
             grow: 0.0,
             is_horizontal_line: None,
         }
@@ -38,7 +39,7 @@ impl Separator {
     /// this is the width of the separator widget.
     #[inline]
     pub fn spacing(mut self, spacing: f32) -> Self {
-        self.spacing = spacing;
+        self.spacing = Some(spacing);
         self
     }
 
@@ -102,10 +103,12 @@ impl Widget for Separator {
             ui.available_size_before_wrap()
         };
 
+        let item_spacing = ui.style().spacing.item_spacing;
+
         let size = if is_horizontal_line {
-            vec2(available_space.x, spacing)
+            vec2(available_space.x, spacing.unwrap_or(item_spacing.y))
         } else {
-            vec2(spacing, available_space.y)
+            vec2(spacing.unwrap_or(item_spacing.x), available_space.y)
         };
 
         let (rect, response) = ui.allocate_at_least(size, Sense::hover());

--- a/crates/egui/src/widgets/separator.rs
+++ b/crates/egui/src/widgets/separator.rs
@@ -13,7 +13,7 @@ use crate::{vec2, Response, Sense, Ui, Vec2, Widget};
 /// ```
 #[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct Separator {
-    /// None if inheriting from Spacing::item_spacing()
+    /// None if inheriting from `Spacing::item_spacing()` (the default)
     spacing: Option<f32>,
     grow: f32,
     is_horizontal_line: Option<bool>,


### PR DESCRIPTION
This is a simple PR, which addresses some comments in the Discord asking why there were hardcoded values for the margins in Frame. This PR also addresses a comment which pointed out that Separator could use the Style's item_spacing by default. Note that the default item_spacing value does not exactly match the previous default spacing value, so this change does modify the default appearance of the GUI slightly.

I'm marking this as a draft, because there may be other magic numbers to find.