### PR TITLE
Increate wgpu kittest wait timeout

### DIFF
--- a/crates/egui_kittest/src/wgpu.rs
+++ b/crates/egui_kittest/src/wgpu.rs
@@ -8,7 +8,12 @@ use image::RgbaImage;
 use crate::texture_to_image::texture_to_image;
 
 /// Timeout for waiting on the GPU to finish rendering.
-pub(crate) const WAIT_TIMEOUT: Duration = Duration::from_secs(1);
+///
+/// Windows will reset native drivers after 2 seconds of being stuck (known was TDR - timeout detection & recovery).
+/// However, software rasterizers like lavapipe may not do that and take longer if there's a lot of work in flight.
+/// In the end, what we really want to protect here against is undetected errors that lead to device loss
+/// and therefore infinite waits it happens occasionally on MacOS/Metal as of writing.
+pub(crate) const WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Default wgpu setup used for the wgpu renderer.
 pub fn default_wgpu_setup() -> egui_wgpu::WgpuSetup {


### PR DESCRIPTION
I figured 1 second should be enough. I was wrong! See
https://github.com/rerun-io/rerun/actions/runs/18219779577/job/51876964734?pr=11419

.. and more rationale in the comment.


(Emil predicted this https://github.com/emilk/egui/pull/7580#discussion_r2399506560)