### PR TITLE
Ensure TextEdit cursor is never out of bounds

### DIFF
--- a/crates/egui/src/text_selection/text_cursor_state.rs
+++ b/crates/egui/src/text_selection/text_cursor_state.rs
@@ -39,6 +39,14 @@ impl TextCursorState {
     pub fn set_char_range(&mut self, ccursor_range: Option<CCursorRange>) {
         self.ccursor_range = ccursor_range;
     }
+
+    /// Clamp the cursors to be in bounds of the galley.
+    pub fn ensure_in_bounds(&mut self, galley: &Galley) {
+        if let Some(range) = self.ccursor_range.as_mut() {
+            range.primary = galley.clamp_cursor(&range.primary);
+            range.secondary = galley.clamp_cursor(&range.secondary);
+        }
+    }
 }
 
 impl TextCursorState {

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -553,10 +553,7 @@ impl TextEdit<'_> {
         // it's possible the app changed the TextBuffer (e.g. when submitting a chat input) so here
         // we detect if the galley changed from the last known one and clamp the cursor to the new one
         if let Some(last_galley) = state.last_galley.as_ref() {
-            let changed = last_galley
-                .upgrade()
-                .map_or(true, |last_galley| last_galley != galley);
-            if changed {
+            if last_galley.upgrade().as_ref() != Some(&galley) {
                 state.cursor.ensure_in_bounds(&galley);
                 state.last_galley = Some(Arc::downgrade(&galley));
             }

--- a/crates/egui/src/widgets/text_edit/state.rs
+++ b/crates/egui/src/widgets/text_edit/state.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use crate::mutex::Mutex;
 
@@ -57,6 +57,10 @@ pub struct TextEditState {
     /// Used to pause the cursor animation when typing.
     #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) last_interaction_time: f64,
+
+    /// The last galley that was used to render the text. When this changes, we need to ensure the cursor is still in bounds.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub(crate) last_galley: Option<Weak<epaint::Galley>>,
 }
 
 impl TextEditState {

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -1104,6 +1104,10 @@ impl Galley {
         }
     }
 
+    pub fn clamp_cursor(&self, cursor: &CCursor) -> CCursor {
+        self.cursor_from_layout(self.layout_from_cursor(*cursor))
+    }
+
     pub fn cursor_up_one_row(
         &self,
         cursor: &CCursor,


### PR DESCRIPTION
When rendering a TextArea we don't know if the saved cursor applies to the current galley since it's possible the app changed the TextBuffer (e.g. when submitting a chat input)

So we now detect if the galley changed from the last known one and clamp the cursor to ensure it's not out of bounds.

This fixes an issue where backspace and arrow keys can suddenly stop working. In this video I changed the `TextArea` to not lose focus when enter is pressed (using `.return_key`). And instead, the app clears the `String`. Which is what we do in our chat and REPL UIs.

![Screenshot 2025-05-23 at 01 36 14](https://github.com/user-attachments/assets/f9ab6207-108e-4ee9-9e85-1cdec845439e)

Repro:
 - Render TextArea with long-ish text (say 20 chars)
 - Without losing focus, clear the text
 - Write something short (say 5 chars)
 - Result: backspace doesn't work because the cursor position is wrong
 
I think this issue started happening when [this function](https://github.com/emilk/egui/pull/5785/files#diff-09cc53b30f3c2a6481d438328f86236eb723a6ba5152101b58592a9013b1eb69L60) was removed in #5785

(cc @valadaptive in case you happen to know of a better fix that doesn't require keeping the Galley in the TextEdit state)

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [x] I have followed the instructions in the PR template
