### PR TITLE
Always check for `is_decidedly_dragging` when dragging a widget

### DIFF
--- a/crates/egui/src/interaction.rs
+++ b/crates/egui/src/interaction.rs
@@ -191,20 +191,8 @@ pub(crate) fn interact(
     if dragged.is_none() {
         // Check if we started dragging something new:
         if let Some(widget) = interaction.potential_drag_id.and_then(|id| widgets.get(id)) {
-            if widget.enabled {
-                let is_dragged = if widget.sense.senses_click() && widget.sense.senses_drag() {
-                    // This widget is sensitive to both clicks and drags.
-                    // When the mouse first is pressed, it could be either,
-                    // so we postpone the decision until we know.
-                    input.pointer.is_decidedly_dragging()
-                } else {
-                    // This widget is just sensitive to drags, so we can mark it as dragged right away:
-                    widget.sense.senses_drag()
-                };
-
-                if is_dragged {
-                    dragged = Some(widget.id);
-                }
+            if widget.enabled && input.pointer.is_decidedly_dragging() {
+                dragged = Some(widget.id);
             }
         }
     }


### PR DESCRIPTION
Lowering the repaint rate in https://github.com/emilk/egui/pull/7482 also highlighted an issue with the drag interaction of windows among other elements. It seems that the drag gets registered on the first mouse down and the window then moves based on the cursor movement since the previous frame, making it the dragged element jump.
This is with a refresh rate of 2:

[drag.webm](https://github.com/user-attachments/assets/9a95cdcc-7c81-42c7-b98b-d4164c3b8a9d)

The fix I found for this was to always check for `is_decidedly_dragging`. I didn't notice any input delays or other negative effects from this. 
