### PR TITLE
fix: show hover flag in impl Debug for Sense

### DIFF
--- a/crates/egui/src/sense.rs
+++ b/crates/egui/src/sense.rs
@@ -25,6 +25,9 @@ bitflags::bitflags! {
 impl std::fmt::Debug for Sense {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Sense {{")?;
+        if self.senses_hover() {
+            write!(f, " hover")?;
+        }
         if self.senses_click() {
             write!(f, " click")?;
         }
@@ -86,6 +89,11 @@ impl Sense {
     #[inline]
     pub fn interactive(&self) -> bool {
         self.intersects(Self::CLICK | Self::DRAG)
+    }
+
+    #[inline]
+    pub fn senses_hover(&self) -> bool {
+        self.contains(Self::HOVER)
     }
 
     #[inline]


### PR DESCRIPTION
Currently the debug string for Sense::none() and Sense::HOVER are identical, which was confusing.  Add hover to the Debug impl.

Do I need to make an issue for small fixes like this?

* [x] I have followed the instructions in the PR template
