### PR TITLE
Feature: Extend EguiEvent::Key of it's text representation

### DIFF
--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -159,7 +159,7 @@ fn install_keydown(runner_ref: &WebRunner, target: &EventTarget) -> Result<(), J
                 && !runner.text_agent.has_focus()
                 && let Some(text) = text_from_keyboard_event(&event)
             {
-                let egui_event = egui::Event::from_text(text);
+                let egui_event = egui::Event::from_text(text).expect("Text is not valid Event");
                 let should_stop_propagation =
                     (runner.web_options.should_stop_propagation)(&egui_event);
                 let should_prevent_default =

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -206,6 +206,7 @@ pub(crate) fn on_keydown(event: web_sys::KeyboardEvent, runner: &mut AppRunner) 
             pressed: true,
             repeat: false, // egui will fill this in for us!
             modifiers,
+            text: None,
         };
         let should_stop_propagation = (runner.web_options.should_stop_propagation)(&egui_event);
         runner.input.raw.events.push(egui_event);
@@ -299,6 +300,7 @@ pub(crate) fn on_keyup(event: web_sys::KeyboardEvent, runner: &mut AppRunner) {
             pressed: false,
             repeat: false,
             modifiers,
+            text: None,
         };
         should_stop_propagation &= (runner.web_options.should_stop_propagation)(&egui_event);
         runner.input.raw.events.push(egui_event);
@@ -320,6 +322,7 @@ pub(crate) fn on_keyup(event: web_sys::KeyboardEvent, runner: &mut AppRunner) {
                 pressed: false,
                 repeat: false,
                 modifiers,
+                text: None,
             };
             should_stop_propagation &= (runner.web_options.should_stop_propagation)(&egui_event);
             runner.input.raw.events.push(egui_event);

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -159,7 +159,7 @@ fn install_keydown(runner_ref: &WebRunner, target: &EventTarget) -> Result<(), J
                 && !runner.text_agent.has_focus()
                 && let Some(text) = text_from_keyboard_event(&event)
             {
-                let egui_event = egui::Event::Text(text);
+                let egui_event = egui::Event::from_text(text);
                 let should_stop_propagation =
                     (runner.web_options.should_stop_propagation)(&egui_event);
                 let should_prevent_default =

--- a/crates/eframe/src/web/text_agent.rs
+++ b/crates/eframe/src/web/text_agent.rs
@@ -329,7 +329,7 @@ impl InputState {
                 active_range_chars,
             })
         } else {
-            egui::Event::from_text(preedit_text)
+            egui::Event::from_text(preedit_text).expect("Text is not valid Event")
         };
         runner.input.raw.events.push(out_event);
 
@@ -351,7 +351,11 @@ impl InputState {
 
         let text = self.input.value();
 
-        runner.input.raw.events.push(egui::Event::from_text(text));
+        runner
+            .input
+            .raw
+            .events
+            .push(egui::Event::from_text(text).expect("Text is not valid Event"));
         self.clear();
     }
 

--- a/crates/eframe/src/web/text_agent.rs
+++ b/crates/eframe/src/web/text_agent.rs
@@ -329,7 +329,7 @@ impl InputState {
                 active_range_chars,
             })
         } else {
-            egui::Event::Text(preedit_text)
+            egui::Event::from_text(preedit_text)
         };
         runner.input.raw.events.push(out_event);
 
@@ -351,7 +351,7 @@ impl InputState {
 
         let text = self.input.value();
 
-        runner.input.raw.events.push(egui::Event::Text(text));
+        runner.input.raw.events.push(egui::Event::from_text(text));
         self.clear();
     }
 

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1028,6 +1028,20 @@ impl State {
             physical_key
         );
 
+        // Filter text of control characters
+        let text = match text
+            .as_ref()
+            .map(|t| t.as_str())
+            .or_else(|| winit_logical_key.to_text())
+        {
+            // On some platforms we get here when the user presses Cmd-C (copy), ctrl-W, etc.
+            // We need to ignore these characters that are side-effects of commands.
+            Some(text) if !text.is_empty() && text.chars().all(is_printable_char) => {
+                Some(text.to_owned())
+            }
+            _ => None,
+        };
+
         // "Logical OR physical key" is a fallback mechanism for keyboard layouts without Latin characters: it lets them
         // emit events as if the corresponding keys from the Latin layout were pressed. In this case, clipboard shortcuts
         // are mapped to the physical keys that normally contain C, X, V, etc.
@@ -1065,28 +1079,22 @@ impl State {
                 pressed,
                 repeat: false, // egui will fill this in for us!
                 modifiers: self.modifiers,
+                text: text.clone(),
             });
         }
 
-        if let Some(text) = text
-            .as_ref()
-            .map(|t| t.as_str())
-            .or_else(|| winit_logical_key.to_text())
-        {
-            // Make sure there is text, and that it is not control characters
-            // (e.g. delete is sent as "\u{f728}" on macOS).
-            if !text.is_empty() && text.chars().all(is_printable_char) {
-                // On some platforms we get here when the user presses Cmd-C (copy), ctrl-W, etc.
-                // We need to ignore these characters that are side-effects of commands.
-                // Also make sure the key is pressed (not released). On Linux, text might
-                // contain some data even when the key is released.
-                let is_cmd =
-                    self.modifiers.ctrl || self.modifiers.command || self.modifiers.mac_cmd;
-                if pressed && !is_cmd {
-                    self.egui_input
-                        .events
-                        .push(egui::Event::Text(text.to_owned()));
-                }
+        // Make sure there is text, and that it is not control characters
+        // (e.g. delete is sent as "\u{f728}" on macOS).
+        if let Some(text) = text {
+            // On some platforms we get here when the user presses Cmd-C (copy), ctrl-W, etc.
+            // We need to ignore these characters that are side-effects of commands.
+            // Also make sure the key is pressed (not released). On Linux, text might
+            // contain some data even when the key is released.
+
+            let is_cmd = self.modifiers.ctrl || self.modifiers.command || self.modifiers.mac_cmd;
+
+            if pressed && !is_cmd {
+                self.egui_input.events.push(egui::Event::Text(text));
             }
         }
     }

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1093,8 +1093,8 @@ impl State {
 
             let is_cmd = self.modifiers.ctrl || self.modifiers.command || self.modifiers.mac_cmd;
 
+            #[expect(deprecated)]
             if pressed && !is_cmd {
-                #[allow(deprecated)]
                 self.egui_input.events.push(egui::Event::Text(text));
             }
         }

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1094,6 +1094,7 @@ impl State {
             let is_cmd = self.modifiers.ctrl || self.modifiers.command || self.modifiers.mac_cmd;
 
             if pressed && !is_cmd {
+                #[allow(deprecated)]
                 self.egui_input.events.push(egui::Event::Text(text));
             }
         }

--- a/crates/egui/src/data/input/event.rs
+++ b/crates/egui/src/data/input/event.rs
@@ -76,6 +76,8 @@ pub enum Event {
 
         /// The state of the modifier keys at the time of the event.
         modifiers: Modifiers,
+
+        text: Option<String>,
     },
 
     /// The set of held modifier keys changed.

--- a/crates/egui/src/data/input/event.rs
+++ b/crates/egui/src/data/input/event.rs
@@ -36,6 +36,7 @@ pub enum Event {
     /// Text input, e.g. via keyboard.
     ///
     /// When the user presses enter/return, do not send a [`Text`](Event::Text) (just [`Key::Enter`]).
+    #[deprecated(since = "0.31.1", note = "please use `Event::Key.text` instead")]
     Text(String),
 
     /// A key was pressed or released.
@@ -77,6 +78,15 @@ pub enum Event {
         /// The state of the modifier keys at the time of the event.
         modifiers: Modifiers,
 
+        /// Text representation. This is used either for:
+        /// a) For the attached keyboard is a keyboard mapping configured.
+        ///    So that for the key press Alt+a the german letter "ä" should be
+        ///    written.
+        /// b) Some platforms might send multiple characters/words text inputs
+        ///    in one single event
+        ///
+        /// If you want to create a simple fake [`Event::Key`] event with this field
+        /// filled, check out [`Event::from_text`].
         text: Option<String>,
     },
 
@@ -187,4 +197,20 @@ pub enum Event {
 
     /// An assistive technology (e.g. screen reader) requested an action.
     AccessKitActionRequest(accesskit::ActionRequest),
+}
+
+impl Event {
+    /// Create a valid [`Event::Key`] from text. This fakes
+    /// a Key event if you need to inject some [`Event::Key { text: Some(text), ..}`]
+    /// Helpful if you relied on creating [`Event::Text`] before it's deprecation.
+    pub fn from_text(text: String) -> Self {
+        Self::Key {
+            key: Key::from_name(&text.chars().nth(0).unwrap_or('a').to_string()).unwrap_or(Key::A),
+            physical_key: None,
+            pressed: true,
+            repeat: false,
+            modifiers: Modifiers::NONE,
+            text: Some(text),
+        }
+    }
 }

--- a/crates/egui/src/data/input/event.rs
+++ b/crates/egui/src/data/input/event.rs
@@ -199,22 +199,32 @@ pub enum Event {
     AccessKitActionRequest(accesskit::ActionRequest),
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EventFromTextError {
+    IsEmpty,
+    FirstCharNotValidKey,
+}
+
 impl Event {
     /// Create a valid [`Event::Key`] from text. This fakes
     /// a Key event if you need to inject some [`Event::Key { text: Some(text), ..}`]
     /// Helpful if you relied on creating [`Event::Text`] before it's deprecation.
     /// This function panics if text is empty or the first char in text is not a valid [`Key`].
-    pub fn from_text(text: String) -> Self {
-        let first_char = &text.chars().nth(0).expect("text is empty").to_string();
+    pub fn from_text(text: String) -> Result<Self, EventFromTextError> {
+        let first_char = &text
+            .chars()
+            .nth(0)
+            .ok_or(EventFromTextError::IsEmpty)?
+            .to_string();
         let first_char_key: Key =
-            Key::from_name(first_char).expect("first char is not a valid key");
-        Self::Key {
+            Key::from_name(first_char).ok_or(EventFromTextError::FirstCharNotValidKey)?;
+        Ok(Self::Key {
             key: first_char_key,
             physical_key: None,
             pressed: true,
             repeat: false,
             modifiers: Modifiers::NONE,
             text: Some(text),
-        }
+        })
     }
 }

--- a/crates/egui/src/data/input/event.rs
+++ b/crates/egui/src/data/input/event.rs
@@ -203,9 +203,13 @@ impl Event {
     /// Create a valid [`Event::Key`] from text. This fakes
     /// a Key event if you need to inject some [`Event::Key { text: Some(text), ..}`]
     /// Helpful if you relied on creating [`Event::Text`] before it's deprecation.
+    /// This function panics if text is empty or the first char in text is not a valid [`Key`].
     pub fn from_text(text: String) -> Self {
+        let first_char = &text.chars().nth(0).expect("text is empty").to_string();
+        let first_char_key: Key =
+            Key::from_name(first_char).expect("first char is not a valid key");
         Self::Key {
-            key: Key::from_name(&text.chars().nth(0).unwrap_or('a').to_string()).unwrap_or(Key::A),
+            key: first_char_key,
             physical_key: None,
             pressed: true,
             repeat: false,

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -1159,7 +1159,12 @@ fn events(
                     Some(CursorMutation::Selection(CCursorRange::one(ccursor)))
                 }
             }
-            Event::Text(text_to_insert) => {
+            Event::Key {
+                text: Some(text_to_insert),
+                pressed: true,
+                modifiers,
+                ..
+            } if !modifiers.ctrl && !modifiers.command && !modifiers.mac_cmd => {
                 // Newlines are handled by `Key::Enter`.
                 if !text_to_insert.is_empty() && text_to_insert != "\n" && text_to_insert != "\r" {
                     let mut ccursor = text.delete_selected(&cursor_range);

--- a/crates/egui_kittest/src/lib.rs
+++ b/crates/egui_kittest/src/lib.rs
@@ -589,6 +589,7 @@ impl<'a, State> Harness<'a, State> {
             modifiers: Modifiers::default(),
             repeat: false,
             physical_key: None,
+            text: None,
         });
     }
 
@@ -600,6 +601,7 @@ impl<'a, State> Harness<'a, State> {
                 modifiers,
                 repeat: false,
                 physical_key: None,
+                text: None,
             },
             modifiers,
         );
@@ -612,6 +614,7 @@ impl<'a, State> Harness<'a, State> {
             modifiers: Modifiers::default(),
             repeat: false,
             physical_key: None,
+            text: None,
         });
     }
 
@@ -623,6 +626,7 @@ impl<'a, State> Harness<'a, State> {
                 modifiers,
                 repeat: false,
                 physical_key: None,
+                text: None,
             },
             modifiers,
         );

--- a/crates/egui_kittest/src/lib.rs
+++ b/crates/egui_kittest/src/lib.rs
@@ -668,6 +668,7 @@ impl<'a, State> Harness<'a, State> {
                     modifiers,
                     repeat: false,
                     physical_key: None,
+                    text: None,
                 });
             }
         }

--- a/crates/egui_kittest/src/node.rs
+++ b/crates/egui_kittest/src/node.rs
@@ -137,7 +137,7 @@ impl<'tree> Node<'tree> {
     }
 
     pub fn type_text(&self, text: &str) {
-        self.event(egui::Event::Text(text.to_owned()));
+        self.event(egui::Event::from_text(text.to_owned()));
     }
 
     pub fn value(&self) -> Option<String> {

--- a/crates/egui_kittest/src/node.rs
+++ b/crates/egui_kittest/src/node.rs
@@ -137,7 +137,7 @@ impl<'tree> Node<'tree> {
     }
 
     pub fn type_text(&self, text: &str) {
-        self.event(egui::Event::from_text(text.to_owned()));
+        self.event(egui::Event::from_text(text.to_owned()).expect("Text is not valid Event"));
     }
 
     pub fn value(&self) -> Option<String> {

--- a/examples/custom_keypad/src/keypad.rs
+++ b/examples/custom_keypad/src/keypad.rs
@@ -39,6 +39,7 @@ impl State {
                 pressed: true,
                 repeat: false,
                 modifiers: Default::default(),
+                text: None,
             });
         }
         events.push(egui::Event::Text(c.to_string()));
@@ -52,6 +53,7 @@ impl State {
             pressed: true,
             repeat: false,
             modifiers: Default::default(),
+                text: None,
         });
     }
 }

--- a/examples/custom_keypad/src/keypad.rs
+++ b/examples/custom_keypad/src/keypad.rs
@@ -32,6 +32,7 @@ impl State {
 
     fn queue_char(&mut self, c: char) {
         let events = self.events.get_or_insert(vec![]);
+        let text = Some(c.to_string());
         if let Some(key) = egui::Key::from_name(&c.to_string()) {
             events.push(egui::Event::Key {
                 key,
@@ -39,10 +40,9 @@ impl State {
                 pressed: true,
                 repeat: false,
                 modifiers: Default::default(),
-                text: None,
+                text,
             });
         }
-        events.push(egui::Event::Text(c.to_string()));
     }
 
     fn queue_key(&mut self, key: egui::Key) {
@@ -53,7 +53,7 @@ impl State {
             pressed: true,
             repeat: false,
             modifiers: Default::default(),
-                text: None,
+            text: None,
         });
     }
 }


### PR DESCRIPTION
This pr adds the text representation of the key to the EguiEvent::Key struct.
This way we get the character that the keyboard layout actually represents and not only
the key combination. For example on EurKey layout, if i press AltRight+A, it's mapped to "ä".
`Key { key: A, physical_key: Some(A), pressed: false, repeat: false, modifiers: Modifiers::NONE, text: Some("ä") }`

* Addresses <https://github.com/emilk/egui/discussions/1590>
* [x] I have followed the instructions in the PR template
