### PR TITLE
Load images on the ui thread for tests

### DIFF
--- a/crates/egui_extras/src/loaders/image_loader.rs
+++ b/crates/egui_extras/src/loaders/image_loader.rs
@@ -8,9 +8,6 @@ use egui::{
 use image::ImageFormat;
 use std::{mem::size_of, path::Path, sync::Arc, task::Poll};
 
-#[cfg(not(target_arch = "wasm32"))]
-use std::thread;
-
 type Entry = Poll<Result<Arc<ColorImage>, String>>;
 
 #[derive(Default)]
@@ -88,7 +85,7 @@ impl ImageLoader for ImageCrateLoader {
             cache.lock().insert(uri.clone(), Poll::Pending);
 
             // Do the image parsing on a bg thread
-            thread::Builder::new()
+            std::thread::Builder::new()
                 .name(format!("egui_extras::ImageLoader::load({uri:?})"))
                 .spawn({
                     let ctx = ctx.clone();

--- a/crates/egui_extras/src/loaders/image_loader.rs
+++ b/crates/egui_extras/src/loaders/image_loader.rs
@@ -76,7 +76,7 @@ impl ImageLoader for ImageCrateLoader {
             return Err(LoadError::NotSupported);
         }
 
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(any(target_arch = "wasm32", test)))]
         #[expect(clippy::unnecessary_wraps)] // needed here to match other return types
         fn load_image(
             ctx: &egui::Context,
@@ -116,7 +116,8 @@ impl ImageLoader for ImageCrateLoader {
             Ok(ImagePoll::Pending { size: None })
         }
 
-        #[cfg(target_arch = "wasm32")]
+        // Load images on the current thread for tests, so they are less flaky
+        #[cfg(any(target_arch = "wasm32", test))]
         fn load_image(
             _ctx: &egui::Context,
             uri: &str,


### PR DESCRIPTION
https://github.com/emilk/egui/pull/5394 made it so images would load on a background thread, which is great. But this makes snapshot tests that have images via include_image!() flakey since they might or might not load by the time the snapshot is rendered. 
This is no perfect solution, since the underlying problem of "waiting for something async to happen" still exists and we should add some more general solution for that. 