### PR TITLE
`kitdiff`, a kittest snapshot viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,10 +225,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -877,6 +921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -885,8 +930,22 @@ version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -926,6 +985,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
@@ -1976,6 +2041,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "git2"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
+dependencies = [
+ "bitflags 2.9.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2460,6 +2540,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,13 +2654,16 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 name = "kitdiff"
 version = "0.32.3"
 dependencies = [
+ "clap",
  "dify",
  "eframe",
  "egui_extras",
+ "git2",
  "ignore",
  "image",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -2627,6 +2716,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.16.2+1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2661,6 +2764,32 @@ dependencies = [
  "bitflags 2.9.0",
  "libc",
  "redox_syscall 0.5.7",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3324,10 +3453,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "oorandom"
 version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -4364,6 +4517,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4926,6 +5085,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "v_frame"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4935,6 +5100,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,6 +2393,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "kitdiff"
+version = "0.32.3"
+dependencies = [
+ "eframe",
+ "egui_extras",
+]
+
+[[package]]
 name = "kittest"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2658,6 +2658,7 @@ dependencies = [
  "dify",
  "eframe",
  "egui_extras",
+ "ehttp",
  "git2",
  "ignore",
  "image",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +237,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +260,17 @@ dependencies = [
  "percent-encoding",
  "windows-sys 0.60.2",
  "x11rb",
+]
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -285,7 +311,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand",
+ "rand 0.9.2",
  "raw-window-handle",
  "serde",
  "serde_repr",
@@ -510,6 +536,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "av1-grain"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3efb2ca85bc610acfa917b5aaa36f3fcbebed5b3182d7f877b02531c4b80c8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c8fbc0f831f4519fe8b810b6a7a91410ec83031b8233f730a0480029f6a23f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +619,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +638,12 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bitstream-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 
 [[package]]
 name = "block"
@@ -631,6 +692,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "built"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
 
 [[package]]
 name = "bumpalo"
@@ -724,6 +791,16 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
+]
 
 [[package]]
 name = "cfg-if"
@@ -1343,7 +1420,7 @@ dependencies = [
  "egui_kittest",
  "image",
  "mimalloc",
- "rand",
+ "rand 0.9.2",
  "serde",
  "unicode_names2",
 ]
@@ -1556,6 +1633,26 @@ name = "epaint_default_fonts"
 version = "0.32.3"
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,6 +1693,21 @@ checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "exr"
+version = "1.73.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83197f59927b46c04a183a619b7c29df34e63e63c7869320862268c0ef687e0"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
 ]
 
 [[package]]
@@ -2240,10 +2352,15 @@ dependencies = [
  "bytemuck",
  "byteorder-lite",
  "color_quant",
+ "exr",
  "gif",
  "image-webp",
  "num-traits",
  "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
  "tiff",
  "zune-core",
  "zune-jpeg",
@@ -2276,6 +2393,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
+name = "imgref"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
+
+[[package]]
 name = "indexmap"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2283,6 +2406,17 @@ checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2301,6 +2435,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2396,8 +2539,12 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 name = "kitdiff"
 version = "0.32.3"
 dependencies = [
+ "dify",
  "eframe",
  "egui_extras",
+ "image",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2428,10 +2575,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lebe"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
+
+[[package]]
 name = "libc"
 version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libloading"
@@ -2517,6 +2680,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,6 +2701,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2594,6 +2775,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2695,6 +2882,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,10 +2907,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -3370,6 +3620,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3414,12 +3673,33 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3429,7 +3709,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -3446,6 +3735,55 @@ name = "range-alloc"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
+
+[[package]]
+name = "rav1e"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
+dependencies = [
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.12.1",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "profiling",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "simd_helpers",
+ "system-deps",
+ "thiserror 1.0.66",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.11.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5825c26fddd16ab9f515930d49028a630efec172e903483c94796cfe31893e6b"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rgb",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -3804,6 +4142,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serial_windows"
 version = "0.1.0"
 dependencies = [
@@ -3832,6 +4179,15 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
 
 [[package]]
 name = "similar"
@@ -4060,6 +4416,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "tempfile"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4280,10 +4655,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -4292,6 +4682,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -4502,6 +4894,23 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version-compare"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "version_check"
@@ -5716,6 +6125,15 @@ name = "zune-core"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-jpeg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,19 +1066,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,15 +1089,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2009,6 +1987,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "glow"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,6 +2357,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "image"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2533,16 +2540,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jwalk"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
-dependencies = [
- "crossbeam",
- "rayon",
-]
-
-[[package]]
 name = "keyboard_events"
 version = "0.1.0"
 dependencies = [
@@ -2574,8 +2571,8 @@ dependencies = [
  "dify",
  "eframe",
  "egui_extras",
+ "ignore",
  "image",
- "jwalk",
  "serde",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,6 +1066,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1102,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2511,6 +2533,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
+dependencies = [
+ "crossbeam",
+ "rayon",
+]
+
+[[package]]
 name = "keyboard_events"
 version = "0.1.0"
 dependencies = [
@@ -2543,6 +2575,7 @@ dependencies = [
  "eframe",
  "egui_extras",
  "image",
+ "jwalk",
  "serde",
  "serde_json",
 ]

--- a/crates/egui/src/load.rs
+++ b/crates/egui/src/load.rs
@@ -517,6 +517,16 @@ impl TexturePoll {
             Self::Ready { texture } => Some(texture.id),
         }
     }
+
+    #[inline]
+    pub fn is_pending(&self) -> bool {
+        matches!(self, Self::Pending { .. })
+    }
+
+    #[inline]
+    pub fn is_ready(&self) -> bool {
+        matches!(self, Self::Ready { .. })
+    }
 }
 
 pub type TextureLoadResult = Result<TexturePoll>;

--- a/crates/egui/src/load.rs
+++ b/crates/egui/src/load.rs
@@ -387,7 +387,7 @@ pub type ImageLoadResult = Result<ImagePoll>;
 /// An `ImageLoader` decodes raw bytes into a [`ColorImage`].
 ///
 /// Implementations are expected to cache at least each `URI`.
-pub trait ImageLoader {
+pub trait ImageLoader: std::any::Any {
     /// Unique ID of this loader.
     ///
     /// To reduce the chance of collisions, include `module_path!()` as part of this ID.

--- a/crates/egui_extras/src/lib.rs
+++ b/crates/egui_extras/src/lib.rs
@@ -17,7 +17,7 @@ pub mod syntax_highlighting;
 #[doc(hidden)]
 pub mod image;
 mod layout;
-mod loaders;
+pub mod loaders;
 mod sizing;
 mod strip;
 mod table;

--- a/crates/egui_extras/src/loaders.rs
+++ b/crates/egui_extras/src/loaders.rs
@@ -108,16 +108,16 @@ pub fn install_image_loaders(ctx: &egui::Context) {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-mod file_loader;
+pub mod file_loader;
 
 #[cfg(feature = "http")]
-mod ehttp_loader;
+pub mod ehttp_loader;
 
 #[cfg(feature = "gif")]
-mod gif_loader;
+pub mod gif_loader;
 #[cfg(feature = "image")]
-mod image_loader;
+pub mod image_loader;
 #[cfg(feature = "svg")]
-mod svg_loader;
+pub mod svg_loader;
 #[cfg(feature = "webp")]
-mod webp_loader;
+pub mod webp_loader;

--- a/examples/kitdiff/Cargo.toml
+++ b/examples/kitdiff/Cargo.toml
@@ -12,7 +12,7 @@ dify = "0.7"
 serde.workspace = true
 serde_json = "1.0"
 image.workspace = true
-jwalk = "0.8"
+ignore = "0.4"
 
 [lints]
 workspace = true

--- a/examples/kitdiff/Cargo.toml
+++ b/examples/kitdiff/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "kitdiff"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+eframe.workspace = true
+egui_extras = { workspace = true, features = ["image", "file"]}
+
+[lints]
+workspace = true

--- a/examples/kitdiff/Cargo.toml
+++ b/examples/kitdiff/Cargo.toml
@@ -13,6 +13,9 @@ serde.workspace = true
 serde_json = "1.0"
 image.workspace = true
 ignore = "0.4"
+clap = { version = "4.0", features = ["derive"] }
+git2 = "0.18"
+tempfile = "3.0"
 
 [lints]
 workspace = true

--- a/examples/kitdiff/Cargo.toml
+++ b/examples/kitdiff/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 [dependencies]
 eframe = { workspace = true, features = ["glow", "default"] }
 egui_extras = { workspace = true, features = ["image", "file", "http"]}
+ehttp = { version = "0.5" }
 dify = "0.7"
 serde.workspace = true
 serde_json = "1.0"

--- a/examples/kitdiff/Cargo.toml
+++ b/examples/kitdiff/Cargo.toml
@@ -12,6 +12,7 @@ dify = "0.7"
 serde.workspace = true
 serde_json = "1.0"
 image.workspace = true
+jwalk = "0.8"
 
 [lints]
 workspace = true

--- a/examples/kitdiff/Cargo.toml
+++ b/examples/kitdiff/Cargo.toml
@@ -7,7 +7,7 @@ version.workspace = true
 
 [dependencies]
 eframe = { workspace = true, features = ["glow", "default"] }
-egui_extras = { workspace = true, features = ["image", "file"]}
+egui_extras = { workspace = true, features = ["image", "file", "http"]}
 dify = "0.7"
 serde.workspace = true
 serde_json = "1.0"

--- a/examples/kitdiff/Cargo.toml
+++ b/examples/kitdiff/Cargo.toml
@@ -6,8 +6,12 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-eframe.workspace = true
+eframe = { workspace = true, features = ["glow", "default"] }
 egui_extras = { workspace = true, features = ["image", "file"]}
+dify = "0.7"
+serde.workspace = true
+serde_json = "1.0"
+image.workspace = true
 
 [lints]
 workspace = true

--- a/examples/kitdiff/src/diff_loader.rs
+++ b/examples/kitdiff/src/diff_loader.rs
@@ -1,0 +1,130 @@
+use eframe::egui::load::{ImageLoadResult, ImageLoader, ImagePoll, LoadError};
+use eframe::egui::mutex::Mutex;
+use eframe::egui::{ColorImage, Context, Image, ImageSource, SizeHint};
+use eframe::epaint::ahash::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[derive(Default)]
+pub struct DiffLoader {
+    diffs: Arc<Mutex<HashMap<String, ImageLoadResult>>>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DiffUri {
+    pub old: String,
+    pub new: String,
+}
+
+impl DiffUri {
+    pub fn from_uri(uri: &str) -> Option<Self> {
+        let stripped = uri.strip_prefix("diff://")?;
+        serde_json::from_str(stripped).ok()
+    }
+
+    pub fn to_uri(&self) -> String {
+        format!("diff://{}", serde_json::to_string(self).unwrap())
+    }
+}
+
+impl ImageLoader for DiffLoader {
+    fn id(&self) -> &str {
+        "DiffLoader"
+    }
+
+    fn load(&self, ctx: &Context, uri: &str, size_hint: SizeHint) -> ImageLoadResult {
+        if !uri.starts_with("diff://") {
+            return ImageLoadResult::Err(LoadError::NotSupported);
+        }
+        if let Some(image) = self.diffs.lock().get(uri) {
+            image.clone()
+        } else {
+            if let Some(diff_uri) = DiffUri::from_uri(uri) {
+                let cache = self.diffs.clone();
+                let ctx = ctx.clone();
+
+                self.diffs.lock().insert(
+                    diff_uri.to_uri(),
+                    ImageLoadResult::Ok(ImagePoll::Pending { size: None }),
+                );
+
+                let uri = uri.to_string();
+                std::thread::spawn(move || {
+                    ctx.request_repaint();
+                    let result = load_diffs(&ctx, size_hint, diff_uri);
+                    cache.lock().insert(uri, result);
+                });
+                ImageLoadResult::Ok(ImagePoll::Pending { size: None })
+            } else {
+                ImageLoadResult::Err(LoadError::NotSupported)
+            }
+        }
+    }
+
+    fn forget(&self, uri: &str) {
+        todo!()
+    }
+
+    fn forget_all(&self) {
+        todo!()
+    }
+
+    fn byte_size(&self) -> usize {
+        todo!()
+    }
+}
+
+pub fn load_diffs(ctx: &Context, size_hint: SizeHint, diff_uri: DiffUri) -> ImageLoadResult {
+    let (old_img, new_img) = loop {
+        let old_image = ctx.try_load_image(&diff_uri.old, size_hint);
+        let new_image = ctx.try_load_image(&diff_uri.new, size_hint);
+
+        let old_image = old_image?;
+        let new_image = new_image?;
+
+        if let (ImagePoll::Ready { image: old_image }, ImagePoll::Ready { image: new_image }) =
+            (old_image, new_image)
+        {
+            break (old_image, new_image);
+        }
+
+        std::thread::sleep(Duration::from_millis(10));
+    };
+
+    let old = image::RgbaImage::from_vec(
+        old_img.width() as u32,
+        old_img.height() as u32,
+        old_img.as_raw().to_vec(),
+    )
+    .ok_or(LoadError::Loading(
+        "Failed to convert to RgbaImage".to_string(),
+    ))?;
+
+    let new = image::RgbaImage::from_vec(
+        new_img.width() as u32,
+        new_img.height() as u32,
+        new_img.as_raw().to_vec(),
+    )
+    .ok_or(LoadError::Loading(
+        "Failed to convert to RgbaImage".to_string(),
+    ))?;
+
+    let result = dify::diff::get_results(old, new, 1.0, false, None, &None, &None);
+
+    if let Some((pixels, image)) = result {
+        let image = ColorImage::from_rgba_unmultiplied(
+            [image.width() as usize, image.height() as usize],
+            image.as_raw(),
+        );
+
+        let arc_image = Arc::new(image);
+        Ok(ImagePoll::Ready { image: arc_image })
+    } else {
+        Ok(ImagePoll::Ready {
+            image: Arc::new(ColorImage::filled(
+                [1, 1],
+                eframe::egui::Color32::TRANSPARENT,
+            )),
+        })
+    }
+}

--- a/examples/kitdiff/src/diff_loader.rs
+++ b/examples/kitdiff/src/diff_loader.rs
@@ -152,6 +152,12 @@ pub fn load_diffs(
         "Failed to convert to RgbaImage".to_string(),
     ))?;
 
+    if old.dimensions() != new.dimensions() {
+        return ImageLoadResult::Err(LoadError::Loading(
+            "Images must have the same dimensions".to_string(),
+        ));
+    }
+
     let result = dify::diff::get_results(
         old,
         new,

--- a/examples/kitdiff/src/file_diff.rs
+++ b/examples/kitdiff/src/file_diff.rs
@@ -1,4 +1,4 @@
-use crate::Snapshot;
+use crate::{Snapshot, FileReference};
 use eframe::egui::Context;
 use ignore::WalkBuilder;
 use ignore::types::TypesBuilder;
@@ -59,16 +59,16 @@ fn try_create_snapshot(png_path: &Path) -> Option<Snapshot> {
         // old.png exists, use original as new and old.png as old
         Some(Snapshot {
             path: relative_path.to_path_buf(),
-            old: old_path,
-            new: png_path.to_path_buf(),
+            old: FileReference::Path(old_path),
+            new: FileReference::Path(png_path.to_path_buf()),
             diff: Some(diff_path),
         })
     } else if new_path.exists() {
         // new.png exists, use original as old and new.png as new
         Some(Snapshot {
             path: relative_path.to_path_buf(),
-            old: png_path.to_path_buf(),
-            new: new_path,
+            old: FileReference::Path(png_path.to_path_buf()),
+            new: FileReference::Path(new_path),
             diff: Some(diff_path),
         })
     } else {

--- a/examples/kitdiff/src/file_diff.rs
+++ b/examples/kitdiff/src/file_diff.rs
@@ -1,0 +1,78 @@
+use crate::Snapshot;
+use eframe::egui::Context;
+use ignore::WalkBuilder;
+use ignore::types::TypesBuilder;
+use std::path::Path;
+use std::sync::mpsc;
+
+pub fn file_discovery(path: &str, sender: mpsc::Sender<Snapshot>, ctx: Context) {
+    let path = path.to_string();
+
+    std::thread::spawn(move || {
+        // Create type matcher for .png files
+        let mut types_builder = TypesBuilder::new();
+        types_builder.add("png", "*.png").unwrap();
+        types_builder.select("png");
+        let types = types_builder.build().unwrap();
+
+        // Build sequential walker for .png files only to maintain order
+        for result in WalkBuilder::new(&path).types(types).build() {
+            if let Ok(entry) = result {
+                if entry.file_type().map_or(false, |ft| ft.is_file()) {
+                    if let Some(snapshot) = try_create_snapshot(entry.path()) {
+                        if sender.send(snapshot).is_ok() {
+                            ctx.request_repaint();
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+fn try_create_snapshot(png_path: &Path) -> Option<Snapshot> {
+    let file_name = png_path.file_name()?.to_str()?;
+
+    // Skip files that are already variants (.old.png, .new.png, .diff.png)
+    if file_name.ends_with(".old.png")
+        || file_name.ends_with(".new.png")
+        || file_name.ends_with(".diff.png")
+    {
+        return None;
+    }
+
+    // Get base path without .png extension
+    let base_path = png_path.with_extension("");
+    let old_path = base_path.with_extension("old.png");
+    let new_path = base_path.with_extension("new.png");
+    let diff_path = base_path.with_extension("diff.png");
+
+    // Only create snapshot if diff exists
+    if !diff_path.exists() {
+        return None;
+    }
+
+    // Determine which files exist and create appropriate snapshot
+    let relative_path = png_path.strip_prefix(".").unwrap_or(png_path);
+
+    if old_path.exists() {
+        // old.png exists, use original as new and old.png as old
+        Some(Snapshot {
+            path: relative_path.to_path_buf(),
+            old: old_path,
+            new: png_path.to_path_buf(),
+            diff: Some(diff_path),
+        })
+    } else if new_path.exists() {
+        // new.png exists, use original as old and new.png as new
+        Some(Snapshot {
+            path: relative_path.to_path_buf(),
+            old: png_path.to_path_buf(),
+            new: new_path,
+            diff: Some(diff_path),
+        })
+    } else {
+        // No old or new variant, skip this snapshot
+        None
+    }
+}

--- a/examples/kitdiff/src/git_loader.rs
+++ b/examples/kitdiff/src/git_loader.rs
@@ -146,6 +146,17 @@ fn create_git_snapshot(
         }
     };
 
+    // Get the current file from the current branch's tree to compare git objects properly
+    let head_commit = repo.head()?.peel_to_commit()?;
+    let head_tree = head_commit.tree()?;
+
+    // Compare git object content (both should be LFS pointers if using LFS)
+    if let Ok(current_content) = get_file_from_tree(repo, &head_tree, relative_path) {
+        if default_file_content == current_content {
+            return Ok(None);
+        }
+    }
+
     // Check if this is an LFS pointer file
     let default_image_source = if is_lfs_pointer(&default_file_content) {
         // If we have GitHub repo info, create media URL

--- a/examples/kitdiff/src/git_loader.rs
+++ b/examples/kitdiff/src/git_loader.rs
@@ -1,0 +1,167 @@
+use crate::{FileReference, Snapshot};
+use eframe::egui::load::Bytes;
+use eframe::egui::{Context, ImageSource};
+use git2::{ObjectType, Repository};
+use ignore::{WalkBuilder, types::TypesBuilder};
+use std::borrow::Cow;
+use std::path::Path;
+use std::sync::mpsc;
+
+#[derive(Debug)]
+pub enum GitError {
+    RepoNotFound,
+    BranchNotFound,
+    FileNotFound,
+    GitError(git2::Error),
+    IoError(std::io::Error),
+}
+
+impl From<git2::Error> for GitError {
+    fn from(err: git2::Error) -> Self {
+        GitError::GitError(err)
+    }
+}
+
+impl From<std::io::Error> for GitError {
+    fn from(err: std::io::Error) -> Self {
+        GitError::IoError(err)
+    }
+}
+
+pub fn git_discovery(sender: mpsc::Sender<Snapshot>, ctx: Context) -> Result<(), GitError> {
+    std::thread::spawn(move || {
+        if let Err(e) = run_git_discovery(sender, ctx) {
+            eprintln!("Git discovery error: {:?}", e);
+        }
+    });
+    Ok(())
+}
+
+fn run_git_discovery(sender: mpsc::Sender<Snapshot>, ctx: Context) -> Result<(), GitError> {
+    // Open git repository in current directory
+    let repo = Repository::open(".").map_err(|_| GitError::RepoNotFound)?;
+
+    // Get current branch
+    let head = repo.head()?;
+    let current_branch = head.shorthand().unwrap_or("HEAD").to_string();
+
+    // Find default branch (try main, then master, then first branch)
+    let default_branch = find_default_branch(&repo)?;
+
+    // Don't compare branch with itself
+    if current_branch == default_branch {
+        eprintln!(
+            "Current branch is the same as default branch ({})",
+            current_branch
+        );
+        return Ok(());
+    }
+
+    // Get the commit from default branch
+    let default_commit = repo
+        .resolve_reference_from_short_name(&default_branch)?
+        .peel_to_commit()?;
+
+    // Create type matcher for .png files
+    let mut types_builder = TypesBuilder::new();
+    types_builder.add("png", "*.png").unwrap();
+    types_builder.select("png");
+    let types = types_builder.build().unwrap();
+
+    // Walk current working tree for .png files
+    for result in WalkBuilder::new(".").types(types).build() {
+        if let Ok(entry) = result {
+            if entry.file_type().map_or(false, |ft| ft.is_file()) {
+                if let Some(snapshot) =
+                    create_git_snapshot(&repo, &default_commit.tree()?, entry.path())?
+                {
+                    if sender.send(snapshot).is_ok() {
+                        ctx.request_repaint();
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn find_default_branch(repo: &Repository) -> Result<String, GitError> {
+    // Try common default branch names
+    for branch_name in ["main", "master"] {
+        if repo.resolve_reference_from_short_name(branch_name).is_ok() {
+            return Ok(branch_name.to_string());
+        }
+    }
+
+    // Fall back to first branch found
+    let branches = repo.branches(Some(git2::BranchType::Local))?;
+    for branch in branches {
+        let (branch, _) = branch?;
+        if let Some(name) = branch.name()? {
+            return Ok(name.to_string());
+        }
+    }
+
+    Err(GitError::BranchNotFound)
+}
+
+fn create_git_snapshot(
+    repo: &Repository,
+    default_tree: &git2::Tree,
+    current_path: &Path,
+) -> Result<Option<Snapshot>, GitError> {
+    // Skip files that are variants
+    let file_name = current_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or(GitError::FileNotFound)?;
+
+    if file_name.ends_with(".old.png")
+        || file_name.ends_with(".new.png")
+        || file_name.ends_with(".diff.png")
+    {
+        return Ok(None);
+    }
+
+    // Try to get the file from default branch
+    let relative_path = current_path.strip_prefix(".").unwrap_or(current_path);
+
+    let default_file_content = match get_file_from_tree(repo, default_tree, relative_path) {
+        Ok(content) => content,
+        Err(_) => {
+            // File doesn't exist in default branch, skip
+            return Ok(None);
+        }
+    };
+
+    // Create ImageSource from the git file content
+    let default_image_source = ImageSource::Bytes {
+        uri: Cow::Owned(format!("bytes://{}", relative_path.display())),
+        bytes: Bytes::Shared(default_file_content.into()),
+    };
+
+    Ok(Some(Snapshot {
+        path: relative_path.to_path_buf(),
+        old: FileReference::Source(default_image_source), // Default branch version as ImageSource
+        new: FileReference::Path(current_path.to_path_buf()), // Current working tree version
+        diff: None,                                       // Always None for git mode
+    }))
+}
+
+fn get_file_from_tree(
+    repo: &Repository,
+    tree: &git2::Tree,
+    path: &Path,
+) -> Result<Vec<u8>, GitError> {
+    let entry = tree.get_path(path)?;
+    let object = entry.to_object(repo)?;
+
+    match object.kind() {
+        Some(ObjectType::Blob) => {
+            let blob = object.as_blob().unwrap();
+            Ok(blob.content().to_vec())
+        }
+        _ => Err(GitError::FileNotFound),
+    }
+}

--- a/examples/kitdiff/src/main.rs
+++ b/examples/kitdiff/src/main.rs
@@ -25,11 +25,11 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Compare snapshot test files (.png with .old/.new/.diff variants)
+    /// Compare snapshot test files (.png with .old/.new/.diff variants) (default)
     Files,
     /// Compare images between current branch and default branch
     Git,
-    /// Compare images between PR branches from GitHub PR URL
+    /// Compare images between PR branches from GitHub PR URL (needs to be run from within the repo)
     Pr { url: String },
 }
 

--- a/examples/kitdiff/src/main.rs
+++ b/examples/kitdiff/src/main.rs
@@ -1,11 +1,11 @@
 mod diff_loader;
 
 use crate::diff_loader::DiffLoader;
-use eframe::egui::{Context, Image, ImageSource, Slider};
+use eframe::egui::{Context, Image, ImageSource, SizeHint, Slider};
 use eframe::{Frame, NativeOptions, egui};
 use egui_extras::install_image_loaders;
+use jwalk::WalkDir;
 use std::collections::{BTreeMap, HashMap};
-use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -39,6 +39,39 @@ struct Snapshot {
     name: String,
     old: PathBuf,
     new: PathBuf,
+    diff: Option<PathBuf>,
+}
+
+impl Snapshot {
+    fn old_uri(&self) -> String {
+        format!("file://{}", self.old.display())
+    }
+
+    fn new_uri(&self) -> String {
+        format!("file://{}", self.new.display())
+    }
+
+    fn file_diff_uri(&self) -> Option<String> {
+        self.diff
+            .as_ref()
+            .map(|p| format!("file://{}", p.display()))
+    }
+
+    fn diff_uri(&self) -> String {
+        self.file_diff_uri().unwrap_or_else(|| {
+            diff_loader::DiffUri {
+                old: self.old_uri(),
+                new: self.new_uri(),
+            }
+            .to_uri()
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum ImageMode {
+    Pixel,
+    Fit,
 }
 
 struct App {
@@ -46,6 +79,7 @@ struct App {
     index: usize,
     new_opacity: f32,
     diff_opacity: f32,
+    mode: ImageMode,
 }
 
 impl App {
@@ -58,76 +92,77 @@ impl App {
             snapshots,
             index: 0,
             new_opacity: 0.5,
-            diff_opacity: 1.0,
+            diff_opacity: 0.25,
+            mode: ImageMode::Fit,
         }
     }
 
     fn discover_snapshots(path: &str) -> Vec<Snapshot> {
         let mut snapshots = Vec::new();
-        let mut snapshot_groups: BTreeMap<String, SnapshotGroup> = Default::default();
+        let mut snapshot_groups: HashMap<String, SnapshotGroup> = Default::default();
 
-        Self::collect_snapshots_recursive(path, &mut snapshot_groups);
+        for entry in WalkDir::new(path)
+            .skip_hidden(true)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            if let Some(file_name) = entry.file_name().to_str() {
+                if file_name.ends_with(".png") {
+                    let entry_path = entry.path();
+                    let relative_path = entry_path.strip_prefix(".").unwrap_or(&entry_path);
+                    let key = format!("{}", relative_path.display());
+
+                    if file_name.ends_with(".old.png") {
+                        let base_key = key.strip_suffix(".old.png").unwrap().to_string();
+                        snapshot_groups.entry(base_key).or_default().old =
+                            Some(entry_path.to_path_buf());
+                    } else if file_name.ends_with(".new.png") {
+                        let base_key = key.strip_suffix(".new.png").unwrap().to_string();
+                        snapshot_groups.entry(base_key).or_default().new =
+                            Some(entry_path.to_path_buf());
+                    } else if file_name.ends_with(".diff.png") {
+                        let base_key = key.strip_suffix(".diff.png").unwrap().to_string();
+                        snapshot_groups.entry(base_key).or_default().diff =
+                            Some(entry_path.to_path_buf());
+                    } else {
+                        let base_key = key.strip_suffix(".png").unwrap().to_string();
+                        if !file_name.ends_with(".old.png")
+                            && !file_name.ends_with(".new.png")
+                            && !file_name.ends_with(".diff.png")
+                        {
+                            snapshot_groups.entry(base_key).or_default().current =
+                                Some(entry_path.to_path_buf());
+                        }
+                    }
+                }
+            }
+        }
 
         for (name, group) in snapshot_groups {
-            if let Some(_diff) = group.diff {
+            if let Some(diff) = group.diff {
                 if let Some(current_path) = group.current {
                     if let Some(old) = group.old {
                         snapshots.push(Snapshot {
                             name,
                             old: old.clone(),
                             new: current_path.clone(),
+                            diff: Some(diff.clone()),
                         });
                     } else if let Some(new) = group.new {
                         snapshots.push(Snapshot {
                             name,
                             old: current_path.clone(),
                             new: new.clone(),
+                            diff: Some(diff.clone()),
                         });
                     }
                 }
             }
         }
 
+        snapshots.sort_by(|a, b| a.name.cmp(&b.name));
+
         snapshots
-    }
-
-    fn collect_snapshots_recursive(
-        path: &str,
-        snapshot_groups: &mut BTreeMap<String, SnapshotGroup>,
-    ) {
-        if let Ok(entries) = fs::read_dir(path) {
-            for entry in entries.flatten() {
-                let entry_path = entry.path();
-
-                if entry_path.is_dir() {
-                    if let Some(dir_name) = entry_path.to_str() {
-                        Self::collect_snapshots_recursive(dir_name, snapshot_groups);
-                    }
-                } else if let Some(file_name) = entry.file_name().to_str() {
-                    if file_name.ends_with(".png") {
-                        let relative_path = entry_path.strip_prefix(".").unwrap_or(&entry_path);
-                        let key = format!("{}", relative_path.display());
-
-                        if file_name.ends_with(".old.png") {
-                            let base_key = key.strip_suffix(".old.png").unwrap().to_string();
-                            snapshot_groups.entry(base_key).or_default().old = Some(entry_path);
-                        } else if file_name.ends_with(".new.png") {
-                            let base_key = key.strip_suffix(".new.png").unwrap().to_string();
-                            snapshot_groups.entry(base_key).or_default().new = Some(entry_path);
-                        } else if file_name.ends_with(".diff.png") {
-                            let base_key = key.strip_suffix(".diff.png").unwrap().to_string();
-                            snapshot_groups.entry(base_key).or_default().diff = Some(entry_path);
-                        } else {
-                            let base_key = key.strip_suffix(".png").unwrap().to_string();
-                            if !file_name.ends_with(".old.png") && !file_name.ends_with(".new.png") && !file_name.ends_with(".diff.png")
-                            {
-                                snapshot_groups.entry(base_key).or_default().current = Some(entry_path);
-                            }
-                        }
-                    }
-                }
-            }
-        }
     }
 }
 
@@ -145,31 +180,54 @@ impl eframe::App for App {
                 }
             }
 
-            ui.add(Slider::new(&mut self.new_opacity, 0.0..=1.0).text("New Opacity"));
-            ui.add(Slider::new(&mut self.diff_opacity, 0.0..=1.0).text("Diff Opacity"));
+            ui.horizontal_wrapped(|ui| {
+                ui.add(Slider::new(&mut self.new_opacity, 0.0..=1.0).text("New Opacity"));
+                ui.add(Slider::new(&mut self.diff_opacity, 0.0..=1.0).text("Diff Opacity"));
+                ui.add(
+                    Slider::new(&mut self.index, 0..=self.snapshots.len().saturating_sub(1))
+                        .text("Snapshot Index"),
+                );
+
+                ui.selectable_value(&mut self.mode, ImageMode::Pixel, "1:1");
+                ui.selectable_value(&mut self.mode, ImageMode::Fit, "Fit");
+            });
 
             if let Some(snapshot) = self.snapshots.get(self.index) {
                 let rect = ui.available_rect_before_wrap();
 
-                ui.place(
-                    rect,
-                    Image::new(format!("file://{}", snapshot.old.display())),
-                );
+                let ppp = ui.pixels_per_point();
+                let make_image = |uri: String| {
+                    let mut img = Image::new(uri);
+                    if self.mode == ImageMode::Pixel {
+                        img = img.fit_to_original_size(1.0 / ppp);
+                    }
+                    img
+                };
+
+                ui.place(rect, make_image(snapshot.old_uri()));
 
                 ui.set_opacity(self.new_opacity);
-                ui.place(
-                    rect,
-                    Image::new(format!("file://{}", snapshot.new.display())),
-                );
-
-                let diff_uri = diff_loader::DiffUri {
-                    old: format!("file://{}", snapshot.old.display()),
-                    new: format!("file://{}", snapshot.new.display()),
-                }
-                .to_uri();
+                ui.place(rect, make_image(snapshot.new_uri()));
 
                 ui.set_opacity(self.diff_opacity);
-                ui.place(rect, Image::new(diff_uri));
+                ui.place(rect, make_image(snapshot.diff_uri()));
+
+                // Preload surrounding snapshots
+                for i in -2..=2 {
+                    if let Some(surrounding_snapshot) =
+                        self.snapshots.get((self.index as isize + i) as usize)
+                    {
+                        ui.ctx()
+                            .try_load_image(&surrounding_snapshot.old_uri(), SizeHint::default())
+                            .ok();
+                        ui.ctx()
+                            .try_load_image(&surrounding_snapshot.new_uri(), SizeHint::default())
+                            .ok();
+                        if let Some(diff_uri) = surrounding_snapshot.file_diff_uri() {
+                            ui.ctx().try_load_image(&diff_uri, SizeHint::default()).ok();
+                        }
+                    }
+                }
             } else {
                 ui.label("No snapshots found.");
             }

--- a/examples/kitdiff/src/main.rs
+++ b/examples/kitdiff/src/main.rs
@@ -305,6 +305,16 @@ impl eframe::App for App {
             );
 
             if let Some(snapshot) = self.snapshots.get(self.index) {
+                let diff_uri = self
+                    .use_original_diff
+                    .then_some(snapshot.file_diff_uri())
+                    .flatten()
+                    .unwrap_or(snapshot.diff_uri());
+
+                ui.label(format!("old: {}", snapshot.old_uri()));
+                ui.label(format!("new: {}", snapshot.new_uri()));
+                ui.label(format!("diff: {}", diff_uri));
+
                 let rect = ui.available_rect_before_wrap();
 
                 let ppp = ui.pixels_per_point();
@@ -334,11 +344,6 @@ impl eframe::App for App {
                     if show_all {
                         ui.set_opacity(self.diff_opacity);
                     }
-                    let diff_uri = self
-                        .use_original_diff
-                        .then_some(snapshot.file_diff_uri())
-                        .flatten()
-                        .unwrap_or(snapshot.diff_uri());
                     ui.place(rect, make_image(diff_uri));
                 }
 

--- a/examples/kitdiff/src/main.rs
+++ b/examples/kitdiff/src/main.rs
@@ -1,36 +1,158 @@
-use eframe::egui::{Context, ImageSource};
+mod diff_loader;
+
+use crate::diff_loader::DiffLoader;
+use eframe::egui::{Context, Image, ImageSource, Slider};
 use eframe::{Frame, NativeOptions, egui};
+use egui_extras::install_image_loaders;
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 fn main() -> eframe::Result<()> {
     eframe::run_native(
         "kitdiff",
         NativeOptions::default(),
-        Box::new(|_cc| Ok(Box::new(App {}))),
+        Box::new(|cc| Ok(Box::new(App::new(cc)))),
     )
 }
 
 struct Snapshot {
     name: String,
-    current: ImageSource<'static>,
-    old: Option<ImageSource<'static>>,
-    new: Option<ImageSource<'static>>,
+    old: PathBuf,
+    new: PathBuf,
 }
 
 struct App {
     snapshots: Vec<Snapshot>,
+    index: usize,
+    new_opacity: f32,
+    diff_opacity: f32,
 }
 
 impl App {
-    pub fn new() -> Self {
-        /// TODO
+    pub fn new(cc: &eframe::CreationContext) -> Self {
+        install_image_loaders(&cc.egui_ctx);
+        cc.egui_ctx
+            .add_image_loader(Arc::new(DiffLoader::default()));
+        let snapshots = Self::discover_snapshots(".");
+        Self {
+            snapshots,
+            index: 0,
+            new_opacity: 0.5,
+            diff_opacity: 1.0,
+        }
+    }
+
+    fn discover_snapshots(path: &str) -> Vec<Snapshot> {
+        let mut snapshots = Vec::new();
+        let mut snapshot_groups: BTreeMap<
+            String,
+            (Option<PathBuf>, Option<PathBuf>, Option<PathBuf>),
+        > = Default::default();
+
+        Self::collect_snapshots_recursive(path, &mut snapshot_groups);
+
+        for (name, (current, old, new)) in snapshot_groups {
+            if let Some(current_path) = current {
+                if let Some(old) = old {
+                    snapshots.push(Snapshot {
+                        name,
+                        old: old.clone(),
+                        new: current_path.clone(),
+                    });
+                } else if let Some(new) = new {
+                    snapshots.push(Snapshot {
+                        name,
+                        old: current_path.clone(),
+                        new: new.clone(),
+                    });
+                }
+            }
+        }
+
+        snapshots
+    }
+
+    fn collect_snapshots_recursive(
+        path: &str,
+        snapshot_groups: &mut BTreeMap<String, (Option<PathBuf>, Option<PathBuf>, Option<PathBuf>)>,
+    ) {
+        if let Ok(entries) = fs::read_dir(path) {
+            for entry in entries.flatten() {
+                let entry_path = entry.path();
+
+                if entry_path.is_dir() {
+                    if let Some(dir_name) = entry_path.to_str() {
+                        Self::collect_snapshots_recursive(dir_name, snapshot_groups);
+                    }
+                } else if let Some(file_name) = entry.file_name().to_str() {
+                    if file_name.ends_with(".png") {
+                        let relative_path = entry_path.strip_prefix(".").unwrap_or(&entry_path);
+                        let key = format!("{}", relative_path.display());
+
+                        if file_name.ends_with(".old.png") {
+                            let base_key = key.strip_suffix(".old.png").unwrap().to_string();
+                            snapshot_groups.entry(base_key).or_default().1 = Some(entry_path);
+                        } else if file_name.ends_with(".new.png") {
+                            let base_key = key.strip_suffix(".new.png").unwrap().to_string();
+                            snapshot_groups.entry(base_key).or_default().2 = Some(entry_path);
+                        } else {
+                            let base_key = key.strip_suffix(".png").unwrap().to_string();
+                            if !file_name.ends_with(".old.png") && !file_name.ends_with(".new.png")
+                            {
+                                snapshot_groups.entry(base_key).or_default().0 = Some(entry_path);
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
 impl eframe::App for App {
     fn update(&mut self, ctx: &Context, frame: &mut Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
-            ui.label("Hello, World!");
+            if ui.input_mut(|i| i.key_pressed(egui::Key::ArrowRight)) {
+                if self.index + 1 < self.snapshots.len() {
+                    self.index += 1;
+                }
+            }
+            if ui.input_mut(|i| i.key_pressed(egui::Key::ArrowLeft)) {
+                if self.index > 0 {
+                    self.index -= 1;
+                }
+            }
+
+            ui.add(Slider::new(&mut self.new_opacity, 0.0..=1.0).text("New Opacity"));
+            ui.add(Slider::new(&mut self.diff_opacity, 0.0..=1.0).text("Diff Opacity"));
+
+            if let Some(snapshot) = self.snapshots.get(self.index) {
+                let rect = ui.available_rect_before_wrap();
+
+                ui.place(
+                    rect,
+                    Image::new(format!("file://{}", snapshot.old.display())),
+                );
+
+                ui.set_opacity(self.new_opacity);
+                ui.place(
+                    rect,
+                    Image::new(format!("file://{}", snapshot.new.display())),
+                );
+
+                let diff_uri = diff_loader::DiffUri {
+                    old: format!("file://{}", snapshot.old.display()),
+                    new: format!("file://{}", snapshot.new.display()),
+                }
+                .to_uri();
+
+                ui.set_opacity(self.diff_opacity);
+                ui.place(rect, Image::new(diff_uri));
+            } else {
+                ui.label("No snapshots found.");
+            }
         });
     }
 }

--- a/examples/kitdiff/src/main.rs
+++ b/examples/kitdiff/src/main.rs
@@ -1,0 +1,36 @@
+use eframe::egui::{Context, ImageSource};
+use eframe::{Frame, NativeOptions, egui};
+use std::path::PathBuf;
+
+fn main() -> eframe::Result<()> {
+    eframe::run_native(
+        "kitdiff",
+        NativeOptions::default(),
+        Box::new(|_cc| Ok(Box::new(App {}))),
+    )
+}
+
+struct Snapshot {
+    name: String,
+    current: ImageSource<'static>,
+    old: Option<ImageSource<'static>>,
+    new: Option<ImageSource<'static>>,
+}
+
+struct App {
+    snapshots: Vec<Snapshot>,
+}
+
+impl App {
+    pub fn new() -> Self {
+        /// TODO
+    }
+}
+
+impl eframe::App for App {
+    fn update(&mut self, ctx: &Context, frame: &mut Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.label("Hello, World!");
+        });
+    }
+}

--- a/examples/kitdiff/src/main.rs
+++ b/examples/kitdiff/src/main.rs
@@ -8,8 +8,8 @@ use crate::git_loader::{git_discovery, pr_git_discovery};
 use clap::{Parser, Subcommand};
 use eframe::egui::panel::Side;
 use eframe::egui::{
-    Align, Context, Image, ImageSource, RichText, ScrollArea, SizeHint, Slider, TextEdit,
-    TextureFilter, TextureOptions,
+    Align, Context, Image, ImageSource, Modifiers, RichText, ScrollArea, SizeHint, Slider,
+    TextEdit, TextureFilter, TextureOptions,
 };
 use eframe::{Frame, NativeOptions, egui};
 use egui_extras::install_image_loaders;
@@ -224,19 +224,14 @@ impl eframe::App for App {
             .position(|(i, _)| *i == self.index)
             .unwrap_or(0);
 
-
         let mut new_index = None;
-        if ctx.input_mut(|i| {
-            i.key_pressed(egui::Key::ArrowRight) || i.key_pressed(egui::Key::ArrowDown)
-        }) {
+        if ctx.input_mut(|i| i.consume_key(Modifiers::NONE, egui::Key::ArrowDown)) {
             // Find next snapshot that matches filter
             if current_filtered_index + 1 < filtered.len() {
                 new_index = Some(filtered[current_filtered_index + 1].0);
             }
         }
-        if ctx
-            .input_mut(|i| i.key_pressed(egui::Key::ArrowLeft) || i.key_pressed(egui::Key::ArrowUp))
-        {
+        if ctx.input_mut(|i| i.consume_key(Modifiers::NONE, egui::Key::ArrowUp)) {
             // Find previous snapshot that matches filter
             if current_filtered_index > 0 {
                 new_index = Some(filtered[current_filtered_index - 1].0);

--- a/examples/kitdiff/src/main.rs
+++ b/examples/kitdiff/src/main.rs
@@ -221,8 +221,12 @@ impl eframe::App for App {
             .collect::<Vec<_>>();
         let current_filtered_index = filtered
             .iter()
-            .position(|(i, _)| *i == self.index)
-            .unwrap_or(0);
+            .position(|(i, _)| *i == self.index);
+        if current_filtered_index.is_none() && !filtered.is_empty() {
+            // Current index is filtered out, jump to first filtered
+            self.index = filtered[0].0;
+        }
+        let current_filtered_index = current_filtered_index.unwrap_or(0);
 
         let mut new_index = None;
         if ctx.input_mut(|i| i.consume_key(Modifiers::NONE, egui::Key::ArrowDown)) {


### PR DESCRIPTION
I got frustrated with the experience of reviewing snapshot changes in my ide and on github, so I made something really cool:

Just run `kitdiff` in your terminal and it'll visualize all the diffs! You can use the `1, 2, 3` keys to switch between `original, new, diff` images. You can also generate diffs on the fly to play with different threshold options. Also, it's wicked quick! 

https://github.com/user-attachments/assets/c9324ef3-eb24-481f-83b8-42a37b6b075d

**but wait, there's more**

You can do `kitdiff pr https://github.com/rerun-io/rerun/pull/11253` to view a diff of that PR, you don't even need to check out the branch!


https://github.com/user-attachments/assets/d5c0b15a-0a75-4506-8dae-51b8bb83836f


