### PR TITLE
Make Clipboard::new unsafe

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -125,6 +125,14 @@ impl State {
             ..Default::default()
         };
 
+        // SAFETY: The display handle is obtained from `display_target` which the caller
+        // is responsible for keeping alive. Winit display handles remain valid for the
+        // duration of the event loop, which outlives any `State` instance.
+        #[expect(unsafe_code)]
+        let clipboard = unsafe {
+            clipboard::Clipboard::new(display_target.display_handle().ok().map(|h| h.as_raw()))
+        };
+
         let mut slf = Self {
             egui_ctx,
             viewport_id,
@@ -133,10 +141,7 @@ impl State {
             pointer_pos_in_points: None,
             any_pointer_button_down: false,
             current_cursor_icon: None,
-
-            clipboard: clipboard::Clipboard::new(
-                display_target.display_handle().ok().map(|h| h.as_raw()),
-            ),
+            clipboard,
 
             simulate_touch_screen: false,
             pointer_touch_id: None,


### PR DESCRIPTION
The smithay-clipboard Clipboard::new method requires the display pointer to remain valid for the lifetime of the Clipboard. Since egui-winit's Clipboard::new cannot guarantee this invariant, it must be marked unsafe and pass the safety requirement to the caller.

Fixes #7743 (more details there)

* Closes <https://github.com/emilk/egui/issues/7743>
* [x] I have followed the instructions in the PR template
