### PR TITLE
Fix glyph rendering: clamp coverage to [0, 1]

### DIFF
--- a/crates/epaint/src/image.rs
+++ b/crates/epaint/src/image.rs
@@ -384,6 +384,7 @@ impl AlphaFromCoverage {
     /// Convert coverage to alpha.
     #[inline(always)]
     pub fn alpha_from_coverage(&self, coverage: f32) -> f32 {
+        let coverage = coverage.clamp(0.0, 1.0);
         match self {
             Self::Linear => coverage,
             Self::Gamma(gamma) => coverage.powf(*gamma),


### PR DESCRIPTION
* Closes  #7366
* Closes https://github.com/emilk/egui/pull/7388