### PR TITLE
Fix image button panicking with tiny `available_space`

### DIFF
--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -249,7 +249,7 @@ impl Widget for Button<'_> {
             )
         } else {
             (
-                ui.available_size() - 2.0 * button_padding,
+                (ui.available_size() - 2.0 * button_padding).at_least(Vec2::ZERO),
                 default_font_height(),
             )
         };


### PR DESCRIPTION



* Fixes <https://github.com/emilk/egui/issues/6772>
* [x] I have followed the instructions in the PR template
