### PR TITLE
Mention VTK 3D integration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ You can also render your 3D scene to a texture and display it using [`ui.image(â
 
 Examples:
 * Using [`egui-miniquad`]( https://github.com/not-fl3/egui-miniquad): https://github.com/not-fl3/egui-miniquad/blob/master/examples/render_to_egui_image.rs
+* Using [`eframe`](https://github.com/emilk/egui/tree/main/crates/eframe) + [`VTK (C++)`](https://vtk.org/): https://github.com/Gerharddc/vtk-egui-demo
 
 
 ## Other


### PR DESCRIPTION
This commit adds a reference to an additional 3D integration example (using the VTK C++ library) to the README.

![Demo](https://github.com/user-attachments/assets/99cbe4e6-0aaf-41c2-9b18-179d58047284)
