### PR TITLE
[issue - dont merge] Button::is_pointer_button_down_on returns false

### DIFF
--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -45,10 +45,15 @@ impl eframe::App for MyApp {
                     .labelled_by(name_label.id);
             });
             ui.add(egui::Slider::new(&mut self.age, 0..=120).text("age"));
-            if ui.button("Increment").clicked() {
+            if ui.button("Increment").is_pointer_button_down_on() {
                 self.age += 1;
+                ui.label(format!("Hello '{}', age {}", self.name, self.age));
             }
-            ui.label(format!("Hello '{}', age {}", self.name, self.age));
+
+            if ui.label("Clickable label").is_pointer_button_down_on() {
+                self.age += 1;
+                ui.label(format!("Hello '{}', age {}", self.name, self.age));
+            }
 
             ui.image(egui::include_image!(
                 "../../../crates/egui/assets/ferris.png"


### PR DESCRIPTION
<!--
First look if there is already a similar bug report. If there is, upvote the issue with 👍

Please also check if the bug is still present in latest main! Do so by adding the following lines to your Cargo.toml:


[patch.crates-io]
egui = { git = "https://github.com/emilk/egui", branch = "main" }
# if you're using eframe:
eframe = { git = "https://github.com/emilk/egui", branch = "main" }
-->

**Describe the bug**
<!-- A clear and concise description of what the bug is. An image is good, a gif or movie is better! -->

`Button::is_pointer_button_down_on()` starts returning false after a while when still holding down the mouse button when the gui is refreshed(for example by the blinking cursor shown in the image)

**To Reproduce**
Steps to reproduce the behavior:
1. In the example modified in the PR
2. Click into the "Name" field so the cursor blinks
3. Hold down on the button, this now shows "Hello '{}', age {}"
4. Wait a second while keeping the button pressed
5. Boom - egui thinks the button is released while it is not

**Expected behavior**
<!-- A clear and concise description of what you expected to happen. -->
I would have expected the button to not be released

**Screenshots**
<!-- If applicable, add screenshots to help explain your problem. -->
![egui-bug](https://github.com/user-attachments/assets/da3763e2-f606-4eac-9caf-14c2641e2b3f)

The mouse is held over the button with the left mouse button kept down. I release the mouse which can be seen when the light border appears on the button

**Desktop (please complete the following information):**
 - OS: 6.16.8-1-MANJARO with KDE X11


**Additional context**
Same thing on the clickable label works fine, no issue.
