### PR TITLE
Fix new `move_to_top` flag breaking widget order

### DIFF
--- a/crates/egui/src/widget_rect.rs
+++ b/crates/egui/src/widget_rect.rs
@@ -190,7 +190,7 @@ impl WidgetRects {
                     if move_to_top {
                         layer_widgets.remove(*idx_in_layer);
                         shift_layer_index_after = Some(*idx_in_layer);
-                        *idx_in_layer = layer_widgets.len() - 1;
+                        *idx_in_layer = layer_widgets.len();
                         layer_widgets.push(*existing);
                     } else {
                         layer_widgets[*idx_in_layer] = *existing;


### PR DESCRIPTION
* closes https://github.com/emilk/egui/issues/7812
* related https://github.com/emilk/egui/pull/7805

That pr introduced a bug that caused a mismatch in the `by_layer` / `by_id` widget rects. This should fix it by updating the index of all following widgets. Not super pretty and efficient, but I'm not sure if there's a better way. 

Maybe we could also just leave a "tombstone" / duplicate there in the by_layer map so we don't need to update the indexes?