### PR TITLE
Remove `font_weight` API

### DIFF
--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -337,9 +337,6 @@ pub struct FontFace {
     font: FontCell,
     tweak: FontTweak,
 
-    /// The font weight (100-900) if available from the font file.
-    weight: Option<u16>,
-
     /// Variable font location (for weight axis, etc.)
     location: skrifa::instance::Location,
     glyph_info_cache: ahash::HashMap<char, GlyphInfo>,
@@ -436,16 +433,10 @@ impl FontFace {
             name,
             font,
             tweak,
-            weight,
             location,
             glyph_info_cache: Default::default(),
             glyph_alloc_cache: Default::default(),
         })
-    }
-
-    /// Get the font weight (100-900) if available from the font file.
-    pub fn weight(&self) -> Option<u16> {
-        self.weight
     }
 
     /// Code points that will always be replaced by the replacement character.

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -861,26 +861,6 @@ impl FontsImpl {
             atlas: &mut self.atlas,
         }
     }
-
-    /// Get the weight of a font by name, if available.
-    ///
-    /// Returns the weight value (100-900) read from the font file's OS/2 table,
-    /// or `None` if the font is not found or doesn't contain weight information.
-    ///
-    /// # Example
-    /// ```
-    /// # use epaint::text::{FontDefinitions, FontsImpl};
-    /// # use epaint::TextOptions;
-    /// let fonts_impl = FontsImpl::new(TextOptions::default(), FontDefinitions::default());
-    /// if let Some(weight) = fonts_impl.font_weight("Hack") {
-    ///     println!("Hack font weight: {}", weight);
-    /// }
-    /// ```
-    pub fn font_weight(&self, font_name: &str) -> Option<u16> {
-        let key = self.fonts_by_name.get(font_name)?;
-        let font_face = self.fonts_by_id.get(key)?;
-        font_face.weight()
-    }
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
* Closes N/A
* [x] I have followed the instructions in the PR template

This appears to have snuck in as part of https://github.com/emilk/egui/pull/7790, which claimed to only be a bugfix but introduced a new `font_weight` method.

I believe there's no way to access the method from *public* code since it's only defined on `FontsImpl`, not the public-facing `FontsView`. It's also not used *privately* in epaint, meaning it's completely dead code.

Even if we *do* want some sort of future API for getting a font's weight, it requires more consideration. For instance, this API will return the default weight for variable fonts, which is not documented anywhere and might not be what we want.