### PR TITLE
Make `ThemePreference::radio_buttons` not wrap its buttons in a `ui.horizontal`

### DIFF
--- a/crates/egui/src/memory/mod.rs
+++ b/crates/egui/src/memory/mod.rs
@@ -406,7 +406,7 @@ impl Options {
         CollapsingHeader::new("🎑 Style")
             .default_open(true)
             .show(ui, |ui| {
-                theme_preference.radio_buttons(ui);
+                ui.horizontal(|ui| theme_preference.radio_buttons(ui));
 
                 let style = std::sync::Arc::make_mut(match theme {
                     Theme::Dark => dark_style,

--- a/crates/egui/src/memory/theme.rs
+++ b/crates/egui/src/memory/theme.rs
@@ -88,33 +88,31 @@ impl From<Theme> for ThemePreference {
 impl ThemePreference {
     /// Show radio-buttons to switch between light mode, dark mode and following the system theme.
     pub fn radio_buttons(&mut self, ui: &mut crate::Ui) {
-        ui.horizontal(|ui| {
-            let system_theme = ui.input(|i| i.raw.system_theme);
+        let system_theme = ui.input(|i| i.raw.system_theme);
 
-            ui.selectable_value(self, Self::System, "💻 System")
-                .on_hover_ui(|ui| {
-                    ui.label("Follow the system theme preference.");
+        ui.selectable_value(self, Self::System, "💻 System")
+            .on_hover_ui(|ui| {
+                ui.label("Follow the system theme preference.");
 
-                    ui.add_space(4.0);
+                ui.add_space(4.0);
 
-                    if let Some(system_theme) = system_theme {
-                        ui.label(format!(
-                            "The current system theme is: {}",
-                            match system_theme {
-                                Theme::Dark => "dark",
-                                Theme::Light => "light",
-                            }
-                        ));
-                    } else {
-                        ui.label("The system theme is unknown.");
-                    }
-                });
+                if let Some(system_theme) = system_theme {
+                    ui.label(format!(
+                        "The current system theme is: {}",
+                        match system_theme {
+                            Theme::Dark => "dark",
+                            Theme::Light => "light",
+                        }
+                    ));
+                } else {
+                    ui.label("The system theme is unknown.");
+                }
+            });
 
-            ui.selectable_value(self, Self::Dark, "🌙 Dark")
-                .on_hover_text("Use the dark mode theme");
+        ui.selectable_value(self, Self::Dark, "🌙 Dark")
+            .on_hover_text("Use the dark mode theme");
 
-            ui.selectable_value(self, Self::Light, "☀ Light")
-                .on_hover_text("Use the light mode theme");
-        });
+        ui.selectable_value(self, Self::Light, "☀ Light")
+            .on_hover_text("Use the light mode theme");
     }
 }


### PR DESCRIPTION
This makes it properly usable in a menu. I'm unsure whether this constitutes a breaking change; when the buttons are in a `MenuBar` like in the eframe template this visually changes nothing.

* [x] I have followed the instructions in the PR template
