### PR TITLE
Deprecated `ImageButton` and removed `WidgetType::ImageButton`

### DIFF
--- a/crates/egui/src/data/output.rs
+++ b/crates/egui/src/data/output.rs
@@ -713,7 +713,6 @@ impl WidgetInfo {
             WidgetType::Slider => "slider",
             WidgetType::DragValue => "drag value",
             WidgetType::ColorButton => "color button",
-            WidgetType::ImageButton => "image button",
             WidgetType::Image => "image",
             WidgetType::CollapsingHeader => "collapsing header",
             WidgetType::ProgressIndicator => "progress indicator",

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -668,8 +668,6 @@ pub enum WidgetType {
 
     ColorButton,
 
-    ImageButton,
-
     Image,
 
     CollapsingHeader,

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -847,14 +847,13 @@ impl Response {
             WidgetType::Label => Role::Label,
             WidgetType::Link => Role::Link,
             WidgetType::TextEdit => Role::TextInput,
-            WidgetType::Button | WidgetType::ImageButton | WidgetType::CollapsingHeader => {
+            WidgetType::Button | WidgetType::CollapsingHeader | WidgetType::SelectableLabel => {
                 Role::Button
             }
             WidgetType::Image => Role::Image,
             WidgetType::Checkbox => Role::CheckBox,
             WidgetType::RadioButton => Role::RadioButton,
             WidgetType::RadioGroup => Role::RadioGroup,
-            WidgetType::SelectableLabel => Role::Button,
             WidgetType::ComboBox => Role::ComboBox,
             WidgetType::Slider => Role::Slider,
             WidgetType::DragValue => Role::SpinButton,

--- a/crates/egui/src/widgets/image_button.rs
+++ b/crates/egui/src/widgets/image_button.rs
@@ -6,6 +6,7 @@ use crate::{
 /// A clickable image within a frame.
 #[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 #[derive(Clone, Debug)]
+#[deprecated(since = "0.33.0", note = "Use egui::Button::image instead")]
 pub struct ImageButton<'a> {
     pub(crate) image: Image<'a>,
     sense: Sense,
@@ -14,6 +15,7 @@ pub struct ImageButton<'a> {
     alt_text: Option<String>,
 }
 
+#[expect(deprecated)]
 impl<'a> ImageButton<'a> {
     pub fn new(image: impl Into<Image<'a>>) -> Self {
         Self {
@@ -82,6 +84,7 @@ impl<'a> ImageButton<'a> {
     }
 }
 
+#[expect(deprecated)]
 impl Widget for ImageButton<'_> {
     fn ui(self, ui: &mut Ui) -> Response {
         let padding = if self.frame {
@@ -101,7 +104,7 @@ impl Widget for ImageButton<'_> {
         let padded_size = image_size + 2.0 * padding;
         let (rect, response) = ui.allocate_exact_size(padded_size, self.sense);
         response.widget_info(|| {
-            let mut info = WidgetInfo::new(WidgetType::ImageButton);
+            let mut info = WidgetInfo::new(WidgetType::Button);
             info.label = self.alt_text.clone();
             info
         });

--- a/crates/egui/src/widgets/image_button.rs
+++ b/crates/egui/src/widgets/image_button.rs
@@ -84,7 +84,7 @@ impl<'a> ImageButton<'a> {
     }
 }
 
-#[expect(deprecated)]
+#[expect(deprecated, reason = "Deprecated in egui 0.33.0")]
 impl Widget for ImageButton<'_> {
     fn ui(self, ui: &mut Ui) -> Response {
         let padding = if self.frame {

--- a/crates/egui/src/widgets/image_button.rs
+++ b/crates/egui/src/widgets/image_button.rs
@@ -15,7 +15,7 @@ pub struct ImageButton<'a> {
     alt_text: Option<String>,
 }
 
-#[expect(deprecated)]
+#[expect(deprecated, reason = "Deprecated in egui 0.33.0")]
 impl<'a> ImageButton<'a> {
     pub fn new(image: impl Into<Image<'a>>) -> Self {
         Self {

--- a/crates/egui/src/widgets/mod.rs
+++ b/crates/egui/src/widgets/mod.rs
@@ -24,6 +24,7 @@ pub mod text_edit;
 
 #[expect(deprecated)]
 pub use self::selected_label::SelectableLabel;
+#[expect(deprecated)]
 pub use self::{
     button::Button,
     checkbox::Checkbox,

--- a/crates/egui/src/widgets/mod.rs
+++ b/crates/egui/src/widgets/mod.rs
@@ -24,7 +24,7 @@ pub mod text_edit;
 
 #[expect(deprecated)]
 pub use self::selected_label::SelectableLabel;
-#[expect(deprecated)]
+#[expect(deprecated, reason = "Deprecated in egui 0.33.0")]
 pub use self::{
     button::Button,
     checkbox::Checkbox,


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes <https://github.com/emilk/egui/issues/7466>
* [x] I have followed the instructions in the PR template
* I have ran `./scripts/check.sh` and it has no fails
* I have run `cargo fmt` and `cargo clippy`

Added the deprecated tag to ImageButton struct
Removed the `WidgetType::ImageButton` variant. ImageButton will use `WidgetType::Button` for its WidgetInfo

*This is my first PR ever, please let me know if I did something wrong so I can change it*
