### PR TITLE
Make `Galley::pos_from_layout_cursor` `pub`

### DIFF
--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -934,7 +934,7 @@ impl Galley {
     }
 
     /// Returns a 0-width Rect.
-    fn pos_from_layout_cursor(&self, layout_cursor: &LayoutCursor) -> Rect {
+    pub fn pos_from_layout_cursor(&self, layout_cursor: &LayoutCursor) -> Rect {
         let Some(row) = self.rows.get(layout_cursor.row) else {
             return self.end_pos();
         };


### PR DESCRIPTION
* [x] I have followed the instructions in the PR template

This PR just exposes the pos_from_layout_cursor function as public.

Hi, I'm trying to make a git gui with a merge editor, and for this I need a much more efficient and flexible text editor than the one currently in egui. So I'm working on building a more suitable one, which I intend to contribute back once it's working, but for now I would like to not need to fork the entirety of egui. By exposing this one function I (and others) can much more easily reuse Galleys. 
I suggest also exposing end_pos, but I'm not currently using that. Let me know if I should update this PR to do so.

Thanks for the otherwise awesome tool :)