### PR TITLE
Fix vulnerability in the branch name check workflow

### DIFF
--- a/.github/workflows/enforce_branch_name.yml
+++ b/.github/workflows/enforce_branch_name.yml
@@ -4,17 +4,23 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize]
 
+permissions:
+  issues: write
+
 jobs:
   check-source-branch:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Check PR source branch
+        env:
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           # Check if PR is from a fork
-          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
+          if [[ "$IS_FORK" == "true" ]]; then
             # Check if PR is from the master/main branch of a fork
-            if [[ "${{ github.event.pull_request.head.ref }}" == "master" || "${{ github.event.pull_request.head.ref }}" == "main" ]]; then
+            if [[ "$HEAD_REF" == "master" || "$HEAD_REF" == "main" ]]; then
               echo "ERROR: Pull requests from the master/main branch of forks are not allowed, because it prevents maintainers from contributing to your PR"
               echo "Please create a feature branch in your fork and submit the PR from that branch instead."
               exit 1


### PR DESCRIPTION
Before, a crafted branch name could be used to exfiltrate the github token and wreak havoc 😅