### PR TITLE
Make `Memory::keep_popup_open` less of a footgun

### DIFF
--- a/crates/egui/src/containers/combo_box.rs
+++ b/crates/egui/src/containers/combo_box.rs
@@ -293,7 +293,7 @@ impl ComboBox {
 
     /// Check if the [`ComboBox`] with the given id has its popup menu currently opened.
     pub fn is_open(ctx: &Context, id: Id) -> bool {
-        ctx.memory(|m| m.is_popup_open(Self::widget_to_popup_id(id)))
+        ctx.memory(|m| m.is_showing_popup(Self::widget_to_popup_id(id)))
     }
 
     /// Convert a [`ComboBox`] id to the id used to store it's popup state.
@@ -315,7 +315,7 @@ fn combo_box_dyn<'c, R>(
 ) -> InnerResponse<Option<R>> {
     let popup_id = ComboBox::widget_to_popup_id(button_id);
 
-    let is_popup_open = ui.memory(|m| m.is_popup_open(popup_id));
+    let is_popup_open = ui.memory(|m| m.is_showing_popup(popup_id));
 
     let wrap_mode = wrap_mode.unwrap_or_else(|| ui.wrap_mode());
 

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -127,7 +127,7 @@ impl OpenKind<'_> {
             OpenKind::Open => true,
             OpenKind::Closed => false,
             OpenKind::Bool(open) => **open,
-            OpenKind::Memory { .. } => ctx.memory(|mem| mem.is_popup_open(id)),
+            OpenKind::Memory { .. } => ctx.memory(|mem| mem.is_showing_popup(id)),
         }
     }
 }
@@ -446,7 +446,7 @@ impl<'a> Popup<'a> {
             OpenKind::Open => true,
             OpenKind::Closed => false,
             OpenKind::Bool(open) => **open,
-            OpenKind::Memory { .. } => self.ctx.memory(|mem| mem.is_popup_open(self.id)),
+            OpenKind::Memory { .. } => self.ctx.memory(|mem| mem.is_showing_popup(self.id)),
         }
     }
 
@@ -531,7 +531,7 @@ impl<'a> Popup<'a> {
                     mem.toggle_popup(id);
                 }
                 None => {
-                    mem.keep_popup_open(id);
+                    mem.show_popup(id);
                 }
             });
         }

--- a/crates/egui/src/widgets/color_picker.rs
+++ b/crates/egui/src/widgets/color_picker.rs
@@ -491,7 +491,7 @@ pub fn color_picker_color32(ui: &mut Ui, srgba: &mut Color32, alpha: Alpha) -> b
 
 pub fn color_edit_button_hsva(ui: &mut Ui, hsva: &mut Hsva, alpha: Alpha) -> Response {
     let popup_id = ui.auto_id_with("popup");
-    let open = ui.memory(|mem| mem.is_popup_open(popup_id));
+    let open = ui.memory(|mem| mem.is_showing_popup(popup_id));
     let mut button_response = color_button(ui, (*hsva).into(), open);
     if ui.style().explanation_tooltips {
         button_response = button_response.on_hover_text("Click to edit color");


### PR DESCRIPTION

* Closes #7037 

The breaking change is intentional, to force people to think about this, since otherwise the keep_popup_open thing would silently break popups.