### PR TITLE
Fix debug-panic in ScrollArea if contents fit without scrolling

### DIFF
--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -1315,11 +1315,15 @@ impl Prepared {
                     });
 
                 let new_handle_top = pointer_pos[d] - *scroll_start_offset_from_top_left;
-                state.offset[d] = remap(
-                    new_handle_top,
-                    scroll_bar_rect.min[d]..=(scroll_bar_rect.max[d] - handle_rect.size()[d]),
-                    0.0..=max_offset[d],
-                );
+                state.offset[d] = if max_offset[d] > 0.0 {
+                    remap(
+                        new_handle_top,
+                        scroll_bar_rect.min[d]..=(scroll_bar_rect.max[d] - handle_rect.size()[d]),
+                        0.0..=max_offset[d],
+                    )
+                } else {
+                    0.0
+                };
 
                 // some manual action taken, scroll not stuck
                 state.scroll_stuck_to_end[d] = false;

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -1315,14 +1315,12 @@ impl Prepared {
                     });
 
                 let new_handle_top = pointer_pos[d] - *scroll_start_offset_from_top_left;
-                state.offset[d] = if max_offset[d] > 0.0 {
-                    remap(
-                        new_handle_top,
-                        scroll_bar_rect.min[d]..=(scroll_bar_rect.max[d] - handle_rect.size()[d]),
-                        0.0..=max_offset[d],
-                    )
-                } else {
+                let handle_travel =
+                    scroll_bar_rect.min[d]..=(scroll_bar_rect.max[d] - handle_rect.size()[d]);
+                state.offset[d] = if handle_travel.start() == handle_travel.end() {
                     0.0
+                } else {
+                    remap(new_handle_top, handle_travel, 0.0..=max_offset[d])
                 };
 
                 // some manual action taken, scroll not stuck


### PR DESCRIPTION
If the ScrollArea's contents are smaller than the inner rect, but the scrollbar is set to always visible, clicking on it led to a remap from an empty range to calculate the new offset, which triggered a debug assertion in the remap function, because the result is indeterminate.

Since in this case there is no need to scroll, we just skip the remap and set the offset to 0 directly.

* Closes <https://github.com/emilk/egui/issues/7362>
* [x] I have followed the instructions in the PR template
