### PR TITLE
Allow multiple atoms in `Button::shortcut_text` and `right_text`

### DIFF
--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -223,22 +223,29 @@ impl<'a> Button<'a> {
     ///
     /// See also [`Self::right_text`].
     #[inline]
-    pub fn shortcut_text(mut self, shortcut_text: impl Into<Atom<'a>>) -> Self {
-        let mut atom = shortcut_text.into();
-        atom.kind = match atom.kind {
-            AtomKind::Text(text) => AtomKind::Text(text.weak()),
-            other => other,
-        };
+    pub fn shortcut_text(mut self, shortcut_text: impl IntoAtoms<'a>) -> Self {
         self.layout.push_right(Atom::grow());
-        self.layout.push_right(atom);
+
+        for mut atom in shortcut_text.into_atoms() {
+            atom.kind = match atom.kind {
+                AtomKind::Text(text) => AtomKind::Text(text.weak()),
+                other => other,
+            };
+            self.layout.push_right(atom);
+        }
+
         self
     }
 
     /// Show some text on the right side of the button.
     #[inline]
-    pub fn right_text(mut self, right_text: impl Into<Atom<'a>>) -> Self {
+    pub fn right_text(mut self, right_text: impl IntoAtoms<'a>) -> Self {
         self.layout.push_right(Atom::grow());
-        self.layout.push_right(right_text.into());
+
+        for atom in right_text.into_atoms() {
+            self.layout.push_right(atom);
+        }
+
         self
     }
 

--- a/tests/egui_tests/tests/snapshots/button_shortcut.png
+++ b/tests/egui_tests/tests/snapshots/button_shortcut.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5befd84158b582c79a968f36e43c7017187b364824eb4470b048d133e62f9360
+size 1600

--- a/tests/egui_tests/tests/test_atoms.rs
+++ b/tests/egui_tests/tests/test_atoms.rs
@@ -108,3 +108,14 @@ fn test_intrinsic_size() {
         }
     }
 }
+
+#[test]
+fn test_button_shortcut_text() {
+    let mut harness = HarnessBuilder::default().build_ui(|ui| {
+        ui.add(egui::Button::new("Click me").shortcut_text(("1", "2", "3")));
+    });
+    harness.run();
+    harness.fit_contents();
+
+    harness.snapshot("button_shortcut");
+}


### PR DESCRIPTION
Useful when intermixing text and icons (e.g. for modifiers)