### PR TITLE
Color emojis 🦀

### DIFF
--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -2,6 +2,10 @@
 #![allow(rustdoc::missing_crate_level_docs)] // it's an example
 
 use eframe::egui;
+use eframe::egui::{
+    Color32, ColorImage, FontFamily, FontId, FontSelection, RichText, TextEdit,
+    global_theme_preference_switch, include_image,
+};
 
 fn main() -> eframe::Result {
     env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
@@ -26,10 +30,14 @@ struct MyApp {
     age: u32,
 }
 
+fn font_id() -> FontId {
+    FontId::new(30.0, FontFamily::Proportional)
+}
+
 impl Default for MyApp {
     fn default() -> Self {
         Self {
-            name: "Arthur".to_owned(),
+            name: "Ferris :crab:".to_owned(),
             age: 42,
         }
     }
@@ -38,21 +46,28 @@ impl Default for MyApp {
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
-            ui.heading("My egui Application");
-            ui.horizontal(|ui| {
-                let name_label = ui.label("Your name: ");
-                ui.text_edit_singleline(&mut self.name)
-                    .labelled_by(name_label.id);
-            });
-            ui.add(egui::Slider::new(&mut self.age, 0..=120).text("age"));
-            if ui.button("Increment").clicked() {
-                self.age += 1;
-            }
-            ui.label(format!("Hello '{}', age {}", self.name, self.age));
+            global_theme_preference_switch(ui);
 
-            ui.image(egui::include_image!(
-                "../../../crates/egui/assets/ferris.png"
-            ));
+            ctx.fonts(|f| {
+                let mut fonts = f.lock();
+                let font = fonts.fonts.font(&font_id());
+                if !font.has_glyph('🦀') {
+                    let image = include_bytes!("../../../crates/egui/assets/ferris.png");
+
+                    let image = egui_extras::image::load_image_bytes(image).unwrap();
+
+                    font.allocate_custom_glyph('🦀', image);
+                }
+            });
+
+            TextEdit::singleline(&mut self.name)
+                .font(FontSelection::FontId(font_id()))
+                .text_color(Color32::WHITE)
+                .show(ui);
+
+            self.name = self.name.replace(":crab:", "🦀");
+
+            ui.label(RichText::new(&self.name).font(font_id()).strong());
         });
     }
 }


### PR DESCRIPTION
#7298 and [a discussion on discord](https://discord.com/channels/900275882684477440/900275883124858921/1392919531516727397) made me realize that adding custom color emoji support would be quite trivial now, so I made this prototype:

https://github.com/user-attachments/assets/8407ab60-dcde-4769-b0a4-e102f386fae1

It currently only works with dark mode, we probably need some flag on the Glyph that it has color data and should not be affected with any tint. 
Also this won't work for loading fonts with color emojis, for that we need #5784 or ab_glyph needs texture data support. It's more for loading custom emojis like on discord and slack (which would be perfectly fine for my usecase)
