### PR TITLE
Improve accessibility and testability of `ComboBox`

### DIFF
--- a/crates/egui/src/containers/combo_box.rs
+++ b/crates/egui/src/containers/combo_box.rs
@@ -239,7 +239,7 @@ impl ComboBox {
             let mut ir = combo_box_dyn(
                 ui,
                 button_id,
-                selected_text,
+                selected_text.clone(),
                 menu_contents,
                 icon,
                 wrap_mode,
@@ -247,14 +247,16 @@ impl ComboBox {
                 popup_style,
                 (width, height),
             );
+            ir.response.widget_info(|| {
+                let mut info = WidgetInfo::new(WidgetType::ComboBox);
+                info.enabled = ui.is_enabled();
+                info.current_text_value = Some(selected_text.text().to_owned());
+                info
+            });
             if let Some(label) = label {
-                ir.response.widget_info(|| {
-                    WidgetInfo::labeled(WidgetType::ComboBox, ui.is_enabled(), label.text())
-                });
-                ir.response |= ui.label(label);
-            } else {
-                ir.response
-                    .widget_info(|| WidgetInfo::labeled(WidgetType::ComboBox, ui.is_enabled(), ""));
+                let label_response = ui.label(label);
+                ir.response = ir.response.labelled_by(label_response.id);
+                ir.response |= label_response;
             }
             ir
         })

--- a/tests/egui_tests/tests/regression_tests.rs
+++ b/tests/egui_tests/tests/regression_tests.rs
@@ -61,3 +61,17 @@ fn text_edit_rtl() {
         harness.snapshot(format!("text_edit_rtl_{i}"));
     }
 }
+
+#[test]
+fn combobox_should_have_value() {
+    let harness = Harness::new_ui(|ui| {
+        egui::ComboBox::from_label("Select an option")
+            .selected_text("Option 1")
+            .show_ui(ui, |_ui| {});
+    });
+
+    assert_eq!(
+        harness.get_by_label("Select an option").value().as_deref(),
+        Some("Option 1")
+    );
+}


### PR DESCRIPTION
Changed it to use labeled_by to avoid kittest finding the label when searching for the ComboBox and also set the value so a screen reader will know what's selected.