### PR TITLE
Rename `egui::containers::menu::Bar` to `egui::MenuBar`

### DIFF
--- a/crates/egui/src/containers/menu.rs
+++ b/crates/egui/src/containers/menu.rs
@@ -252,8 +252,8 @@ impl MenuBar {
 
 /// A thin wrapper around a [`Button`] that shows a [`Popup::menu`] when clicked.
 ///
-/// The only thing this does is search for the current menu config (if set via [`Bar`]).
-/// If your menu button is not in a [`Bar`] it's fine to use [`Ui::button`] and [`Popup::menu`]
+/// The only thing this does is search for the current menu config (if set via [`MenuBar`]).
+/// If your menu button is not in a [`MenuBar`] it's fine to use [`Ui::button`] and [`Popup::menu`]
 /// directly.
 pub struct MenuButton<'a> {
     pub button: Button<'a>,

--- a/crates/egui/src/containers/menu.rs
+++ b/crates/egui/src/containers/menu.rs
@@ -1,3 +1,5 @@
+//! See [`MenuBar`] for an example
+
 use crate::style::StyleModifier;
 use crate::{
     Button, Color32, Context, Frame, Id, InnerResponse, IntoAtoms, Layout, Popup,
@@ -163,13 +165,30 @@ impl MenuState {
 /// The menu bar goes well in a [`crate::TopBottomPanel::top`],
 /// but can also be placed in a [`crate::Window`].
 /// In the latter case you may want to wrap it in [`Frame`].
+///
+/// ### Example:
+/// ```
+/// # egui::__run_test_ui(|ui| {
+/// egui::MenuBar::new().ui(ui, |ui| {
+///     ui.menu_button("File", |ui| {
+///         if ui.button("Quit").clicked() {
+///             ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+///         }
+///     });
+/// });
+/// # });
+/// ```
+/// ```
 #[derive(Clone, Debug)]
-pub struct Bar {
+pub struct MenuBar {
     config: MenuConfig,
     style: StyleModifier,
 }
 
-impl Default for Bar {
+#[deprecated = "Renamed to `egui::MenuBar`"]
+pub type Bar = MenuBar;
+
+impl Default for MenuBar {
     fn default() -> Self {
         Self {
             config: MenuConfig::default(),
@@ -178,7 +197,7 @@ impl Default for Bar {
     }
 }
 
-impl Bar {
+impl MenuBar {
     pub fn new() -> Self {
         Self::default()
     }

--- a/crates/egui/src/containers/menu.rs
+++ b/crates/egui/src/containers/menu.rs
@@ -178,7 +178,6 @@ impl MenuState {
 /// });
 /// # });
 /// ```
-/// ```
 #[derive(Clone, Debug)]
 pub struct MenuBar {
     config: MenuConfig,

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -481,7 +481,7 @@ pub mod text {
 
 pub use self::{
     atomics::*,
-    containers::*,
+    containers::{menu::MenuBar, *},
     context::{Context, RepaintCause, RequestRepaintInfo},
     data::{
         Key, UserData,

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -87,7 +87,7 @@ fn set_menu_style(style: &mut Style) {
 /// The menu bar goes well in a [`crate::TopBottomPanel::top`],
 /// but can also be placed in a [`crate::Window`].
 /// In the latter case you may want to wrap it in [`Frame`].
-#[deprecated = "Use `crate::containers::menu::Bar` instead"]
+#[deprecated = "Use `egui::MenuBar::new().ui(` instead"]
 pub fn bar<R>(ui: &mut Ui, add_contents: impl FnOnce(&mut Ui) -> R) -> InnerResponse<R> {
     ui.horizontal(|ui| {
         set_menu_style(ui.style_mut());

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -237,7 +237,7 @@ impl DemoWindows {
 
     fn mobile_top_bar(&mut self, ctx: &Context) {
         egui::TopBottomPanel::top("menu_bar").show(ctx, |ui| {
-            menu::Bar::new()
+            menu::MenuBar::new()
                 .config(menu::MenuConfig::new().style(StyleModifier::default()))
                 .ui(ui, |ui| {
                     let font_size = 16.5;
@@ -290,7 +290,7 @@ impl DemoWindows {
             });
 
         egui::TopBottomPanel::top("menu_bar").show(ctx, |ui| {
-            menu::Bar::new().ui(ui, |ui| {
+            menu::MenuBar::new().ui(ui, |ui| {
                 file_menu_button(ui);
             });
         });

--- a/crates/egui_kittest/tests/menu.rs
+++ b/crates/egui_kittest/tests/menu.rs
@@ -1,4 +1,4 @@
-use egui::containers::menu::{Bar, MenuConfig, SubMenuButton};
+use egui::containers::menu::{MenuBar, MenuConfig, SubMenuButton};
 use egui::{PopupCloseBehavior, Ui, include_image};
 use egui_kittest::{Harness, SnapshotResults};
 use kittest::Queryable as _;
@@ -18,7 +18,7 @@ impl TestMenu {
 
     fn ui(&mut self, ui: &mut Ui) {
         ui.vertical(|ui| {
-            Bar::new().config(self.config.clone()).ui(ui, |ui| {
+            MenuBar::new().config(self.config.clone()).ui(ui, |ui| {
                 egui::Sides::new().show(
                     ui,
                     |ui| {


### PR DESCRIPTION
The old name is still there, just deprecated.