### PR TITLE
fix: vec2 debug impl

### DIFF
--- a/crates/emath/src/vec2.rs
+++ b/crates/emath/src/vec2.rs
@@ -488,7 +488,7 @@ impl fmt::Debug for Vec2 {
         if let Some(precision) = f.precision() {
             write!(f, "[{1:.0$} {2:.0$}]", precision, self.x, self.y)
         } else {
-            write!(f, "[{:.1} {:.1}]", self.x, self.y)
+            write!(f, "[{:?} {:?}]", self.x, self.y)
         }
     }
 }

--- a/crates/emath/src/vec2.rs
+++ b/crates/emath/src/vec2.rs
@@ -569,4 +569,22 @@ mod test {
             assert!(vn.is_normalized());
         }
     }
+
+    #[test]
+    fn test_vec2_debug_precision() {
+        let v = vec2(0.01, -0.01);
+        let debug_output = format!("{v:?}");
+
+        // The default Debug formatting should preserve the digits
+        assert!(
+            debug_output.contains("0.01") && debug_output.contains("-0.01"),
+            "Debug output was truncated: `{debug_output}`"
+        );
+        let display_output = format!("{v}");
+        // in this case the Display formatting and the Debug formatting should be the same
+        assert_eq!(
+            debug_output, display_output,
+            "Display and Debug output should match: Display:`{display_output}` Debug:`{debug_output}`"
+        );
+    }
 }


### PR DESCRIPTION
Now we use the standard debug impl from f32
* Closes <https://github.com/emilk/egui/issues/7085>
* [x] I have followed the instructions in the PR template
