### PR TITLE
Slightly change interact behavior around thin splitters

### DIFF
--- a/crates/egui/src/hit_test.rs
+++ b/crates/egui/src/hit_test.rs
@@ -2,7 +2,7 @@ use ahash::HashMap;
 
 use emath::TSTransform;
 
-use crate::{LayerId, Pos2, Rect, Sense, WidgetRect, WidgetRects, ahash, emath, id::IdSet};
+use crate::{LayerId, Pos2, Sense, WidgetRect, WidgetRects, ahash, emath, id::IdSet};
 
 /// Result of a hit-test against [`WidgetRects`].
 ///
@@ -427,16 +427,6 @@ fn find_closest_within(
 
         let dist_sq = widget.interact_rect.distance_sq_to_pos(pos);
 
-        if let Some(closest) = closest
-            && dist_sq == closest_dist_sq
-        {
-            // It's a tie! Pick the thin candidate over the thick one.
-            // This makes it easier to hit a thin resize-handle, for instance:
-            if should_prioritize_hits_on_back(closest.interact_rect, widget.interact_rect) {
-                continue;
-            }
-        }
-
         // In case of a tie, take the last one = the one on top.
         if dist_sq <= closest_dist_sq {
             closest_dist_sq = dist_sq;
@@ -445,27 +435,6 @@ fn find_closest_within(
     }
 
     closest
-}
-
-/// Should we prioritize hits on `back` over those on `front`?
-///
-/// `back` should be behind the `front` widget.
-///
-/// Returns true if `back` is a small hit-target and `front` is not.
-fn should_prioritize_hits_on_back(back: Rect, front: Rect) -> bool {
-    if front.contains_rect(back) {
-        return false; // back widget is fully occluded; no way to hit it
-    }
-
-    // Reduce each rect to its width or height, whichever is smaller:
-    let back = back.width().min(back.height());
-    let front = front.width().min(front.height());
-
-    // These are hard-coded heuristics that could surely be improved.
-    let back_is_much_thinner = back <= 0.5 * front;
-    let back_is_thin = back <= 16.0;
-
-    back_is_much_thinner && back_is_thin
 }
 
 #[cfg(test)]

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1392,7 +1392,7 @@ impl Default for Interaction {
     fn default() -> Self {
         Self {
             interact_radius: 5.0,
-            resize_grab_radius_side: 5.0,
+            resize_grab_radius_side: 3.0,
             resize_grab_radius_corner: 10.0,
             show_tooltips_only_when_still: true,
             tooltip_delay: 0.5,


### PR DESCRIPTION
* Added in https://github.com/emilk/egui/pull/5468
* Related to https://github.com/emilk/egui/pull/7803

The code doesn't seem to longer be needed. Interacting with a resize splitter isn't very difficult, and I never liked that special case.