### PR TITLE
Update to wgpu v26.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = "0.3.73"
 web-time = "1.1.0" # Timekeeping for native and web
-wgpu = { version = "25.0.0", default-features = false }
+wgpu = { version = "26.0.0", default-features = false }
 windows-sys = "0.59"
 winit = { version = "0.30.7", default-features = false }
 

--- a/crates/egui_demo_app/Cargo.toml
+++ b/crates/egui_demo_app/Cargo.toml
@@ -91,7 +91,7 @@ rfd = { version = "0.15.3", optional = true }
 
 # web:
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "=0.2.97"
+wasm-bindgen = "=0.2.100"
 wasm-bindgen-futures.workspace = true
 web-sys.workspace = true
 


### PR DESCRIPTION
Hi, hoping this comes not too late for the 0.32 release - the newest version of wgpu is out, and doesn´t include any breaking changes.
