### PR TITLE
fix: `SubMenu` should not display when ui is disabled

### DIFF
--- a/crates/egui/src/containers/menu.rs
+++ b/crates/egui/src/containers/menu.rs
@@ -446,7 +446,7 @@ impl SubMenu {
         let is_hovered = hover_pos.is_some_and(|pos| button_rect.contains(pos));
 
         // The clicked handler is there for accessibility (keyboard navigation)
-        if (!is_any_open && is_hovered) || button_response.clicked() {
+        if (!is_any_open && is_hovered && ui.is_enabled()) || button_response.clicked() {
             set_open = Some(true);
             is_open = true;
             // Ensure that all other sub menus are closed when we open the menu


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

Adds a check for `ui.is_enabled()` when displaying the SubMenu items. There were a few places the condition could be placed, but I figured there was simplest. The inner button will already not be able to be clicked due to ui being disabled.

cc @lucasmerlin 

* [x] I have followed the instructions in the PR template
