### PR TITLE
Relax required version for arboard dependency

### DIFF
--- a/crates/egui-winit/Cargo.toml
+++ b/crates/egui-winit/Cargo.toml
@@ -86,6 +86,6 @@ smithay-clipboard = { version = "0.7.2", optional = true }
 wayland-cursor = { version = "0.31.1", default-features = false, optional = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-arboard = { version = "3.3", optional = true, default-features = false, features = [
+arboard = { version = "3", optional = true, default-features = false, features = [
     "image-data",
 ] }


### PR DESCRIPTION
Due to semantic versioning guarantees, there is no need to require v3.3 specifically, as any 3.x release will be backwards compatible.

This is important because 3.3 uses an older version of the image crate, causing duplicate dependency issues in the servo project. See https://github.com/servo/servo/pull/36680#issuecomment-3146509476 for details.

* [X] I have followed the instructions in the PR template (except for `check.sh` due to https://github.com/emilk/egui/issues/7405)
