### PR TITLE
`Button` inherits the `alt_text` of the `Image` in it, if any

### DIFF
--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -314,11 +314,15 @@ impl Widget for Button<'_> {
 
         let (rect, mut response) = ui.allocate_at_least(desired_size, sense);
         response.widget_info(|| {
+            let mut widget_info = WidgetInfo::new(WidgetType::Button);
+            widget_info.enabled = ui.is_enabled();
+
             if let Some(galley) = &galley {
-                WidgetInfo::labeled(WidgetType::Button, ui.is_enabled(), galley.text())
-            } else {
-                WidgetInfo::new(WidgetType::Button)
+                widget_info.label = Some(galley.text().to_owned());
+            } else if let Some(image) = &image {
+                widget_info.label = image.alt_text.clone();
             }
+            widget_info
         });
 
         if ui.is_rect_visible(rect) {

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -54,7 +54,7 @@ pub struct Image<'a> {
     sense: Sense,
     size: ImageSize,
     pub(crate) show_loading_spinner: Option<bool>,
-    alt_text: Option<String>,
+    pub(crate) alt_text: Option<String>,
 }
 
 impl<'a> Image<'a> {


### PR DESCRIPTION
If a `Button` has an `Image` in it (and no text), then the `Image::alt_text` will be used as the accessibility label for the button.