### PR TITLE
Make `TextEdit` work with `Atoms`

### DIFF
--- a/crates/egui/src/atomics/atom.rs
+++ b/crates/egui/src/atomics/atom.rs
@@ -1,5 +1,5 @@
 use crate::{AtomKind, FontSelection, Id, SizedAtom, Ui};
-use emath::{NumExt as _, Vec2};
+use emath::{Align2, NumExt as _, Vec2};
 use epaint::text::TextWrapMode;
 
 /// A low-level ui building block.
@@ -29,6 +29,9 @@ pub struct Atom<'a> {
     /// See [`crate::AtomExt::atom_shrink`]
     pub shrink: bool,
 
+    /// See [`crate::AtomExt::atom_align`]
+    pub align: Align2,
+
     /// The atom type
     pub kind: AtomKind<'a>,
 }
@@ -41,6 +44,7 @@ impl Default for Atom<'_> {
             max_size: Vec2::INFINITY,
             grow: false,
             shrink: false,
+            align: Align2::CENTER_CENTER,
             kind: AtomKind::Empty,
         }
     }
@@ -106,6 +110,7 @@ impl<'a> Atom<'a> {
             size,
             intrinsic_size: intrinsic.at_least(self.size.unwrap_or_default()),
             grow: self.grow,
+            align: self.align,
             kind,
         }
     }

--- a/crates/egui/src/atomics/atom.rs
+++ b/crates/egui/src/atomics/atom.rs
@@ -14,6 +14,9 @@ use epaint::text::TextWrapMode;
 /// ```
 #[derive(Clone, Debug)]
 pub struct Atom<'a> {
+    /// See [`crate::AtomExt::atom_id`]
+    pub id: Option<Id>,
+
     /// See [`crate::AtomExt::atom_size`]
     pub size: Option<Vec2>,
 
@@ -33,6 +36,7 @@ pub struct Atom<'a> {
 impl Default for Atom<'_> {
     fn default() -> Self {
         Atom {
+            id: None,
             size: None,
             max_size: Vec2::INFINITY,
             grow: false,
@@ -82,6 +86,13 @@ impl<'a> Atom<'a> {
             wrap_mode = Some(TextWrapMode::Truncate);
         }
 
+        let id = match &self.kind {
+            AtomKind::Custom(id) => {
+                Some(self.id.unwrap_or(*id))
+            }
+            _ => self.id,
+        };
+
         let (intrinsic, kind) = self
             .kind
             .into_sized(ui, available_size, wrap_mode, fallback_font);
@@ -91,6 +102,7 @@ impl<'a> Atom<'a> {
             .map_or_else(|| kind.size(), |s| s.at_most(self.max_size));
 
         SizedAtom {
+            id,
             size,
             intrinsic_size: intrinsic.at_least(self.size.unwrap_or_default()),
             grow: self.grow,

--- a/crates/egui/src/atomics/atom_ext.rs
+++ b/crates/egui/src/atomics/atom_ext.rs
@@ -84,6 +84,11 @@ pub trait AtomExt<'a> {
         let height = ui.fonts_mut(|f| f.row_height(&font_id));
         self.atom_max_height(height)
     }
+
+    /// Sets the [`Align2`] of a single atom within its available space.
+    ///
+    /// Defaults to center-center.
+    fn atom_align(self, align: emath::Align2) -> Atom<'a>;
 }
 
 impl<'a, T> AtomExt<'a> for T
@@ -129,6 +134,12 @@ where
     fn atom_max_height(self, max_height: f32) -> Atom<'a> {
         let mut atom = self.into();
         atom.max_size.y = max_height;
+        atom
+    }
+
+    fn atom_align(self, align: emath::Align2) -> Atom<'a> {
+        let mut atom = self.into();
+        atom.align = align;
         atom
     }
 }

--- a/crates/egui/src/atomics/atom_ext.rs
+++ b/crates/egui/src/atomics/atom_ext.rs
@@ -1,10 +1,31 @@
-use crate::{Atom, FontSelection, Ui};
+use crate::{Atom, FontSelection, Id, Ui};
 use emath::Vec2;
 
 /// A trait for conveniently building [`Atom`]s.
 ///
 /// The functions are prefixed with `atom_` to avoid conflicts with e.g. [`crate::RichText::size`].
 pub trait AtomExt<'a> {
+    /// Set the [`Id`] custom rendering.
+    ///
+    /// You can get the [`crate::Rect`] with the [`Id`] from [`crate::AtomLayoutResponse`] and use a
+    /// [`crate::Painter`] or [`Ui::place`] to add/draw some custom content.
+    ///
+    /// Example:
+    /// ```
+    /// # use egui::{AtomExt, AtomKind, Atom, Button, Id, __run_test_ui};
+    /// # use emath::Vec2;
+    /// # __run_test_ui(|ui| {
+    /// let id = Id::new("my_button");
+    /// let response = Button::new(("Hi!", Atom::custom(id, Vec2::splat(18.0)))).atom_ui(ui);
+    ///
+    /// let rect = response.rect(id);
+    /// if let Some(rect) = rect {
+    ///     ui.place(rect, Button::new("⏵"));
+    /// }
+    /// # });
+    /// ```
+    fn atom_id(self, id: Id) -> Atom<'a>;
+
     /// Set the atom to a fixed size.
     ///
     /// If [`Atom::grow`] is `true`, this will be the minimum width.
@@ -69,6 +90,12 @@ impl<'a, T> AtomExt<'a> for T
 where
     T: Into<Atom<'a>> + Sized,
 {
+    fn atom_id(self, id: Id) -> Atom<'a> {
+        let mut atom = self.into();
+        atom.id = Some(id);
+        atom
+    }
+
     fn atom_size(self, size: Vec2) -> Atom<'a> {
         let mut atom = self.into();
         atom.size = Some(size);

--- a/crates/egui/src/atomics/atom_kind.rs
+++ b/crates/egui/src/atomics/atom_kind.rs
@@ -1,7 +1,7 @@
-use std::fmt::Debug;
 use crate::{FontSelection, Id, Image, ImageSource, SizedAtomKind, Ui, WidgetText};
 use emath::Vec2;
 use epaint::text::TextWrapMode;
+use std::fmt::Debug;
 
 /// The different kinds of [`crate::Atom`]s.
 #[derive(Default)]
@@ -70,7 +70,19 @@ pub enum AtomKind<'a> {
     /// When cloning, this will be cloned as [`AtomKind::Empty`].
     #[doc(hidden)]
     Closure(
-        Box<dyn FnOnce(&Ui, Vec2, TextWrapMode, FontSelection) -> (Vec2, SizedAtomKind<'a>) + 'a>,
+        Box<
+            dyn FnOnce(
+                    &Ui,
+                    Vec2,
+                    TextWrapMode,
+                    FontSelection,
+                ) -> (
+                    Vec2,
+                    // We need 'static here (or need to introduce another lifetime on the enum).
+                    // Other a single 'static Atom would force the closure to be 'static.
+                    SizedAtomKind<'static>,
+                ) + 'a,
+        >,
     ),
 }
 
@@ -108,7 +120,7 @@ impl<'a> AtomKind<'a> {
     }
 
     pub fn closure(
-        func: impl FnOnce(&Ui, Vec2, TextWrapMode, FontSelection) -> (Vec2, SizedAtomKind<'a>) + 'a,
+        func: impl FnOnce(&Ui, Vec2, TextWrapMode, FontSelection) -> (Vec2, SizedAtomKind<'static>) + 'a,
     ) -> Self {
         AtomKind::Closure(Box::new(func))
     }

--- a/crates/egui/src/atomics/atom_kind.rs
+++ b/crates/egui/src/atomics/atom_kind.rs
@@ -1,9 +1,10 @@
+use std::fmt::Debug;
 use crate::{FontSelection, Id, Image, ImageSource, SizedAtomKind, Ui, WidgetText};
 use emath::Vec2;
 use epaint::text::TextWrapMode;
 
 /// The different kinds of [`crate::Atom`]s.
-#[derive(Clone, Default, Debug)]
+#[derive(Default)]
 pub enum AtomKind<'a> {
     /// Empty, that can be used with [`crate::AtomExt::atom_grow`] to reserve space.
     #[default]
@@ -57,7 +58,44 @@ pub enum AtomKind<'a> {
     /// }
     /// # });
     /// ```
+    #[deprecated = "Use Atom::custom(id) instead"]
     Custom(Id),
+
+    /// A custom closure that produces a sized atom.
+    ///
+    /// The vec2 passed in is the available size to this atom. The returned vec2 should be the
+    /// preferred / intrinsic size.
+    ///
+    /// Note: This api is experimental, expect breaking changes here.
+    /// When cloning, this will be cloned as [`AtomKind::Empty`].
+    #[doc(hidden)]
+    Closure(
+        Box<dyn FnOnce(&Ui, Vec2, TextWrapMode, FontSelection) -> (Vec2, SizedAtomKind<'a>) + 'a>,
+    ),
+}
+
+impl Clone for AtomKind<'_> {
+    fn clone(&self) -> Self {
+        match self {
+            AtomKind::Empty => AtomKind::Empty,
+            AtomKind::Text(text) => AtomKind::Text(text.clone()),
+            AtomKind::Image(image) => AtomKind::Image(image.clone()),
+            AtomKind::Custom(id) => AtomKind::Custom(*id),
+            AtomKind::Closure(_) => AtomKind::Empty, // Cannot clone closures
+        }
+    }
+}
+
+impl Debug for AtomKind<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AtomKind::Empty => write!(f, "AtomKind::Empty"),
+            AtomKind::Text(text) => write!(f, "AtomKind::Text({:?})", text),
+            AtomKind::Image(image) => write!(f, "AtomKind::Image({:?})", image),
+            AtomKind::Custom(id) => write!(f, "AtomKind::Custom({:?})", id),
+            AtomKind::Closure(_) => write!(f, "AtomKind::Closure(<closure>)"),
+        }
+    }
 }
 
 impl<'a> AtomKind<'a> {
@@ -67,6 +105,12 @@ impl<'a> AtomKind<'a> {
 
     pub fn image(image: impl Into<Image<'a>>) -> Self {
         AtomKind::Image(image.into())
+    }
+
+    pub fn closure(
+        func: impl FnOnce(&Ui, Vec2, TextWrapMode, FontSelection) -> (Vec2, SizedAtomKind<'a>) + 'a,
+    ) -> Self {
+        AtomKind::Closure(Box::new(func))
     }
 
     /// Turn this [`AtomKind`] into a [`SizedAtomKind`].
@@ -80,9 +124,9 @@ impl<'a> AtomKind<'a> {
         wrap_mode: Option<TextWrapMode>,
         fallback_font: FontSelection,
     ) -> (Vec2, SizedAtomKind<'a>) {
+        let wrap_mode = wrap_mode.unwrap_or(ui.wrap_mode());
         match self {
             AtomKind::Text(text) => {
-                let wrap_mode = wrap_mode.unwrap_or(ui.wrap_mode());
                 let galley = text.into_galley(ui, Some(wrap_mode), available_size.x, fallback_font);
                 (galley.intrinsic_size(), SizedAtomKind::Text(galley))
             }
@@ -91,8 +135,9 @@ impl<'a> AtomKind<'a> {
                 let size = size.unwrap_or(Vec2::ZERO);
                 (size, SizedAtomKind::Image(image, size))
             }
-            AtomKind::Custom(id) => (Vec2::ZERO, SizedAtomKind::Custom(id)),
+            AtomKind::Custom(id) => (Vec2::ZERO, SizedAtomKind::Empty), // id is handled in Atom::into_sized
             AtomKind::Empty => (Vec2::ZERO, SizedAtomKind::Empty),
+            AtomKind::Closure(func) => func(ui, available_size, wrap_mode, fallback_font),
         }
     }
 }

--- a/crates/egui/src/atomics/atom_layout.rs
+++ b/crates/egui/src/atomics/atom_layout.rs
@@ -426,6 +426,14 @@ impl<'atom> AllocatedAtomLayout<'atom> {
             let align = Align2::CENTER_CENTER;
             let rect = align.align_size_within_rect(size, frame);
 
+            if let Some(id) = sized.id {
+                debug_assert!(
+                    !response.custom_rects.iter().any(|(i, _)| *i == id),
+                    "Duplicate custom id"
+                );
+                response.custom_rects.push((id, rect));
+            }
+
             match sized.kind {
                 SizedAtomKind::Text(galley) => {
                     ui.painter().galley(rect.min, galley, fallback_text_color);
@@ -433,14 +441,7 @@ impl<'atom> AllocatedAtomLayout<'atom> {
                 SizedAtomKind::Image(image, _) => {
                     image.paint_at(ui, rect);
                 }
-                SizedAtomKind::Custom(id) => {
-                    debug_assert!(
-                        !response.custom_rects.iter().any(|(i, _)| *i == id),
-                        "Duplicate custom id"
-                    );
-                    response.custom_rects.push((id, rect));
-                }
-                SizedAtomKind::Empty => {}
+                SizedAtomKind::Sized(_) | SizedAtomKind::Empty => {}
             }
         }
 

--- a/crates/egui/src/atomics/atom_layout.rs
+++ b/crates/egui/src/atomics/atom_layout.rs
@@ -422,9 +422,7 @@ impl<'atom> AllocatedAtomLayout<'atom> {
                 .with_min_x(cursor)
                 .with_max_x(cursor + size.x + growth);
             cursor = frame.right() + gap;
-
-            let align = Align2::CENTER_CENTER;
-            let rect = align.align_size_within_rect(size, frame);
+            let rect = sized.align.align_size_within_rect(size, frame);
 
             if let Some(id) = sized.id {
                 debug_assert!(

--- a/crates/egui/src/atomics/atoms.rs
+++ b/crates/egui/src/atomics/atoms.rs
@@ -21,9 +21,24 @@ impl<'a> Atoms<'a> {
         self.0.push(atom.into());
     }
 
+    /// Extend the list of atoms by appending more atoms to the right side.
+    ///
+    /// If you have weird lifetime issues with this, use [`Self::push_right`] in a loop instead.
+    pub fn extend_right(&mut self, atoms: Atoms<'a>) {
+        self.0.extend(atoms.0);
+    }
+
     /// Insert a new [`Atom`] at the beginning of the list (left side).
     pub fn push_left(&mut self, atom: impl Into<Atom<'a>>) {
         self.0.insert(0, atom.into());
+    }
+
+    /// Extend the list of atoms by prepending more atoms to the left side.
+    ///
+    /// If you have weird lifetime issues with this, use [`Self::push_left`] in a loop instead.
+    pub fn extend_left(&mut self, mut atoms: Atoms<'a>) {
+        std::mem::swap(&mut atoms.0, &mut self.0);
+        self.0.extend(atoms.0);
     }
 
     /// Concatenate and return the text contents.
@@ -52,18 +67,6 @@ impl<'a> Atoms<'a> {
         }
 
         string
-    }
-
-    /// Extend the list of atoms by appending more atoms to the right side.
-    pub fn extend_right(&mut self, atoms: impl IntoAtoms<'a>) {
-        atoms.collect(self);
-    }
-
-    /// Extend the list of atoms by prepending more atoms to the left side.
-    pub fn extend_left(&mut self, atoms: impl IntoAtoms<'a>) {
-        let mut new_atoms = atoms.into_atoms();
-        std::mem::swap(&mut new_atoms.0, &mut self.0);
-        self.0.extend(new_atoms.0);
     }
 
     pub fn iter_kinds(&self) -> impl Iterator<Item = &AtomKind<'a>> {

--- a/crates/egui/src/atomics/atoms.rs
+++ b/crates/egui/src/atomics/atoms.rs
@@ -54,6 +54,18 @@ impl<'a> Atoms<'a> {
         string
     }
 
+    /// Extend the list of atoms by appending more atoms to the right side.
+    pub fn extend_right(&mut self, atoms: impl IntoAtoms<'a>) {
+        atoms.collect(self);
+    }
+
+    /// Extend the list of atoms by prepending more atoms to the left side.
+    pub fn extend_left(&mut self, atoms: impl IntoAtoms<'a>) {
+        let mut new_atoms = atoms.into_atoms();
+        std::mem::swap(&mut new_atoms.0, &mut self.0);
+        self.0.extend(new_atoms.0);
+    }
+
     pub fn iter_kinds(&self) -> impl Iterator<Item = &AtomKind<'a>> {
         self.0.iter().map(|atom| &atom.kind)
     }

--- a/crates/egui/src/atomics/sized_atom.rs
+++ b/crates/egui/src/atomics/sized_atom.rs
@@ -4,6 +4,8 @@ use emath::Vec2;
 /// A [`crate::Atom`] which has been sized.
 #[derive(Clone, Debug)]
 pub struct SizedAtom<'a> {
+    pub id: Option<crate::Id>,
+
     pub(crate) grow: bool,
 
     /// The size of the atom.

--- a/crates/egui/src/atomics/sized_atom.rs
+++ b/crates/egui/src/atomics/sized_atom.rs
@@ -17,6 +17,9 @@ pub struct SizedAtom<'a> {
     /// Intrinsic size of the atom. This is used to calculate `Response::intrinsic_size`.
     pub intrinsic_size: Vec2,
 
+    /// How will the atom be aligned in its available space?
+    pub align: emath::Align2,
+
     pub kind: SizedAtomKind<'a>,
 }
 

--- a/crates/egui/src/atomics/sized_atom_kind.rs
+++ b/crates/egui/src/atomics/sized_atom_kind.rs
@@ -10,7 +10,7 @@ pub enum SizedAtomKind<'a> {
     Empty,
     Text(Arc<Galley>),
     Image(Image<'a>, Vec2),
-    Custom(Id),
+    Sized(Vec2),
 }
 
 impl SizedAtomKind<'_> {
@@ -19,7 +19,8 @@ impl SizedAtomKind<'_> {
         match self {
             SizedAtomKind::Text(galley) => galley.size(),
             SizedAtomKind::Image(_, size) => *size,
-            SizedAtomKind::Empty | SizedAtomKind::Custom(_) => Vec2::ZERO,
+            SizedAtomKind::Sized(size) => *size,
+            SizedAtomKind::Empty => Vec2::ZERO,
         }
     }
 }

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -577,7 +577,7 @@ impl TextEdit<'_> {
 
             if text.as_str().is_empty() {
                 for atom in hint_text {
-                    atoms.push_right(atom);
+                    atoms.push_right(atom.atom_align(Align2::LEFT_TOP));
                 }
             }
             atoms.push_right(Atom::grow());
@@ -594,6 +594,7 @@ impl TextEdit<'_> {
                 .sense(sense)
                 .frame(frame)
                 .gap(0.0)
+                .align2(Align2::LEFT_TOP)
                 .allocate(ui);
 
             allocated.frame = if !custom_frame {

--- a/crates/egui_demo_lib/src/demo/widget_gallery.rs
+++ b/crates/egui_demo_lib/src/demo/widget_gallery.rs
@@ -158,7 +158,7 @@ impl WidgetGallery {
         ui.end_row();
 
         ui.add(doc_link_label("TextEdit", "TextEdit"));
-        ui.add(egui::TextEdit::singleline(string).hint_text("Write something here").prefix("$"));
+        ui.add(egui::TextEdit::singleline(string).hint_text("Write something here").prefix("🔎"));
         ui.end_row();
 
         ui.add(doc_link_label("Button", "button"));

--- a/crates/egui_demo_lib/src/demo/widget_gallery.rs
+++ b/crates/egui_demo_lib/src/demo/widget_gallery.rs
@@ -158,7 +158,7 @@ impl WidgetGallery {
         ui.end_row();
 
         ui.add(doc_link_label("TextEdit", "TextEdit"));
-        ui.add(egui::TextEdit::singleline(string).hint_text("Write something here"));
+        ui.add(egui::TextEdit::singleline(string).hint_text("Write something here").prefix("$"));
         ui.end_row();
 
         ui.add(doc_link_label("Button", "button"));


### PR DESCRIPTION
* part of https://github.com/emilk/egui/issues/7264
* part of https://github.com/emilk/egui/issues/7445

This PR changes the layout within the TextEdit to be done with AtomLayout. It also adds a Prefix and Postfix that allows adding permanent icons / icon buttons within the textedit.

<img width="264" height="130" alt="Screenshot 2025-10-06 at 12 25 21" src="https://github.com/user-attachments/assets/03b6b56b-ca82-4ac3-b5c0-585cca336834" />

