### PR TITLE
Change type of corner radius to f32 inside RectShape

### DIFF
--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::if_same_then_else)]
 
 use emath::Align;
-use epaint::{AlphaFromCoverage, CornerRadius, Shadow, Stroke, text::FontTweak};
+use epaint::{AlphaFromCoverage, CornerRadius, CornerRadiusF32, Shadow, Stroke, text::FontTweak};
 use std::{collections::BTreeMap, ops::RangeInclusive, sync::Arc};
 
 use crate::{
@@ -2650,6 +2650,64 @@ impl Widget for &mut CornerRadius {
                     self.se = 1;
                 } else {
                     self.se -= 1;
+                }
+            }
+        }
+
+        response
+    }
+}
+
+impl Widget for &mut CornerRadiusF32 {
+    fn ui(self, ui: &mut Ui) -> Response {
+        let mut same = self.is_same();
+
+        let response = if same {
+            ui.horizontal(|ui| {
+                ui.checkbox(&mut same, "same");
+
+                let mut cr = self.nw;
+                ui.add(DragValue::new(&mut cr).range(0.0..=f32::INFINITY));
+                *self = CornerRadiusF32::same(cr);
+            })
+            .response
+        } else {
+            ui.vertical(|ui| {
+                ui.checkbox(&mut same, "same");
+
+                crate::Grid::new("Corner radius")
+                    .num_columns(2)
+                    .show(ui, |ui| {
+                        ui.label("NW");
+                        ui.add(DragValue::new(&mut self.nw).range(0.0..=f32::INFINITY));
+                        ui.end_row();
+
+                        ui.label("NE");
+                        ui.add(DragValue::new(&mut self.ne).range(0.0..=f32::INFINITY));
+                        ui.end_row();
+
+                        ui.label("SW");
+                        ui.add(DragValue::new(&mut self.sw).range(0.0..=f32::INFINITY));
+                        ui.end_row();
+
+                        ui.label("SE");
+                        ui.add(DragValue::new(&mut self.se).range(0.0..=f32::INFINITY));
+                        ui.end_row();
+                    });
+            })
+            .response
+        };
+
+        // Apply the checkbox:
+        if same {
+            *self = CornerRadiusF32::from(self.average());
+        } else {
+            // Make sure we aren't same:
+            if self.is_same() {
+                if self.average() == 0.0 {
+                    self.se = 1.0;
+                } else {
+                    self.se -= 1.0;
                 }
             }
         }

--- a/crates/epaint/src/corner_radius_f32.rs
+++ b/crates/epaint/src/corner_radius_f32.rs
@@ -109,6 +109,11 @@ impl CornerRadiusF32 {
             se: self.se.min(max),
         }
     }
+
+    /// Average rounding of the corners.
+    pub fn average(&self) -> f32 {
+        (self.nw + self.ne + self.sw + self.se) / 4.0
+    }
 }
 
 impl std::ops::Add for CornerRadiusF32 {

--- a/crates/epaint/src/shapes/rect_shape.rs
+++ b/crates/epaint/src/shapes/rect_shape.rs
@@ -10,7 +10,7 @@ pub struct RectShape {
 
     /// How rounded the corners of the rectangle are.
     ///
-    /// Use [`CornerRadius::ZERO`] for for sharp corners.
+    /// Use [`CornerRadiusF32::ZERO`] for for sharp corners.
     ///
     /// This is the corner radii of the rectangle.
     /// If there is a stroke, then the stroke will have an inner and outer corner radius,
@@ -18,7 +18,7 @@ pub struct RectShape {
     ///
     /// For [`StrokeKind::Inside`], the outside of the stroke coincides with the rectangle,
     /// so the rounding will in this case specify the outer corner radius.
-    pub corner_radius: CornerRadius,
+    pub corner_radius: CornerRadiusF32,
 
     /// How to fill the rectangle.
     pub fill: Color32,
@@ -81,7 +81,7 @@ impl RectShape {
     ) -> Self {
         Self {
             rect,
-            corner_radius: corner_radius.into(),
+            corner_radius: CornerRadiusF32::from(corner_radius.into()),
             fill: fill_color.into(),
             stroke: stroke.into(),
             stroke_kind,
@@ -99,7 +99,7 @@ impl RectShape {
     ) -> Self {
         Self::new(
             rect,
-            corner_radius,
+            CornerRadiusF32::from(corner_radius.into()),
             fill_color,
             Stroke::NONE,
             StrokeKind::Outside, // doesn't matter
@@ -114,7 +114,13 @@ impl RectShape {
         stroke_kind: StrokeKind,
     ) -> Self {
         let fill = Color32::TRANSPARENT;
-        Self::new(rect, corner_radius, fill, stroke, stroke_kind)
+        Self::new(
+            rect,
+            CornerRadiusF32::from(corner_radius.into()),
+            fill,
+            stroke,
+            stroke_kind,
+        )
     }
 
     /// Set if the stroke is on the inside, outside, or centered on the rectangle.

--- a/crates/epaint/src/shapes/shape.rs
+++ b/crates/epaint/src/shapes/shape.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use emath::{Align2, Pos2, Rangef, Rect, TSTransform, Vec2, pos2};
 
 use crate::{
-    Color32, CornerRadius, Mesh, Stroke, StrokeKind, TextureId,
+    Color32, CornerRadius, CornerRadiusF32, Mesh, Stroke, StrokeKind, TextureId,
     stroke::PathStroke,
     text::{FontId, Fonts, Galley},
 };
@@ -283,7 +283,11 @@ impl Shape {
         corner_radius: impl Into<CornerRadius>,
         fill_color: impl Into<Color32>,
     ) -> Self {
-        Self::Rect(RectShape::filled(rect, corner_radius, fill_color))
+        Self::Rect(RectShape::filled(
+            rect,
+            CornerRadiusF32::from(corner_radius.into()),
+            fill_color,
+        ))
     }
 
     /// See also [`Self::rect_filled`].
@@ -294,7 +298,12 @@ impl Shape {
         stroke: impl Into<Stroke>,
         stroke_kind: StrokeKind,
     ) -> Self {
-        Self::Rect(RectShape::stroke(rect, corner_radius, stroke, stroke_kind))
+        Self::Rect(RectShape::stroke(
+            rect,
+            CornerRadiusF32::from(corner_radius.into()),
+            stroke,
+            stroke_kind,
+        ))
     }
 
     #[expect(clippy::needless_pass_by_value)]

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -8,10 +8,10 @@
 use emath::{GuiRounding as _, NumExt as _, Pos2, Rect, Rot2, Vec2, pos2, remap, vec2};
 
 use crate::{
-    CircleShape, ClippedPrimitive, ClippedShape, Color32, CornerRadiusF32, CubicBezierShape,
-    EllipseShape, Mesh, PathShape, Primitive, QuadraticBezierShape, RectShape, Shape, Stroke,
-    StrokeKind, TextShape, TextureId, Vertex, WHITE_UV, color::ColorMode, emath,
-    stroke::PathStroke, texture_atlas::PreparedDisc,
+    CircleShape, ClippedPrimitive, ClippedShape, Color32, CubicBezierShape, EllipseShape, Mesh,
+    PathShape, Primitive, QuadraticBezierShape, RectShape, Shape, Stroke, StrokeKind, TextShape,
+    TextureId, Vertex, WHITE_UV, color::ColorMode, emath, stroke::PathStroke,
+    texture_atlas::PreparedDisc,
 };
 
 // ----------------------------------------------------------------------------
@@ -1774,7 +1774,7 @@ impl Tessellator {
             brush: _, // brush is extracted on its own, because it is not Copy
         } = *rect_shape;
 
-        let mut corner_radius = CornerRadiusF32::from(corner_radius);
+        let mut corner_radius = corner_radius; // we need mutable access here
         let round_to_pixels = round_to_pixels.unwrap_or(self.options.round_rects_to_pixels);
 
         if stroke.width == 0.0 {


### PR DESCRIPTION
Makes it possible to draw rect shapes with better precision. For example, in my case, I am drawing a rect with scaling via `TSTransform` and I want my rect to preserve the same corner radius at different scale solutions.