### PR TITLE
[eframe/web] Clear hidden <input> when focusing

### DIFF
--- a/crates/eframe/src/web/text_agent.rs
+++ b/crates/eframe/src/web/text_agent.rs
@@ -177,6 +177,8 @@ impl TextAgent {
 
         log::trace!("Focusing text agent");
 
+        self.input.set_value("");
+
         if let Err(err) = self.input.focus() {
             log::error!("failed to set focus: {}", super::string_from_js_value(&err));
         }


### PR DESCRIPTION
This small PR clears the hidden `<input>` element, when it is focused (not the actual TextEdit, just the helper element for Web). This prevents that content from one TextEdit is leaked into another one.

* Closes <https://github.com/emilk/egui/issues/7632
* [x ] I have followed the instructions in the PR template
