### PR TITLE
Add back old `Tooltip::new`

### DIFF
--- a/crates/egui/src/containers/old_popup.rs
+++ b/crates/egui/src/containers/old_popup.rs
@@ -61,7 +61,7 @@ pub fn show_tooltip_at_pointer<R>(
     widget_id: Id,
     add_contents: impl FnOnce(&mut Ui) -> R,
 ) -> Option<R> {
-    Tooltip::new(ctx.clone(), parent_layer, widget_id, PopupAnchor::Pointer)
+    Tooltip::always_open(ctx.clone(), parent_layer, widget_id, PopupAnchor::Pointer)
         .gap(12.0)
         .show(add_contents)
         .map(|response| response.inner)
@@ -78,7 +78,7 @@ pub fn show_tooltip_for<R>(
     widget_rect: &Rect,
     add_contents: impl FnOnce(&mut Ui) -> R,
 ) -> Option<R> {
-    Tooltip::new(ctx.clone(), parent_layer, widget_id, *widget_rect)
+    Tooltip::always_open(ctx.clone(), parent_layer, widget_id, *widget_rect)
         .show(add_contents)
         .map(|response| response.inner)
 }
@@ -94,7 +94,7 @@ pub fn show_tooltip_at<R>(
     suggested_position: Pos2,
     add_contents: impl FnOnce(&mut Ui) -> R,
 ) -> Option<R> {
-    Tooltip::new(ctx.clone(), parent_layer, widget_id, suggested_position)
+    Tooltip::always_open(ctx.clone(), parent_layer, widget_id, suggested_position)
         .show(add_contents)
         .map(|response| response.inner)
 }

--- a/crates/egui/src/containers/tooltip.rs
+++ b/crates/egui/src/containers/tooltip.rs
@@ -17,7 +17,25 @@ pub struct Tooltip<'a> {
 
 impl Tooltip<'_> {
     /// Show a tooltip that is always open.
+    #[deprecated = "Use `Tooltip::always_open` instead."]
     pub fn new(
+        parent_widget: Id,
+        ctx: Context,
+        anchor: impl Into<PopupAnchor>,
+        parent_layer: LayerId,
+    ) -> Self {
+        Self {
+            popup: Popup::new(parent_widget, ctx, anchor.into(), parent_layer)
+                .kind(PopupKind::Tooltip)
+                .gap(4.0)
+                .sense(Sense::hover()),
+            parent_layer,
+            parent_widget,
+        }
+    }
+
+    /// Show a tooltip that is always open.
+    pub fn always_open(
         ctx: Context,
         parent_layer: LayerId,
         parent_widget: Id,


### PR DESCRIPTION
I was a bit too hasty in https://github.com/emilk/egui/pull/7151 and changed a public API in a breaking way, for no good reason