### PR TITLE
Add `Button::left_text`

### DIFF
--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -240,6 +240,18 @@ impl<'a> Button<'a> {
         self
     }
 
+    /// Show some text on the left side of the button.
+    #[inline]
+    pub fn left_text(mut self, left_text: impl IntoAtoms<'a>) -> Self {
+        self.layout.push_left(Atom::grow());
+
+        for atom in left_text.into_atoms() {
+            self.layout.push_left(atom);
+        }
+
+        self
+    }
+
     /// Show some text on the right side of the button.
     #[inline]
     pub fn right_text(mut self, right_text: impl IntoAtoms<'a>) -> Self {


### PR DESCRIPTION
feat: Add left_text() to egui::Button

This PR introduces the `left_text()` method to `egui::Button`. It enables placing additional text content on the left side of the button's primary label, which is useful for displaying auxiliary information, labels, and for facilitating left-aligned text within the button.

```rust
                            let is_selected = true;
                            let selectable_label_widget = egui::Button::selectable(
                                is_selected,
                                "",
                            ).left_text("Left");

                            let desired_width = ui.available_width();
                            let desired_height = ui.spacing().interact_size.y;

                            interaction_response = ui.add_sized(
                                egui::vec2(desired_width, desired_height),
                                selectable_label_widget,
                            );
```
