### PR TITLE
fix: disable Enter while IME is active

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -1171,7 +1171,8 @@ fn remove_ime_incompatible_events(events: &mut Vec<Event>) {
                         | Key::ArrowUp
                         | Key::ArrowDown
                         | Key::ArrowLeft
-                        | Key::ArrowRight,
+                        | Key::ArrowRight
+                        | Key::Enter,
                     ..
                 }
         )


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->


This PR adds <kbd>Enter</kbd> to the list of keys that is disabled during IME is active.

This Branch:

https://github.com/user-attachments/assets/c44a09dd-0b24-414b-bb9b-695cbe792579

Main Branch (unfocused every time I commit preedits)

https://github.com/user-attachments/assets/72048468-f414-4544-8ff8-106e39038807


* Closes <https://github.com/emilk/egui/issues/7809>
* [x] I have followed the instructions in the PR template
