### PR TITLE
Heed constrain rect when auto-positioning windows

### DIFF
--- a/crates/egui/src/containers/area.rs
+++ b/crates/egui/src/containers/area.rs
@@ -459,7 +459,7 @@ impl Area {
             state.pivot_pos = Some(new_pos);
         }
         state.pivot_pos.get_or_insert_with(|| {
-            default_pos.unwrap_or_else(|| automatic_area_position(ctx, layer_id))
+            default_pos.unwrap_or_else(|| automatic_area_position(ctx, constrain_rect, layer_id))
         });
         state.interactable = interactable;
 
@@ -699,7 +699,7 @@ fn pointer_pressed_on_area(ctx: &Context, layer_id: LayerId) -> bool {
     }
 }
 
-fn automatic_area_position(ctx: &Context, layer_id: LayerId) -> Pos2 {
+fn automatic_area_position(ctx: &Context, constrain_rect: Rect, layer_id: LayerId) -> Pos2 {
     let mut existing: Vec<Rect> = ctx.memory(|mem| {
         mem.areas()
             .visible_windows()
@@ -710,13 +710,9 @@ fn automatic_area_position(ctx: &Context, layer_id: LayerId) -> Pos2 {
     });
     existing.sort_by_key(|r| r.left().round() as i32);
 
-    // NOTE: for the benefit of the egui demo, we position the windows so they don't
-    // cover the side panels, which means we use `available_rect` here instead of `constrain_rect` or `screen_rect`.
-    let available_rect = ctx.globally_available_rect();
-
     let spacing = 16.0;
-    let left = available_rect.left() + spacing;
-    let top = available_rect.top() + spacing;
+    let left = constrain_rect.left() + spacing;
+    let top = constrain_rect.top() + spacing;
 
     if existing.is_empty() {
         return pos2(left, top);
@@ -750,14 +746,14 @@ fn automatic_area_position(ctx: &Context, layer_id: LayerId) -> Pos2 {
 
     // Find first column with some available space at the bottom of it:
     for col_bb in &column_bbs {
-        if col_bb.bottom() < available_rect.center().y {
+        if col_bb.bottom() < constrain_rect.center().y {
             return pos2(col_bb.left(), col_bb.bottom() + spacing);
         }
     }
 
     // Maybe we can fit a new column?
     let rightmost = column_bbs.last().unwrap().right();
-    if rightmost + 200.0 < available_rect.right() {
+    if rightmost + 200.0 < constrain_rect.right() {
         return pos2(rightmost + spacing, top);
     }
 


### PR DESCRIPTION
The default `Window` and `Area` position will now respect `constrain_to` rectangle