### PR TITLE
Update resvg to 0.47

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ puffin_http = "0.16.1"
 rand = "0.9.2"
 raw-window-handle = "0.6.2"
 rayon = "1.11.0"
-resvg = { version = "0.45.1", default-features = false }
+resvg = { version = "0.47.0", default-features = false }
 rfd = "0.15.4"
 ron = "0.11.0"
 self_cell = "1.2.1"


### PR DESCRIPTION
## Summary
- Update `resvg` dependency from 0.45.1 to 0.47.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Rationale: the `resvg` version (`0.45.x`) used by `egui_extras` does not compile past `nightly-2026-02-15`. 