### PR TITLE
Document platform compatibility on `viewport::WindowLevel` and dependents

### DIFF
--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -630,6 +630,8 @@ impl ViewportBuilder {
     }
 
     /// Control if window is always-on-top, always-on-bottom, or neither.
+    ///
+    /// For platform compatibility see [`egui::viewport::WindowLevel`] documentation
     #[inline]
     pub fn with_window_level(mut self, level: WindowLevel) -> Self {
         self.window_level = Some(level);
@@ -637,6 +639,8 @@ impl ViewportBuilder {
     }
 
     /// This window is always on top
+    ///
+    /// For platform compatibility see [`egui::viewport::WindowLevel`] documentation
     #[inline]
     pub fn with_always_on_top(self) -> Self {
         self.with_window_level(WindowLevel::AlwaysOnTop)
@@ -898,6 +902,7 @@ impl ViewportBuilder {
     }
 }
 
+/// For winit platform compatibility, see [`WindowLevel` documentation](https://docs.rs/winit/latest/winit/window/enum.WindowLevel.html#platform-specific)
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum WindowLevel {

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -902,7 +902,7 @@ impl ViewportBuilder {
     }
 }
 
-/// For winit platform compatibility, see [`WindowLevel` documentation](https://docs.rs/winit/latest/winit/window/enum.WindowLevel.html#platform-specific)
+/// For winit platform compatibility, see [`winit::WindowLevel` documentation](https://docs.rs/winit/latest/winit/window/enum.WindowLevel.html#platform-specific)
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum WindowLevel {

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -631,7 +631,7 @@ impl ViewportBuilder {
 
     /// Control if window is always-on-top, always-on-bottom, or neither.
     ///
-    /// For platform compatibility see [`egui::viewport::WindowLevel`] documentation
+    /// For platform compatibility see [`crate::viewport::WindowLevel`] documentation
     #[inline]
     pub fn with_window_level(mut self, level: WindowLevel) -> Self {
         self.window_level = Some(level);
@@ -640,7 +640,7 @@ impl ViewportBuilder {
 
     /// This window is always on top
     ///
-    /// For platform compatibility see [`egui::viewport::WindowLevel`] documentation
+    /// For platform compatibility see [`crate::viewport::WindowLevel`] documentation
     #[inline]
     pub fn with_always_on_top(self) -> Self {
         self.with_window_level(WindowLevel::AlwaysOnTop)


### PR DESCRIPTION
Documents platform compatibility on the WindowLevel struct and some of the methods that are dependent on it. Provides a link to `winit::window::WindowLevel` documentation section that provides a list of which platforms are supported.

* Closes [Issue 7419](https://github.com/emilk/egui/issues/7419)
* [x] I have followed the instructions in the PR template
