### PR TITLE
grid: expose cell alignment parameter

### DIFF
--- a/crates/egui/src/grid.rs
+++ b/crates/egui/src/grid.rs
@@ -79,6 +79,7 @@ pub(crate) struct GridLayout {
     min_cell_size: Vec2,
     max_cell_size: Vec2,
     color_picker: Option<ColorPickerFn>,
+    cell_alignment: Align2,
 
     // Cursor:
     col: usize,
@@ -114,6 +115,7 @@ impl GridLayout {
             min_cell_size: ui.spacing().interact_size,
             max_cell_size: Vec2::INFINITY,
             color_picker: None,
+            cell_alignment: Align2::LEFT_CENTER,
 
             col: 0,
             row: 0,
@@ -184,10 +186,8 @@ impl GridLayout {
         Rect::from_min_size(cursor.min, size).round_ui()
     }
 
-    #[expect(clippy::unused_self)]
     pub(crate) fn align_size_within_rect(&self, size: Vec2, frame: Rect) -> Rect {
-        // TODO(emilk): allow this alignment to be customized
-        Align2::LEFT_CENTER
+        self.cell_alignment
             .align_size_within_rect(size, frame)
             .round_ui()
     }
@@ -318,6 +318,7 @@ pub struct Grid {
     spacing: Option<Vec2>,
     start_row: usize,
     color_picker: Option<ColorPickerFn>,
+    cell_alignment: Align2,
 }
 
 impl Grid {
@@ -332,6 +333,7 @@ impl Grid {
             spacing: None,
             start_row: 0,
             color_picker: None,
+            cell_alignment: Align2::LEFT_CENTER,
         }
     }
 
@@ -405,6 +407,14 @@ impl Grid {
         self.start_row = start_row;
         self
     }
+
+    /// Change the default alignment of content inside grid cells.
+    /// Default: [`crate::Align2::LEFT_CENTER`]
+    #[inline]
+    pub fn with_cell_alignment(mut self, alignment: Align2) -> Self {
+        self.cell_alignment = alignment;
+        self
+    }
 }
 
 impl Grid {
@@ -426,6 +436,7 @@ impl Grid {
             spacing,
             start_row,
             mut color_picker,
+            cell_alignment,
         } = self;
         let min_col_width = min_col_width.unwrap_or_else(|| ui.spacing().interact_size.x);
         let min_row_height = min_row_height.unwrap_or_else(|| ui.spacing().interact_size.y);
@@ -466,6 +477,7 @@ impl Grid {
                     max_cell_size,
                     spacing,
                     row: start_row,
+                    cell_alignment,
                     ..GridLayout::new(ui, id, prev_state)
                 };
 

--- a/crates/egui_demo_lib/src/demo/tests/grid_test.rs
+++ b/crates/egui_demo_lib/src/demo/tests/grid_test.rs
@@ -5,6 +5,7 @@ pub struct GridTest {
     min_col_width: f32,
     max_col_width: f32,
     text_length: usize,
+    cell_alignment: egui::Align2,
 }
 
 impl Default for GridTest {
@@ -15,6 +16,7 @@ impl Default for GridTest {
             min_col_width: 10.0,
             max_col_width: 200.0,
             text_length: 10,
+            cell_alignment: egui::Align2::LEFT_CENTER,
         }
     }
 }
@@ -43,6 +45,56 @@ impl crate::View for GridTest {
         ui.add(egui::Slider::new(&mut self.num_cols, 0..=5).text("Columns"));
         ui.add(egui::Slider::new(&mut self.num_rows, 0..=20).text("Rows"));
 
+        ui.label("Cell alignment");
+        egui::Grid::new("cell-alignment").show(ui, |ui| {
+            ui.selectable_value(&mut self.cell_alignment, egui::Align2::LEFT_TOP, "LEFT_TOP");
+            ui.selectable_value(
+                &mut self.cell_alignment,
+                egui::Align2::CENTER_TOP,
+                "CENTER_TOP",
+            );
+            ui.selectable_value(
+                &mut self.cell_alignment,
+                egui::Align2::RIGHT_TOP,
+                "RIGHT_TOP",
+            );
+            ui.end_row();
+
+            ui.selectable_value(
+                &mut self.cell_alignment,
+                egui::Align2::LEFT_CENTER,
+                "LEFT_CENTER",
+            );
+            ui.selectable_value(
+                &mut self.cell_alignment,
+                egui::Align2::CENTER_CENTER,
+                "CENTER_CENTER",
+            );
+            ui.selectable_value(
+                &mut self.cell_alignment,
+                egui::Align2::RIGHT_CENTER,
+                "RIGHT_CENTER",
+            );
+            ui.end_row();
+
+            ui.selectable_value(
+                &mut self.cell_alignment,
+                egui::Align2::LEFT_BOTTOM,
+                "LEFT_BOTTOM",
+            );
+            ui.selectable_value(
+                &mut self.cell_alignment,
+                egui::Align2::CENTER_BOTTOM,
+                "CENTER_BOTTOM",
+            );
+            ui.selectable_value(
+                &mut self.cell_alignment,
+                egui::Align2::RIGHT_BOTTOM,
+                "RIGHT_BOTTOM",
+            );
+            ui.end_row();
+        });
+
         ui.separator();
 
         let words = [
@@ -54,6 +106,7 @@ impl crate::View for GridTest {
             .striped(true)
             .min_col_width(self.min_col_width)
             .max_col_width(self.max_col_width)
+            .with_cell_alignment(self.cell_alignment)
             .show(ui, |ui| {
                 for row in 0..self.num_rows {
                     for col in 0..self.num_cols {


### PR DESCRIPTION
It's currently done globally, for all cell grids.
[cell_alignment.webm](https://github.com/user-attachments/assets/7c7d09da-1430-4995-973f-8948e056b3f1)
