### PR TITLE
Enable x11 or wayland when running check script on Linux

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -33,21 +33,25 @@ cargo check --quiet  -p egui_demo_app --lib --target wasm32-unknown-unknown --al
 cargo test  --quiet --all-targets --all-features
 cargo test  --quiet --doc # slow - checks all doc-tests
 
-cargo check --quiet -p eframe --no-default-features --features "glow"
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    cargo check --quiet -p eframe --no-default-features --features "glow","x11"
+    cargo check --quiet -p eframe --no-default-features --features "glow","wayland"
     cargo check --quiet -p eframe --no-default-features --features "wgpu","x11"
     cargo check --quiet -p eframe --no-default-features --features "wgpu","wayland"
 else
+    cargo check --quiet -p eframe --no-default-features --features "glow"
     cargo check --quiet -p eframe --no-default-features --features "wgpu"
 fi
 
 cargo check --quiet -p egui --no-default-features --features "serde"
-cargo check --quiet -p egui_demo_app --no-default-features --features "glow"
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    cargo check --quiet -p egui_demo_app --no-default-features --features "glow","x11"
+    cargo check --quiet -p egui_demo_app --no-default-features --features "glow","wayland"
     cargo check --quiet -p egui_demo_app --no-default-features --features "wgpu","x11"
     cargo check --quiet -p egui_demo_app --no-default-features --features "wgpu","wayland"
 else
+    cargo check --quiet -p egui_demo_app --no-default-features --features "glow"
     cargo check --quiet -p egui_demo_app --no-default-features --features "wgpu"
 fi
 


### PR DESCRIPTION

* [x] I have followed the instructions in the PR template
