### PR TITLE
Fix incorrect color fringe colors on SVG:s

### DIFF
--- a/crates/egui_demo_lib/Cargo.toml
+++ b/crates/egui_demo_lib/Cargo.toml
@@ -16,7 +16,7 @@ include = [
     "../LICENSE-MIT",
     "**/*.rs",
     "Cargo.toml",
-    "data/icon.png",
+    "data/*",
 ]
 
 [lints]
@@ -43,7 +43,7 @@ syntect = ["egui_extras/syntect"]
 
 [dependencies]
 egui = { workspace = true, default-features = false, features = ["color-hex"] }
-egui_extras = { workspace = true, features = ["default"] }
+egui_extras = { workspace = true, features = ["default", "file", "svg"] }
 
 unicode_names2 = { version = "0.6.0", default-features = false } # this old version has fewer dependencies
 

--- a/crates/egui_demo_lib/data/peace.svg
+++ b/crates/egui_demo_lib/data/peace.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:svg="http://www.w3.org/2000/svg"
+     viewBox="0 0 44 44" width="32" height="32">
+  <g fill="none" stroke="white" stroke-width="3">
+    <circle cx="22" cy="22" r="19"/>
+    <path d="M 22,2 V 41"/>
+    <path d="M 22,2 V 22" transform="rotate(135, 22, 22)"/>
+    <path d="M 22,2 V 22" transform="rotate(225, 22, 22)"/>
+  </g>
+</svg>

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -100,6 +100,7 @@ impl Default for DemoGroups {
                 Box::<super::tests::InputTest>::default(),
                 Box::<super::tests::LayoutTest>::default(),
                 Box::<super::tests::ManualLayoutTest>::default(),
+                Box::<super::tests::SvgTest>::default(),
                 Box::<super::tests::TessellationTest>::default(),
                 Box::<super::tests::WindowResizeTest>::default(),
             ]),

--- a/crates/egui_demo_lib/src/demo/tests/mod.rs
+++ b/crates/egui_demo_lib/src/demo/tests/mod.rs
@@ -6,6 +6,7 @@ mod input_event_history;
 mod input_test;
 mod layout_test;
 mod manual_layout_test;
+mod svg_test;
 mod tessellation_test;
 mod window_resize_test;
 
@@ -17,5 +18,6 @@ pub use input_event_history::InputEventHistory;
 pub use input_test::InputTest;
 pub use layout_test::LayoutTest;
 pub use manual_layout_test::ManualLayoutTest;
+pub use svg_test::SvgTest;
 pub use tessellation_test::TessellationTest;
 pub use window_resize_test::WindowResizeTest;

--- a/crates/egui_demo_lib/src/demo/tests/svg_test.rs
+++ b/crates/egui_demo_lib/src/demo/tests/svg_test.rs
@@ -1,0 +1,32 @@
+pub struct SvgTest {
+    color: egui::Color32,
+}
+
+impl Default for SvgTest {
+    fn default() -> Self {
+        Self {
+            color: egui::Color32::LIGHT_RED,
+        }
+    }
+}
+
+impl crate::Demo for SvgTest {
+    fn name(&self) -> &'static str {
+        "SVG Test"
+    }
+
+    fn show(&mut self, ctx: &egui::Context, open: &mut bool) {
+        egui::Window::new(self.name()).open(open).show(ctx, |ui| {
+            use crate::View as _;
+            self.ui(ui);
+        });
+    }
+}
+
+impl crate::View for SvgTest {
+    fn ui(&mut self, ui: &mut egui::Ui) {
+        let Self { color } = self;
+        ui.color_edit_button_srgba(color);
+        ui.add(egui::Image::new(egui::include_image!("../../../data/peace.svg")).tint(*color));
+    }
+}

--- a/crates/egui_extras/src/image.rs
+++ b/crates/egui_extras/src/image.rs
@@ -295,7 +295,7 @@ pub fn load_svg_bytes_with_size(
         &mut pixmap.as_mut(),
     );
 
-    let image = egui::ColorImage::from_rgba_unmultiplied([w as _, h as _], pixmap.data());
+    let image = egui::ColorImage::from_rgba_premultiplied([w as _, h as _], pixmap.data());
 
     Ok(image)
 }


### PR DESCRIPTION
This is a problem that affected the fringes on all SVG:s with transparency, especially on a light background.

## Before
![image](https://github.com/user-attachments/assets/342823ad-005c-4f82-83a6-d2dcccfd3221)


## After
![image](https://github.com/user-attachments/assets/73398265-d333-461b-8c2b-fce405d95a9c)
