### PR TITLE
Panic mutexes that can't lock for 30 seconds, in debug builds

### DIFF
--- a/crates/epaint/src/mutex.rs
+++ b/crates/epaint/src/mutex.rs
@@ -23,7 +23,13 @@ mod mutex_impl {
 
         #[inline(always)]
         pub fn lock(&self) -> MutexGuard<'_, T> {
-            self.0.lock()
+            if cfg!(debug_assertions) {
+                self.0
+                    .try_lock_for(std::time::Duration::from_secs(30))
+                    .expect("Looks like a deadlock!")
+            } else {
+                self.0.lock()
+            }
         }
     }
 }


### PR DESCRIPTION
I'm trying to debug a suspected deadlock in the CI for https://github.com/emilk/egui/pull/7467

Since we use our own mutex wrappers, we can just panic if the lock is too slow. Ugly and effective :)