### PR TITLE
Make `Hsva` derive serde

### DIFF
--- a/crates/ecolor/src/hsva.rs
+++ b/crates/ecolor/src/hsva.rs
@@ -4,6 +4,7 @@ use crate::{
 
 /// Hue, saturation, value, alpha. All in the range [0, 1].
 /// No premultiplied alpha.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Hsva {
     /// hue 0-1


### PR DESCRIPTION
This pull request introduces a change to the `Hsva` struct in the `crates/ecolor/src/hsva.rs` file to enable serialization and deserialization when the `serde` feature is enabled.

* Closes <https://github.com/emilk/egui/issues/7131>
* [x] I have followed the instructions in the PR template
