### PR TITLE
Preserve text format in truncated label tooltip

### DIFF
--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -282,7 +282,7 @@ impl Widget for Label {
         if ui.is_rect_visible(response.rect) {
             if show_tooltip_when_elided && galley.elided {
                 // Show the full (non-elided) text on hover:
-                response = response.on_hover_text(galley.text());
+                response = response.on_hover_text(galley.job.clone());
             }
 
             let response_color = if interactive {

--- a/tests/egui_tests/tests/regression_tests.rs
+++ b/tests/egui_tests/tests/regression_tests.rs
@@ -31,5 +31,5 @@ fn hovering_should_preserve_text_format() {
 
     harness.run_steps(5);
 
-    harness.snapshot("hovering_should_preserve_text_format")
+    harness.snapshot("hovering_should_preserve_text_format");
 }

--- a/tests/egui_tests/tests/regression_tests.rs
+++ b/tests/egui_tests/tests/regression_tests.rs
@@ -1,4 +1,4 @@
-use egui::{Image, include_image};
+use egui::{Color32, Image, Label, RichText, TextWrapMode, include_image};
 use egui_kittest::Harness;
 use egui_kittest::kittest::Queryable as _;
 
@@ -11,4 +11,25 @@ fn image_button_should_have_alt_text() {
     });
 
     harness.get_by_label("Egui");
+}
+
+#[test]
+fn hovering_should_preserve_text_format() {
+    let mut harness = Harness::builder().with_size((200.0, 70.0)).build_ui(|ui| {
+        ui.add(
+            Label::new(
+                RichText::new("Long text that should be elided and has lots of styling")
+                    .italics()
+                    .underline()
+                    .color(Color32::LIGHT_BLUE),
+            )
+            .wrap_mode(TextWrapMode::Truncate),
+        );
+    });
+
+    harness.get_by_label_contains("Long text").hover();
+
+    harness.run_steps(5);
+
+    harness.snapshot("hovering_should_preserve_text_format")
 }

--- a/tests/egui_tests/tests/snapshots/hovering_should_preserve_text_format.png
+++ b/tests/egui_tests/tests/snapshots/hovering_should_preserve_text_format.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc03cdc22b410ed90fdbbc45ced5c61027463132c490673170aab9044d683f88
+size 10254


### PR DESCRIPTION
* Related https://github.com/rerun-io/rerun/issues/10906

This changes the label hover ui to use the provided layout job instead of the text so that the text format is preserved.