### PR TITLE
Add `Ui::take_available_space()` helper function, which sets the Ui's minimum size to the available space

### DIFF
--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -144,8 +144,11 @@ impl SidePanel {
     ///
     /// Default is `true`.
     ///
-    /// If you want your panel to be resizable you also need a widget in it that
-    /// takes up more space as you resize it, such as:
+    /// If you want your panel to be resizable you also need to make the ui use
+    /// the available space.
+    ///
+    /// This can be done by using [`Ui::take_available_space`], or using a
+    /// widget in it that takes up more space as you resize it, such as:
     /// * Wrapping text ([`Ui::horizontal_wrapped`]).
     /// * A [`crate::ScrollArea`].
     /// * A [`crate::Separator`].
@@ -631,8 +634,11 @@ impl TopBottomPanel {
     ///
     /// Default is `false`.
     ///
-    /// If you want your panel to be resizable you also need a widget in it that
-    /// takes up more space as you resize it, such as:
+    /// If you want your panel to be resizable you also need to make the ui use
+    /// the available space.
+    ///
+    /// This can be done by using [`Ui::take_available_space`], or using a
+    /// widget in it that takes up more space as you resize it, such as:
     /// * Wrapping text ([`Ui::horizontal_wrapped`]).
     /// * A [`crate::ScrollArea`].
     /// * A [`crate::Separator`].

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -952,6 +952,22 @@ impl Ui {
         self.set_min_size(self.available_size());
     }
 
+    /// Makes the ui always fill up the available space in the x axis.
+    ///
+    /// This can be useful to call inside a side panel with
+    /// `resizable == true` to make sure the resized space is used.
+    pub fn take_available_width(&mut self) {
+        self.set_min_width(self.available_width());
+    }
+
+    /// Makes the ui always fill up the available space in the y axis.
+    ///
+    /// This can be useful to call inside a top bottom panel with
+    /// `resizable == true` to make sure the resized space is used.
+    pub fn take_available_height(&mut self) {
+        self.set_min_height(self.available_height());
+    }
+
     // ------------------------------------------------------------------------
 
     /// Helper: shrinks the max width to the current width,

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -944,6 +944,14 @@ impl Ui {
         self.placer.set_min_height(height);
     }
 
+    /// Makes the ui always fill up the available space.
+    ///
+    /// This can be useful to call inside a panel with `resizable == true`
+    /// to make sure the resized space is used.
+    pub fn take_available_space(&mut self) {
+        self.set_min_size(self.available_size());
+    }
+
     // ------------------------------------------------------------------------
 
     /// Helper: shrinks the max width to the current width,


### PR DESCRIPTION
A shorthand, and more descriptive version of calling `ui.set_min_size(ui.available_size())`, and mentions this on panel's resizable functions.