### PR TITLE
Eframe: Use alternate display size if browser is firefox

### DIFF
--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -1099,7 +1099,14 @@ fn get_display_size(resize_observer_entries: &js_sys::Array) -> Result<(u32, u32
     let mut dpr = web_sys::window().unwrap().device_pixel_ratio();
 
     let entry: web_sys::ResizeObserverEntry = resize_observer_entries.at(0).dyn_into()?;
-    if JsValue::from_str("devicePixelContentBoxSize").js_in(entry.as_ref()) {
+    if JsValue::from_str("devicePixelContentBoxSize").js_in(entry.as_ref())
+        && !web_sys::window().is_some_and(|window| {
+            window
+                .navigator()
+                .user_agent()
+                .is_ok_and(|val| val.contains("Firefox"))
+        })
+    {
         // NOTE: Only this path gives the correct answer for most browsers.
         // Unfortunately this doesn't work perfectly everywhere.
         let size: web_sys::ResizeObserverSize =


### PR DESCRIPTION
Currently in firefox the display scaling is read as 2x what it should be. This causes issues as cursor position is still using the 1x scaling, and any egui applications being at 2x the desired scale.
This is a patchwork fix that detects is the browser is firefox by looking at the user agent (any of web devs that have a better knowledge of how to detect a firefox browser please let me know) and falls back to an alternate display size calculation that produces the expected 1x scaling.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [x] I have followed the instructions in the PR template
* Related PRs: <https://github.com/emilk/egui/pull/5481>
