### PR TITLE
egui_extras: Enable setting DatePickerButton start and end year explicitly

### DIFF
--- a/crates/egui_extras/src/datepicker/button.rs
+++ b/crates/egui_extras/src/datepicker/button.rs
@@ -19,6 +19,8 @@ pub struct DatePickerButton<'a> {
     show_icon: bool,
     format: String,
     highlight_weekends: bool,
+    start_year: Option<i32>,
+    end_year: Option<i32>,
 }
 
 impl<'a> DatePickerButton<'a> {
@@ -33,6 +35,8 @@ impl<'a> DatePickerButton<'a> {
             show_icon: true,
             format: "%Y-%m-%d".to_owned(),
             highlight_weekends: true,
+            start_year: None,
+            end_year: None,
         }
     }
 
@@ -101,6 +105,20 @@ impl<'a> DatePickerButton<'a> {
         self.highlight_weekends = highlight_weekends;
         self
     }
+
+    /// Set the start year for the date picker. (Default: None)
+    #[inline]
+    pub fn start_year(mut self, start_year: i32) -> Self {
+        self.start_year = Some(start_year);
+        self
+    }
+
+    /// Set the end year for the date picker. (Default: None)
+    #[inline]
+    pub fn end_year(mut self, end_year: i32) -> Self {
+        self.end_year = Some(end_year);
+        self
+    }
 }
 
 impl Widget for DatePickerButton<'_> {
@@ -167,6 +185,8 @@ impl Widget for DatePickerButton<'_> {
                                 calendar: self.calendar,
                                 calendar_week: self.calendar_week,
                                 highlight_weekends: self.highlight_weekends,
+                                start_year: self.start_year,
+                                end_year: self.end_year,
                             }
                             .draw(ui)
                         })

--- a/crates/egui_extras/src/datepicker/popup.rs
+++ b/crates/egui_extras/src/datepicker/popup.rs
@@ -35,6 +35,8 @@ pub(crate) struct DatePickerPopup<'a> {
     pub calendar: bool,
     pub calendar_week: bool,
     pub highlight_weekends: bool,
+    pub start_year: Option<i32>,
+    pub end_year: Option<i32>,
 }
 
 impl DatePickerPopup<'_> {
@@ -84,7 +86,10 @@ impl DatePickerPopup<'_> {
                                 ComboBox::from_id_salt("date_picker_year")
                                     .selected_text(popup_state.year.to_string())
                                     .show_ui(ui, |ui| {
-                                        for year in today.year() - 100..today.year() + 10 {
+                                        let start_year =
+                                            self.start_year.unwrap_or(today.year() - 100);
+                                        let end_year = self.end_year.unwrap_or(today.year() + 10);
+                                        for year in start_year..end_year {
                                             if ui
                                                 .selectable_value(
                                                     &mut popup_state.year,


### PR DESCRIPTION
Add the ability to set the `DatePickerButton`'s start and end years via new `start_year` and `end_year` methods.

Continue to use the existing today - 100 years and today + 10 years behavior if a year is not specified.

* This more fully closes <https://github.com/emilk/egui/issues/3597> and expands on <https://github.com/emilk/egui/pull/3599>.
* [x] I have followed the instructions in the PR template
