### PR TITLE
Properly end winit event loop

### DIFF
--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -818,21 +818,6 @@ impl GlowWinitRunning<'_> {
                     }
                 }
             }
-
-            // TODO(tye-exe): Do any code-paths reach this event?
-            // As handling of the "CloseRequested" event causes running to be none, which
-            // causes "window_event" to return "Exit" instead of executing this function.
-            winit::event::WindowEvent::Destroyed => {
-                log::debug!(
-                    "Received WindowEvent::Destroyed for viewport {:?}",
-                    viewport_id
-                );
-                if viewport_id == Some(ViewportId::ROOT) {
-                    return EventResult::Exit;
-                } else {
-                    return EventResult::Wait;
-                }
-            }
             _ => {}
         }
 

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -470,7 +470,7 @@ impl WinitApp for GlowWinitApp<'_> {
         if let Some(running) = &mut self.running {
             Ok(running.on_window_event(window_id, &event))
         } else {
-            Ok(EventResult::Wait)
+            Ok(EventResult::Exit)
         }
     }
 
@@ -747,7 +747,7 @@ impl GlowWinitRunning<'_> {
         }
 
         if integration.should_close() {
-            Ok(EventResult::Exit)
+            Ok(EventResult::CloseRequested)
         } else {
             Ok(EventResult::Wait)
         }
@@ -798,7 +798,7 @@ impl GlowWinitRunning<'_> {
                     log::debug!(
                         "Received WindowEvent::CloseRequested for main viewport - shutting down."
                     );
-                    return EventResult::Exit;
+                    return EventResult::CloseRequested;
                 }
 
                 log::debug!("Received WindowEvent::CloseRequested for viewport {viewport_id:?}");
@@ -819,6 +819,9 @@ impl GlowWinitRunning<'_> {
                 }
             }
 
+            // TODO(tye-exe): Do any code-paths reach this event?
+            // As handling of the "CloseRequested" event causes running to be none, which
+            // causes "window_event" to return "Exit" instead of executing this function.
             winit::event::WindowEvent::Destroyed => {
                 log::debug!(
                     "Received WindowEvent::Destroyed for viewport {:?}",
@@ -830,12 +833,11 @@ impl GlowWinitRunning<'_> {
                     return EventResult::Wait;
                 }
             }
-
             _ => {}
         }
 
         if self.integration.should_close() {
-            return EventResult::Exit;
+            return EventResult::CloseRequested;
         }
 
         let mut event_response = egui_winit::EventResponse {

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -139,6 +139,11 @@ impl<T: WinitApp> WinitAppWrapper<T> {
                 exit = true;
                 event_result
             }
+            EventResult::CloseRequested => {
+                // The windows need to be dropped whilst the event loop is running to allow for proper cleanup.
+                self.winit_app.save_and_destroy();
+                event_result
+            }
         });
 
         if let Err(err) = combined_result {

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -461,7 +461,8 @@ impl WinitApp for WgpuWinitApp<'_> {
         if let Some(running) = &mut self.running {
             Ok(running.on_window_event(window_id, &event))
         } else {
-            Ok(EventResult::Wait)
+            // running is removed to get ready for exiting
+            Ok(EventResult::Exit)
         }
     }
 
@@ -739,7 +740,7 @@ impl WgpuWinitRunning<'_> {
         }
 
         if integration.should_close() {
-            Ok(EventResult::Exit)
+            Ok(EventResult::CloseRequested)
         } else {
             Ok(EventResult::Wait)
         }
@@ -799,7 +800,7 @@ impl WgpuWinitRunning<'_> {
                     log::debug!(
                         "Received WindowEvent::CloseRequested for main viewport - shutting down."
                     );
-                    return EventResult::Exit;
+                    return EventResult::CloseRequested;
                 }
 
                 log::debug!("Received WindowEvent::CloseRequested for viewport {viewport_id:?}");
@@ -833,7 +834,7 @@ impl WgpuWinitRunning<'_> {
             .unwrap_or_default();
 
         if integration.should_close() {
-            EventResult::Exit
+            EventResult::CloseRequested
         } else if event_response.repaint {
             if repaint_asap {
                 EventResult::RepaintNow(window_id)

--- a/crates/eframe/src/native/winit_integration.rs
+++ b/crates/eframe/src/native/winit_integration.rs
@@ -124,6 +124,25 @@ pub enum EventResult {
     /// Causes a save of the client state when the persistence feature is enabled.
     Save,
 
+    /// Starts the process of ending eframe execution whilst allowing for proper
+    /// clean up of resources.
+    ///
+    /// # Warning
+    /// This event **must** occur before [`Exit`] to correctly exit eframe code.
+    /// If in doubt, return this event.
+    ///
+    /// [`Exit`]: [EventResult::Exit]
+    CloseRequested,
+
+    /// The event loop will exit, now.
+    /// The correct circumstance to return this event is in response to a winit "Destroyed" event.
+    ///
+    /// # Warning
+    /// The [`CloseRequested`] **must** occur before this event to ensure that winit
+    /// is able to remove any open windows. Otherwise the window(s) will remain open
+    /// until the program terminates.
+    ///
+    /// [`CloseRequested`]: EventResult::CloseRequested
     Exit,
 }
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758035966,
+        "narHash": "sha256-qqIJ3yxPiB0ZQTT9//nFGQYn8X/PBoJbofA7hRKZnmE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8d4ddb19d03c65a36ad8d189d001dc32ffb0306b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1758162771,
+        "narHash": "sha256-hdZpMep6Z1gbgg9piUZ0BNusI6ZJaptBw6PHSN/3GD0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "d0cabb6ae8f5b38dffaff9f4e6db57c0ae21d729",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  description = "Environment for a GUI Timer.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      rust-overlay,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs { inherit system overlays; };
+
+        rust-build = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "rust-src" ];
+        };
+
+      in
+      {
+        devShells.default =
+          with pkgs;
+          mkShell {
+            buildInputs = [
+              rust-build
+              bacon
+            ];
+
+            LD_LIBRARY_PATH =
+              let
+                libPath =
+                  with pkgs;
+                  lib.makeLibraryPath [
+                    libGL
+                    libxkbcommon
+                    wayland
+                    xorg.libX11
+                    xorg.libXcursor
+                    xorg.libXi
+                    xorg.libXrandr
+                  ];
+              in
+              libPath;
+          };
+      }
+    );
+}


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

X Keep your PR:s small and focused.
X The PR title is what ends up in the changelog, so make it descriptive!
X If applicable, add a screenshot or gif.
X If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
X Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
X Remember to run `cargo fmt` and `cargo clippy`.
- Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
X When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

This PR changes eframe to comply with the proper methodology of ending winit. This fixes the winit window remaining open on Wayland (Linux) by allowing winit to properly clean up the window.

* Closes <https://github.com/emilk/egui/issues/6757>
* [x] I have followed the instructions in the PR template

### Details
On a winit "CloseRequested" event eframe drops open windows, which then triggers a "Destroyed" event and allows for winit to clean up resources. In response to the "Destroyed" event, the event loop is exited and control flow returned to user code.
This follows the advice recomended in [this winit issue](https://github.com/rust-windowing/winit/issues/4135) in response to a similar problem.

I have tested the new change using:
- glow on Wayland (Linux)
- wgpu on Wayland (Linux)
- glow on X11 (Linux)
- wgpu on X11 (Linux)
- glow on WASM
- wpgu on WASM

### Current implementation
![output1](https://github.com/user-attachments/assets/4623cabd-e29d-4586-80b0-0bcb992c6840)

### After changes
![output](https://github.com/user-attachments/assets/c37d7139-0fc8-4691-802c-dfc7a3d163d0)

### Misc Info
I attempted to run `./scripts/check.sh`, but it fails on the I have branched from on some code that I have not modified.