### PR TITLE
Allow customizing fallback font in AtomLayout

### DIFF
--- a/crates/egui/src/atomics/atom.rs
+++ b/crates/egui/src/atomics/atom.rs
@@ -1,4 +1,4 @@
-use crate::{AtomKind, Id, SizedAtom, Ui};
+use crate::{AtomKind, FontSelection, Id, SizedAtom, Ui};
 use emath::{NumExt as _, Vec2};
 use epaint::text::TextWrapMode;
 
@@ -69,6 +69,7 @@ impl<'a> Atom<'a> {
         ui: &Ui,
         mut available_size: Vec2,
         mut wrap_mode: Option<TextWrapMode>,
+        fallback_font: FontSelection,
     ) -> SizedAtom<'a> {
         if !self.shrink && self.max_size.x.is_infinite() {
             wrap_mode = Some(TextWrapMode::Extend);
@@ -81,7 +82,9 @@ impl<'a> Atom<'a> {
             wrap_mode = Some(TextWrapMode::Truncate);
         }
 
-        let (intrinsic, kind) = self.kind.into_sized(ui, available_size, wrap_mode);
+        let (intrinsic, kind) = self
+            .kind
+            .into_sized(ui, available_size, wrap_mode, fallback_font);
 
         let size = self
             .size

--- a/crates/egui/src/atomics/atom_kind.rs
+++ b/crates/egui/src/atomics/atom_kind.rs
@@ -1,4 +1,4 @@
-use crate::{Id, Image, ImageSource, SizedAtomKind, TextStyle, Ui, WidgetText};
+use crate::{FontSelection, Id, Image, ImageSource, SizedAtomKind, Ui, WidgetText};
 use emath::Vec2;
 use epaint::text::TextWrapMode;
 
@@ -78,12 +78,12 @@ impl<'a> AtomKind<'a> {
         ui: &Ui,
         available_size: Vec2,
         wrap_mode: Option<TextWrapMode>,
+        fallback_font: FontSelection,
     ) -> (Vec2, SizedAtomKind<'a>) {
         match self {
             AtomKind::Text(text) => {
                 let wrap_mode = wrap_mode.unwrap_or(ui.wrap_mode());
-                let galley =
-                    text.into_galley(ui, Some(wrap_mode), available_size.x, TextStyle::Button);
+                let galley = text.into_galley(ui, Some(wrap_mode), available_size.x, fallback_font);
                 (galley.intrinsic_size(), SizedAtomKind::Text(galley))
             }
             AtomKind::Image(image) => {

--- a/crates/egui/src/atomics/atom_layout.rs
+++ b/crates/egui/src/atomics/atom_layout.rs
@@ -1,7 +1,7 @@
 use crate::atomics::ATOMS_SMALL_VEC_SIZE;
 use crate::{
-    AtomKind, Atoms, Frame, Id, Image, IntoAtoms, Response, Sense, SizedAtom, SizedAtomKind, Ui,
-    Widget,
+    AtomKind, Atoms, FontSelection, Frame, Id, Image, IntoAtoms, Response, Sense, SizedAtom,
+    SizedAtomKind, Ui, Widget,
 };
 use emath::{Align2, GuiRounding as _, NumExt as _, Rect, Vec2};
 use epaint::text::TextWrapMode;
@@ -36,6 +36,7 @@ pub struct AtomLayout<'a> {
     pub(crate) frame: Frame,
     pub(crate) sense: Sense,
     fallback_text_color: Option<Color32>,
+    fallback_font: Option<FontSelection>,
     min_size: Vec2,
     wrap_mode: Option<TextWrapMode>,
     align2: Option<Align2>,
@@ -56,6 +57,7 @@ impl<'a> AtomLayout<'a> {
             frame: Frame::default(),
             sense: Sense::hover(),
             fallback_text_color: None,
+            fallback_font: None,
             min_size: Vec2::ZERO,
             wrap_mode: None,
             align2: None,
@@ -91,6 +93,13 @@ impl<'a> AtomLayout<'a> {
     #[inline]
     pub fn fallback_text_color(mut self, color: Color32) -> Self {
         self.fallback_text_color = Some(color);
+        self
+    }
+
+    /// Set the fallback (default) font.
+    #[inline]
+    pub fn fallback_font(mut self, font: impl Into<FontSelection>) -> Self {
+        self.fallback_font = Some(font.into());
         self
     }
 
@@ -154,7 +163,10 @@ impl<'a> AtomLayout<'a> {
             min_size,
             wrap_mode,
             align2,
+            fallback_font,
         } = self;
+
+        let fallback_font = fallback_font.unwrap_or_default();
 
         let wrap_mode = wrap_mode.unwrap_or(ui.wrap_mode());
 
@@ -220,7 +232,12 @@ impl<'a> AtomLayout<'a> {
                     continue;
                 }
             }
-            let sized = item.into_sized(ui, available_inner_size, Some(wrap_mode));
+            let sized = item.into_sized(
+                ui,
+                available_inner_size,
+                Some(wrap_mode),
+                fallback_font.clone(),
+            );
             let size = sized.size;
 
             desired_width += size.x;
@@ -239,7 +256,12 @@ impl<'a> AtomLayout<'a> {
                 available_inner_size.y,
             );
 
-            let sized = item.into_sized(ui, available_size_for_shrink_item, Some(wrap_mode));
+            let sized = item.into_sized(
+                ui,
+                available_size_for_shrink_item,
+                Some(wrap_mode),
+                fallback_font,
+            );
             let size = sized.size;
 
             desired_width += size.x;

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -1,7 +1,7 @@
 use crate::{
     Atom, AtomExt as _, AtomKind, AtomLayout, AtomLayoutResponse, Color32, CornerRadius, Frame,
-    Image, IntoAtoms, NumExt as _, Response, Sense, Stroke, TextWrapMode, Ui, Vec2, Widget,
-    WidgetInfo, WidgetText, WidgetType,
+    Image, IntoAtoms, NumExt as _, Response, Sense, Stroke, TextStyle, TextWrapMode, Ui, Vec2,
+    Widget, WidgetInfo, WidgetText, WidgetType,
 };
 
 /// Clickable button with text.
@@ -40,7 +40,9 @@ pub struct Button<'a> {
 impl<'a> Button<'a> {
     pub fn new(atoms: impl IntoAtoms<'a>) -> Self {
         Self {
-            layout: AtomLayout::new(atoms.into_atoms()).sense(Sense::click()),
+            layout: AtomLayout::new(atoms.into_atoms())
+                .sense(Sense::click())
+                .fallback_font(TextStyle::Button),
             fill: None,
             stroke: None,
             small: false,


### PR DESCRIPTION
- merge after https://github.com/emilk/egui/pull/7361 (this pr requires the clone derive introduced there)

Before it was hard coded to TextStyle::Button, but it should be customizable.
