### PR TITLE
kittest: Format errors with `Display`

### DIFF
--- a/crates/egui_kittest/src/snapshot.rs
+++ b/crates/egui_kittest/src/snapshot.rs
@@ -250,7 +250,7 @@ impl Display for SnapshotError {
                         err => {
                             write!(
                                 f,
-                                "Error reading snapshot: {err:?}\nAt: {}. {HOW_TO_UPDATE_SCREENSHOTS}",
+                                "Error reading snapshot: {err}\nAt: {}. {HOW_TO_UPDATE_SCREENSHOTS}",
                                 path.display()
                             )
                         }
@@ -258,7 +258,7 @@ impl Display for SnapshotError {
                     err => {
                         write!(
                             f,
-                            "Error decoding snapshot: {err:?}\nAt: {}. Make sure git-lfs is setup correctly. Read the instructions here: https://github.com/emilk/egui/blob/main/CONTRIBUTING.md#making-a-pr",
+                            "Error decoding snapshot: {err}\nAt: {}. Make sure git-lfs is setup correctly. Read the instructions here: https://github.com/emilk/egui/blob/main/CONTRIBUTING.md#making-a-pr",
                             path.display()
                         )
                     }
@@ -276,10 +276,10 @@ impl Display for SnapshotError {
             }
             Self::WriteSnapshot { path, err } => {
                 let path = std::path::absolute(path).unwrap_or(path.clone());
-                write!(f, "Error writing snapshot: {err:?}\nAt: {}", path.display())
+                write!(f, "Error writing snapshot: {err}\nAt: {}", path.display())
             }
             Self::RenderError { err } => {
-                write!(f, "Error rendering image: {err:?}")
+                write!(f, "Error rendering image: {err}")
             }
         }
     }

--- a/crates/egui_kittest/src/wgpu.rs
+++ b/crates/egui_kittest/src/wgpu.rs
@@ -206,7 +206,7 @@ impl crate::TestRenderer for WgpuTestRenderer {
         self.render_state
             .device
             .poll(wgpu::PollType::Wait)
-            .map_err(|e| format!("{e:?}"))?;
+            .map_err(|err| format!("PollError: {err}"))?;
 
         Ok(texture_to_image(
             &self.render_state.device,


### PR DESCRIPTION
Very small improvement

Before:

> Error rendering image: "Timeout"

After:

> Error rendering image: PollError: The requested Wait timed out before the submission was completed.