### PR TITLE
Fix kitdiff links in pr comments

### DIFF
--- a/.github/workflows/preview_deploy.yml
+++ b/.github/workflows/preview_deploy.yml
@@ -62,6 +62,6 @@ jobs:
             Preview available at https://egui-pr-preview.github.io/pr/${{ env.URL_SLUG }}
             Note that it might take a couple seconds for the update to show up after the preview_build workflow has completed.
             
-            View snapshot changes at [kitdiff](https://rerun-io.github.io/kitdiff/?url=${{ github.event.pull_request.html_url }})
+            View snapshot changes at [kitdiff](https://rerun-io.github.io/kitdiff/?url=https://github.com/emilk/egui/pull/${{ env.PR_NUMBER }})
           pr_number: ${{ env.PR_NUMBER }}
           comment_tag: 'egui-preview'


### PR DESCRIPTION
The pr data is not accessible in this workflow so I have to hardcode the url with the pr number