### PR TITLE
Change Spinner widget to account for width as well as height

### DIFF
--- a/crates/egui/src/widgets/spinner.rs
+++ b/crates/egui/src/widgets/spinner.rs
@@ -42,7 +42,7 @@ impl Spinner {
             let color = self
                 .color
                 .unwrap_or_else(|| ui.visuals().strong_text_color());
-            let radius = (rect.height() / 2.0) - 2.0;
+            let radius = (rect.height().min(rect.width()) / 2.0) - 2.0;
             let n_points = (radius.round() as u32).clamp(8, 128);
             let time = ui.input(|i| i.time);
             let start_angle = time * std::f64::consts::TAU;


### PR DESCRIPTION
Previously, when `rect` was taller than it was wide, the spinner would render far outside the given rectangle. Now, it always renders inside the smaller of the two dimensions.

I noticed this when upgrading from 0.30 to 0.32. I have an image that's significantly taller than it is wide. In 0.32, when the image is loading, it shows the spinner. Since the spinner radius is determined solely based on rectangle height, the spinner ends up far too wide and covers other elements.

* [x] I have followed the instructions in the PR template
