### PR TITLE
Optimize `Mesh::add_rect_with_uv`

### DIFF
--- a/crates/epaint/src/mesh.rs
+++ b/crates/epaint/src/mesh.rs
@@ -169,9 +169,7 @@ impl Mesh {
     /// Add a triangle.
     #[inline(always)]
     pub fn add_triangle(&mut self, a: u32, b: u32, c: u32) {
-        self.indices.push(a);
-        self.indices.push(b);
-        self.indices.push(c);
+        self.indices.extend_from_slice(&[a, b, c]);
     }
 
     /// Make room for this many additional triangles (will reserve 3x as many indices).
@@ -189,33 +187,35 @@ impl Mesh {
     }
 
     /// Rectangle with a texture and color.
+    #[inline(always)]
     pub fn add_rect_with_uv(&mut self, rect: Rect, uv: Rect, color: Color32) {
         #![allow(clippy::identity_op)]
-
         let idx = self.vertices.len() as u32;
-        self.add_triangle(idx + 0, idx + 1, idx + 2);
-        self.add_triangle(idx + 2, idx + 1, idx + 3);
+        self.indices
+            .extend_from_slice(&[idx + 0, idx + 1, idx + 2, idx + 2, idx + 1, idx + 3]);
 
-        self.vertices.push(Vertex {
-            pos: rect.left_top(),
-            uv: uv.left_top(),
-            color,
-        });
-        self.vertices.push(Vertex {
-            pos: rect.right_top(),
-            uv: uv.right_top(),
-            color,
-        });
-        self.vertices.push(Vertex {
-            pos: rect.left_bottom(),
-            uv: uv.left_bottom(),
-            color,
-        });
-        self.vertices.push(Vertex {
-            pos: rect.right_bottom(),
-            uv: uv.right_bottom(),
-            color,
-        });
+        self.vertices.extend_from_slice(&[
+            Vertex {
+                pos: rect.left_top(),
+                uv: uv.left_top(),
+                color,
+            },
+            Vertex {
+                pos: rect.right_top(),
+                uv: uv.right_top(),
+                color,
+            },
+            Vertex {
+                pos: rect.left_bottom(),
+                uv: uv.left_bottom(),
+                color,
+            },
+            Vertex {
+                pos: rect.right_bottom(),
+                uv: uv.right_bottom(),
+                color,
+            },
+        ]);
     }
 
     /// Uniformly colored rectangle.


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [x] I have followed the instructions in the PR template


While optimizing #7431, I noticed that `Mesh::add_rect_with_uv` was taking quite a bit of time. Using `extend_with_slice` results in much better codegen (fewer branches) and inlining the function makes things faster still. The same applies to `Mesh::add_triangle`.

Current `main`:

```
text_layout_uncached    time:   [65.988 µs 66.042 µs 66.108 µs]
                        change: [+0.1351% +0.3381% +0.5863%] (p = 0.00 < 0.05)
```

With these optimizations:
```
text_layout_uncached    time:   [59.996 µs 60.104 µs 60.269 µs]
                        change: [−9.8641% −9.6530% −9.4583%] (p = 0.00 < 0.05)
                        Performance has improved.
```