### PR TITLE
Delete OpenGL objects on regular drop instead of explicit destroy in glow example

### DIFF
--- a/crates/egui_demo_app/src/apps/custom3d_glow.rs
+++ b/crates/egui_demo_app/src/apps/custom3d_glow.rs
@@ -14,7 +14,7 @@ pub struct Custom3d {
 
 impl Custom3d {
     pub fn new<'a>(cc: &'a eframe::CreationContext<'a>) -> Option<Self> {
-        let gl = cc.gl.as_ref()?;
+        let gl = cc.gl.as_ref()?.clone();
         Some(Self {
             rotating_triangle: Arc::new(Mutex::new(RotatingTriangle::new(gl)?)),
             angle: 0.0,
@@ -44,12 +44,6 @@ impl eframe::App for Custom3d {
                 });
         });
     }
-
-    fn on_exit(&mut self, gl: Option<&glow::Context>) {
-        if let Some(gl) = gl {
-            self.rotating_triangle.lock().destroy(gl);
-        }
-    }
 }
 
 impl Custom3d {
@@ -76,16 +70,17 @@ impl Custom3d {
 }
 
 struct RotatingTriangle {
+    gl: Arc<glow::Context>,
     program: glow::Program,
     vertex_array: glow::VertexArray,
 }
 
 #[expect(unsafe_code)] // we need unsafe code to use glow
 impl RotatingTriangle {
-    fn new(gl: &glow::Context) -> Option<Self> {
+    fn new(gl: Arc<glow::Context>) -> Option<Self> {
         use glow::HasContext as _;
 
-        let shader_version = egui_glow::ShaderVersion::get(gl);
+        let shader_version = egui_glow::ShaderVersion::get(&gl);
 
         unsafe {
             let program = gl.create_program().expect("Cannot create program");
@@ -176,17 +171,10 @@ impl RotatingTriangle {
                 .expect("Cannot create vertex array");
 
             Some(Self {
+                gl,
                 program,
                 vertex_array,
             })
-        }
-    }
-
-    fn destroy(&self, gl: &glow::Context) {
-        use glow::HasContext as _;
-        unsafe {
-            gl.delete_program(self.program);
-            gl.delete_vertex_array(self.vertex_array);
         }
     }
 
@@ -200,6 +188,16 @@ impl RotatingTriangle {
             );
             gl.bind_vertex_array(Some(self.vertex_array));
             gl.draw_arrays(glow::TRIANGLES, 0, 3);
+        }
+    }
+}
+
+impl Drop for RotatingTriangle {
+    fn drop(&mut self) {
+        use glow::HasContext as _;
+        unsafe {
+            self.gl.delete_program(self.program);
+            self.gl.delete_vertex_array(self.vertex_array);
         }
     }
 }


### PR DESCRIPTION
* [x] I have followed the instructions in the PR template.

This is equally a question and a change suggestion: Can I retain a clone of the `Arc<glow::Context>` and use it to deallocate OpenGL objects on drop, instead of having to explicitly listen to the `on_exit` event and pass that down from my top level `App` to all subcomponents that have allocated OpenGL objects?

I'm no OpenGL expert by any means. But from what I can find, OpenGL objects are tied to the contexts they were created under. So it would be surprising if the call to the `destroy` method had another context, than the one we got passed to us on initializiation? And if we always get the same context over and over, is there any reason why we can't just keep our own reference to it internally instead?

This is slightly related to #5285. But instead of dealing with the explicit destroy of the `Painter` in the library, it deals with examples, showing how `egui` users should deallocate their OpenGL objects.

Opening the PR as a draft, since I'm not 100% this solution is valid.