### PR TITLE
Add an option to limit the repaint rate in the web runner

### DIFF
--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -509,6 +509,10 @@ pub struct WebOptions {
     ///
     /// Defaults to true.
     pub should_prevent_default: Box<dyn Fn(&egui::Event) -> bool>,
+
+    /// Maximum rate at which to repaint. This can be used to artificially reduce the repaint rate below
+    /// vsync in order to save resources.
+    pub repaint_rate_limit: Option<u32>,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -527,6 +531,8 @@ impl Default for WebOptions {
 
             should_stop_propagation: Box::new(|_| true),
             should_prevent_default: Box::new(|_| true),
+
+            repaint_rate_limit: None,
         }
     }
 }

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -96,7 +96,8 @@ impl AppRunner {
             wgpu_render_state: None,
         };
 
-        let needs_repaint: std::sync::Arc<NeedRepaint> = Default::default();
+        let needs_repaint: std::sync::Arc<NeedRepaint> =
+            std::sync::Arc::new(NeedRepaint::new(web_options.repaint_rate_limit));
         {
             let needs_repaint = needs_repaint.clone();
             egui_ctx.set_request_repaint_callback(move |info| {

--- a/crates/eframe/src/web/backend.rs
+++ b/crates/eframe/src/web/backend.rs
@@ -50,11 +50,19 @@ impl WebInput {
 // ----------------------------------------------------------------------------
 
 /// Stores when to do the next repaint.
-pub(crate) struct NeedRepaint(Mutex<f64>);
+pub(crate) struct NeedRepaint {
+    /// Time in seconds when the next repaint should happen.
+    next_repaint: Mutex<f64>,
+    /// Rate limit for repaint. 0 means "unlimited". The rate may still be limited by VSync.
+    rate: u32,
+}
 
-impl Default for NeedRepaint {
-    fn default() -> Self {
-        Self(Mutex::new(f64::NEG_INFINITY)) // start with a repaint
+impl NeedRepaint {
+    pub fn new(rate: Option<u32>) -> Self {
+        Self {
+            next_repaint: Mutex::new(f64::NEG_INFINITY), // start with a repaint
+            rate: rate.unwrap_or(0),
+        }
     }
 }
 
@@ -62,25 +70,43 @@ impl NeedRepaint {
     /// Returns the time (in [`now_sec`] scale) when
     /// we should next repaint.
     pub fn when_to_repaint(&self) -> f64 {
-        *self.0.lock()
+        *self.next_repaint.lock()
     }
 
     /// Unschedule repainting.
     pub fn clear(&self) {
-        *self.0.lock() = f64::INFINITY;
+        *self.next_repaint.lock() = f64::INFINITY;
     }
 
     pub fn repaint_after(&self, num_seconds: f64) {
-        let mut repaint_time = self.0.lock();
-        *repaint_time = repaint_time.min(super::now_sec() + num_seconds);
+        let mut repaint_time = self.next_repaint.lock();
+        let mut time = super::now_sec() + num_seconds;
+        time = Self::round_repaint_time_to_rate(time, self.rate);
+        *repaint_time = repaint_time.min(time);
+    }
+
+    /// Request a repaint. Depending on the presence of rate limiting, this may not be instant.
+    pub fn repaint(&self) {
+        let time = Self::round_repaint_time_to_rate(super::now_sec(), self.rate);
+        let mut repaint_time = self.next_repaint.lock();
+        *repaint_time = repaint_time.min(time)
+    }
+
+    pub fn repaint_asap(&self) {
+        *self.next_repaint.lock() = f64::NEG_INFINITY;
     }
 
     pub fn needs_repaint(&self) -> bool {
         self.when_to_repaint() <= super::now_sec()
     }
 
-    pub fn repaint_asap(&self) {
-        *self.0.lock() = f64::NEG_INFINITY;
+    fn round_repaint_time_to_rate(time: f64, rate: u32) -> f64 {
+        if rate == 0 {
+            f64::NEG_INFINITY
+        } else {
+            let interval = 1.0 / rate as f64;
+            (time / interval).ceil() * interval
+        }
     }
 }
 

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -638,7 +638,7 @@ fn install_mousemove(runner_ref: &WebRunner, target: &EventTarget) -> Result<(),
             let should_stop_propagation = (runner.web_options.should_stop_propagation)(&egui_event);
             let should_prevent_default = (runner.web_options.should_prevent_default)(&egui_event);
             runner.input.raw.events.push(egui_event);
-            runner.needs_repaint.repaint_asap();
+            runner.needs_repaint.repaint();
 
             // Use web options to tell if the web event should be propagated to parent elements based on the egui event.
             if should_stop_propagation {
@@ -721,7 +721,7 @@ fn install_touchmove(runner_ref: &WebRunner, target: &EventTarget) -> Result<(),
                 runner.input.raw.events.push(egui_event);
 
                 push_touches(runner, egui::TouchPhase::Move, &event);
-                runner.needs_repaint.repaint_asap();
+                runner.needs_repaint.repaint();
 
                 // Use web options to tell if the web event should be propagated to parent elements based on the egui event.
                 if should_stop_propagation {

--- a/crates/egui/src/interaction.rs
+++ b/crates/egui/src/interaction.rs
@@ -191,20 +191,8 @@ pub(crate) fn interact(
     if dragged.is_none() {
         // Check if we started dragging something new:
         if let Some(widget) = interaction.potential_drag_id.and_then(|id| widgets.get(id)) {
-            if widget.enabled {
-                let is_dragged = if widget.sense.senses_click() && widget.sense.senses_drag() {
-                    // This widget is sensitive to both clicks and drags.
-                    // When the mouse first is pressed, it could be either,
-                    // so we postpone the decision until we know.
-                    input.pointer.is_decidedly_dragging()
-                } else {
-                    // This widget is just sensitive to drags, so we can mark it as dragged right away:
-                    widget.sense.senses_drag()
-                };
-
-                if is_dragged {
-                    dragged = Some(widget.id);
-                }
+            if widget.enabled && input.pointer.is_decidedly_dragging() {
+                dragged = Some(widget.id);
             }
         }
     }


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes <https://github.com/emilk/egui/issues/7371>
* [x] I have followed the instructions in the PR template

The purpose of this change is to limit the amount of time spent redrawing the GUI, which can be highly beneficial on low spec systems as explained in the issue.

Lowering the repaint rate also highlighted an issue with the drag interaction of windows among other elements. It seems that the drag gets registered on the first mouse down and the window then moves based on the cursor movement since the previous frame, making it the dragged element jump.
The fix I found for this was to always check for `is_decidedly_dragging`. I didn't notice any input delays or other negative effects from this. This is with a refresh rate of 2:

[drag.webm](https://github.com/user-attachments/assets/9a95cdcc-7c81-42c7-b98b-d4164c3b8a9d)


To test this feature, change the `WebOptions` to
```rust
eframe::WebOptions {
    repaint_rate_limit: Some(2),
    ..Default::default()
},
```