### PR TITLE
Fix(Web): prevent invisible IME agent from intercepting mouse clicks near cursor

### DIFF
--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -797,9 +797,11 @@ impl TextEdit<'_> {
                         .unwrap_or_default();
 
                     ui.ctx().output_mut(|o| {
+                        let tiny_rect =
+                            Rect::from_min_size(primary_cursor_rect.left_top(), Vec2::ZERO);
                         o.ime = Some(crate::output::IMEOutput {
                             rect: to_global * rect,
-                            cursor_rect: to_global * primary_cursor_rect,
+                            cursor_rect: to_global * tiny_rect,
                         });
                     });
                 }


### PR DESCRIPTION
Fix(Web): prevent invisible IME agent from intercepting mouse clicks near cursor

#### Problem
In WASM/Web environments, `egui` provides `IMEOutput` to the browser to handle IME composition and mobile text input. The browser creates an invisible text agent (like a hidden `<textarea>`) based on the provided `cursor_rect`. 

However, this hidden element often possesses a small physical hitbox (especially to the right of the cursor). This causes a bug where mouse clicks occurring slightly to the right of the text cursor are intercepted by the browser's hidden element and never reach the `egui` canvas, resulting in "dead zones" for user interaction.

#### Solution
This PR modifies the `cursor_rect` passed to `IMEOutput` to be a zero-width `Rect` (`tiny_rect`). 
- By setting the size to `Vec2::ZERO`, the browser's invisible agent no longer has a clickable area, ensuring all pointer events are correctly delivered to the `egui` canvas.
- The `left_top` position is preserved, so IME candidate windows (like Hanja or Emoji pickers) still appear at the correct coordinate relative to the cursor.

#### Impact
- **Fixed:** Clicking near/on the text cursor in `TextEdit` (WASM) is now 100% reliable.
- **No Regression:** IME functionality remains intact as the positional anchor is unchanged.

* Closes #8272 
