### PR TITLE
Bug fix: make sure `end_pass` is called for all loaders

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2316,6 +2316,8 @@ impl ContextImpl {
         let viewport = self.viewports.entry(ended_viewport_id).or_default();
         let pixels_per_point = viewport.input.pixels_per_point;
 
+        self.loaders.end_pass(viewport.repaint.cumulative_pass_nr);
+
         viewport.repaint.cumulative_pass_nr += 1;
 
         self.memory.end_pass(&viewport.this_pass.used_ids);

--- a/crates/egui/src/load.rs
+++ b/crates/egui/src/load.rs
@@ -322,8 +322,8 @@ pub trait BytesLoader {
 
     /// Implementations may use this to perform work at the end of a frame,
     /// such as evicting unused entries from a cache.
-    fn end_pass(&self, frame_index: usize) {
-        let _ = frame_index;
+    fn end_pass(&self, pass_index: u64) {
+        let _ = pass_index;
     }
 
     /// If the loader caches any data, this should return the size of that cache.
@@ -394,8 +394,8 @@ pub trait ImageLoader {
 
     /// Implementations may use this to perform work at the end of a pass,
     /// such as evicting unused entries from a cache.
-    fn end_pass(&self, frame_index: usize) {
-        let _ = frame_index;
+    fn end_pass(&self, pass_index: u64) {
+        let _ = pass_index;
     }
 
     /// If the loader caches any data, this should return the size of that cache.
@@ -539,8 +539,8 @@ pub trait TextureLoader {
 
     /// Implementations may use this to perform work at the end of a pass,
     /// such as evicting unused entries from a cache.
-    fn end_pass(&self, frame_index: usize) {
-        let _ = frame_index;
+    fn end_pass(&self, pass_index: u64) {
+        let _ = pass_index;
     }
 
     /// If the loader caches any data, this should return the size of that cache.
@@ -569,6 +569,29 @@ impl Default for Loaders {
             // By default we only include `DefaultTextureLoader`.
             texture: Mutex::new(vec![Arc::new(DefaultTextureLoader::default())]),
             include,
+        }
+    }
+}
+
+impl Loaders {
+    /// The given pass has just ended.
+    pub fn end_pass(&self, pass_index: u64) {
+        let Self {
+            include,
+            bytes,
+            image,
+            texture,
+        } = self;
+
+        include.end_pass(pass_index);
+        for loader in bytes.lock().iter() {
+            loader.end_pass(pass_index);
+        }
+        for loader in image.lock().iter() {
+            loader.end_pass(pass_index);
+        }
+        for loader in texture.lock().iter() {
+            loader.end_pass(pass_index);
         }
     }
 }

--- a/crates/egui/src/load/texture_loader.rs
+++ b/crates/egui/src/load/texture_loader.rs
@@ -64,8 +64,6 @@ impl TextureLoader for DefaultTextureLoader {
         self.cache.lock().clear();
     }
 
-    fn end_pass(&self, _: usize) {}
-
     fn byte_size(&self) -> usize {
         self.cache
             .lock()


### PR DESCRIPTION
None of the built-in loaders does any cache eviction (yet), but 3rd party ones might have