### PR TITLE
Add reasonable timeouts to all workflows

### DIFF
--- a/.github/workflows/cargo_machete.yml
+++ b/.github/workflows/cargo_machete.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   cargo-machete:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/deploy_web_demo.yml
+++ b/.github/workflows/deploy_web_demo.yml
@@ -29,8 +29,8 @@ jobs:
   # Single deploy job since we're just deploying
   deploy:
     name: Deploy web demo
-
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/enforce_branch_name.yml
+++ b/.github/workflows/enforce_branch_name.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   check-source-branch:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check PR source branch
         run: |

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   label:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check for a "do-not-merge" label
         uses: mheap/github-action-required-labels@v3

--- a/.github/workflows/png_only_on_lfs.yml
+++ b/.github/workflows/png_only_on_lfs.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   check-binary-files:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/preview_build.yml
+++ b/.github/workflows/preview_build.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/preview_cleanup.yml
+++ b/.github/workflows/preview_cleanup.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/preview_deploy.yml
+++ b/.github/workflows/preview_deploy.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ jobs:
   fmt-crank-check-test:
     name: Format + check
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
@@ -79,6 +80,7 @@ jobs:
   check_wasm:
     name: Check wasm32 + wasm-bindgen
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -114,6 +116,7 @@ jobs:
   check_wasm_atomics:
     name: Check wasm32+atomics
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt-get update && sudo apt-get install libgtk-3-dev libatk1.0-dev
@@ -151,6 +154,7 @@ jobs:
 
     name: cargo-deny ${{ matrix.target }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
@@ -165,6 +169,7 @@ jobs:
   android:
     name: android
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
@@ -186,6 +191,7 @@ jobs:
   ios:
     name: ios
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
@@ -206,6 +212,7 @@ jobs:
   windows:
     name: Check Windows
     runs-on: windows-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -227,7 +234,7 @@ jobs:
     name: Run tests
     # We run the tests on macOS because it will run with an actual GPU
     runs-on: macos-latest
-
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/spelling_and_links.yml
+++ b/.github/workflows/spelling_and_links.yml
@@ -8,6 +8,7 @@ jobs:
     # install and run locally: cargo install typos-cli && typos
     name: typos
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout Actions Repository
         uses: actions/checkout@v4
@@ -18,6 +19,7 @@ jobs:
   lychee:
     name: lychee
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Don't check CHANGELOG.md files


### PR DESCRIPTION
Turns out the default timeout for github actions is 6 hours (!). This PR sets some reasonable default for all workflows, the ones invoking cargo in some way are limited to 60 minutes and the remaining ones to 10-15mins. 

