### PR TITLE
Return `0.0` if font not found in `glyph_width` instead of panic

### DIFF
--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -481,10 +481,6 @@ impl Font<'_> {
         if let Some(font) = &self.fonts_by_id.get(&key) {
             glyph_info.advance_width_unscaled.0 * font.ab_glyph_font.px_scale_factor(font_size)
         } else {
-            debug_assert_eq!(
-                glyph_info.advance_width_unscaled.0, 0.0,
-                "We had no font, so this should be the zero-width fallback glyph"
-            );
             0.0
         }
     }

--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -478,12 +478,15 @@ impl Font<'_> {
     /// Width of this character in points.
     pub fn glyph_width(&mut self, c: char, font_size: f32) -> f32 {
         let (key, glyph_info) = self.glyph_info(c);
-        let font = &self
-            .fonts_by_id
-            .get(&key)
-            .expect("Nonexistent font ID")
-            .ab_glyph_font;
-        glyph_info.advance_width_unscaled.0 * font.px_scale_factor(font_size)
+        if let Some(font) = &self.fonts_by_id.get(&key) {
+            glyph_info.advance_width_unscaled.0 * font.ab_glyph_font.px_scale_factor(font_size)
+        } else {
+            debug_assert_eq!(
+                glyph_info.advance_width_unscaled.0, 0.0,
+                "We had no font, so this should be the zero-width fallback glyph"
+            );
+            0.0
+        }
     }
 
     /// Can we display this glyph?

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -651,6 +651,8 @@ impl FontsView<'_> {
     }
 
     /// Width of this character in points.
+    ///
+    /// If the font doesn't exist, this will return `0.0`.
     pub fn glyph_width(&mut self, font_id: &FontId, c: char) -> f32 {
         self.fonts
             .font(&font_id.family)
@@ -1301,5 +1303,14 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_fallback_glyph_width() {
+        let mut fonts = Fonts::new(1024, AlphaFromCoverage::default(), FontDefinitions::empty());
+        let mut view = fonts.with_pixels_per_point(1.0);
+
+        let width = view.glyph_width(&FontId::new(12.0, FontFamily::Proportional), ' ');
+        assert_eq!(width, 0.0);
     }
 }


### PR DESCRIPTION
* Closes #7548 
* related to #7431 

This reverts to the `glyph_width` behaviour before #7431 - return 0.0 if font not found instead of panicing.
The main use for this is when using `__run_test_ui`, which doesn't register any fonts, any code using glyph_width would previously panic. 

