### PR TITLE
Replaced deprecated Frame::none()

### DIFF
--- a/crates/egui/src/containers/frame.rs
+++ b/crates/egui/src/containers/frame.rs
@@ -46,10 +46,9 @@ use epaint::{Color32, CornerRadius, Margin, MarginF32, Rect, Shadow, Shape, Stro
 ///
 /// ```
 /// # egui::__run_test_ui(|ui| {
-/// egui::Frame::none()
-///     .fill(egui::Color32::RED)
+/// egui::Frame::NONE
 ///     .show(ui, |ui| {
-///         ui.label("Label with red background");
+///          ui.label("Label with no background, margin, or border");
 ///     });
 /// # });
 /// ```


### PR DESCRIPTION
Replaced deprecated `egui::Frame::none()` with `egui::Frame::NONE`

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes <https://github.com/emilk/egui/issues/7391>
* [x] I have followed the instructions in the PR template
