### PR TITLE
Fix out-of-the-box Windows build for eframe 0.32

### DIFF
--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -172,6 +172,7 @@ wgpu = { workspace = true, optional = true, features = [
   # without having to explicitly opt-in to backends
   "metal",
   "webgpu",
+  "vulkan",
 ] }
 
 # mac:


### PR DESCRIPTION
wgpu v0.25 made the Vulkan backend optional. As a result, eframe projects on Windows no longer run out of the box, since Vulkan is not enabled by default.

This PR explicitly enables the vulkan feature in wgpu to restore out-of-the-box functionality on Windows.