### PR TITLE
Fix media type with optional parameters

### DIFF
--- a/crates/egui_extras/src/loaders/image_loader.rs
+++ b/crates/egui_extras/src/loaders/image_loader.rs
@@ -50,8 +50,11 @@ fn is_supported_mime(mime: &str) -> bool {
         }
     }
 
+    // Some servers may return a media type with an optional parameter, e.g. "image/jpeg; charset=utf-8".
+    let (mime_type, _) = mime.split_once(';').unwrap_or((mime, ""));
+
     // Uses only the enabled image crate features
-    ImageFormat::from_mime_type(mime).is_some_and(|format| format.reading_enabled())
+    ImageFormat::from_mime_type(mime_type).is_some_and(|format| format.reading_enabled())
 }
 
 impl ImageLoader for ImageCrateLoader {


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

I am having an issue loading this image "https://stacks.stanford.edu/image/iiif/wy534zh7137/SULAIR_rosette/full/400,/0/default.jpg". It has a mime type of "image/jpeg; charset=utf-8", which is not common.

The code doesn't parse the full string that includes the optional parameter "charset=utf-8" to create the jpeg image format. 

A line is added to take only the mime type in the media type before the ";" and ignore the optional parameters. 

* Closes <https://github.com/emilk/egui/issues/7738>
* [x] I have followed the instructions in the PR template
