### PR TITLE
Allow fallback from smithay to arboard when getting clipboard

### DIFF
--- a/crates/egui-winit/src/clipboard.rs
+++ b/crates/egui-winit/src/clipboard.rs
@@ -70,7 +70,7 @@ impl Clipboard {
                 Err(err) => {
                     log::error!("smithay paste error: {err}");
                 }
-            };
+            }
         }
 
         #[cfg(all(


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [X] I have followed the instructions in the PR template

Quick fix -- when the arboard and smithay features are both enabled, Clipboard::get returns early if it can't find a smithay clipboard. This PR just allows fallback to arboard instead of early-returning.