### PR TITLE
Fix TextEdit demo consuming cmd+Y while not being focused

### DIFF
--- a/crates/egui_demo_lib/src/demo/text_edit.rs
+++ b/crates/egui_demo_lib/src/demo/text_edit.rs
@@ -66,7 +66,8 @@ impl crate::View for TextEditDemo {
             egui::Label::new("Press ctrl+Y to toggle the case of selected text (cmd+Y on Mac)"),
         );
 
-        if ui.input_mut(|i| i.consume_key(egui::Modifiers::COMMAND, egui::Key::Y))
+        if output.response.has_focus()
+            && ui.input_mut(|i| i.consume_key(egui::Modifiers::COMMAND, egui::Key::Y))
             && let Some(text_cursor_range) = output.cursor_range
         {
             use egui::TextBuffer as _;


### PR DESCRIPTION
The demo should check whether its `TextEdit` is focused before consuming <kbd>cmd+Y</kbd>, in case there are other demos that do the same and come after it. (I found this while experimenting with my own PoC binding and replicating this demo.)

| | |
|-|-|
| before | ![before](https://github.com/user-attachments/assets/7b89b511-473d-43a2-82d2-7c4e732b2f23) |
| after | ![after](https://github.com/user-attachments/assets/0b82a092-1603-476c-9f1b-2558afcd29c2) |

* Closes N/A
* [x] I have followed the instructions in the PR template
