### PR TITLE
egui_kittest: Close debug_open_snapshot temp file before viewing it

### DIFF
--- a/crates/egui_kittest/src/snapshot.rs
+++ b/crates/egui_kittest/src/snapshot.rs
@@ -721,11 +721,14 @@ impl<State> Harness<'_, State> {
             })
             .unwrap();
 
+        // Close temp file so it isn't locked when `open` tries to launch it (on Windows)
+        let path = temp_file.into_temp_path();
+
         #[expect(clippy::print_stdout)]
         {
             println!("Wrote debug snapshot to: {}", path.display());
         }
-        let result = open::that(path);
+        let result = open::that(&path);
         if let Err(err) = result {
             #[expect(clippy::print_stderr)]
             {


### PR DESCRIPTION
The image file written by debug_open_snapshot was being kept open by the `tempfile` object. On Windows, this prevented `open::that` from successfully launching the viewer sometimes because the file remained locked, which can be avoided by first releasing the file handle.
