### PR TITLE
Add rotation gesture support for trackpad sources

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -492,7 +492,6 @@ impl State {
             WindowEvent::ActivationTokenDone { .. }
             | WindowEvent::AxisMotion { .. }
             | WindowEvent::DoubleTapGesture { .. }
-            | WindowEvent::RotationGesture { .. }
             | WindowEvent::PanGesture { .. } => EventResponse {
                 repaint: false,
                 consumed: false,
@@ -503,6 +502,16 @@ impl State {
                 // Negative delta values indicate shrinking (zooming out).
                 let zoom_factor = (*delta as f32).exp();
                 self.egui_input.events.push(egui::Event::Zoom(zoom_factor));
+                EventResponse {
+                    repaint: true,
+                    consumed: self.egui_ctx.wants_pointer_input(),
+                }
+            }
+
+            WindowEvent::RotationGesture { delta, .. } => {
+                // Positive delta values indicate counterclockwise rotation
+                // Negative delta values indicate clockwise rotation
+                self.egui_input.events.push(egui::Event::Rotate(*delta));
                 EventResponse {
                     repaint: true,
                     consumed: self.egui_ctx.wants_pointer_input(),

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -479,6 +479,12 @@ pub enum Event {
     /// As a user, check [`crate::InputState::smooth_scroll_delta`] to see if the user did any zooming this frame.
     Zoom(f32),
 
+    /// Rotation in radians this frame (e.g. from a rotation gesture).
+    ///
+    /// * `rotation > 0`: rotate counterclockwise
+    /// * `rotation < 0`: rotate clockwise
+    Rotate(f32),
+
     /// IME Event
     Ime(ImeEvent),
 


### PR DESCRIPTION
This adds support to receive rotation gesture information from sources that don't provide touch events, such as trackpads on MacOS. Currently, only the `winit` backend passes through the necessary information. I would also like to add support for the web backend on Safari, as that generates a `GestureEvent` ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/GestureEvent), [WebKit JS](https://developer.apple.com/documentation/webkitjs/gestureevent)) with rotation information. However, since that is a non-standard API, it is not yet exposed in `web-sys`.