### PR TITLE
Allow resize on one both or no axis.

### DIFF
--- a/crates/egui/src/containers/resize.rs
+++ b/crates/egui/src/containers/resize.rs
@@ -252,7 +252,18 @@ impl Resize {
         }
 
         if let Some(user_requested_size) = user_requested_size {
-            state.desired_size = user_requested_size;
+            match self.resizable {
+                Vec2b { x: true, y: true } => {
+                    state.desired_size = user_requested_size;
+                }
+                Vec2b { x: true, y: false } => {
+                    state.desired_size.x = user_requested_size.x;
+                }
+                Vec2b { x: false, y: true } => {
+                    state.desired_size.y = user_requested_size.y;
+                }
+                _ => {}
+            }
         } else {
             // We are not being actively resized, so auto-expand to include size of last frame.
             // This prevents auto-shrinking if the contents contain width-filling widgets (separators etc)

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -2,7 +2,7 @@ use super::{Demo, View};
 
 use egui::{
     vec2, Align, Checkbox, CollapsingHeader, Color32, Context, FontId, Resize, RichText, Sense,
-    Slider, Stroke, TextFormat, TextStyle, Ui, Vec2, Window,
+    Slider, Stroke, TextFormat, TextStyle, Ui, Vec2, Vec2b, Window,
 };
 
 /// Showcase some ui code
@@ -20,6 +20,8 @@ pub struct MiscDemoWindow {
     dummy_bool: bool,
     dummy_usize: usize,
     checklist: [bool; 3],
+
+    resize: Vec2b,
 }
 
 impl Default for MiscDemoWindow {
@@ -36,6 +38,7 @@ impl Default for MiscDemoWindow {
             dummy_bool: false,
             dummy_usize: 0,
             checklist: std::array::from_fn(|i| i == 0),
+            resize: [true, true].into(),
         }
     }
 }
@@ -152,8 +155,18 @@ impl View for MiscDemoWindow {
         CollapsingHeader::new("Resize")
             .default_open(false)
             .show(ui, |ui| {
-                Resize::default().default_height(100.0).show(ui, |ui| {
-                    ui.label("This ui can be resized!");
+                ui.checkbox(&mut self.resize.x, "Resize X");
+                ui.checkbox(&mut self.resize.y, "Resize Y");
+
+                Resize::default()
+                    .resizable(self.resize)
+                    .default_height(100.0).show(ui, |ui| {
+                    match [self.resize.x, self.resize.y] {
+                        [true, true] => ui.label("This ui can be resized in both directions"),
+                        [true, false] => ui.label("This ui can be resized on the X axis only"),
+                        [false, true] => ui.label("This ui can be resized on the Y axis only"),
+                        [false, false] => ui.label("This ui can't be resized (enable the x/y checkboxes to try it out)"),
+                    };
                     ui.label("Just pull the handle on the bottom right");
                 });
             });


### PR DESCRIPTION

* Note: the original API accepted a `Vec2b`, but didn't use the x/y properties independently.

Video:

https://github.com/user-attachments/assets/b92c1828-2304-432b-b567-1d48feadfd3b


* [x] I have followed the instructions in the PR template
