### PR TITLE
Support vertical-only scrolling by holding down Alt

### DIFF
--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -986,6 +986,12 @@ impl std::ops::BitOrAssign for Modifiers {
     }
 }
 
+impl Modifiers {
+    pub fn ui(&self, ui: &mut crate::Ui) {
+        ui.label(ModifierNames::NAMES.format(self, ui.ctx().os().is_mac()));
+    }
+}
+
 // ----------------------------------------------------------------------------
 
 /// Names of different modifier keys.

--- a/crates/egui/src/input_state/mod.rs
+++ b/crates/egui/src/input_state/mod.rs
@@ -425,9 +425,9 @@ impl InputState {
                     #[expect(clippy::collapsible_else_if)]
                     if is_zoom {
                         if is_smooth {
-                            smooth_scroll_delta_for_zoom += delta.y;
+                            smooth_scroll_delta_for_zoom += delta.x + delta.y;
                         } else {
-                            unprocessed_scroll_delta_for_zoom += delta.y;
+                            unprocessed_scroll_delta_for_zoom += delta.x + delta.y;
                         }
                     } else {
                         if is_smooth {

--- a/crates/egui/src/input_state/mod.rs
+++ b/crates/egui/src/input_state/mod.rs
@@ -76,7 +76,7 @@ impl Default for InputOptions {
             max_click_dist: 6.0,
             max_click_duration: 0.8,
             max_double_click_delay: 0.3,
-            zoom_modifier: Modifiers::CTRL | Modifiers::MAC_CMD | Modifiers::COMMAND,
+            zoom_modifier: Modifiers::COMMAND,
             horizontal_scroll_modifier: Modifiers::SHIFT,
             vertical_scroll_modifier: Modifiers::ALT,
         }

--- a/crates/egui/src/input_state/touch_state.rs
+++ b/crates/egui/src/input_state/touch_state.rs
@@ -194,7 +194,7 @@ impl TouchState {
 
             let zoom_delta = state.current.avg_distance / state_previous.avg_distance;
 
-            let zoom_delta2 = match state.pinch_type {
+            let zoom_delta_2d = match state.pinch_type {
                 PinchType::Horizontal => Vec2::new(
                     state.current.avg_abs_distance2.x / state_previous.avg_abs_distance2.x,
                     1.0,
@@ -213,7 +213,7 @@ impl TouchState {
                 start_pos: state.start_pointer_pos,
                 num_touches: self.active_touches.len(),
                 zoom_delta,
-                zoom_delta_2d: zoom_delta2,
+                zoom_delta_2d,
                 rotation_delta: normalized_angle(state.current.heading - state_previous.heading),
                 translation_delta: state.current.avg_pos - state_previous.avg_pos,
                 force: state.current.avg_force,

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -496,7 +496,7 @@ pub use self::{
     epaint::text::TextWrapMode,
     grid::Grid,
     id::{Id, IdMap},
-    input_state::{InputState, MultiTouchInfo, PointerState},
+    input_state::{InputOptions, InputState, MultiTouchInfo, PointerState},
     layers::{LayerId, Order},
     layout::*,
     load::SizeHint,


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/7120

You can now zoom only the X axis by holding down shift, and zoom only the Y axis by holding down ALT.

In summary

* `Shift`: horizontal
* `Alt`: vertical
* `Ctrl`: zoom (`Cmd` on Mac)

Thus follows:
* `scroll`: pan both axis (at least for trackpads and mice with two-axis scroll)
* `Shift + scroll`: pan only horizontal axis
* `Alt + scroll`: pan only vertical axis
* `Ctrl + scroll`: zoom all axes
* `Ctrl + Shift + scroll`: zoom only horizontal axis
* `Ctrl + Alt + scroll`: zoom only vertical axis

This is provided the application uses `zoom_delta_2d` for its zooming needs.

The modifiers are exposed in `InputOptions`, but it is strongly recommended that you do not change them.

## Testing
Unfortunately we have no nice way of testing this in egui.
But I've tested it in `egui_plot`.