### PR TITLE
Add italic button benchmark to test `RichText` performance impact

### DIFF
--- a/crates/egui_demo_lib/benches/benchmark.rs
+++ b/crates/egui_demo_lib/benches/benchmark.rs
@@ -4,7 +4,7 @@ use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 
 use egui::epaint::TextShape;
 use egui::load::SizedTexture;
-use egui::{Button, Id, TextureId, Ui, UiBuilder, Vec2};
+use egui::{Button, Id, RichText, TextureId, Ui, UiBuilder, Vec2};
 use egui_demo_lib::LOREM_IPSUM_LONG;
 use rand::Rng as _;
 
@@ -117,6 +117,15 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                     || create_benchmark_ui(ctx),
                     |ui| {
                         ui.add(Button::image_and_text(image, "Hello World").right_text("⏵"));
+                    },
+                    BatchSize::LargeInput,
+                );
+            });
+            group.bench_function("4_button_italic", |b| {
+                b.iter_batched_ref(
+                    || create_benchmark_ui(ctx),
+                    |ui| {
+                        ui.add(Button::new(RichText::new("Hello World").italics()));
                     },
                     BatchSize::LargeInput,
                 );


### PR DESCRIPTION
Time on my m4 pro macbook:  302.79 ns (vs 303.83 ns for the regular button 🤷)