### PR TITLE
Add much more detailed comments throughout the new atom-based radio_button widget

### DIFF
--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -1,64 +1,161 @@
+// Import necessary types and traits from the crate
 use crate::{
-    Atom, AtomExt as _, AtomKind, AtomLayout, AtomLayoutResponse, Color32, CornerRadius, Frame,
-    Image, IntoAtoms, NumExt as _, Response, Sense, Stroke, TextStyle, TextWrapMode, Ui, Vec2,
-    Widget, WidgetInfo, WidgetText, WidgetType,
+    Atom,               // Individual UI element that can be laid out
+    AtomExt as _,       // Extension traits for atoms (imported with underscore)
+    AtomKind,           // Enum specifying the type of atom (Text, Image, etc.)
+    AtomLayout,         // Layout manager for arranging atoms horizontally/vertically
+    AtomLayoutResponse, // Response from atom layout operations with painting capabilities
+    Color32,            // 32-bit color representation (RGBA)
+    CornerRadius,       // Struct defining corner rounding for rectangles
+    Frame,              // Container with background, borders, and margins
+    Image,              // Image atom for displaying pictures/icons
+    IntoAtoms,          // Trait for converting types into Atoms collection
+    NumExt as _,        // Numeric extension traits
+    Response,           // UI interaction response (clicks, hovers, etc.)
+    Sense,              // What types of interactions the widget responds to
+    Stroke,             // Line style (color, width) for borders
+    TextStyle,          // Predefined text styling (Button, Body, Heading, etc.)
+    TextWrapMode,       // How text should wrap (Wrap, Truncate, Extend)
+    Ui,                 // Main UI context
+    Vec2,               // 2D vector for positions and sizes
+    Widget,             // Trait that all widgets must implement
+    WidgetInfo,         // Accessibility and debugging information
+    WidgetText,         // Text content for widgets
+    WidgetType,         // Enum identifying the type of widget
 };
 
-/// Clickable button with text.
+/// A clickable button widget that can contain text, images, or both.
 ///
-/// See also [`Ui::button`].
+/// Buttons are one of the most fundamental UI elements, providing user interaction
+/// through clicks, drags, or other input methods. This implementation supports
+/// extensive customization including colors, sizing, frames, and content layout.
 ///
+/// ## Basic Usage
+/// The simplest way to create buttons is through [`Ui::button`], but this struct
+/// provides much more control over appearance and behavior.
+///
+/// ## Examples
 /// ```
 /// # egui::__run_test_ui(|ui| {
 /// # fn do_stuff() {}
 ///
+/// // Simple text button
 /// if ui.add(egui::Button::new("Click me")).clicked() {
 ///     do_stuff();
 /// }
 ///
-/// // A greyed-out and non-interactive button:
+/// // Disabled button (greyed-out and non-interactive)
 /// if ui.add_enabled(false, egui::Button::new("Can't click this")).clicked() {
-///     unreachable!();
+///     unreachable!(); // This will never execute because button is disabled
+/// }
+///
+/// // Button with custom styling
+/// if ui.add(
+///     egui::Button::new("Styled button")
+///         .fill(egui::Color32::BLUE)
+///         .corner_radius(10.0)
+///         .min_size(egui::Vec2::new(100.0, 40.0))
+/// ).clicked() {
+///     // Handle click
 /// }
 /// # });
 /// ```
 #[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct Button<'a> {
+    /// The layout manager that handles arrangement of atoms (text, images, etc.)
     layout: AtomLayout<'a>,
+
+    /// Optional override for background fill color
+    /// If None, uses the theme's default button colors
     fill: Option<Color32>,
+
+    /// Optional override for border stroke (color and width)
+    /// If None, uses the theme's default button border
     stroke: Option<Stroke>,
+
+    /// Whether this is a small button suitable for inline text embedding
+    /// Small buttons have reduced vertical padding and minimum size
     small: bool,
+
+    /// Optional override for whether to show a frame/background
+    /// None = use theme default, Some(true/false) = force on/off
     frame: Option<bool>,
+
+    /// Whether to show frame when button is not being interacted with
+    /// Only relevant when frames are enabled
     frame_when_inactive: bool,
+
+    /// Minimum size the button should occupy, regardless of content
     min_size: Vec2,
+
+    /// Optional override for corner rounding
+    /// If None, uses the theme's default button corner radius
     corner_radius: Option<CornerRadius>,
+
+    /// Whether this button should appear in a "selected" state
+    /// Affects coloring and visual feedback
     selected: bool,
+
+    /// Whether image tint should match the text color
+    /// Useful for icon buttons where you want the icon to change color on hover
     image_tint_follows_text_color: bool,
+
+    /// Whether to limit image size to font height for consistent appearance
+    /// Used by image-based button constructors
     limit_image_size: bool,
 }
 
 impl<'a> Button<'a> {
+    /// Creates a new button with the specified content.
+    ///
+    /// This is the most flexible constructor - it accepts anything that can be
+    /// converted into atoms (text, images, or combinations thereof).
+    ///
+    /// # Parameters
+    /// - `atoms`: The content to display (typically text like `"Click me"`)
+    ///
+    /// # Returns
+    /// A new `Button` instance with default settings
+    ///
+    /// # Example
+    /// ```
+    /// let button = egui::Button::new("My Button");
+    /// let button2 = egui::Button::new(egui::WidgetText::from("Styled text"));
+    /// ```
     pub fn new(atoms: impl IntoAtoms<'a>) -> Self {
         Self {
+            // Set up the layout with click sensing and button font styling
             layout: AtomLayout::new(atoms.into_atoms())
-                .sense(Sense::click())
-                .fallback_font(TextStyle::Button),
-            fill: None,
-            stroke: None,
-            small: false,
-            frame: None,
-            frame_when_inactive: true,
-            min_size: Vec2::ZERO,
-            corner_radius: None,
-            selected: false,
-            image_tint_follows_text_color: false,
-            limit_image_size: false,
+                .sense(Sense::click()) // Respond to mouse clicks
+                .fallback_font(TextStyle::Button), // Use button text style as fallback
+
+            // Initialize all customization options to defaults
+            fill: None,                           // Use theme default fill
+            stroke: None,                         // Use theme default stroke
+            small: false,                         // Normal-sized button
+            frame: None,                          // Use theme default frame setting
+            frame_when_inactive: true,            // Show frame even when not hovered
+            min_size: Vec2::ZERO,                 // No minimum size override
+            corner_radius: None,                  // Use theme default corner radius
+            selected: false,                      // Not selected by default
+            image_tint_follows_text_color: false, // Images keep their original color
+            limit_image_size: false,              // Don't limit image size by default
         }
     }
 
-    /// Show a selectable button.
+    /// Creates a selectable button that can be toggled on/off.
     ///
-    /// Equivalent to:
+    /// This is a convenience constructor for creating buttons that represent
+    /// a binary state (like toggle buttons or option selectors).
+    ///
+    /// # Parameters
+    /// - `selected`: Whether the button should appear in selected state
+    /// - `atoms`: The content to display on the button
+    ///
+    /// # Returns
+    /// A configured button with appropriate selection styling
+    ///
+    /// # Equivalent to:
     /// ```rust
     /// # use egui::{Button, IntoAtoms, __run_test_ui};
     /// # __run_test_ui(|ui| {
@@ -67,190 +164,378 @@ impl<'a> Button<'a> {
     /// # });
     /// ```
     ///
-    /// See also:
-    ///   - [`Ui::selectable_value`]
-    ///   - [`Ui::selectable_label`]
+    /// # See also:
+    /// - [`Ui::selectable_value`] - For enum/value selection
+    /// - [`Ui::selectable_label`] - For simpler selectable text
     pub fn selectable(selected: bool, atoms: impl IntoAtoms<'a>) -> Self {
         Self::new(atoms)
-            .selected(selected)
-            .frame_when_inactive(selected)
-            .frame(true)
+            .selected(selected) // Set selection state
+            .frame_when_inactive(selected) // Only show frame when selected and inactive
+            .frame(true) // Always enable frame for selectables
     }
 
-    /// Creates a button with an image. The size of the image as displayed is defined by the provided size.
+    /// Creates a button containing only an image.
     ///
-    /// Note: In contrast to [`Button::new`], this limits the image size to the default font height
-    /// (using [`crate::AtomExt::atom_max_height_font_size`]).
+    /// The image size is automatically limited to the default font height
+    /// for consistent appearance with text elements.
+    ///
+    /// # Parameters
+    /// - `image`: The image to display (can be from various sources)
+    ///
+    /// # Note
+    /// Unlike [`Button::new`], this automatically enables image size limiting
+    /// to ensure the button integrates well with text-based UI elements.
     pub fn image(image: impl Into<Image<'a>>) -> Self {
         Self::opt_image_and_text(Some(image.into()), None)
     }
 
-    /// Creates a button with an image to the left of the text.
+    /// Creates a button with an image on the left and text on the right.
     ///
-    /// Note: In contrast to [`Button::new`], this limits the image size to the default font height
-    /// (using [`crate::AtomExt::atom_max_height_font_size`]).
+    /// This is commonly used for menu items, toolbar buttons, and other
+    /// UI elements that benefit from both visual and textual representation.
+    ///
+    /// # Parameters
+    /// - `image`: The image to display on the left side
+    /// - `text`: The text to display on the right side
+    ///
+    /// # Note
+    /// The image size is automatically limited to font height for consistency.
     pub fn image_and_text(image: impl Into<Image<'a>>, text: impl Into<WidgetText>) -> Self {
         Self::opt_image_and_text(Some(image.into()), Some(text.into()))
     }
 
-    /// Create a button with an optional image and optional text.
+    /// Creates a button with optional image and/or text content.
     ///
-    /// Note: In contrast to [`Button::new`], this limits the image size to the default font height
-    /// (using [`crate::AtomExt::atom_max_height_font_size`]).
+    /// This is the most flexible constructor for mixed content buttons.
+    /// Either parameter can be None to create image-only or text-only buttons.
+    ///
+    /// # Parameters
+    /// - `image`: Optional image to display (positioned left)
+    /// - `text`: Optional text to display (positioned right of image)
+    ///
+    /// # Note
+    /// Image size limiting is automatically enabled for consistent appearance.
     pub fn opt_image_and_text(image: Option<Image<'a>>, text: Option<WidgetText>) -> Self {
+        // Start with an empty button (no default content)
         let mut button = Self::new(());
+
+        // Add image to the right side of layout if provided
         if let Some(image) = image {
             button.layout.push_right(image);
         }
+
+        // Add text to the right side of layout if provided (after image)
         if let Some(text) = text {
             button.layout.push_right(text);
         }
+
+        // Enable automatic image size limiting for font-height consistency
         button.limit_image_size = true;
         button
     }
 
-    /// Set the wrap mode for the text.
+    /// Sets the text wrapping mode for text content in the button.
     ///
-    /// By default, [`crate::Ui::wrap_mode`] will be used, which can be overridden with [`crate::Style::wrap_mode`].
+    /// By default, buttons use the UI's wrap mode setting, which can be
+    /// overridden globally via [`crate::Style::wrap_mode`].
     ///
-    /// Note that any `\n` in the text will always produce a new line.
+    /// # Parameters
+    /// - `wrap_mode`: How text should behave when it exceeds button width
+    ///
+    /// # Note
+    /// Newline characters (`\n`) in the text will always create line breaks
+    /// regardless of the wrap mode setting.
     #[inline]
     pub fn wrap_mode(mut self, wrap_mode: TextWrapMode) -> Self {
         self.layout = self.layout.wrap_mode(wrap_mode);
         self
     }
 
-    /// Set [`Self::wrap_mode`] to [`TextWrapMode::Wrap`].
+    /// Convenience method to enable text wrapping.
+    ///
+    /// Sets [`Self::wrap_mode`] to [`TextWrapMode::Wrap`], allowing text
+    /// to flow to multiple lines when the button is too narrow.
     #[inline]
     pub fn wrap(self) -> Self {
         self.wrap_mode(TextWrapMode::Wrap)
     }
 
-    /// Set [`Self::wrap_mode`] to [`TextWrapMode::Truncate`].
+    /// Convenience method to enable text truncation.
+    ///
+    /// Sets [`Self::wrap_mode`] to [`TextWrapMode::Truncate`], causing
+    /// text to be cut off with "..." when it doesn't fit.
     #[inline]
     pub fn truncate(self) -> Self {
         self.wrap_mode(TextWrapMode::Truncate)
     }
 
-    /// Override background fill color. Note that this will override any on-hover effects.
-    /// Calling this will also turn on the frame.
+    /// Override the background fill color of the button.
+    ///
+    /// This completely replaces theme-based coloring, including hover effects.
+    /// The button frame is automatically enabled when using custom fill.
+    ///
+    /// # Parameters
+    /// - `fill`: The color to use for the button background
+    ///
+    /// # Warning
+    /// This will override **all** hover and interaction effects for the background.
+    /// Consider using theme customization instead for better user experience.
     #[inline]
     pub fn fill(mut self, fill: impl Into<Color32>) -> Self {
         self.fill = Some(fill.into());
         self
     }
 
-    /// Override button stroke. Note that this will override any on-hover effects.
-    /// Calling this will also turn on the frame.
+    /// Override the border stroke (outline) of the button.
+    ///
+    /// This replaces theme-based border styling, including hover effects.
+    /// The button frame is automatically enabled when using custom stroke.
+    ///
+    /// # Parameters
+    /// - `stroke`: The stroke style (color and width) for the button border
+    ///
+    /// # Warning
+    /// This will override **all** hover and interaction effects for the border.
     #[inline]
     pub fn stroke(mut self, stroke: impl Into<Stroke>) -> Self {
         self.stroke = Some(stroke.into());
-        self.frame = Some(true);
+        self.frame = Some(true); // Automatically enable frame for custom stroke
         self
     }
 
-    /// Make this a small button, suitable for embedding into text.
+    /// Makes this a small button suitable for embedding within text.
+    ///
+    /// Small buttons have:
+    /// - No vertical padding
+    /// - No minimum height requirement
+    /// - Reduced visual weight for inline use
+    ///
+    /// # Use cases
+    /// - Inline buttons within paragraphs
+    /// - Compact toolbar buttons
+    /// - Secondary actions that shouldn't dominate the UI
     #[inline]
     pub fn small(mut self) -> Self {
         self.small = true;
         self
     }
 
-    /// Turn off the frame
+    /// Controls whether the button has a visible frame (background/border).
+    ///
+    /// # Parameters
+    /// - `frame`: true to force frame on, false to force frame off
+    ///
+    /// # Note
+    /// When disabled, the button appears as plain text until hovered.
+    /// This is useful for creating subtle buttons that don't dominate the UI.
     #[inline]
     pub fn frame(mut self, frame: bool) -> Self {
         self.frame = Some(frame);
         self
     }
 
-    /// If `false`, the button will not have a frame when inactive.
+    /// Controls frame visibility when the button is not being interacted with.
     ///
-    /// Default: `true`.
+    /// When set to `false`, the frame only appears on hover/click, creating
+    /// a more subtle appearance for inactive buttons.
     ///
-    /// Note: When [`Self::frame`] (or `ui.visuals().button_frame`) is `false`, this setting
-    /// has no effect.
+    /// # Parameters
+    /// - `frame_when_inactive`: Whether to show frame when not interacting
+    ///
+    /// # Default
+    /// `true` - frames are always visible when enabled
+    ///
+    /// # Note
+    /// This setting has no effect when [`Self::frame`] or `ui.visuals().button_frame`
+    /// is `false`.
     #[inline]
     pub fn frame_when_inactive(mut self, frame_when_inactive: bool) -> Self {
         self.frame_when_inactive = frame_when_inactive;
         self
     }
 
-    /// By default, buttons senses clicks.
-    /// Change this to a drag-button with `Sense::drag()`.
+    /// Changes the interaction sensing mode of the button.
+    ///
+    /// By default, buttons respond to clicks. You can change this to create
+    /// drag buttons, hover-sensitive buttons, or other interaction patterns.
+    ///
+    /// # Parameters
+    /// - `sense`: The type of interaction to detect
+    ///
+    /// # Examples
+    /// - `Sense::click()` - Normal button (default)
+    /// - `Sense::drag()` - Drag button for sliders or draggable items
+    /// - `Sense::hover()` - Button that responds to mouse hover
     #[inline]
     pub fn sense(mut self, sense: Sense) -> Self {
         self.layout = self.layout.sense(sense);
         self
     }
 
-    /// Set the minimum size of the button.
+    /// Sets the minimum size the button should occupy.
+    ///
+    /// The button will be at least this large, even if the content is smaller.
+    /// This is useful for creating consistent button sizes or ensuring
+    /// touch-friendly target sizes.
+    ///
+    /// # Parameters
+    /// - `min_size`: Minimum width and height in UI units
+    ///
+    /// # Example
+    /// ```
+    /// # use egui::{Button, Vec2};
+    /// let button = Button::new("OK").min_size(Vec2::new(80.0, 30.0));
+    /// ```
     #[inline]
     pub fn min_size(mut self, min_size: Vec2) -> Self {
         self.min_size = min_size;
         self
     }
 
-    /// Set the rounding of the button.
+    /// Sets the corner rounding of the button.
+    ///
+    /// This allows creating buttons with rounded corners, from slightly
+    /// rounded rectangles to pill-shaped buttons.
+    ///
+    /// # Parameters
+    /// - `corner_radius`: How much to round the corners (can be uniform or per-corner)
+    ///
+    /// # Examples
+    /// ```
+    /// # use egui::{Button, CornerRadius};
+    /// let rounded_button = Button::new("Rounded").corner_radius(8.0);
+    /// let pill_button = Button::new("Pill").corner_radius(CornerRadius::same(100.0));
+    /// ```
     #[inline]
     pub fn corner_radius(mut self, corner_radius: impl Into<CornerRadius>) -> Self {
         self.corner_radius = Some(corner_radius.into());
         self
     }
 
+    /// Deprecated alias for [`corner_radius`].
+    ///
+    /// This method has been renamed for clarity. Use `corner_radius` instead.
     #[inline]
     #[deprecated = "Renamed to `corner_radius`"]
     pub fn rounding(self, corner_radius: impl Into<CornerRadius>) -> Self {
         self.corner_radius(corner_radius)
     }
 
-    /// If true, the tint of the image is multiplied by the widget text color.
+    /// Controls whether image tint follows the text color.
     ///
-    /// This makes sense for images that are white, that should have the same color as the text color.
-    /// This will also make the icon color depend on hover state.
+    /// When enabled, any images in the button will be tinted to match
+    /// the current text color, including hover state changes.
     ///
-    /// Default: `false`.
+    /// # Parameters
+    /// - `image_tint_follows_text_color`: Whether to tint images to match text
+    ///
+    /// # Use cases
+    /// - White/monochrome icons that should match theme colors
+    /// - Icons that should change color on hover
+    /// - Maintaining consistent color schemes across text and icons
+    ///
+    /// # Default
+    /// `false` - images retain their original colors
     #[inline]
     pub fn image_tint_follows_text_color(mut self, image_tint_follows_text_color: bool) -> Self {
         self.image_tint_follows_text_color = image_tint_follows_text_color;
         self
     }
 
-    /// Show some text on the right side of the button, in weak color.
+    /// Adds shortcut text on the right side of the button in a weak/subdued color.
     ///
-    /// Designed for menu buttons, for setting a keyboard shortcut text (e.g. `Ctrl+S`).
+    /// This is specifically designed for menu buttons to display keyboard
+    /// shortcuts (like "Ctrl+S", "F1", etc.) in a visually secondary way.
     ///
-    /// The text can be created with [`crate::Context::format_shortcut`].
+    /// # Parameters
+    /// - `shortcut_text`: The shortcut text to display (often created with
+    ///   [`crate::Context::format_shortcut`])
     ///
-    /// See also [`Self::right_text`].
+    /// # Layout
+    /// The shortcut text is positioned on the far right with a flexible
+    /// space separator, creating a typical menu item appearance:
+    /// `[Button Text          Ctrl+S]`
+    ///
+    /// # See also
+    /// [`Self::right_text`] for normal-colored right-aligned text
     #[inline]
     pub fn shortcut_text(mut self, shortcut_text: impl Into<Atom<'a>>) -> Self {
         let mut atom = shortcut_text.into();
+
+        // Convert the atom to weak/subdued styling if it's text
         atom.kind = match atom.kind {
-            AtomKind::Text(text) => AtomKind::Text(text.weak()),
-            other => other,
+            AtomKind::Text(text) => AtomKind::Text(text.weak()), // Apply weak styling
+            other => other,                                      // Non-text atoms remain unchanged
         };
+
+        // Add flexible space to push shortcut to the right
         self.layout.push_right(Atom::grow());
+        // Add the styled shortcut text
         self.layout.push_right(atom);
         self
     }
 
-    /// Show some text on the right side of the button.
+    /// Adds normal text on the right side of the button.
+    ///
+    /// Unlike [`Self::shortcut_text`], this displays the text in normal
+    /// color/weight, making it more prominent.
+    ///
+    /// # Parameters
+    /// - `right_text`: The text to display on the right side
+    ///
+    /// # Layout
+    /// Similar to shortcut text but with normal styling:
+    /// `[Button Text          Right Text]`
     #[inline]
     pub fn right_text(mut self, right_text: impl Into<Atom<'a>>) -> Self {
+        // Add flexible space to push text to the right
         self.layout.push_right(Atom::grow());
+        // Add the text with normal styling
         self.layout.push_right(right_text.into());
         self
     }
 
-    /// If `true`, mark this button as "selected".
+    /// Marks this button as selected or unselected.
+    ///
+    /// Selected buttons typically appear with different coloring to indicate
+    /// their state, similar to pressed or active buttons.
+    ///
+    /// # Parameters
+    /// - `selected`: Whether the button should appear selected
+    ///
+    /// # Use cases
+    /// - Toggle buttons showing on/off state
+    /// - Tab buttons showing active tab
+    /// - Tool palette showing selected tool
     #[inline]
     pub fn selected(mut self, selected: bool) -> Self {
         self.selected = selected;
         self
     }
 
-    /// Show the button and return a [`AtomLayoutResponse`] for painting custom contents.
+    /// Renders the button and returns a detailed response for custom painting.
+    ///
+    /// This is the main rendering method that handles layout, interaction,
+    /// and drawing. It returns an [`AtomLayoutResponse`] which includes
+    /// both the user interaction response and information for custom painting.
+    ///
+    /// # Parameters
+    /// - `ui`: The UI context to render into
+    ///
+    /// # Returns
+    /// An [`AtomLayoutResponse`] containing:
+    /// - `response`: User interaction information (clicks, hovers, etc.)
+    /// - Layout information for custom drawing
+    ///
+    /// # Process
+    /// 1. Calculate sizing and layout
+    /// 2. Handle image size limiting if enabled
+    /// 3. Allocate space in the UI
+    /// 4. Apply visual styling based on interaction state
+    /// 5. Draw the button frame and content
+    /// 6. Set up accessibility information
     pub fn atom_ui(self, ui: &mut Ui) -> AtomLayoutResponse {
+        // Destructure self to get owned values
         let Button {
             mut layout,
             fill,
@@ -265,79 +550,110 @@ impl<'a> Button<'a> {
             limit_image_size,
         } = self;
 
+        // Calculate minimum size based on button type
         if !small {
+            // Normal buttons have minimum height for touch-friendly interaction
             min_size.y = min_size.y.at_least(ui.spacing().interact_size.y);
         }
+        // Small buttons can be as small as their content
 
+        // Apply image size limiting if requested
         if limit_image_size {
             layout.map_atoms(|atom| {
                 if matches!(&atom.kind, AtomKind::Image(_)) {
+                    // Limit image height to font size for consistency
                     atom.atom_max_height_font_size(ui)
                 } else {
-                    atom
+                    atom // Non-image atoms pass through unchanged
                 }
             });
         }
 
+        // Extract text for accessibility purposes
         let text = layout.text().map(String::from);
 
+        // Determine if button should have frame/background
         let has_frame_margin = frame.unwrap_or_else(|| ui.visuals().button_frame);
 
+        // Calculate padding based on frame presence
         let mut button_padding = if has_frame_margin {
-            ui.spacing().button_padding
+            ui.spacing().button_padding // Normal padding for framed buttons
         } else {
-            Vec2::ZERO
+            Vec2::ZERO // No padding for frameless buttons
         };
+
+        // Small buttons get no vertical padding
         if small {
             button_padding.y = 0.0;
         }
 
+        // Set up layout with frame and allocate space
         let mut prepared = layout
-            .frame(Frame::new().inner_margin(button_padding))
-            .min_size(min_size)
-            .allocate(ui);
+            .frame(Frame::new().inner_margin(button_padding)) // Add padding frame
+            .min_size(min_size) // Apply minimum size
+            .allocate(ui); // Reserve space and get interaction
 
+        // Only render if the button is visible on screen (optimization)
         let response = if ui.is_rect_visible(prepared.response.rect) {
+            // Get visual styling based on interaction state and selection
             let visuals = ui.style().interact_selectable(&prepared.response, selected);
 
+            // Determine when to show the frame
             let visible_frame = if frame_when_inactive {
+                // Always show frame when enabled
                 has_frame_margin
             } else {
+                // Only show frame during interaction
                 has_frame_margin
-                    && (prepared.response.hovered()
-                        || prepared.response.is_pointer_button_down_on()
-                        || prepared.response.has_focus())
+                    && (prepared.response.hovered()                    // Mouse over
+                        || prepared.response.is_pointer_button_down_on() // Mouse pressed
+                        || prepared.response.has_focus()) // Keyboard focus
             };
 
+            // Apply image tinting if enabled
             if image_tint_follows_text_color {
                 prepared.map_images(|image| image.tint(visuals.text_color()));
             }
 
+            // Set fallback text color from visual styling
             prepared.fallback_text_color = visuals.text_color();
 
+            // Draw the frame if it should be visible
             if visible_frame {
+                // Use custom stroke or theme default
                 let stroke = stroke.unwrap_or(visuals.bg_stroke);
+                // Use custom fill or theme default
                 let fill = fill.unwrap_or(visuals.weak_bg_fill);
+
+                // Configure the frame appearance
                 prepared.frame = prepared
                     .frame
+                    // Adjust inner margin for visual expansion and stroke width
                     .inner_margin(
                         button_padding + Vec2::splat(visuals.expansion) - Vec2::splat(stroke.width),
                     )
+                    // Adjust outer margin for visual expansion
                     .outer_margin(-Vec2::splat(visuals.expansion))
+                    // Apply colors and styling
                     .fill(fill)
                     .stroke(stroke)
                     .corner_radius(corner_radius.unwrap_or(visuals.corner_radius));
             }
 
+            // Paint the button and get the final response
             prepared.paint(ui)
         } else {
+            // Button is not visible, return empty response to save processing
             AtomLayoutResponse::empty(prepared.response)
         };
 
+        // Set up accessibility information for screen readers
         response.response.widget_info(|| {
             if let Some(text) = &text {
+                // Button with text label
                 WidgetInfo::labeled(WidgetType::Button, ui.is_enabled(), text)
             } else {
+                // Button without text (image-only, etc.)
                 WidgetInfo::new(WidgetType::Button)
             }
         });
@@ -346,7 +662,22 @@ impl<'a> Button<'a> {
     }
 }
 
+/// Implementation of the Widget trait for standard UI integration
 impl Widget for Button<'_> {
+    /// Renders the button and returns a standard interaction response.
+    ///
+    /// This is the standard Widget trait implementation that most users
+    /// will interact with through `ui.add(button)`.
+    ///
+    /// # Parameters
+    /// - `ui`: The UI context to render into
+    ///
+    /// # Returns
+    /// A [`Response`] containing user interaction information
+    ///
+    /// # Note
+    /// This is a convenience wrapper around [`Button::atom_ui`] that
+    /// extracts just the interaction response.
     fn ui(self, ui: &mut Ui) -> Response {
         self.atom_ui(ui).response
     }

--- a/crates/egui/src/widgets/checkbox.rs
+++ b/crates/egui/src/widgets/checkbox.rs
@@ -1,45 +1,157 @@
+// Import necessary types and traits from the crate
 use crate::{
-    Atom, AtomLayout, Atoms, Id, IntoAtoms, NumExt as _, Response, Sense, Shape, Ui, Vec2, Widget,
-    WidgetInfo, WidgetType, epaint, pos2,
+    Atom,        // Individual UI element that can be laid out
+    AtomLayout,  // Layout manager for atoms
+    Atoms,       // Collection of atoms
+    Id,          // Unique identifier for UI elements
+    IntoAtoms,   // Trait for converting types into Atoms
+    NumExt as _, // Numeric extension traits (imported with underscore to avoid naming conflicts)
+    Response,    // UI interaction response (clicks, hovers, etc.)
+    Sense,       // What types of interactions the widget responds to
+    Shape,       // Geometric shapes for drawing (lines, rectangles, etc.)
+    Ui,          // Main UI context
+    Vec2,        // 2D vector for positions and sizes
+    Widget,      // Trait that all widgets must implement
+    WidgetInfo,  // Accessibility and debugging information about widgets
+    WidgetType,  // Enum identifying the type of widget
+    epaint,      // Low-level painting/drawing functionality
+    pos2,        // Function to create 2D position coordinates
 };
 
 // TODO(emilk): allow checkbox without a text label
-/// Boolean on/off control with text label.
+/// A boolean on/off control widget with an optional text label.
 ///
-/// Usually you'd use [`Ui::checkbox`] instead.
+/// Checkboxes allow users to toggle between two states: checked (true) and unchecked (false).
+/// Unlike radio buttons which are mutually exclusive, checkboxes are independent and can be
+/// used for multiple selections or individual boolean settings.
 ///
+/// The checkbox displays as a square box that shows a checkmark when selected, and can also
+/// display an indeterminate state (horizontal line) for tri-state logic.
+///
+/// ## Usage
+/// Usually you'd use the convenience method [`Ui::checkbox`] instead of creating this
+/// widget directly, but this struct gives you more control over the behavior.
+///
+/// ## Examples
 /// ```
 /// # egui::__run_test_ui(|ui| {
 /// # let mut my_bool = true;
-/// // These are equivalent:
+/// // Simple convenience method (recommended for most cases)
 /// ui.checkbox(&mut my_bool, "Checked");
+///
+/// // Equivalent manual creation:
 /// ui.add(egui::Checkbox::new(&mut my_bool, "Checked"));
+///
+/// // Checkbox without text label:
+/// ui.add(egui::Checkbox::without_text(&mut my_bool));
+///
+/// // Indeterminate checkbox (shows horizontal line instead of checkmark):
+/// ui.add(egui::Checkbox::new(&mut my_bool, "Maybe").indeterminate(true));
 /// # });
 /// ```
+///
+/// ## Visual States
+/// - **Unchecked**: Empty square box
+/// - **Checked**: Square box with checkmark
+/// - **Indeterminate**: Square box with horizontal line (for tri-state logic)
 #[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct Checkbox<'a> {
+    /// Mutable reference to the boolean value this checkbox controls
+    /// When clicked, this value will be toggled (!*checked)
     checked: &'a mut bool,
+
+    /// The content atoms that make up this checkbox (typically text label)
+    /// Uses a lifetime parameter 'a to avoid unnecessary string allocations
     atoms: Atoms<'a>,
+
+    /// Whether to display in indeterminate state (horizontal line instead of checkmark)
+    /// Useful for tri-state logic where the checkbox represents "some of many" selected
     indeterminate: bool,
 }
 
 impl<'a> Checkbox<'a> {
+    /// Creates a new checkbox with the specified boolean reference and content.
+    ///
+    /// # Parameters
+    /// - `checked`: Mutable reference to a boolean that this checkbox will control.
+    ///   When the checkbox is clicked, this value will be toggled.
+    /// - `atoms`: The content to display next to the checkbox (usually text label).
+    ///   This accepts anything that implements `IntoAtoms`, such as `&str`, `String`, etc.
+    ///
+    /// # Returns
+    /// A new `Checkbox` instance ready to be added to a UI
+    ///
+    /// # Example
+    /// ```
+    /// # egui::__run_test_ui(|ui| {
+    /// let mut enabled = false;
+    /// let checkbox = egui::Checkbox::new(&mut enabled, "Enable feature");
+    /// if ui.add(checkbox).clicked() {
+    ///     println!("Checkbox toggled! New value: {}", enabled);
+    /// }
+    /// # });
+    /// ```
     pub fn new(checked: &'a mut bool, atoms: impl IntoAtoms<'a>) -> Self {
         Checkbox {
             checked,
-            atoms: atoms.into_atoms(),
-            indeterminate: false,
+            atoms: atoms.into_atoms(), // Convert the input into the internal Atoms representation
+            indeterminate: false,      // Default to normal checked/unchecked behavior
         }
     }
 
+    /// Creates a checkbox without any text label.
+    ///
+    /// This is useful when you want a standalone checkbox, perhaps in a table cell
+    /// or when the context makes the purpose clear without additional text.
+    ///
+    /// # Parameters
+    /// - `checked`: Mutable reference to the boolean this checkbox controls
+    ///
+    /// # Returns
+    /// A new `Checkbox` instance with no text content
+    ///
+    /// # Example
+    /// ```
+    /// # egui::__run_test_ui(|ui| {
+    /// let mut selected = true;
+    /// ui.add(egui::Checkbox::without_text(&mut selected));
+    /// # });
+    /// ```
     pub fn without_text(checked: &'a mut bool) -> Self {
-        Self::new(checked, ())
+        Self::new(checked, ()) // Empty tuple converts to empty atoms
     }
 
-    /// Display an indeterminate state (neither checked nor unchecked)
+    /// Sets the checkbox to display in indeterminate state.
     ///
-    /// This only affects the checkbox's appearance. It will still toggle its boolean value when
-    /// clicked.
+    /// In indeterminate state, the checkbox shows a horizontal line instead of a checkmark,
+    /// indicating a "mixed" or "partially selected" state. This is commonly used in
+    /// hierarchical selections where some but not all child items are selected.
+    ///
+    /// # Parameters
+    /// - `indeterminate`: Whether to show indeterminate state (horizontal line)
+    ///
+    /// # Important Note
+    /// This only affects the checkbox's **visual appearance**. The underlying boolean
+    /// value still behaves normally - clicking will still toggle between true/false.
+    /// The indeterminate state is purely visual feedback for the user.
+    ///
+    /// # Use Cases
+    /// - Parent checkbox in a tree where some children are selected
+    /// - "Select All" checkbox when only some items are selected
+    /// - Any tri-state logic display (true/false/mixed)
+    ///
+    /// # Example
+    /// ```
+    /// # egui::__run_test_ui(|ui| {
+    /// let mut parent_selected = false;
+    /// let some_children_selected = true; // Some logic determines this
+    ///
+    /// ui.add(
+    ///     egui::Checkbox::new(&mut parent_selected, "Select All")
+    ///         .indeterminate(some_children_selected && !parent_selected)
+    /// );
+    /// # });
+    /// ```
     #[inline]
     pub fn indeterminate(mut self, indeterminate: bool) -> Self {
         self.indeterminate = indeterminate;
@@ -47,91 +159,153 @@ impl<'a> Checkbox<'a> {
     }
 }
 
+/// Implementation of the Widget trait, which defines how the checkbox is rendered and behaves
 impl Widget for Checkbox<'_> {
+    /// Main method that handles the widget's layout, interaction, and rendering
+    ///
+    /// # Parameters
+    /// - `ui`: Mutable reference to the UI context where this widget will be displayed
+    ///
+    /// # Returns
+    /// A `Response` containing information about user interactions (clicks, hovers, etc.)
+    ///
+    /// # Process Overview
+    /// 1. Calculate sizing for the checkbox icon and overall widget
+    /// 2. Set up the atom layout with the checkbox icon on the left
+    /// 3. Handle user interaction (clicking toggles the boolean)
+    /// 4. Set up accessibility information
+    /// 5. If visible, draw the checkbox background and appropriate state indicator
     fn ui(self, ui: &mut Ui) -> Response {
+        // Destructure self to get owned values (required since ui() consumes self)
         let Checkbox {
             checked,
             mut atoms,
             indeterminate,
         } = self;
 
+        // Get spacing configuration from the UI style
         let spacing = &ui.spacing();
+
+        // Calculate the width of the checkbox icon based on UI spacing settings
         let icon_width = spacing.icon_width;
 
+        // Set minimum size for the entire widget
+        // Start with a square based on the standard interaction size height
         let mut min_size = Vec2::splat(spacing.interact_size.y);
+        // Ensure the height is at least as tall as the icon width for proper visual balance
         min_size.y = min_size.y.at_least(icon_width);
 
-        // In order to center the checkbox based on min_size we set the icon height to at least min_size.y
+        // Calculate the actual size of the checkbox icon
+        // Start with a square icon based on the icon width
         let mut icon_size = Vec2::splat(icon_width);
+        // Ensure the icon height matches the minimum widget height for proper centering
         icon_size.y = icon_size.y.at_least(min_size.y);
+
+        // Create a unique identifier for the checkbox's square icon area
+        // This ID is used internally for layout and hit-testing
         let rect_id = Id::new("egui::checkbox");
+
+        // Add the checkbox icon as a custom atom to the left side of the widget
+        // This reserves space for the square checkbox graphic
         atoms.push_left(Atom::custom(rect_id, icon_size));
 
+        // Extract text content from atoms for accessibility purposes
+        // Convert to owned String if text exists, otherwise None
         let text = atoms.text().map(String::from);
 
+        // Create the layout for all atoms and handle user interaction
         let mut prepared = AtomLayout::new(atoms)
-            .sense(Sense::click())
-            .min_size(min_size)
-            .allocate(ui);
+            .sense(Sense::click()) // Make the widget respond to mouse clicks
+            .min_size(min_size) // Set the minimum size we calculated
+            .allocate(ui); // Reserve space in the UI and get interaction response
 
+        // Handle click interaction - toggle the boolean value
         if prepared.response.clicked() {
-            *checked = !*checked;
-            prepared.response.mark_changed();
+            *checked = !*checked; // Toggle the boolean value
+            prepared.response.mark_changed(); // Mark this as a state change for UI framework
         }
+
+        // Set up accessibility information for screen readers and debugging tools
         prepared.response.widget_info(|| {
             if indeterminate {
+                // For indeterminate state, we can't use "selected" since it's neither true nor false
+                // Just provide a labeled checkbox without selection state
                 WidgetInfo::labeled(
-                    WidgetType::Checkbox,
-                    ui.is_enabled(),
-                    text.as_deref().unwrap_or(""),
+                    WidgetType::Checkbox,          // Identify this as a checkbox
+                    ui.is_enabled(),               // Whether the widget is interactive
+                    text.as_deref().unwrap_or(""), // Text label or empty string
                 )
             } else {
+                // For normal checked/unchecked state, provide full selection information
                 WidgetInfo::selected(
-                    WidgetType::Checkbox,
-                    ui.is_enabled(),
-                    *checked,
-                    text.as_deref().unwrap_or(""),
+                    WidgetType::Checkbox,          // Identify this as a checkbox
+                    ui.is_enabled(),               // Whether the widget is interactive
+                    *checked,                      // Current checked state
+                    text.as_deref().unwrap_or(""), // Text label or empty string
                 )
             }
         });
 
+        // Only proceed with rendering if the widget is actually visible on screen
+        // This is an optimization to avoid unnecessary drawing operations
         if ui.is_rect_visible(prepared.response.rect) {
-            // let visuals = ui.style().interact_selectable(&response, *checked); // too colorful
+            // Get visual styling based on the widget's interaction state
+            // Note: We use the general interact() method instead of interact_selectable()
+            // because the selectable version can be "too colorful" according to the comment
             let visuals = *ui.style().interact(&prepared.response);
+
+            // Set the fallback text color for any text atoms
             prepared.fallback_text_color = visuals.text_color();
+
+            // Paint the widget content (text and other atoms) and get the final response
             let response = prepared.paint(ui);
 
+            // Draw the checkbox icon if we have a rectangle allocated for it
             if let Some(rect) = response.rect(rect_id) {
+                // Calculate two concentric rectangles for the checkbox:
+                // - big_icon_rect: outer square (background and border)
+                // - small_icon_rect: inner area (for checkmark or indeterminate line)
                 let (small_icon_rect, big_icon_rect) = ui.spacing().icon_rectangles(rect);
+
+                // Draw the outer square (background square with border)
                 ui.painter().add(epaint::RectShape::new(
-                    big_icon_rect.expand(visuals.expansion),
-                    visuals.corner_radius,
-                    visuals.bg_fill,
-                    visuals.bg_stroke,
-                    epaint::StrokeKind::Inside,
+                    big_icon_rect.expand(visuals.expansion), // Rectangle with visual expansion
+                    visuals.corner_radius,                   // Corner rounding from theme
+                    visuals.bg_fill,                         // Background fill color
+                    visuals.bg_stroke,                       // Border color and width
+                    epaint::StrokeKind::Inside,              // Draw stroke inside the rectangle
                 ));
 
+                // Draw the appropriate state indicator inside the checkbox
                 if indeterminate {
-                    // Horizontal line:
+                    // Indeterminate state: draw horizontal line across the middle
                     ui.painter().add(Shape::hline(
-                        small_icon_rect.x_range(),
-                        small_icon_rect.center().y,
-                        visuals.fg_stroke,
+                        small_icon_rect.x_range(),  // Horizontal span of the line
+                        small_icon_rect.center().y, // Vertical position (center)
+                        visuals.fg_stroke,          // Line color and thickness
                     ));
                 } else if *checked {
-                    // Check mark:
+                    // Checked state: draw a checkmark
+                    // The checkmark is drawn as a polyline with three points forming a "✓" shape
                     ui.painter().add(Shape::line(
                         vec![
+                            // Start point: left side, vertically centered
                             pos2(small_icon_rect.left(), small_icon_rect.center().y),
+                            // Middle point: center horizontally, bottom vertically (the "knee" of the checkmark)
                             pos2(small_icon_rect.center().x, small_icon_rect.bottom()),
+                            // End point: right side, top (completing the checkmark)
                             pos2(small_icon_rect.right(), small_icon_rect.top()),
                         ],
-                        visuals.fg_stroke,
+                        visuals.fg_stroke, // Line color and thickness
                     ));
                 }
+                // If unchecked and not indeterminate, we draw nothing inside (just the empty square)
             }
+
+            // Return the response from the painted widget
             response.response
         } else {
+            // Widget is not visible, so just return the basic response without rendering
             prepared.response
         }
     }

--- a/crates/egui/src/widgets/radio_button.rs
+++ b/crates/egui/src/widgets/radio_button.rs
@@ -1,22 +1,43 @@
+// Import necessary types and traits from the crate
 use crate::{
-    Atom, AtomLayout, Atoms, Id, IntoAtoms, NumExt as _, Response, Sense, Ui, Vec2, Widget,
-    WidgetInfo, WidgetType, epaint,
+    Atom,        // Individual UI element that can be laid out
+    AtomLayout,  // Layout manager for atoms
+    Atoms,       // Collection of atoms
+    Id,          // Unique identifier for UI elements
+    IntoAtoms,   // Trait for converting types into Atoms
+    NumExt as _, // Numeric extension traits (imported with underscore to avoid naming conflicts)
+    Response,    // UI interaction response (clicks, hovers, etc.)
+    Sense,       // What types of interactions the widget responds to
+    Ui,          // Main UI context
+    Vec2,        // 2D vector for positions and sizes
+    Widget,      // Trait that all widgets must implement
+    WidgetInfo,  // Accessibility and debugging information about widgets
+    WidgetType,  // Enum identifying the type of widget
+    epaint,      // Low-level painting/drawing functionality
 };
 
-/// One out of several alternatives, either selected or not.
+/// A radio button widget representing one option out of several mutually exclusive alternatives.
+/// The radio button can be either selected (checked) or not selected (unchecked).
 ///
-/// Usually you'd use [`Ui::radio_value`] or [`Ui::radio`] instead.
+/// Radio buttons are typically used in groups where only one option can be selected at a time,
+/// unlike checkboxes which allow multiple selections.
 ///
+/// ## Usage
+/// Usually you'd use the convenience methods [`Ui::radio_value`] or [`Ui::radio`] instead
+/// of creating this widget directly, but this struct gives you more control over the behavior.
+///
+/// ## Example
 /// ```
 /// # egui::__run_test_ui(|ui| {
+/// // Define an enum for our radio button options
 /// #[derive(PartialEq)]
 /// enum Enum { First, Second, Third }
 /// let mut my_enum = Enum::First;
 ///
+/// // Simple way using ui.radio_value (recommended)
 /// ui.radio_value(&mut my_enum, Enum::First, "First");
 ///
-/// // is equivalent to:
-///
+/// // Equivalent manual way using RadioButton directly:
 /// if ui.add(egui::RadioButton::new(my_enum == Enum::First, "First")).clicked() {
 ///     my_enum = Enum::First
 /// }
@@ -24,82 +45,146 @@ use crate::{
 /// ```
 #[must_use = "You should put this widget in a ui with `ui.add(widget);`"]
 pub struct RadioButton<'a> {
+    /// Whether this radio button is currently selected/checked
     checked: bool,
+
+    /// The content atoms that make up this radio button (typically text label)
+    /// Uses a lifetime parameter 'a to avoid unnecessary string allocations
     atoms: Atoms<'a>,
 }
 
 impl<'a> RadioButton<'a> {
+    /// Creates a new radio button with the specified checked state and content.
+    ///
+    /// # Parameters
+    /// - `checked`: Whether the radio button should appear selected
+    /// - `atoms`: The content to display (usually text, but can be other UI elements)
+    ///   This accepts anything that implements `IntoAtoms`, such as `&str`, `String`, etc.
+    ///
+    /// # Returns
+    /// A new `RadioButton` instance ready to be added to a UI
+    ///
+    /// # Example
+    /// ```
+    /// let radio = egui::RadioButton::new(true, "Selected option");
+    /// let radio2 = egui::RadioButton::new(false, "Unselected option");
+    /// ```
     pub fn new(checked: bool, atoms: impl IntoAtoms<'a>) -> Self {
         Self {
             checked,
-            atoms: atoms.into_atoms(),
+            atoms: atoms.into_atoms(), // Convert the input into the internal Atoms representation
         }
     }
 }
 
+/// Implementation of the Widget trait, which defines how the radio button is rendered and behaves
 impl Widget for RadioButton<'_> {
+    /// Main method that handles the widget's layout, interaction, and rendering
+    ///
+    /// # Parameters
+    /// - `ui`: Mutable reference to the UI context where this widget will be displayed
+    ///
+    /// # Returns
+    /// A `Response` containing information about user interactions (clicks, hovers, etc.)
     fn ui(self, ui: &mut Ui) -> Response {
+        // Destructure self to get owned values (required since ui() consumes self)
         let Self { checked, mut atoms } = self;
 
+        // Get spacing configuration from the UI style
         let spacing = &ui.spacing();
+
+        // Calculate the width of the radio button icon based on UI spacing settings
         let icon_width = spacing.icon_width;
 
+        // Set minimum size for the entire widget
+        // Start with a square based on the standard interaction size height
         let mut min_size = Vec2::splat(spacing.interact_size.y);
+        // Ensure the height is at least as tall as the icon width for proper visual balance
         min_size.y = min_size.y.at_least(icon_width);
 
-        // In order to center the checkbox based on min_size we set the icon height to at least min_size.y
+        // Calculate the actual size of the radio button icon
+        // Start with a square icon based on the icon width
         let mut icon_size = Vec2::splat(icon_width);
+        // Ensure the icon height matches the minimum widget height for proper centering
         icon_size.y = icon_size.y.at_least(min_size.y);
+
+        // Create a unique identifier for the radio button's circular icon area
+        // This ID is used internally for layout and hit-testing
         let rect_id = Id::new("egui::radio_button");
+
+        // Add the radio button icon as a custom atom to the left side of the widget
+        // This reserves space for the circular radio button graphic
         atoms.push_left(Atom::custom(rect_id, icon_size));
 
+        // Extract text content from atoms for accessibility purposes
+        // Convert to owned String if text exists, otherwise None
         let text = atoms.text().map(String::from);
 
+        // Create the layout for all atoms and handle user interaction
         let mut prepared = AtomLayout::new(atoms)
-            .sense(Sense::click())
-            .min_size(min_size)
-            .allocate(ui);
+            .sense(Sense::click()) // Make the widget respond to mouse clicks
+            .min_size(min_size) // Set the minimum size we calculated
+            .allocate(ui); // Reserve space in the UI and get interaction response
 
+        // Set up accessibility information for screen readers and debugging tools
         prepared.response.widget_info(|| {
             WidgetInfo::selected(
-                WidgetType::RadioButton,
-                ui.is_enabled(),
-                checked,
-                text.as_deref().unwrap_or(""),
+                WidgetType::RadioButton,       // Identify this as a radio button
+                ui.is_enabled(),               // Whether the widget is interactive
+                checked,                       // Current selection state
+                text.as_deref().unwrap_or(""), // Text label or empty string
             )
         });
 
+        // Only proceed with rendering if the widget is actually visible on screen
+        // This is an optimization to avoid unnecessary drawing operations
         if ui.is_rect_visible(prepared.response.rect) {
-            // let visuals = ui.style().interact_selectable(&response, checked); // too colorful
+            // Get visual styling based on the widget's interaction state
+            // Note: We use the general interact() method instead of interact_selectable()
+            // because the selectable version can be "too colorful" according to the comment
             let visuals = *ui.style().interact(&prepared.response);
 
+            // Set the fallback text color for any text atoms
             prepared.fallback_text_color = visuals.text_color();
+
+            // Paint the widget content (text and other atoms) and get the final response
             let response = prepared.paint(ui);
 
+            // Draw the radio button icon if we have a rectangle allocated for it
             if let Some(rect) = response.rect(rect_id) {
+                // Calculate two concentric rectangles for the radio button:
+                // - big_icon_rect: outer circle (background and border)
+                // - small_icon_rect: inner filled circle (when selected)
                 let (small_icon_rect, big_icon_rect) = ui.spacing().icon_rectangles(rect);
 
+                // Get the painter object for drawing shapes
                 let painter = ui.painter();
 
+                // Draw the outer circle (background circle with border)
                 painter.add(epaint::CircleShape {
-                    center: big_icon_rect.center(),
-                    radius: big_icon_rect.width() / 2.0 + visuals.expansion,
-                    fill: visuals.bg_fill,
-                    stroke: visuals.bg_stroke,
+                    center: big_icon_rect.center(), // Center point
+                    radius: big_icon_rect.width() / 2.0 + visuals.expansion, // Radius with visual expansion
+                    fill: visuals.bg_fill,     // Background fill color
+                    stroke: visuals.bg_stroke, // Border color and width
                 });
 
+                // If this radio button is selected, draw the inner filled circle
                 if checked {
                     painter.add(epaint::CircleShape {
-                        center: small_icon_rect.center(),
-                        radius: small_icon_rect.width() / 3.0,
-                        fill: visuals.fg_stroke.color, // Intentional to use stroke and not fill
-                        // fill: ui.visuals().selection.stroke.color, // too much color
-                        stroke: Default::default(),
+                        center: small_icon_rect.center(),      // Same center as outer circle
+                        radius: small_icon_rect.width() / 3.0, // Much smaller radius for inner dot
+                        fill: visuals.fg_stroke.color, // Use foreground stroke color for fill
+                        // Note: Intentionally using stroke color instead of fill color
+                        // visuals.selection.stroke.color would be "too much color"
+                        stroke: Default::default(), // No border on inner circle
                     });
                 }
             }
+
+            // Return the response from the painted widget
             response.response
         } else {
+            // Widget is not visible, so just return the basic response without rendering
             prepared.response
         }
     }


### PR DESCRIPTION
The goal of this pull request is to add many more detailed comments to the ```radio_button``` widget code to help better understand the new atom-based widgets.

A visual diff has been completed and the demo app has been compiled to check for errors or warning: 

```cargo run --release  -p egui_demo_app``` 

The comments were written by Claude AI and have been entirely checked to the best of my ability.