### PR TITLE
Warn if `DYLD_LIBRARY_PATH` is set and we find no wgpu adapter

### DIFF
--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -117,7 +117,7 @@ async fn request_adapter(
                     // I don't want to debug this again.
                     // See https://github.com/rerun-io/rerun/issues/11351 for more
                     log::warn!(
-                        "No wgpu adapter found. This could be because of DYLD_LIBRARY_PATH. Try restarting with DYLD_LIBRARY_PATH=''"
+                        "No wgpu adapter found. This could be because DYLD_LIBRARY_PATH causes dylibs to be loaded that interfere with Metal device creation. Try restarting with DYLD_LIBRARY_PATH=''"
                     );
                 } else {
                     log::info!("No wgpu adapter found");

--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -267,7 +267,6 @@ impl RenderState {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 fn describe_adapters(adapters: &[wgpu::Adapter]) -> String {
     if adapters.is_empty() {
         "(none)".to_owned()


### PR DESCRIPTION
* See https://github.com/rerun-io/rerun/issues/11351

I had a crazy problem where I could not start any graphics application. Turns out it was because I had added the `DYLD_LIBRARY_PATH` env-var to my `.zshrc`.

This PR adds a warning to make this faster to debug next time.

Also cleaned up the code to replace some `#[cfg(` with `if cfg!`