### PR TITLE
Use custom github token for commiting snapshots

### DIFF
--- a/.github/workflows/update_kittest_snapshots.yml
+++ b/.github/workflows/update_kittest_snapshots.yml
@@ -23,7 +23,9 @@ jobs:
           lfs: true
           # We can't use the workflow token since that would prevent our commit to cause further workflows.
           # See https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
-          token: '${{ secrets.GITHUB_TOKEN }}'
+          # This token should be a personal access token with at least Read and write permission to `Contents`.
+          # The commit action below will use the token this the code was checked out with.
+          token: '${{ secrets.SNAPSHOT_COMMIT_GITHUB_TOKEN }}'
 
       - name: Accept snapshots
         env:


### PR DESCRIPTION
... to ensure that workflows are run


