### PR TITLE
Remove line breaks when pasting into single line TextEdit

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -945,8 +945,12 @@ fn events(
             Event::Paste(text_to_insert) => {
                 if !text_to_insert.is_empty() {
                     let mut ccursor = text.delete_selected(&cursor_range);
-
-                    text.insert_text_at(&mut ccursor, text_to_insert, char_limit);
+                    if multiline {
+                        text.insert_text_at(&mut ccursor, text_to_insert, char_limit);
+                    } else {
+                        let single_line = text_to_insert.replace(['\r', '\n'], " ");
+                        text.insert_text_at(&mut ccursor, &single_line, char_limit);
+                    }
 
                     Some(CCursorRange::one(ccursor))
                 } else {


### PR DESCRIPTION
The line breaks are now replaced by spaces, matching the usual behavior of text fields in HTML.

* Closes <https://github.com/emilk/egui/issues/7389>
* [x] I have followed the instructions in the PR template
