### PR TITLE
Remove deprecated fields from `PlatformOutput`

### DIFF
--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -304,8 +304,6 @@ impl AppRunner {
     }
 
     fn handle_platform_output(&self, platform_output: egui::PlatformOutput) {
-        #![allow(deprecated)]
-
         #[cfg(feature = "web_screen_reader")]
         if self.egui_ctx.options(|o| o.screen_reader) {
             super::screen_reader::speak(&platform_output.events_description());
@@ -314,8 +312,6 @@ impl AppRunner {
         let egui::PlatformOutput {
             commands,
             cursor_icon,
-            open_url,
-            copied_text,
             events: _,                    // already handled
             mutable_text_under_cursor: _, // TODO(#4569): https://github.com/emilk/egui/issues/4569
             ime,
@@ -340,14 +336,6 @@ impl AppRunner {
         }
 
         super::set_cursor_icon(cursor_icon);
-
-        if let Some(open) = open_url {
-            super::open_url(&open.url, open.new_tab);
-        }
-
-        if !copied_text.is_empty() {
-            super::set_clipboard_text(&copied_text);
-        }
 
         if self.has_focus() {
             // The eframe app has focus.

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -827,14 +827,11 @@ impl State {
         window: &Window,
         platform_output: egui::PlatformOutput,
     ) {
-        #![allow(deprecated)]
         profiling::function_scope!();
 
         let egui::PlatformOutput {
             commands,
             cursor_icon,
-            open_url,
-            copied_text,
             events: _,                    // handled elsewhere
             mutable_text_under_cursor: _, // only used in eframe web
             ime,
@@ -859,14 +856,6 @@ impl State {
         }
 
         self.set_cursor_icon(window, cursor_icon);
-
-        if let Some(open_url) = open_url {
-            open_url_in_browser(&open_url.url);
-        }
-
-        if !copied_text.is_empty() {
-            self.clipboard.set_text(copied_text);
-        }
 
         let allow_ime = ime.is_some();
         if self.allow_ime != allow_ime {

--- a/crates/egui/src/data/output.rs
+++ b/crates/egui/src/data/output.rs
@@ -113,24 +113,6 @@ pub struct PlatformOutput {
     /// Set the cursor to this icon.
     pub cursor_icon: CursorIcon,
 
-    /// If set, open this url.
-    #[deprecated = "Use `Context::open_url` or `PlatformOutput::commands` instead"]
-    pub open_url: Option<OpenUrl>,
-
-    /// If set, put this text in the system clipboard. Ignore if empty.
-    ///
-    /// This is often a response to [`crate::Event::Copy`] or [`crate::Event::Cut`].
-    ///
-    /// ```
-    /// # egui::__run_test_ui(|ui| {
-    /// if ui.button("📋").clicked() {
-    ///     ui.output_mut(|o| o.copied_text = "some_text".to_string());
-    /// }
-    /// # });
-    /// ```
-    #[deprecated = "Use `Context::copy_text` or `PlatformOutput::commands` instead"]
-    pub copied_text: String,
-
     /// Events that may be useful to e.g. a screen reader.
     pub events: Vec<OutputEvent>,
 
@@ -187,13 +169,9 @@ impl PlatformOutput {
 
     /// Add on new output.
     pub fn append(&mut self, newer: Self) {
-        #![allow(deprecated)]
-
         let Self {
             mut commands,
             cursor_icon,
-            open_url,
-            copied_text,
             mut events,
             mutable_text_under_cursor,
             ime,
@@ -205,12 +183,6 @@ impl PlatformOutput {
 
         self.commands.append(&mut commands);
         self.cursor_icon = cursor_icon;
-        if open_url.is_some() {
-            self.open_url = open_url;
-        }
-        if !copied_text.is_empty() {
-            self.copied_text = copied_text;
-        }
         self.events.append(&mut events);
         self.mutable_text_under_cursor = mutable_text_under_cursor;
         self.ime = ime.or(self.ime);


### PR DESCRIPTION
They have been deprecated since [0.31.0](https://github.com/emilk/egui/releases/tag/0.31.0) (2025 Feb 4)