### PR TITLE
Remove `preload_font_glyphs` flag

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -625,18 +625,6 @@ impl ContextImpl {
             profiling::scope!("Fonts::begin_pass");
             fonts.begin_pass(max_texture_side, text_alpha_from_coverage);
         }
-
-        if is_new && self.memory.options.preload_font_glyphs {
-            profiling::scope!("preload_font_glyphs");
-            // Preload the most common characters for the most common fonts.
-            // This is not very important to do, but may save a few GPU operations.
-            for font_id in self.memory.options.style().text_styles.values() {
-                fonts
-                    .fonts
-                    .font(&font_id.family)
-                    .preload_common_characters();
-            }
-        }
     }
 
     #[cfg(feature = "accesskit")]

--- a/crates/egui/src/memory/mod.rs
+++ b/crates/egui/src/memory/mod.rs
@@ -272,14 +272,6 @@ pub struct Options {
     /// which is supported by `eframe`.
     pub screen_reader: bool,
 
-    /// If true, the most common glyphs (ASCII) are pre-rendered to the texture atlas.
-    ///
-    /// Only the fonts in [`Style::text_styles`] will be pre-cached.
-    ///
-    /// This can lead to fewer texture operations, but may use up the texture atlas quicker
-    /// if you are changing [`Style::text_styles`], or have a lot of text styles.
-    pub preload_font_glyphs: bool,
-
     /// Check reusing of [`Id`]s, and show a visual warning on screen when one is found.
     ///
     /// By default this is `true` in debug builds.
@@ -316,7 +308,6 @@ impl Default for Options {
             repaint_on_widget_change: false,
             max_passes: NonZeroUsize::new(2).unwrap(),
             screen_reader: false,
-            preload_font_glyphs: true,
             warn_on_id_clash: cfg!(debug_assertions),
 
             // Input:
@@ -372,7 +363,6 @@ impl Options {
             repaint_on_widget_change,
             max_passes,
             screen_reader: _, // needs to come from the integration
-            preload_font_glyphs: _,
             warn_on_id_clash,
             input_options,
             reduce_texture_memory,

--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -452,17 +452,6 @@ impl Font<'_> {
         }
     }
 
-    pub fn preload_common_characters(&mut self) {
-        // Preload the printable ASCII characters [32, 126] (which excludes control codes):
-        const FIRST_ASCII: usize = 32; // 32 == space
-        const LAST_ASCII: usize = 126;
-        for c in (FIRST_ASCII..=LAST_ASCII).map(|c| c as u8 as char) {
-            self.glyph_info(c);
-        }
-        self.glyph_info('°');
-        self.glyph_info(crate::text::PASSWORD_REPLACEMENT_CHAR);
-    }
-
     /// All supported characters, and in which font they are available in.
     pub fn characters(&mut self) -> &BTreeMap<char, Vec<String>> {
         self.cached_family.characters.get_or_insert_with(|| {


### PR DESCRIPTION
This is not pulling its own weight, especially since it doesn't even paint into the font atlas anymore.

A long time ago it was a very important optimization, because we would re-upload a huge font atlas on each new character, but today we only upload the small section of the font atlas that changes.