### PR TITLE
Custom storage providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,6 +1129,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "custom_storage"
+version = "0.1.0"
+dependencies = [
+ "eframe",
+ "egui_demo_lib",
+ "egui_extras",
+ "env_logger",
+ "image",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "custom_style"
 version = "0.1.0"
 dependencies = [

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -202,8 +202,8 @@ pub trait App {
     ///
     /// On web the state is stored to "Local Storage".
     ///
-    /// On native the path is picked using [`crate::storage_dir`].
-    /// The path can be customized via [`NativeOptions::persistence_path`].
+    /// On native by default the path is picked using [`crate::storage_dir`].
+    /// The path can be customized via [`NativeOptions::storage_build`].
     fn save(&mut self, _storage: &mut dyn Storage) {}
 
     /// Called once on shutdown, after [`Self::save`].
@@ -294,12 +294,15 @@ pub enum HardwareAcceleration {
 #[derive(Default, Clone)]
 pub enum StorageProvider {
     #[default]
-    /// eframe will use a default
+    /// `eframe` will use a default
     /// data storage path for each target system.
+    /// The path is picked using [`crate::storage_dir`].
     Default,
+
     /// `eframe` will store the app state in the specified file in the ron format.
     /// On web builds, this will behave the same as [`Self::Default`].
     AtPath(std::path::PathBuf),
+
     /// Custom storage provider.
     /// It allows specifying function that will be called during context creation to provide
     Custom(fn(&str) -> Option<Box<dyn Storage>>),
@@ -499,7 +502,7 @@ impl Default for NativeOptions {
 
             persist_window: true,
 
-            storage_build: StorageProviderBuild::Default,
+            storage_build: StorageProvider::Default,
 
             dithering: true,
 
@@ -587,7 +590,7 @@ impl Default for WebOptions {
             should_prevent_default: Box::new(|_| true),
 
             max_fps: None,
-            storage_build: StorageProviderBuild::Default,
+            storage_build: StorageProvider::Default,
         }
     }
 }

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -290,6 +290,21 @@ pub enum HardwareAcceleration {
     Off,
 }
 
+/// Specifies how the app will create a storage provider
+#[derive(Default, Clone)]
+pub enum StorageProvider {
+    #[default]
+    /// eframe will use a default
+    /// data storage path for each target system.
+    Default,
+    /// `eframe` will store the app state in the specified file in the ron format.
+    /// On web builds, this will behave the same as [`Self::Default`].
+    AtPath(std::path::PathBuf),
+    /// Custom storage provider.
+    /// It allows specifying function that will be called during context creation to provide
+    Custom(fn(&str) -> Option<Box<dyn Storage>>),
+}
+
 /// Options controlling the behavior of a native window.
 ///
 /// Additional windows can be opened using (egui viewports)[`egui::viewport`].
@@ -402,9 +417,9 @@ pub struct NativeOptions {
     /// persisted (only if the "persistence" feature is enabled).
     pub persist_window: bool,
 
-    /// The folder where `eframe` will store the app state. If not set, eframe will use a default
-    /// data storage path for each target system.
-    pub persistence_path: Option<std::path::PathBuf>,
+    /// Specified how the `eframe` would attempt to create a persistent storage where `eframe` will store the app state.
+    /// If not set, eframe will use a default data storage path for each target system.
+    pub storage_build: StorageProvider,
 
     /// Controls whether to apply dithering to minimize banding artifacts.
     ///
@@ -441,7 +456,7 @@ impl Clone for NativeOptions {
             #[cfg(feature = "wgpu_no_default_features")]
             wgpu_options: self.wgpu_options.clone(),
 
-            persistence_path: self.persistence_path.clone(),
+            storage_build: self.storage_build.clone(),
 
             #[cfg(target_os = "android")]
             android_app: self.android_app.clone(),
@@ -484,7 +499,7 @@ impl Default for NativeOptions {
 
             persist_window: true,
 
-            persistence_path: None,
+            storage_build: StorageProviderBuild::Default,
 
             dithering: true,
 
@@ -545,6 +560,10 @@ pub struct WebOptions {
     /// Maximum rate at which to repaint. This can be used to artificially reduce the repaint rate below
     /// vsync in order to save resources.
     pub max_fps: Option<u32>,
+
+    /// Specified how the `eframe` would attempt to create a persistent storage where `eframe` will store the app state.
+    /// If not set, eframe will use a default data storage path for each target system.
+    pub storage_build: StorageProvider,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -568,6 +587,7 @@ impl Default for WebOptions {
             should_prevent_default: Box::new(|_| true),
 
             max_fps: None,
+            storage_build: StorageProviderBuild::Default,
         }
     }
 }

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -151,9 +151,9 @@ impl epi::StorageProvider {
     /// Not available on wasm32. For web, use `try_create_storage_web`.
     pub fn try_create_storage(&self, app_name: &str) -> Option<Box<dyn epi::Storage>> {
         match self {
-            epi::StorageProviderBuild::Default => create_storage(app_name),
-            epi::StorageProviderBuild::AtPath(path) => create_storage_with_file(path),
-            epi::StorageProviderBuild::Custom(f) => f(app_name),
+            epi::StorageProvider::Default => create_storage(app_name),
+            epi::StorageProvider::AtPath(path) => create_storage_with_file(path),
+            epi::StorageProvider::Custom(f) => f(app_name),
         }
     }
 }

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -145,6 +145,19 @@ pub fn create_storage_with_file(_file: impl Into<PathBuf>) -> Option<Box<dyn epi
     None
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+impl epi::StorageProvider {
+    /// For loading/saving app state and/or egui memory to disk.
+    /// Not available on wasm32. For web, use `try_create_storage_web`.
+    pub fn try_create_storage(&self, app_name: &str) -> Option<Box<dyn epi::Storage>> {
+        match self {
+            epi::StorageProviderBuild::Default => create_storage(app_name),
+            epi::StorageProviderBuild::AtPath(path) => create_storage_with_file(path),
+            epi::StorageProviderBuild::Custom(f) => f(app_name),
+        }
+    }
+}
+
 // ----------------------------------------------------------------------------
 
 /// Everything needed to make a winit-based integration for [`epi`].

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -196,18 +196,13 @@ impl<'app> GlowWinitApp<'app> {
         event_loop: &ActiveEventLoop,
     ) -> Result<&mut GlowWinitRunning<'app>> {
         profiling::function_scope!();
-
-        let storage = if let Some(file) = &self.native_options.persistence_path {
-            epi_integration::create_storage_with_file(file)
-        } else {
-            epi_integration::create_storage(
-                self.native_options
-                    .viewport
-                    .app_id
-                    .as_ref()
-                    .unwrap_or(&self.app_name),
-            )
-        };
+        let storage = self.native_options.storage_build.try_create_storage(
+            self.native_options
+                .viewport
+                .app_id
+                .as_ref()
+                .unwrap_or(&self.app_name),
+        );
 
         let egui_ctx = create_egui_context(storage.as_deref());
 

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -406,17 +406,13 @@ impl WinitApp for WgpuWinitApp<'_> {
             self.recreate_window(event_loop, running);
             running
         } else {
-            let storage = if let Some(file) = &self.native_options.persistence_path {
-                epi_integration::create_storage_with_file(file)
-            } else {
-                epi_integration::create_storage(
-                    self.native_options
-                        .viewport
-                        .app_id
-                        .as_ref()
-                        .unwrap_or(&self.app_name),
-                )
-            };
+            let storage = self.native_options.storage_build.try_create_storage(
+                self.native_options
+                    .viewport
+                    .app_id
+                    .as_ref()
+                    .unwrap_or(&self.app_name),
+            );
             let egui_ctx = winit_integration::create_egui_context(storage.as_deref());
             let (window, builder) = create_window(
                 &egui_ctx,

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -430,10 +430,10 @@ impl epi::StorageProvider {
     /// For loading/saving app state and/or egui memory to disk.
     pub fn try_create_storage_web(&self, app_name: &str) -> Option<Box<dyn epi::Storage>> {
         match self {
-            epi::StorageProviderBuild::Default | epi::StorageProviderBuild::AtPath(_) => {
+            epi::StorageProvider::Default | epi::StorageProvider::AtPath(_) => {
                 Some(Box::new(LocalStorage::default()))
             }
-            epi::StorageProviderBuild::Custom(f) => f(app_name),
+            epi::StorageProvider::Custom(f) => f(app_name),
         }
     }
 }

--- a/examples/custom_storage/.gitignore
+++ b/examples/custom_storage/.gitignore
@@ -1,0 +1,1 @@
+custom_storage.json

--- a/examples/custom_storage/Cargo.toml
+++ b/examples/custom_storage/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "custom_storage"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+edition = "2024"
+rust-version = "1.92"
+publish = false
+
+[lints]
+workspace = true
+
+
+[package.metadata.cargo-machete]
+ignored = ["image"] # We need the .png feature
+
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json = "1.0"
+eframe = { workspace = true, features = [
+  "default",
+  "persistence",
+  "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
+] }
+env_logger = { workspace = true, features = ["auto-color", "humantime"] }
+egui_demo_lib.workspace = true
+egui_extras = { workspace = true, features = ["image"] }
+image = { workspace = true, features = ["png"] }

--- a/examples/custom_storage/README.md
+++ b/examples/custom_storage/README.md
@@ -1,0 +1,5 @@
+Example of how to implement custom storage and use it in application.
+
+```sh
+cargo run -p custom_storage
+```

--- a/examples/custom_storage/src/main.rs
+++ b/examples/custom_storage/src/main.rs
@@ -1,0 +1,106 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
+#![expect(rustdoc::missing_crate_level_docs)] // it's an example
+
+use std::path::PathBuf;
+
+use eframe::{
+    Storage, StorageProviderBuild,
+    egui::{self, ahash::HashMap},
+};
+
+fn main() -> eframe::Result {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([350.0, 590.0]),
+        storage_build: StorageProviderBuild::Custom(custom_storage),
+        ..Default::default()
+    };
+    eframe::run_native(
+        "egui example: custom style",
+        options,
+        Box::new(|cc| Ok(Box::new(MyApp::new(cc)))),
+    )
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+struct MyApp {
+    pub custom_data: String,
+    pub custom_data2: String,
+}
+
+impl Default for MyApp {
+    fn default() -> Self {
+        Self {
+            custom_data: "Hello".to_string(),
+            custom_data2: "World".to_string(),
+        }
+    }
+}
+
+impl MyApp {
+    fn new(cc: &eframe::CreationContext<'_>) -> Self {
+        egui_extras::install_image_loaders(&cc.egui_ctx); // Needed for the "Widget Gallery" demo
+        cc.storage
+            .and_then(|storage| eframe::get_value(storage, "app"))
+            .unwrap_or_default()
+    }
+}
+
+impl eframe::App for MyApp {
+    fn save(&mut self, storage: &mut dyn Storage) {
+        eframe::set_value(storage, "app", &self);
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show_inside(ui, |ui| {
+            ui.heading("egui using a custom storage for app");
+            ui.label("Change data and restart the app to see it.");
+            ui.separator();
+            ui.text_edit_singleline(&mut self.custom_data);
+            ui.text_edit_singleline(&mut self.custom_data2);
+        });
+    }
+}
+
+fn custom_storage(_app_name: &str) -> Option<Box<dyn Storage>> {
+    CustomStorageData::new(
+        std::env::current_dir()
+            .unwrap_or_default()
+            .join("custom_storage.json"),
+    )
+    .map(|data| Box::new(data) as Box<dyn Storage>)
+}
+
+#[derive(Default, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CustomStorageData {
+    hashmap: HashMap<String, String>,
+    path: PathBuf,
+}
+
+impl CustomStorageData {
+    pub fn new(path: PathBuf) -> Option<Self> {
+        let hashmap: HashMap<String, String> = std::fs::read(&path)
+            .ok()
+            .and_then(|contents| serde_json::from_slice(contents.as_slice()).ok())
+            .unwrap_or_default();
+
+        Some(Self { hashmap, path })
+    }
+}
+
+impl Storage for CustomStorageData {
+    fn get_string(&self, key: &str) -> Option<String> {
+        self.hashmap.get(key).cloned()
+    }
+
+    fn set_string(&mut self, key: &str, value: String) {
+        self.hashmap.insert(key.to_string(), value);
+    }
+
+    fn flush(&mut self) {
+        let Ok(content) = serde_json::to_string_pretty(&self.hashmap) else {
+            return;
+        };
+        _ = std::fs::write(&self.path, content);
+    }
+}

--- a/examples/custom_storage/src/main.rs
+++ b/examples/custom_storage/src/main.rs
@@ -4,7 +4,7 @@
 use std::path::PathBuf;
 
 use eframe::{
-    Storage, StorageProviderBuild,
+    Storage, StorageProvider,
     egui::{self, ahash::HashMap},
 };
 
@@ -12,7 +12,7 @@ fn main() -> eframe::Result {
     env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default().with_inner_size([350.0, 590.0]),
-        storage_build: StorageProviderBuild::Custom(custom_storage),
+        storage_build: StorageProvider::Custom(custom_storage),
         ..Default::default()
     };
     eframe::run_native(


### PR DESCRIPTION
It replaces the `persistence_path` field in `NativeOptions` with `storage_build` and allowing to specify a custom `Storage` for apps. No functionality is lost, app creator can still specify file to use by using `storage_build: StorageProvider::AtPath(path)` instead of `persistence_path: Some(path)`. 

This allows to add a custom storage on all platforms(wasm as well), which is especially useful if anyone wants to create app for platform which is not as supported like mobile.

There is also example which shows a custom storage implementation where data is stored in text file in the directory from which the program was called.