### PR TITLE
Fix crash when dragging a DragValue through small floats.

### DIFF
--- a/crates/emath/src/smart_aim.rs
+++ b/crates/emath/src/smart_aim.rs
@@ -2,7 +2,7 @@
 
 use crate::fast_midpoint;
 
-const NUM_DECIMALS: usize = 15;
+const NUM_DECIMALS: usize = 16;
 
 /// Find the "simplest" number in a closed range [min, max], i.e. the one with the fewest decimal digits.
 ///
@@ -143,6 +143,10 @@ fn from_decimal_string(s: [u8; NUM_DECIMALS]) -> u64 {
 #[expect(clippy::approx_constant)]
 #[test]
 fn test_aim() {
+    assert_eq!(
+        best_in_range_f64(0.0799999999999996, 0.09999999999999995),
+        0.08,
+    );
     assert_eq!(best_in_range_f64(-0.2, 0.0), 0.0, "Prefer zero");
     assert_eq!(best_in_range_f64(-10_004.23, 3.14), 0.0, "Prefer zero");
     assert_eq!(best_in_range_f64(-0.2, 100.0), 0.0, "Prefer zero");


### PR DESCRIPTION
Increased smart_aim `NUM_DECIMALS` from 15 to 16 to fix crash in `best_in_range_f64`
The f64 value 0.09999999999999995, when multiplied by `scale_factor` and rounded, becomes 16 digits (999999999999999.5 -> 1000000000000000) and the leading 1 is clipped off by `to_decimal_string` resulting in all 0s and triggering the debug_assert! message "Bug in smart aim code"

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes <https://github.com/emilk/egui/issues/7747 >
* [x] I have followed the instructions in the PR template
