### PR TITLE
Update area struct to allow force resizing

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -366,9 +366,13 @@ impl Area {
     /// area contents area dynamic and you need to need to make sure the area adjusts its size
     /// accordingly.
     ///
+    /// This should only be set to true during the specific frames you want force a sizing pass.
+    /// Do NOT hard-code this as `.sizing_pass(true)`, as it will cause the area to never be
+    /// visible.
+    ///
     /// # Arguments
     /// - resize: If true, the area will be resized to fit its contents. False will keep the
-    ///         default area resizing behavior.
+    ///   default area resizing behavior.
     ///
     /// Default: `false`.
     #[inline]

--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -121,6 +121,7 @@ pub struct Area {
     new_pos: Option<Pos2>,
     fade_in: bool,
     layout: Layout,
+    force_resize_to_content: bool,
 }
 
 impl WidgetWithState for Area {
@@ -147,6 +148,7 @@ impl Area {
             anchor: None,
             fade_in: true,
             layout: Layout::default(),
+            force_resize_to_content: false,
         }
     }
 
@@ -355,6 +357,11 @@ impl Area {
     #[inline]
     pub fn layout(mut self, layout: Layout) -> Self {
         self.layout = layout;
+    }
+
+    #[inline]
+    pub fn force_resize_to_content(mut self, resize: bool) -> Self {
+        self.force_resize_to_content = resize;
         self
     }
 }
@@ -410,6 +417,7 @@ impl Area {
             constrain_rect,
             fade_in,
             layout,
+            force_resize_to_content,
         } = self;
 
         let constrain_rect = constrain_rect.unwrap_or_else(|| ctx.screen_rect());
@@ -425,6 +433,10 @@ impl Area {
             interactable,
             last_became_visible_at: None,
         });
+        if force_resize_to_content {
+            sizing_pass = true;
+            state.size = None;
+        }
         state.pivot = pivot;
         state.interactable = interactable;
         if let Some(new_pos) = new_pos {

--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -121,7 +121,7 @@ pub struct Area {
     new_pos: Option<Pos2>,
     fade_in: bool,
     layout: Layout,
-    force_resize_to_content: bool,
+    sizing_pass: bool,
 }
 
 impl WidgetWithState for Area {
@@ -148,7 +148,7 @@ impl Area {
             anchor: None,
             fade_in: true,
             layout: Layout::default(),
-            force_resize_to_content: false,
+            sizing_pass: false,
         }
     }
 
@@ -357,11 +357,23 @@ impl Area {
     #[inline]
     pub fn layout(mut self, layout: Layout) -> Self {
         self.layout = layout;
+        self
     }
 
+    /// While true, a sizing pass will be done. This means the area will be invisible
+    /// and the contents will be laid out to estimate the proper containing size of the area.
+    /// If false, there will be no change to the default area behavior. This is useful if the
+    /// area contents area dynamic and you need to need to make sure the area adjusts its size
+    /// accordingly.
+    ///
+    /// # Arguments
+    /// - resize: If true, the area will be resized to fit its contents. False will keep the
+    ///         default area resizing behavior.
+    ///
+    /// Default: `false`.
     #[inline]
-    pub fn force_resize_to_content(mut self, resize: bool) -> Self {
-        self.force_resize_to_content = resize;
+    pub fn sizing_pass(mut self, resize: bool) -> Self {
+        self.sizing_pass = resize;
         self
     }
 }
@@ -417,7 +429,7 @@ impl Area {
             constrain_rect,
             fade_in,
             layout,
-            force_resize_to_content,
+            sizing_pass: force_sizing_pass,
         } = self;
 
         let constrain_rect = constrain_rect.unwrap_or_else(|| ctx.screen_rect());
@@ -433,7 +445,7 @@ impl Area {
             interactable,
             last_became_visible_at: None,
         });
-        if force_resize_to_content {
+        if force_sizing_pass {
             sizing_pass = true;
             state.size = None;
         }

--- a/crates/egui/src/memory/mod.rs
+++ b/crates/egui/src/memory/mod.rs
@@ -1155,20 +1155,6 @@ impl Areas {
         self.areas.get(&id)
     }
 
-    /// Remove an area by its `LayerId`.
-    pub fn remove(&mut self, layer_id: LayerId) {
-        self.areas.remove(&layer_id.id);
-        self.visible_areas_last_frame.remove(&layer_id);
-        self.visible_areas_current_frame.remove(&layer_id);
-        self.order.retain(|l| l != &layer_id);
-        self.order_map.remove(&layer_id);
-        self.wants_to_be_on_top.remove(&layer_id);
-        self.sublayers.retain(|parent, children| {
-            children.remove(&layer_id);
-            !children.is_empty() || *parent != layer_id
-        });
-    }
-
     /// All layers back-to-front, top is last.
     pub(crate) fn order(&self) -> &[LayerId] {
         &self.order

--- a/crates/egui/src/memory/mod.rs
+++ b/crates/egui/src/memory/mod.rs
@@ -1155,8 +1155,18 @@ impl Areas {
         self.areas.get(&id)
     }
 
-    pub fn remove(&mut self, id: Id) -> Option<area::AreaState> {
-        self.areas.remove(&id)
+    /// Remove an area by its `LayerId`.
+    pub fn remove(&mut self, layer_id: LayerId) {
+        self.areas.remove(&layer_id.id);
+        self.visible_areas_last_frame.remove(&layer_id);
+        self.visible_areas_current_frame.remove(&layer_id);
+        self.order.retain(|l| l != &layer_id);
+        self.order_map.remove(&layer_id);
+        self.wants_to_be_on_top.remove(&layer_id);
+        self.sublayers.retain(|parent, children| {
+            children.remove(&layer_id);
+            !children.is_empty() || *parent != layer_id
+        });
     }
 
     /// All layers back-to-front, top is last.

--- a/crates/egui/src/memory/mod.rs
+++ b/crates/egui/src/memory/mod.rs
@@ -1155,7 +1155,7 @@ impl Areas {
         self.areas.get(&id)
     }
 
-    pub(crate) fn remove(&mut self, id: Id) -> Option<area::AreaState> {
+    pub fn remove(&mut self, id: Id) -> Option<area::AreaState> {
         self.areas.remove(&id)
     }
 

--- a/crates/egui/src/memory/mod.rs
+++ b/crates/egui/src/memory/mod.rs
@@ -1155,6 +1155,10 @@ impl Areas {
         self.areas.get(&id)
     }
 
+    pub(crate) fn remove(&mut self, id: Id) -> Option<area::AreaState> {
+        self.areas.remove(&id)
+    }
+
     /// All layers back-to-front, top is last.
     pub(crate) fn order(&self) -> &[LayerId] {
         &self.order


### PR DESCRIPTION
This is a really small PR so I am skipping the issue (based on contributing.md). This change adds an optional field and thus non breaking for the API. 

I ran into an issue during my development of an alerts manager widget ([see PR](https://github.com/blackberryfloat/egui_widget_ext/pull/2)) where I needed a scrollable overlay that did not block clicking areas of a parent widget when my alerts did not take up the entire parent. To achieve this I detect the sizing pass via the invisible flag and only render the alerts content and then on the next pass I add the scroll bar in around the alert content. Whenever the alert content changed though I would need to create a new Area with a new id to get proper sizing. That is a memory leak so I wanted to reset the size state to trigger a sizing pass. Memory is rightfully protected enough that the path to remove memory was dropped and I just added a hook to set a resize flag. 

I am sure there are better ways but this is what made sense to me. Looking forward to thoughts.

~~Logistics wise, I have proposed it as a patch because I was based off 0.31.1 for testing. I was also thinking it could be released quickly. I am happy to cherry pick onto main after. If that is not allowed I can rebase to main and pull against that.~~ (rebased on main)