### PR TITLE
Fix popups immediately closing on mouse button release

### DIFF
--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -594,7 +594,7 @@ impl<'a> Popup<'a> {
         });
 
         // If the popup was just opened with a click, we don't want to immediately close it again.
-        let close_click = was_open_last_frame && ctx.input(|i| i.pointer.any_click());
+        let close_click = was_open_last_frame && ctx.input(|i| i.pointer.any_pressed());
 
         let closed_by_click = match close_behavior {
             PopupCloseBehavior::CloseOnClick => close_click,


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [x] I have followed the instructions in the PR template

The PR makes it so a popup is closed on a press of a button but not click (i.e. release) of a button - this fixes the issue of a popup immediately closing after releasing a button.

I can reproduce the issue with the following code in `bevy_egui`:

```rust
    let popup = egui::Popup::new(
        egui::Id::new("A unique popup"),
        ctx.clone(),
        egui::PopupAnchor::PointerFixed,
        egui::LayerId::new(egui::Order::Foreground, egui::Id::new("popup layer")),
    );

    let mut open_command = None;
    for message in mouse_button_input_reader.read() {
        if message.state.is_pressed() && message.button == MouseButton::Right {
            open_command = Some(SetOpenCommand::Bool(true));
        }
    }

    popup.open_memory(open_command).show(|ui| {
        ui.label("This is a popup");
    });
```

When a popup is open due to a "press" event, it will get closed on the next "release" event (as they aren't likely to happen at the same frame). One could argue that the intended usage here is to open a popup only on a release of a button, but for users that have it open on a button press the current `egui` behavior could be counterintuitive.

I haven't tested this extensively, but if you find that this fix breaks any other behavior or some intended design where we do expect a popup close only on a button release, feel free to close this.
