### PR TITLE
Skip zero-length layout job sections

### DIFF
--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -927,7 +927,7 @@ impl GalleyCache {
                     current_section += 1;
                 } else if end < section_range.start {
                     break; // Haven't reached this one yet.
-                } else {
+                } else if section_range.start < section_range.end {
                     // Section range overlaps with paragraph range
                     debug_assert!(
                         section_range.start < section_range.end,


### PR DESCRIPTION
Fixes #7378 

Includes a regression test that previously failed and now succeeds.

* [x] I have followed the instructions in the PR template
