### PR TITLE
docs: fix outdated link to egui_extras::install_image_loaders

### DIFF
--- a/crates/egui/src/load.rs
+++ b/crates/egui/src/load.rs
@@ -4,7 +4,7 @@
 //! will get you up and running quickly with its reasonable default implementations of the traits described below.
 //!
 //! 1. Add [`egui_extras`](https://crates.io/crates/egui_extras/) as a dependency with the `all_loaders` feature (`cargo add egui_extras -F all_loaders`).
-//! 2. Add a call to [`egui_extras::install_image_loaders`](https://docs.rs/egui_extras/latest/egui_extras/fn.install_image_loaders.html)
+//! 2. Add a call to [`egui_extras::install_image_loaders`](https://docs.rs/egui_extras/latest/egui_extras/loaders/fn.install_image_loaders.html)
 //!    in your app's setup code.
 //! 3. Use [`Ui::image`][`crate::ui::Ui::image`] with some [`ImageSource`][`crate::ImageSource`].
 //!


### PR DESCRIPTION
The old link

https://docs.rs/egui_extras/latest/egui_extras/fn.install_image_loaders.html

now "The requested resource does not exist
no such resource" on docs.rs because the function lives in the loaders module (even though it is still re-exported at the crate root).

Updated to the working link:

https://docs.rs/egui_extras/latest/egui_extras/loaders/fn.install_image_loaders.html