### PR TITLE
Select all text in DragValue when gaining focus via keyboard

### DIFF
--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -569,6 +569,16 @@ impl Widget for DragValue<'_> {
                     .font(text_style),
             );
 
+            // Select all text when the edit gains focus.
+            if ui.memory_mut(|mem| mem.gained_focus(id)) {
+                let mut state = TextEdit::load_state(ui.ctx(), id).unwrap_or_default();
+                state.cursor.set_char_range(Some(text::CCursorRange::two(
+                    text::CCursor::default(),
+                    text::CCursor::new(value_text.chars().count()),
+                )));
+                state.store(ui.ctx(), response.id);
+            }
+
             let update = if update_while_editing {
                 // Update when the edit content has changed.
                 response.changed()


### PR DESCRIPTION
Previously, the `DragValue` widget selected all text when focus was gained via a mouse click, but didn't when focus was gained via keyboard.

https://github.com/user-attachments/assets/5e82ca2c-0214-4201-ad2d-056dabc05e92

This PR makes both gained focus behaving the same way by selecting the text on focus gained via keyboard.

https://github.com/user-attachments/assets/f246c779-3368-428c-a6b2-cec20dbc20a6

