### PR TITLE
Allow specifying override_redirect x11 window attribute

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1668,6 +1668,7 @@ pub fn create_winit_window_attributes(
 
         // x11
         window_type: _window_type,
+        override_redirect: _override_redirect,
 
         mouse_passthrough: _, // handled in `apply_viewport_builder_to_window`
         clamp_size_to_monitor_size: _, // Handled in `viewport_builder` in `epi_integration.rs`
@@ -1767,8 +1768,8 @@ pub fn create_winit_window_attributes(
 
     #[cfg(all(feature = "x11", target_os = "linux"))]
     {
+        use winit::platform::x11::WindowAttributesExtX11 as _;
         if let Some(window_type) = _window_type {
-            use winit::platform::x11::WindowAttributesExtX11 as _;
             use winit::platform::x11::WindowType;
             window_attributes = window_attributes.with_x11_window_type(vec![match window_type {
                 egui::X11WindowType::Normal => WindowType::Normal,
@@ -1786,6 +1787,9 @@ pub fn create_winit_window_attributes(
                 egui::X11WindowType::Combo => WindowType::Combo,
                 egui::X11WindowType::Dnd => WindowType::Dnd,
             }]);
+        }
+        if let Some(override_redirect) = _override_redirect {
+            window_attributes = window_attributes.with_override_redirect(override_redirect);
         }
     }
 

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -332,6 +332,7 @@ pub struct ViewportBuilder {
 
     // X11
     pub window_type: Option<X11WindowType>,
+    pub override_redirect: Option<bool>,
 }
 
 impl ViewportBuilder {
@@ -663,10 +664,19 @@ impl ViewportBuilder {
 
     /// ### On X11
     /// This sets the window type.
-    /// Maps directly to [`_NET_WM_WINDOW_TYPE`](https://specifications.freedesktop.org/wm-spec/wm-spec-1.5.html).
+    /// Maps directly to [`_NET_WM_WINDOW_TYPE`](https://specifications.freedesktop.org/wm/1.5/ar01s05.html#id-1.6.7).
     #[inline]
     pub fn with_window_type(mut self, value: X11WindowType) -> Self {
         self.window_type = Some(value);
+        self
+    }
+
+    /// ### On X11
+    /// This sets the override-redirect flag. When this is set to true the window type should be specified.
+    /// Maps directly to [`Override-redirect windows`](https://specifications.freedesktop.org/wm/1.5/ar01s02.html#id-1.3.13).
+    #[inline]
+    pub fn with_override_redirect(mut self, value: bool) -> Self {
+        self.override_redirect = Some(value);
         self
     }
 
@@ -706,6 +716,7 @@ impl ViewportBuilder {
             mouse_passthrough: new_mouse_passthrough,
             taskbar: new_taskbar,
             window_type: new_window_type,
+            override_redirect: new_override_redirect,
         } = new_vp_builder;
 
         let mut commands = Vec::new();
@@ -900,6 +911,11 @@ impl ViewportBuilder {
 
         if new_window_type.is_some() && self.window_type != new_window_type {
             self.window_type = new_window_type;
+            recreate_window = true;
+        }
+
+        if new_override_redirect.is_some() && self.override_redirect != new_override_redirect {
+            self.override_redirect = new_override_redirect;
             recreate_window = true;
         }
 


### PR DESCRIPTION
This adds functionality to propagate a value to winit's [with_override_redirect](https://docs.rs/winit/latest/winit/window/struct.WindowAttributes.html#method.with_override_redirect), see the [override-redirect windows](https://specifications.freedesktop.org/wm/1.5/ar01s02.html#id-1.3.13) section in the freedesktop specification. Implementation is pretty mechanical and follows the `window_type` precedent.

The most common use case of this is to bypass the window manager, which allows creating overlays that are active on all workspaces / virtual desktops. Without specifying this flag it is not possible to create an overlay that is present on all workspaces.

Without override_redirect the behaviour:

https://github.com/user-attachments/assets/d74e091c-c122-4f7e-b015-fb701fd47d73

With override_redirect set to true:

https://github.com/user-attachments/assets/df551c79-cce8-4bf1-b6db-93951fa00047


<details>

<summary>Minimal code example used in video.</summary>

```rust
use eframe::egui::{self, Color32, ViewportCommand};

pub fn main() -> eframe::Result {
    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
    let options = eframe::NativeOptions {
        viewport: egui::ViewportBuilder::default()
            .with_inner_size([1920.0, 1080.0]) // also needs a viewport command.
            // .with_resizable(false)
            // .with_fullscreen(true)
            // .with_maximized(true)
            .with_transparent(true) // also needs a viewport command.
            .with_mouse_passthrough(true) // also needs a viewport command.
            .with_always_on_top() // Trumped by override redirect.
            .with_decorations(false) // Trumped by override redirect.
            .with_titlebar_shown(false) // Trumped by override redirect.
            .with_override_redirect(true)
            .with_window_type(egui::X11WindowType::Splash),
        ..Default::default()
    };
    eframe::run_native(
        "FullScreenOverlay",
        options,
        Box::new(|_cc| Ok(Box::<MyApp>::default())),
    )
}

#[derive(Default)]
pub struct MyApp {
    counter: f32,
}

impl eframe::App for MyApp {
    fn clear_color(&self, _visuals: &egui::Visuals) -> [f32; 4] {
        egui::Rgba::TRANSPARENT.to_array()
    }
    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
        let ctx = ui.ctx();
        ctx.set_pixels_per_point(1.0); // Ensure correct pixel positioning.
        ctx.global_style_mut(|style| {
            // Make the background of the progress bar semi-transparent
            style.visuals.extreme_bg_color = egui::Color32::from_rgba_unmultiplied(10, 10, 10, 128);
        });
        ctx.send_viewport_cmd(ViewportCommand::InnerSize((1920.0, 1080.0).into()));
        ctx.send_viewport_cmd(ViewportCommand::MousePassthrough(true));
        ctx.send_viewport_cmd(ViewportCommand::WindowLevel(egui::WindowLevel::AlwaysOnTop));
        let pos = egui::pos2(1920.0 / 2.0 - 100.0, 1080.0 / 2.0 - 100.0);
        self.counter = self.counter.rem_euclid(1.0) + 0.005;
        egui::CentralPanel::default()
            .frame(egui::Frame::default().fill(Color32::TRANSPARENT))
            .show_inside(ui, |ui| {
                egui::Area::new(egui::Id::new("my_label"))
                    .fixed_pos(pos + egui::vec2(-100.0, 0.0))
                    .show(ui.ctx(), |ui| ui.label("Normal text"));
                egui::Area::new(egui::Id::new("my_progressbar"))
                    .fixed_pos(pos)
                    .default_size(egui::vec2(50.0, 200.0))
                    .show(ui.ctx(), |ui| {
                        ui.add(egui::widgets::ProgressBar::new(self.counter))
                    });
            });
    }
}


```

</details>


* [x] I have followed the instructions in the PR template
