### PR TITLE
Remove easymark from default demo app

### DIFF
--- a/crates/egui_demo_app/Cargo.toml
+++ b/crates/egui_demo_app/Cargo.toml
@@ -25,10 +25,10 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["wgpu", "persistence"]
 
-# image_viewer adds about 0.9 MB of WASM
 web_app = ["http", "persistence"]
 
 accessibility_inspector = ["dep:accesskit", "dep:accesskit_consumer", "eframe/accesskit"]
+easymark = [] # easymark is off by default, because it a pretty shitty markup language
 http = ["ehttp", "image/jpeg", "poll-promise", "egui_extras/image"]
 image_viewer = ["image/jpeg", "egui_extras/all_loaders", "rfd"]
 persistence = ["eframe/persistence", "egui_extras/serde", "egui/persistence", "serde"]

--- a/crates/egui_demo_app/src/wrap_app.rs
+++ b/crates/egui_demo_app/src/wrap_app.rs
@@ -8,12 +8,14 @@ use core::any::Any;
 
 use crate::DemoApp;
 
+#[cfg(feature = "easymark")]
 #[derive(Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 struct EasyMarkApp {
     editor: egui_demo_lib::easy_mark::EasyMarkEditor,
 }
 
+#[cfg(feature = "easymark")]
 impl DemoApp for EasyMarkApp {
     fn demo_ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         self.editor.panels(ui);
@@ -152,12 +154,18 @@ enum Command {
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct State {
     demo: DemoWindows,
+
+    #[cfg(feature = "easymark")]
     easy_mark_editor: EasyMarkApp,
+
     #[cfg(feature = "http")]
     http: crate::apps::HttpApp,
+
     #[cfg(feature = "image_viewer")]
     image_viewer: crate::apps::ImageViewer,
+
     pub clock: FractalClockApp,
+
     rendering_test: ColorTestApp,
 
     selected_anchor: Anchor,
@@ -212,6 +220,7 @@ impl WrapApp {
                 Anchor::Demo,
                 &mut self.state.demo as &mut dyn DemoApp,
             ),
+            #[cfg(feature = "easymark")]
             (
                 "🖹 EasyMark editor",
                 Anchor::EasyMarkEditor,


### PR DESCRIPTION
I don't want to give the impression `easymark` is either official, useful, or indeed "good"