### PR TITLE
Fix panic on Stroke style editor widget

### DIFF
--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -2708,7 +2708,7 @@ impl Widget for &mut Stroke {
         let Stroke { width, color } = self;
 
         ui.horizontal(|ui| {
-            ui.add(DragValue::new(width).speed(0.1).range(0.0..=f32::INFINITY))
+            ui.add(DragValue::new(width).speed(0.1).range(0.0..=1e9))
                 .on_hover_text("Width");
             ui.color_edit_button_srgba(color);
 


### PR DESCRIPTION
The infinite limit caused arithmetic issues when rendering the preview with very large values, which led to a panic. The new limit should still be higher than anyone would reasonably want to set a stroke width to, but not high enough to trigger a panic.

* Closes <https://github.com/emilk/egui/issues/7348>
* [x] I have followed the instructions in the PR template
