### PR TITLE
Fix: prevent calendar popup from closing on dropdown change

### DIFF
--- a/crates/egui_extras/src/datepicker/button.rs
+++ b/crates/egui_extras/src/datepicker/button.rs
@@ -192,8 +192,11 @@ impl Widget for DatePickerButton<'_> {
                 button_response.mark_changed();
             }
 
+            // We don't want to close our popup if any other popup is open, since other popups would
+            // most likely be the combo boxes in the date picker.
+            let any_popup_open = ui.ctx().is_popup_open();
             if !button_response.clicked()
-                && !ui.ctx().is_popup_open()
+                && !any_popup_open
                 && (ui.input(|i| i.key_pressed(Key::Escape)) || area_response.clicked_elsewhere())
             {
                 button_state.picker_visible = false;

--- a/crates/egui_extras/src/datepicker/button.rs
+++ b/crates/egui_extras/src/datepicker/button.rs
@@ -193,6 +193,7 @@ impl Widget for DatePickerButton<'_> {
             }
 
             if !button_response.clicked()
+                && !ui.ctx().is_popup_open()
                 && (ui.input(|i| i.key_pressed(Key::Escape)) || area_response.clicked_elsewhere())
             {
                 button_state.picker_visible = false;

--- a/crates/egui_extras/src/datepicker/button.rs
+++ b/crates/egui_extras/src/datepicker/button.rs
@@ -138,12 +138,16 @@ impl Widget for DatePickerButton<'_> {
             button = button.fill(visuals.weak_bg_fill).stroke(visuals.bg_stroke);
         }
         let mut button_response = ui.add(button);
-        if button_response.clicked() {
+        let just_opened = if button_response.clicked() {
             button_state.picker_visible = true;
             ui.data_mut(|data| data.insert_persisted(id, button_state.clone()));
-        }
+            true
+        } else {
+            false
+        };
 
         if button_state.picker_visible {
+            let ctx = ui.ctx();
             let width = 333.0;
             let mut pos = button_response.rect.left_bottom();
             let width_with_padding = width
@@ -154,19 +158,17 @@ impl Widget for DatePickerButton<'_> {
                 pos.x = button_response.rect.right() - width_with_padding;
             }
 
-            // Check to make sure the calendar never is displayed out of window
             pos.x = pos.x.max(ui.style().spacing.window_margin.leftf());
 
-            //TODO(elwerene): Better positioning
-
+            let popup_id = ui.make_persistent_id(self.id_salt);
             let InnerResponse {
                 inner: saved,
                 response: area_response,
-            } = Area::new(ui.make_persistent_id(self.id_salt))
+            } = Area::new(popup_id)
                 .kind(egui::UiKind::Picker)
                 .order(Order::Foreground)
                 .fixed_pos(pos)
-                .show(ui.ctx(), |ui| {
+                .show(ctx, |ui| {
                     let frame = Frame::popup(ui.style());
                     frame
                         .show(ui, |ui| {
@@ -183,7 +185,7 @@ impl Widget for DatePickerButton<'_> {
                                 highlight_weekends: self.highlight_weekends,
                                 start_end_years: self.start_end_years,
                             }
-                            .draw(ui)
+                                .draw(ui)
                         })
                         .inner
                 });
@@ -192,8 +194,10 @@ impl Widget for DatePickerButton<'_> {
                 button_response.mark_changed();
             }
 
-            if !button_response.clicked()
-                && (ui.input(|i| i.key_pressed(Key::Escape)) || area_response.clicked_elsewhere())
+            let escape_pressed = ctx.input(|i| i.key_pressed(Key::Escape));
+            let pointer_over_popup = ctx.is_pointer_over_area();
+
+            if !just_opened && !pointer_over_popup && (escape_pressed || area_response.clicked_elsewhere())
             {
                 button_state.picker_visible = false;
                 ui.data_mut(|data| data.insert_persisted(id, button_state));


### PR DESCRIPTION
Currently, DatePickerButton will close without saving whenever a user clicks a dropdown from year/month/date. The issue is caused because the system mistakenly interprets the user as clicking off of the calendar. This is unexpected and creates an unpleasant experience for the user. This change now allows the user to use the dropdowns as expected; it will close on save or cancel. The calendar still closes when user clicks off of it, as before. The changes here are made in:  
crates/egui_extras/src/datepicker/button.rs

I will admit that I am not an experienced Rust developer. The changes were made with the help of ChatGPT 4.0. 
I have tested the changes locally, as I am using the date picker in my project.


<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes <https://github.com/emilk/egui/issues/THE_RELEVANT_ISSUE>
* [x] I have followed the instructions in the PR template
