### PR TITLE
plugin: export `TypedPluginGuard` and `TypedPluginHandle`

### DIFF
--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -413,7 +413,7 @@ pub mod os;
 mod painter;
 mod pass_state;
 pub(crate) mod placer;
-mod plugin;
+pub mod plugin;
 pub mod response;
 mod sense;
 pub mod style;

--- a/crates/egui/src/plugin.rs
+++ b/crates/egui/src/plugin.rs
@@ -55,6 +55,9 @@ pub(crate) struct PluginHandle {
     plugin: Box<dyn Plugin>,
 }
 
+/// A typed handle to a registered [`Plugin`].
+///
+/// Use [`Self::lock`] to access the plugin.
 pub struct TypedPluginHandle<P: Plugin> {
     handle: Arc<Mutex<PluginHandle>>,
     _type: std::marker::PhantomData<P>,
@@ -68,6 +71,9 @@ impl<P: Plugin> TypedPluginHandle<P> {
         }
     }
 
+    /// Lock the plugin for access.
+    ///
+    /// Returns a guard that dereferences to the plugin.
     pub fn lock(&self) -> TypedPluginGuard<'_, P> {
         TypedPluginGuard {
             guard: self.handle.lock(),
@@ -76,6 +82,7 @@ impl<P: Plugin> TypedPluginHandle<P> {
     }
 }
 
+/// A guard that provides access to a [`Plugin`].
 pub struct TypedPluginGuard<'a, P: Plugin> {
     guard: MutexGuard<'a, PluginHandle>,
     _type: std::marker::PhantomData<P>,


### PR DESCRIPTION
We have made this patch internally on our fork as we use `TypedPluginGuard` and `TypedPluginHandle` internally

* [x] I have followed the instructions in the PR template
