### PR TITLE
fix: avoid CentralPanel overflowing in a window

### DIFF
--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -1121,10 +1121,14 @@ impl CentralPanel {
         panel_ui.set_clip_rect(panel_rect); // If we overflow, don't do so visibly (#4475)
 
         let frame = frame.unwrap_or_else(|| Frame::central_panel(ui.style()));
-        frame.show(&mut panel_ui, |ui| {
+        let inner_response = frame.show(&mut panel_ui, |ui| {
             ui.expand_to_include_rect(ui.max_rect()); // Expand frame to include it all
             add_contents(ui)
-        })
+        });
+
+        ui.expand_to_include_rect(inner_response.response.rect);
+
+        inner_response
     }
 
     /// Show the panel at the top level.


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

```rust
use eframe::egui;

fn main() -> eframe::Result<()> {
    eframe::run_simple_native("window overflow", Default::default(), |ctx, _| {
        egui::Window::new("window overflow").show(ctx, |ui| {
            ui.label("Hello, World");
        });
    })
}
```

Old behavior:

![image](https://github.com/user-attachments/assets/9f4e6d18-ebb4-4536-b08f-4b036594588d)

New behavior:

![image](https://github.com/user-attachments/assets/7a6bbbf2-f430-4e53-bb6c-dd01871cf75a)

I'd ideally add a test for this but I'm not sure how to go about doing that.

* Closes <https://github.com/emilk/egui/issues/901>
* [x] I have followed the instructions in the PR template
