### PR TITLE
Fix links and text selection in horizontal_wrapped layout

### DIFF
--- a/crates/egui/src/text_selection/accesskit_text.rs
+++ b/crates/egui/src/text_selection/accesskit_text.rs
@@ -45,7 +45,7 @@ pub fn update_accesskit_for_text_widget(
             let row_id = parent_id.with(row_index);
             ctx.accesskit_node_builder(row_id, |builder| {
                 builder.set_role(accesskit::Role::TextRun);
-                let rect = global_from_galley * row.rect();
+                let rect = global_from_galley * row.rect_without_leading_space();
                 builder.set_bounds(accesskit::Rect {
                     x0: rect.min.x.into(),
                     y0: rect.min.y.into(),

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -1,11 +1,9 @@
 use std::sync::Arc;
 
 use crate::{
-    epaint, pos2, text_selection, Align, Direction, FontSelection, Galley, Pos2, Response, Sense,
-    Stroke, TextWrapMode, Ui, Widget, WidgetInfo, WidgetText, WidgetType,
+    epaint, pos2, text_selection::LabelSelectionState, Align, Direction, FontSelection, Galley,
+    Pos2, Response, Sense, Stroke, TextWrapMode, Ui, Widget, WidgetInfo, WidgetText, WidgetType,
 };
-
-use self::text_selection::LabelSelectionState;
 
 /// Static text.
 ///
@@ -216,9 +214,9 @@ impl Label {
             let pos = pos2(ui.max_rect().left(), ui.cursor().top());
             assert!(!galley.rows.is_empty(), "Galleys are never empty");
             // collect a response from many rows:
-            let mut rect = galley.rows[0].rect().translate(pos.to_vec2());
-            // The rect ignores first_row_indentation, so we add it back:
-            rect.min.x += first_row_indentation;
+            let rect = galley.rows[0]
+                .rect_without_leading_space()
+                .translate(pos.to_vec2());
             let mut response = ui.allocate_rect(rect, sense);
             for placed_row in galley.rows.iter().skip(1) {
                 let rect = placed_row.rect().translate(pos.to_vec2());

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 
 use crate::{
-    epaint, pos2, text_selection::LabelSelectionState, Align, Direction, FontSelection, Galley,
-    Pos2, Response, Sense, Stroke, TextWrapMode, Ui, Widget, WidgetInfo, WidgetText, WidgetType,
+    epaint, pos2, text_selection, Align, Direction, FontSelection, Galley, Pos2, Response, Sense,
+    Stroke, TextWrapMode, Ui, Widget, WidgetInfo, WidgetText, WidgetType,
 };
+
+use self::text_selection::LabelSelectionState;
 
 /// Static text.
 ///
@@ -214,7 +216,9 @@ impl Label {
             let pos = pos2(ui.max_rect().left(), ui.cursor().top());
             assert!(!galley.rows.is_empty(), "Galleys are never empty");
             // collect a response from many rows:
-            let rect = galley.rows[0].rect().translate(pos.to_vec2());
+            let mut rect = galley.rows[0].rect().translate(pos.to_vec2());
+            // The rect ignores first_row_indentation, so we add it back:
+            rect.min.x += first_row_indentation;
             let mut response = ui.allocate_rect(rect, sense);
             for placed_row in galley.rows.iter().skip(1) {
                 let rect = placed_row.rect().translate(pos.to_vec2());

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -1,11 +1,9 @@
 use std::sync::Arc;
 
 use crate::{
-    epaint, pos2, text_selection, Align, Direction, FontSelection, Galley, Pos2, Response, Sense,
-    Stroke, TextWrapMode, Ui, Widget, WidgetInfo, WidgetText, WidgetType,
+    epaint, pos2, text_selection::LabelSelectionState, Align, Direction, FontSelection, Galley,
+    Pos2, Response, Sense, Stroke, TextWrapMode, Ui, Widget, WidgetInfo, WidgetText, WidgetType,
 };
-
-use self::text_selection::LabelSelectionState;
 
 /// Static text.
 ///
@@ -216,9 +214,7 @@ impl Label {
             let pos = pos2(ui.max_rect().left(), ui.cursor().top());
             assert!(!galley.rows.is_empty(), "Galleys are never empty");
             // collect a response from many rows:
-            let mut rect = galley.rows[0].rect().translate(pos.to_vec2());
-            // The rect ignores first_row_indentation, so we add it back:
-            rect.min.x += first_row_indentation;
+            let rect = galley.rows[0].rect().translate(pos.to_vec2());
             let mut response = ui.allocate_rect(rect, sense);
             for placed_row in galley.rows.iter().skip(1) {
                 let rect = placed_row.rect().translate(pos.to_vec2());

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -216,7 +216,9 @@ impl Label {
             let pos = pos2(ui.max_rect().left(), ui.cursor().top());
             assert!(!galley.rows.is_empty(), "Galleys are never empty");
             // collect a response from many rows:
-            let rect = galley.rows[0].rect().translate(pos.to_vec2());
+            let mut rect = galley.rows[0].rect().translate(pos.to_vec2());
+            // The rect ignores first_row_indentation, so we add it back:
+            rect.min.x += first_row_indentation;
             let mut response = ui.allocate_rect(rect, sense);
             for placed_row in galley.rows.iter().skip(1) {
                 let rect = placed_row.rect().translate(pos.to_vec2());

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -561,9 +561,14 @@ pub struct PlacedRow {
 
 impl PlacedRow {
     /// Logical bounding rectangle on font heights etc.
+    ///
     /// Use this when drawing a selection or similar!
+    ///
+    /// If `LayoutSection::leading_space` is set, the returned [`Rect`] will be offset by that.
     pub fn rect(&self) -> Rect {
-        Rect::from_min_size(self.pos, self.row.size)
+        let x = self.glyphs.first().map_or(self.pos.x, |g| g.pos.x);
+        let size_x = self.size.x - x;
+        Rect::from_min_size(Pos2::new(x, self.pos.y), Vec2::new(size_x, self.size.y))
     }
 }
 

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -561,9 +561,17 @@ pub struct PlacedRow {
 
 impl PlacedRow {
     /// Logical bounding rectangle on font heights etc.
-    /// Use this when drawing a selection or similar!
+    ///
+    /// This ignores / includes the `LayoutSection::leading_space`.
     pub fn rect(&self) -> Rect {
         Rect::from_min_size(self.pos, self.row.size)
+    }
+
+    /// Same as [`Self::rect`] but excluding the `LayoutSection::leading_space`.
+    pub fn rect_without_leading_space(&self) -> Rect {
+        let x = self.glyphs.first().map_or(self.pos.x, |g| g.pos.x);
+        let size_x = self.size.x - x;
+        Rect::from_min_size(Pos2::new(x, self.pos.y), Vec2::new(size_x, self.size.y))
     }
 }
 

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -561,14 +561,9 @@ pub struct PlacedRow {
 
 impl PlacedRow {
     /// Logical bounding rectangle on font heights etc.
-    ///
     /// Use this when drawing a selection or similar!
-    ///
-    /// If `LayoutSection::leading_space` is set, the returned [`Rect`] will be offset by that.
     pub fn rect(&self) -> Rect {
-        let x = self.glyphs.first().map_or(self.pos.x, |g| g.pos.x);
-        let size_x = self.size.x - x;
-        Rect::from_min_size(Pos2::new(x, self.pos.y), Vec2::new(size_x, self.size.y))
+        Rect::from_min_size(self.pos, self.row.size)
     }
 }
 


### PR DESCRIPTION
* Closes <https://github.com/emilk/egui/issues/6904>
* [x] I have followed the instructions in the PR template

This was broken in https://github.com/emilk/egui/pull/5411. Not sure if this is the best fix or if `PlacedRow::rect` should be updated, but I think it makes sense that PlacedRow::rect ignores leading space.