### PR TITLE
Fixes the overly aggressive overflow elision in `truncate()` and similar for os scaling other than 100%

### DIFF
--- a/tests/egui_tests/tests/regression_tests.rs
+++ b/tests/egui_tests/tests/regression_tests.rs
@@ -1,8 +1,5 @@
 use egui::accesskit::Role;
-use egui::{
-    Align, Button, Color32, Image, Label, Layout, RichText, Sense, TextWrapMode, include_image,
-    vec2,
-};
+use egui::{Align, Color32, Image, Label, Layout, RichText, Sense, TextWrapMode, include_image};
 use egui_kittest::Harness;
 use egui_kittest::kittest::Queryable as _;
 


### PR DESCRIPTION
* Closes #7818
* [x] I have followed the instructions in the PR template
