### PR TITLE
Fix override_text_color priority

### DIFF
--- a/crates/egui/src/widget_text.rs
+++ b/crates/egui/src/widget_text.rs
@@ -746,11 +746,15 @@ impl WidgetText {
     ) -> Arc<Galley> {
         match self {
             Self::Text(text) => {
+                let color = style
+                    .visuals
+                    .override_text_color
+                    .unwrap_or(crate::Color32::PLACEHOLDER);
                 let mut layout_job = LayoutJob::simple_format(
                     text,
                     TextFormat {
                         font_id: FontSelection::Default.resolve(style),
-                        color: crate::Color32::PLACEHOLDER,
+                        color,
                         valign: default_valign,
                         ..Default::default()
                     },


### PR DESCRIPTION
The override_text_color is now used when rendering text from a String or &str. This is consistent with the RichText variant and makes the option behave as advertised, taking precedence over WidgetVisuals and overriding the color for all text unless explicitly changed for a single widget (via RichText or LayoutJob).

* Closes <https://github.com/emilk/egui/issues/7367>
* [x] I have followed the instructions in the PR template
