### PR TITLE
Pass in an explicit id in `UiBuilder`, to avoid wrapping passed in ids with Id::new()

### DIFF
--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -55,7 +55,7 @@ impl UiBuilder {
     /// This is a shortcut for `.id_salt(my_id).global_scope(true)`.
     #[inline]
     pub fn id(mut self, id: Id) -> Self {
-        self.id_salt = Some(Id::new(id));
+        self.id_salt = Some(id);
         self.global_scope = true;
         self
     }


### PR DESCRIPTION
I was really confused why I couldn't find the response for my ui with explicit id. Turns out the id I passed in was wrapped by `Id::new`