### PR TITLE
Change `Rect::area` to return zero for negative rectangles

### DIFF
--- a/crates/emath/src/rect.rs
+++ b/crates/emath/src/rect.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{Div, Mul, Pos2, Rangef, Rot2, Vec2, lerp, pos2, vec2};
+use crate::{Div, Mul, NumExt as _, Pos2, Rangef, Rot2, Vec2, lerp, pos2, vec2};
 
 /// A rectangular region of space.
 ///
@@ -341,11 +341,13 @@ impl Rect {
         self.max - self.min
     }
 
+    /// Note: this can be negative.
     #[inline(always)]
     pub fn width(&self) -> f32 {
         self.max.x - self.min.x
     }
 
+    /// Note: this can be negative.
     #[inline(always)]
     pub fn height(&self) -> f32 {
         self.max.y - self.min.y
@@ -373,9 +375,10 @@ impl Rect {
         }
     }
 
+    /// This is never negative, and instead returns zero for negative rectangles.
     #[inline(always)]
     pub fn area(&self) -> f32 {
-        self.width() * self.height()
+        self.width().at_least(0.0) * self.height().at_least(0.0)
     }
 
     /// The distance from the rect to the position.


### PR DESCRIPTION
Previously a single-negative rectangle (where `min.x > max.x` XOR `min.y > max.y`) would return a negative area, while a doubly-negative rectangle (`min.x > max.x` AND `min.y > max.y`) would return a positive area. Now both return zero instead.