### PR TITLE
Add `Response::clicked_with_open_in_background`

### DIFF
--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -218,6 +218,14 @@ impl Response {
             && self.ctx.input(|i| i.pointer.button_triple_clicked(button))
     }
 
+    /// Was this widget middle-clicked or clicked while holding down a modifier key?
+    ///
+    /// This is used by [`crate::Hyperlink`] to check if a URL should be opened
+    /// in a new tab, using [`crate::OpenUrl::new_tab`].
+    pub fn clicked_with_open_in_background(&self) -> bool {
+        self.middle_clicked() || self.clicked() && self.ctx.input(|i| i.modifiers.any())
+    }
+
     /// `true` if there was a click *outside* the rect of this widget.
     ///
     /// Clicks on widgets contained in this one counts as clicks inside this widget,

--- a/crates/egui/src/widgets/hyperlink.rs
+++ b/crates/egui/src/widgets/hyperlink.rs
@@ -129,17 +129,15 @@ impl Widget for Hyperlink {
 
         let response = ui.add(Link::new(text));
 
-        if response.clicked() {
-            let modifiers = ui.ctx().input(|i| i.modifiers);
-            ui.ctx().open_url(crate::OpenUrl {
-                url: url.clone(),
-                new_tab: new_tab || modifiers.any(),
-            });
-        }
-        if response.middle_clicked() {
+        if response.clicked_with_open_in_background() {
             ui.ctx().open_url(crate::OpenUrl {
                 url: url.clone(),
                 new_tab: true,
+            });
+        } else if response.clicked() {
+            ui.ctx().open_url(crate::OpenUrl {
+                url: url.clone(),
+                new_tab,
             });
         }
 


### PR DESCRIPTION
Useful for buttons that should act as Hyperlinks