### PR TITLE
Remove the `compact_menu_style` setting. This was replaced by customizing `MenuConfig`.

### DIFF
--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -75,13 +75,11 @@ impl std::ops::DerefMut for BarState {
 }
 
 fn set_menu_style(style: &mut Style) {
-    if style.compact_menu_style {
-        style.spacing.button_padding = vec2(2.0, 0.0);
-        style.visuals.widgets.active.bg_stroke = Stroke::NONE;
-        style.visuals.widgets.hovered.bg_stroke = Stroke::NONE;
-        style.visuals.widgets.inactive.weak_bg_fill = Color32::TRANSPARENT;
-        style.visuals.widgets.inactive.bg_stroke = Stroke::NONE;
-    }
+    style.spacing.button_padding = vec2(2.0, 0.0);
+    style.visuals.widgets.active.bg_stroke = Stroke::NONE;
+    style.visuals.widgets.hovered.bg_stroke = Stroke::NONE;
+    style.visuals.widgets.inactive.weak_bg_fill = Color32::TRANSPARENT;
+    style.visuals.widgets.inactive.bg_stroke = Stroke::NONE;
 }
 
 /// The menu bar goes well in a [`crate::TopBottomPanel::top`],

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -345,9 +345,6 @@ pub struct Style {
 
     /// The animation that should be used when scrolling a [`crate::ScrollArea`] using e.g. [`Ui::scroll_to_rect`].
     pub scroll_animation: ScrollAnimation,
-
-    /// Use a more compact style for menus.
-    pub compact_menu_style: bool,
 }
 
 #[test]
@@ -1337,7 +1334,6 @@ impl Default for Style {
             url_in_tooltip: false,
             always_scroll_the_only_direction: false,
             scroll_animation: ScrollAnimation::default(),
-            compact_menu_style: true,
         }
     }
 }
@@ -1645,7 +1641,6 @@ impl Style {
             url_in_tooltip,
             always_scroll_the_only_direction,
             scroll_animation,
-            compact_menu_style,
         } = self;
 
         crate::Grid::new("_options").show(ui, |ui| {
@@ -1750,8 +1745,6 @@ impl Style {
 
         #[cfg(debug_assertions)]
         ui.collapsing("🐛 Debug", |ui| debug.ui(ui));
-
-        ui.checkbox(compact_menu_style, "Compact menu style");
 
         ui.checkbox(explanation_tooltips, "Explanation tooltips")
             .on_hover_text(


### PR DESCRIPTION
This feature is no longer needed as the menu styling is now configurable through `MenuConfig`.