### PR TITLE
Fix: repaint on drag-and-drop files

### DIFF
--- a/crates/egui/src/input_state/mod.rs
+++ b/crates/egui/src/input_state/mod.rs
@@ -661,6 +661,8 @@ impl InputState {
         if self.pointer.wants_repaint()
             || self.wheel.unprocessed_wheel_delta.abs().max_elem() > 0.2
             || !self.events.is_empty()
+            || !self.raw.hovered_files.is_empty()
+            || !self.raw.dropped_files.is_empty()
         {
             // Immediate repaint
             return Some(Duration::ZERO);


### PR DESCRIPTION
When someone drag-and-drops files onto an egui/eframe app, it makes sense to wake it up