### PR TITLE
Change `Ui::put` to not affect the current Uis cursor

### DIFF
--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -1744,13 +1744,12 @@ impl Ui {
     ///
     /// See also [`Self::add`] and [`Self::add_sized`].
     pub fn put(&mut self, max_rect: Rect, widget: impl Widget) -> Response {
-        self.scope_builder(
+        self.new_child(
             UiBuilder::new()
                 .max_rect(max_rect)
                 .layout(Layout::centered_and_justified(Direction::TopDown)),
-            |ui| ui.add(widget),
         )
-        .inner
+        .add(widget)
     }
 
     /// Add a single [`Widget`] that is possibly disabled, i.e. greyed out and non-interactive.


### PR DESCRIPTION
* Closes <https://github.com/emilk/egui/issues/7353>

Currently `ui.put` moves the cursor after the placed widget. In my opinion that is a bit unexpected and counterproductive in most cases where `ui.put` makes sense.

The following example breakes with the current behavior and looks right with my change:
```rs
            ui.horizontal(|ui| {
                let custom_button_id = Id::new("custom_button");
                let response = Button::new((
                    Atom::custom(custom_button_id, Vec2::splat(18.0)),
                    "Look at my mini button!",
                ))
                .atom_ui(ui);
                if let Some(rect) = response.rect(custom_button_id) {
                    ui.put(rect, Button::new("🔎").frame_when_inactive(false));
                }

                let custom_button_id = Id::new("custom_button");
                let response = Button::new((
                    Atom::custom(custom_button_id, Vec2::splat(18.0)),
                    "Look at my mini button!",
                ))
                .atom_ui(ui);
                if let Some(rect) = response.rect(custom_button_id) {
                    ui.put(rect, Button::new("🔎").frame_when_inactive(false));
                }
            });

            ui.add_space(10.0);

            let response = ui.button("Notifications");

            ui.put(
                Rect::from_center_size(response.rect.right_top(), Vec2::splat(12.0)),
                |ui: &mut Ui| {
                    Frame::new()
                        .fill(Color32::RED)
                        .corner_radius(10.0)
                        .show(ui, |ui| {
                            ui.label(RichText::new("11").size(8.0).color(Color32::WHITE));
                        }).response
                },
            );

            ui.button("Some other button");
```

<img width="253" height="86" alt="Screenshot 2025-07-14 at 10 58 30" src="https://github.com/user-attachments/assets/fca56e60-e3c0-4b59-8e2d-0a39aefea9f9" />


<img width="361" height="107" alt="Screenshot 2025-07-14 at 10 58 51" src="https://github.com/user-attachments/assets/85e2fbf9-9174-41e0-adaa-60c721b16bf6" />

I had a look at eguis and reruns source code and there are no uses of `ui.put` that would break with this change (very little usages in general).
