### PR TITLE
containers/modal: Fix double negative in documentation

### DIFF
--- a/crates/egui/src/containers/modal.rs
+++ b/crates/egui/src/containers/modal.rs
@@ -11,7 +11,7 @@ use crate::{
 ///
 /// You can show multiple modals on top of each other. The topmost modal will always be
 /// the most recently shown one.
-/// If multiple modals are newly shown in the same frame, the order of the modals not undefined
+/// If multiple modals are newly shown in the same frame, the order of the modals is undefined
 /// (either first or second could be top).
 pub struct Modal {
     pub area: Area,


### PR DESCRIPTION
The double negative of not undefined conflicted with the example given in parens, This just removes the double negative to agree with the rest of the doc line. I have *not* audited to see if this ordering actually is strictly forced elsewhere. (Apologies for the smallest documentation pull request ever)

* [x] I have followed the instructions in the PR template
