### PR TITLE
Report image alt text as text if widget contains no other text

### DIFF
--- a/crates/egui/src/atomics/atoms.rs
+++ b/crates/egui/src/atomics/atoms.rs
@@ -42,6 +42,15 @@ impl<'a> Atoms<'a> {
                 }
             }
         }
+
+        // If there is no text, try to find an image with alt text.
+        if string.is_none() {
+            string = self.iter().find_map(|a| match &a.kind {
+                AtomKind::Image(image) => image.alt_text.as_deref().map(Cow::Borrowed),
+                _ => None,
+            });
+        }
+
         string
     }
 

--- a/tests/egui_tests/tests/regression_tests.rs
+++ b/tests/egui_tests/tests/regression_tests.rs
@@ -1,0 +1,14 @@
+use egui::{include_image, Image};
+use egui_kittest::kittest::Queryable as _;
+use egui_kittest::Harness;
+
+#[test]
+fn image_button_should_have_alt_text() {
+    let harness = Harness::new_ui(|ui| {
+        _ = ui.button(
+            Image::new(include_image!("../../../crates/eframe/data/icon.png")).alt_text("Egui"),
+        );
+    });
+
+    harness.get_by_label("Egui");
+}


### PR DESCRIPTION
- Same as https://github.com/emilk/egui/pull/7136 but now for atomics