### PR TITLE
Show menu without a click if another menu is open

### DIFF
--- a/crates/egui/src/containers/menu.rs
+++ b/crates/egui/src/containers/menu.rs
@@ -11,7 +11,8 @@
 use crate::style::StyleModifier;
 use crate::{
     Button, Color32, Context, Frame, Id, InnerResponse, IntoAtoms, Layout, Popup,
-    PopupCloseBehavior, Response, Style, Ui, UiBuilder, UiKind, UiStack, UiStackInfo, Widget as _,
+    PopupCloseBehavior, Response, SetOpenCommand, Style, Ui, UiBuilder, UiKind, UiStack,
+    UiStackInfo, Widget as _,
 };
 use emath::{Align, RectAlign, Vec2, vec2};
 use epaint::Stroke;
@@ -325,7 +326,15 @@ impl<'a> MenuButton<'a> {
         let response = self.button.ui(ui);
         let mut config = self.config.unwrap_or_else(|| MenuConfig::find(ui));
         config.bar = false;
-        let inner = Popup::menu(&response)
+
+        let mut menu = Popup::menu(&response);
+        if Popup::is_any_open(ui.ctx()) && response.hovered() {
+            // If another menu is already open, then open this menu on hover
+            // (instead of requiring a click).  This is a typical UI for
+            // top-of-window menu bars.
+            menu = menu.open_memory(Some(SetOpenCommand::Bool(true)));
+        }
+        let inner = menu
             .close_behavior(config.close_behavior)
             .style(config.style.clone())
             .info(


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

https://github.com/emilk/egui/issues/4607 accidentally removed the behavior where – once a menu is open – moving the mouse to another menu opens that one instead (on hover, without requiring a click).  This is a pretty easy fix!

* Closes <https://github.com/emilk/egui/issues/7346>
* [X] I have followed the instructions in the PR template
