### PR TITLE
Fix `leading_space` sometimes being ignored during paragraph splitting

### DIFF
--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -913,7 +913,7 @@ impl GalleyCache {
                         "Bad new section range: {new_range:?}"
                     );
                     paragraph_job.sections.push(LayoutSection {
-                        leading_space: if start <= new_range.start {
+                        leading_space: if start <= section_range.start {
                             *leading_space
                         } else {
                             0.0


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/emilk/egui/pull/5411 (possibly https://github.com/emilk/egui/pull/5411/commits/d74bee536f7c57d83014b759b18a0ddef8725552) that breaks `leading_space` handling.
I think this is what the condition should be but I haven't touched this code in a while.