### PR TITLE
Fix typo in deprecation message for `ComboBox::from_id_source`

### DIFF
--- a/crates/egui/src/containers/combo_box.rs
+++ b/crates/egui/src/containers/combo_box.rs
@@ -86,7 +86,7 @@ impl ComboBox {
     }
 
     /// Without label.
-    #[deprecated = "Renamed id_salt"]
+    #[deprecated = "Renamed from_id_salt"]
     pub fn from_id_source(id_salt: impl std::hash::Hash) -> Self {
         Self::from_id_salt(id_salt)
     }


### PR DESCRIPTION
This PR corrects the deprecation note on ComboBox::from_id_source:

Changed:
`#[deprecated = "Renamed id_salt"]`

To:
`#[deprecated = "Renamed from_id_salt"]`
