### PR TITLE
Add `ImageLoader::has_pending` and `wait_for_pending_images`

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -3546,6 +3546,14 @@ impl Context {
     pub fn loaders(&self) -> Arc<Loaders> {
         self.read(|this| this.loaders.clone())
     }
+
+    /// Returns `true` if any image is currently being loaded.
+    pub fn has_pending_images(&self) -> bool {
+        self.read(|this| {
+            this.loaders.image.lock().iter().any(|i| i.has_pending())
+                || this.loaders.bytes.lock().iter().any(|i| i.has_pending())
+        })
+    }
 }
 
 /// ## Viewports

--- a/crates/egui/src/load.rs
+++ b/crates/egui/src/load.rs
@@ -328,6 +328,11 @@ pub trait BytesLoader {
 
     /// If the loader caches any data, this should return the size of that cache.
     fn byte_size(&self) -> usize;
+
+    /// Returns `true` if some data is currently being loaded.
+    fn has_pending(&self) -> bool {
+        false
+    }
 }
 
 /// Represents an image which is currently being loaded.
@@ -395,6 +400,13 @@ pub trait ImageLoader {
 
     /// If the loader caches any data, this should return the size of that cache.
     fn byte_size(&self) -> usize;
+
+    /// Returns `true` if some image is currently being loaded.
+    ///  
+    /// NOTE: You probably also want to check [`BytesLoader::has_pending`].
+    fn has_pending(&self) -> bool {
+        false
+    }
 }
 
 /// A texture with a known size.

--- a/crates/egui_extras/src/loaders/ehttp_loader.rs
+++ b/crates/egui_extras/src/loaders/ehttp_loader.rs
@@ -125,4 +125,8 @@ impl BytesLoader for EhttpLoader {
             })
             .sum()
     }
+
+    fn has_pending(&self) -> bool {
+        self.cache.lock().values().any(|entry| entry.is_pending())
+    }
 }

--- a/crates/egui_extras/src/loaders/file_loader.rs
+++ b/crates/egui_extras/src/loaders/file_loader.rs
@@ -128,4 +128,8 @@ impl BytesLoader for FileLoader {
             })
             .sum()
     }
+
+    fn has_pending(&self) -> bool {
+        self.cache.lock().values().any(|entry| entry.is_pending())
+    }
 }

--- a/crates/egui_extras/src/loaders/image_loader.rs
+++ b/crates/egui_extras/src/loaders/image_loader.rs
@@ -8,6 +8,9 @@ use egui::{
 use image::ImageFormat;
 use std::{mem::size_of, path::Path, sync::Arc, task::Poll};
 
+#[cfg(not(target_arch = "wasm32"))]
+use std::thread;
+
 type Entry = Poll<Result<Arc<ColorImage>, String>>;
 
 #[derive(Default)]
@@ -73,7 +76,7 @@ impl ImageLoader for ImageCrateLoader {
             return Err(LoadError::NotSupported);
         }
 
-        #[cfg(not(any(target_arch = "wasm32", test)))]
+        #[cfg(not(target_arch = "wasm32"))]
         #[expect(clippy::unnecessary_wraps)] // needed here to match other return types
         fn load_image(
             ctx: &egui::Context,
@@ -85,7 +88,7 @@ impl ImageLoader for ImageCrateLoader {
             cache.lock().insert(uri.clone(), Poll::Pending);
 
             // Do the image parsing on a bg thread
-            std::thread::Builder::new()
+            thread::Builder::new()
                 .name(format!("egui_extras::ImageLoader::load({uri:?})"))
                 .spawn({
                     let ctx = ctx.clone();
@@ -113,8 +116,7 @@ impl ImageLoader for ImageCrateLoader {
             Ok(ImagePoll::Pending { size: None })
         }
 
-        // Load images on the current thread for tests, so they are less flaky
-        #[cfg(any(target_arch = "wasm32", test))]
+        #[cfg(target_arch = "wasm32")]
         fn load_image(
             _ctx: &egui::Context,
             uri: &str,

--- a/crates/egui_extras/src/loaders/image_loader.rs
+++ b/crates/egui_extras/src/loaders/image_loader.rs
@@ -179,6 +179,10 @@ impl ImageLoader for ImageCrateLoader {
             })
             .sum()
     }
+
+    fn has_pending(&self) -> bool {
+        self.cache.lock().values().any(|result| result.is_pending())
+    }
 }
 
 #[cfg(test)]

--- a/crates/egui_kittest/Cargo.toml
+++ b/crates/egui_kittest/Cargo.toml
@@ -63,7 +63,7 @@ document-features = { workspace = true, optional = true }
 [dev-dependencies]
 egui = { workspace = true, features = ["default_fonts"] }
 image = { workspace = true, features = ["png"] }
-egui_extras = { workspace = true, features = ["image"] }
+egui_extras = { workspace = true, features = ["image", "http"] }
 
 [lints]
 workspace = true

--- a/crates/egui_kittest/src/builder.rs
+++ b/crates/egui_kittest/src/builder.rs
@@ -1,6 +1,6 @@
 use crate::app_kind::AppKind;
 use crate::{Harness, LazyRenderer, TestRenderer};
-use egui::{Pos2, Rect, Vec2};
+use egui::{Context, Pos2, Rect, Vec2};
 use std::marker::PhantomData;
 
 /// Builder for [`Harness`].
@@ -11,6 +11,7 @@ pub struct HarnessBuilder<State = ()> {
     pub(crate) step_dt: f32,
     pub(crate) state: PhantomData<State>,
     pub(crate) renderer: Box<dyn TestRenderer>,
+    pub(crate) wait_for_pending_images: bool,
 }
 
 impl<State> Default for HarnessBuilder<State> {
@@ -22,6 +23,7 @@ impl<State> Default for HarnessBuilder<State> {
             renderer: Box::new(LazyRenderer::default()),
             max_steps: 4,
             step_dt: 1.0 / 4.0,
+            wait_for_pending_images: true,
         }
     }
 }
@@ -60,6 +62,18 @@ impl<State> HarnessBuilder<State> {
     #[inline]
     pub fn with_step_dt(mut self, step_dt: f32) -> Self {
         self.step_dt = step_dt;
+        self
+    }
+
+    /// Should we wait for pending images?
+    ///
+    /// If `true`, [`Harness::run`] and related methods will check if there are pending images
+    /// (via [`Context::has_pending_images`]) and sleep for [`Self::with_step_dt`] up to
+    /// [`Self::with_max_steps`] times.
+    ///
+    /// Default: `true`
+    pub fn with_wait_for_pending_images(mut self, wait_for_pending_images: bool) -> Self {
+        self.wait_for_pending_images = wait_for_pending_images;
         self
     }
 

--- a/crates/egui_kittest/tests/tests.rs
+++ b/crates/egui_kittest/tests/tests.rs
@@ -1,4 +1,4 @@
-use egui::Modifiers;
+use egui::{include_image, Modifiers, Vec2};
 use egui_kittest::Harness;
 use kittest::{Key, Queryable as _};
 
@@ -56,4 +56,22 @@ fn test_modifiers() {
     assert!(state.cmd_clicked, "The button wasn't command-clicked");
     assert!(state.cmd_z_pressed, "Cmd+Z wasn't pressed");
     assert!(state.cmd_y_pressed, "Cmd+Y wasn't pressed");
+}
+
+#[test]
+fn should_wait_for_images() {
+    let mut harness = Harness::new_ui(|ui| {
+        egui_extras::install_image_loaders(ui.ctx());
+        let size = Vec2::splat(30.0);
+        ui.label("Url:");
+        ui.add_sized(size, egui::Image::new("https://raw.githubusercontent.com/emilk/egui/refs/heads/master/crates/eframe/data/icon.png"));
+
+        ui.label("Include:");
+        ui.add_sized(
+            size,
+            egui::Image::new(include_image!("../../eframe/data/icon.png")),
+        );
+    });
+
+    harness.snapshot("should_wait_for_images");
 }


### PR DESCRIPTION
With kittest it was difficult to wait for images to be loaded before taking a snapshot test. 
This PR adds `Harness::with_wait_for_pending_images` (true by default) which will cause `Harness::run` to sleep until all images are loaded (or `HarnessBuilder::with_max_steps` is exceeded).

It also adds a new ImageLoader::has_pending and BytesLoader::has_pending, which should be implemented if things are loaded / decoded asynchronously.