### PR TITLE
Fix build error in egui-winit with profiling enabled

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1361,7 +1361,7 @@ fn process_viewport_command(
     info: &mut ViewportInfo,
     actions_requested: &mut Vec<ActionRequested>,
 ) {
-    profiling::function_scope!(format!("{command:?}"));
+    profiling::function_scope!(&format!("{command:?}"));
 
     use winit::window::ResizeDirection;
 


### PR DESCRIPTION
Fixes https://github.com/emilk/egui/issues/7555.

Verified by patching `ruffle` to use a checked out `egui` repo with this change, and running `cargo run --release --features=tracy` in it.

I hesitated between `&` and `.as_str()` - if you'd prefer the latter, let me know.