### PR TITLE
Fix preview build on contributor PRs

### DIFF
--- a/.github/workflows/preview_build.yml
+++ b/.github/workflows/preview_build.yml
@@ -17,20 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-
-      - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v2
-        env:
-          URL_SLUG: ${{ github.event.number }}-${{ github.head_ref }}
-        with:
-          message: |
-            Preview is being built...
-            
-            Preview will be available at https://egui-pr-preview.github.io/pr/${{ env.URL_SLUG }}
-            
-            View snapshot changes at [kitdiff](https://rerun-io.github.io/kitdiff/?url=${{ github.event.pull_request.html_url }})
-          comment_tag: 'egui-preview'
-
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/preview_comment.yml
+++ b/.github/workflows/preview_comment.yml
@@ -1,0 +1,23 @@
+name: preview_comment.yml
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v2
+        env:
+          URL_SLUG: ${{ github.event.number }}-${{ github.head_ref }}
+        with:
+          message: |
+            Preview is being built...
+            
+            Preview will be available at https://egui-pr-preview.github.io/pr/${{ env.URL_SLUG }}
+            
+            View snapshot changes at [kitdiff](https://rerun-io.github.io/kitdiff/?url=${{ github.event.pull_request.html_url }})
+          comment_tag: 'egui-preview'
+


### PR DESCRIPTION
- I broke this in #7577 

`pull_request` workflows don't have permission to comment, so we have to do this via a `pull_request_target` workflow.

The point of this early comment is that the kitdiff link appears as soon as possible and isn't dependent on the preview build suceeding. 