### PR TITLE
Improve `OrderedFloat` hash performance

### DIFF
--- a/crates/emath/src/ordered_float.rs
+++ b/crates/emath/src/ordered_float.rs
@@ -124,13 +124,15 @@ mod private {
 
         #[inline]
         fn hash<H: Hasher>(&self, state: &mut H) {
-            if *self == 0.0 {
-                state.write_u8(0);
-            } else if self.is_nan() {
-                state.write_u8(1);
+            let bits = if self.is_nan() {
+                // "Canonical" NaN.
+                0x7fc00000
             } else {
-                self.to_bits().hash(state);
-            }
+                // A trick taken from the `ordered-float` crate: -0.0 + 0.0 == +0.0.
+                // https://github.com/reem/rust-ordered-float/blob/1841f0541ea0e56779cbac03de2705149e020675/src/lib.rs#L2178-L2181
+                (self + 0.0).to_bits()
+            };
+            bits.hash(state);
         }
     }
 
@@ -142,13 +144,13 @@ mod private {
 
         #[inline]
         fn hash<H: Hasher>(&self, state: &mut H) {
-            if *self == 0.0 {
-                state.write_u8(0);
-            } else if self.is_nan() {
-                state.write_u8(1);
+            let bits = if self.is_nan() {
+                // "Canonical" NaN.
+                0x7ff8000000000000
             } else {
-                self.to_bits().hash(state);
-            }
+                (self + 0.0).to_bits()
+            };
+            bits.hash(state);
         }
     }
 }


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [x] I have followed the instructions in the PR template

Another thing that showed up in the profiler when working on #7431. I'm doing a lot of caching of fonts by size, which involves hashing a lot of `OrderedFloat`s. We can [take a page from the `ordered-float` crate](https://github.com/reem/rust-ordered-float/blob/1841f0541ea0e56779cbac03de2705149e020675/src/lib.rs#L2178-L2181) and save a branch, which speeds things up by a couple percent in the `text_layout_uncached` benchmark.
