### PR TITLE
Fix multi-line `TextShape` rotation

### DIFF
--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -2031,7 +2031,12 @@ impl Tessellator {
                 continue;
             }
 
-            let final_row_pos = galley_pos + row.pos.to_vec2();
+            let final_row_pos = galley_pos
+                + if *angle != 0.0 {
+                    rotator * row.pos.to_vec2()
+                } else {
+                    row.pos.to_vec2()
+                };
 
             let mut row_rect = row.visuals.mesh_bounds;
             if *angle != 0.0 {

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -2031,12 +2031,7 @@ impl Tessellator {
                 continue;
             }
 
-            let final_row_pos = galley_pos
-                + if *angle != 0.0 {
-                    rotator * row.pos.to_vec2()
-                } else {
-                    row.pos.to_vec2()
-                };
+            let final_row_pos = galley_pos + rotator * row.pos.to_vec2();
 
             let mut row_rect = row.visuals.mesh_bounds;
             if *angle != 0.0 {


### PR DESCRIPTION
* Closes <https://github.com/emilk/egui/issues/7397>
* [X] I have followed the instructions in the PR template
I do admit I got a peak NixOS `RequestDeviceError` and deemed it entirely not worth it to think about that.

https://github.com/emilk/egui/pull/5411 broke rotation of multi-line `TextShape`s because `PlacedRow::pos` was no longer being rotated, so let's rotate it.