### PR TITLE
Don't enable `arboard` on iOS

### DIFF
--- a/crates/egui-winit/src/clipboard.rs
+++ b/crates/egui-winit/src/clipboard.rs
@@ -5,7 +5,10 @@ use raw_window_handle::RawDisplayHandle;
 /// If the "clipboard" feature is off, or we cannot connect to the OS clipboard,
 /// then a fallback clipboard that just works within the same app is used instead.
 pub struct Clipboard {
-    #[cfg(all(feature = "arboard", not(target_os = "android")))]
+    #[cfg(all(
+        not(any(target_os = "android", target_os = "ios")),
+        feature = "arboard",
+    ))]
     arboard: Option<arboard::Clipboard>,
 
     #[cfg(all(
@@ -28,7 +31,10 @@ impl Clipboard {
     /// Construct a new instance
     pub fn new(_raw_display_handle: Option<RawDisplayHandle>) -> Self {
         Self {
-            #[cfg(all(feature = "arboard", not(target_os = "android")))]
+            #[cfg(all(
+                not(any(target_os = "android", target_os = "ios")),
+                feature = "arboard",
+            ))]
             arboard: init_arboard(),
 
             #[cfg(all(
@@ -68,7 +74,10 @@ impl Clipboard {
             };
         }
 
-        #[cfg(all(feature = "arboard", not(target_os = "android")))]
+        #[cfg(all(
+            not(any(target_os = "android", target_os = "ios")),
+            feature = "arboard",
+        ))]
         if let Some(clipboard) = &mut self.arboard {
             return match clipboard.get_text() {
                 Ok(text) => Some(text),
@@ -98,7 +107,10 @@ impl Clipboard {
             return;
         }
 
-        #[cfg(all(feature = "arboard", not(target_os = "android")))]
+        #[cfg(all(
+            not(any(target_os = "android", target_os = "ios")),
+            feature = "arboard",
+        ))]
         if let Some(clipboard) = &mut self.arboard {
             if let Err(err) = clipboard.set_text(text) {
                 log::error!("arboard copy/cut error: {err}");
@@ -110,7 +122,10 @@ impl Clipboard {
     }
 
     pub fn set_image(&mut self, image: &egui::ColorImage) {
-        #[cfg(all(feature = "arboard", not(target_os = "android")))]
+        #[cfg(all(
+            not(any(target_os = "android", target_os = "ios")),
+            feature = "arboard",
+        ))]
         if let Some(clipboard) = &mut self.arboard {
             if let Err(err) = clipboard.set_image(arboard::ImageData {
                 width: image.width(),
@@ -130,7 +145,10 @@ impl Clipboard {
     }
 }
 
-#[cfg(all(feature = "arboard", not(target_os = "android")))]
+#[cfg(all(
+    not(any(target_os = "android", target_os = "ios")),
+    feature = "arboard",
+))]
 fn init_arboard() -> Option<arboard::Clipboard> {
     profiling::function_scope!();
 


### PR DESCRIPTION
`arboard` [doesn't support support iOS yet](https://github.com/1Password/arboard/pull/103), so this PR adds iOS to the conditions that prevent `arboard` from being enabled.

Launching an app on a physical device results in a long timeout (~8s) while trying to connect to the X11 server (the timeout is immediate when launching on a simulator), with the following trace:

```
egui_winit::clipboard: Failed to initialize arboard clipboard: Unknown error while interacting with the clipboard: X11 server connection timed out because it was unreachable
```

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [x] I have followed the instructions in the PR template
