### PR TITLE
fix: Prevent widget jittering in justified layouts by applying a small offset

### DIFF
--- a/crates/egui/src/layout.rs
+++ b/crates/egui/src/layout.rs
@@ -623,12 +623,12 @@ impl Layout {
         if (self.is_vertical() && self.horizontal_align() == Align::Center)
             || self.horizontal_justify()
         {
-            frame_size.x = frame_size.x.max(available_rect.width().floor()); // fill full width
+            frame_size.x = frame_size.x.max(available_rect.width() - 1.0); // fill full width
         }
         if (self.is_horizontal() && self.vertical_align() == Align::Center)
             || self.vertical_justify()
         {
-            frame_size.y = frame_size.y.max(available_rect.height().floor()); // fill full height
+            frame_size.y = frame_size.y.max(available_rect.height() - 1.0); // fill full height
         }
 
         let align2 = match self.main_dir {


### PR DESCRIPTION
**fix: Prevent widget jittering in justified layouts by applying a small offset**

* Closes #7937 

This PR fixes a pixel-jittering issue (flickering between sizes) that occurs when using `centered_and_justified` or other justified layouts.

**The Problem:**
When the `available_rect` has fractional dimensions (e.g., due to UI scaling or parent layout constraints), the rounding logic in `round_ui()` can cause the `frame_size` to oscillate between two integer pixel values across different frames. While flooring was considered, it wasn't sufficient in all cases to stabilize the layout. This leads to visible jittering, especially noticeable with images or containers that strictly follow the justified size.

**The Solution:**
By subtracting `1.0` from the `available_rect` width and height before using them to calculate `frame_size.x` and `frame_size.y`, we provide a sufficient buffer to ensure a stable size. This prevents the "feedback loop" where rounding up and down alternates, resulting in a much smoother and "pixel-perfect" UI experience by avoiding boundary overflow.

**Changes:**
- Modified `next_frame_ignore_wrap` in `layout.rs` to subtract `1.0` from `available_rect` dimensions when `horizontal_justify` or `vertical_justify` is enabled.
