### PR TITLE
Use `AtomLayoutResponse` in `TextEditOutput`

### DIFF
--- a/crates/egui/src/atomics/atom_layout.rs
+++ b/crates/egui/src/atomics/atom_layout.rs
@@ -520,6 +520,20 @@ impl AtomLayoutResponse {
     }
 }
 
+impl Deref for AtomLayoutResponse {
+    type Target = Response;
+
+    fn deref(&self) -> &Self::Target {
+        &self.response
+    }
+}
+
+impl DerefMut for AtomLayoutResponse {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.response
+    }
+}
+
 impl Widget for AtomLayout<'_> {
     fn ui(self, ui: &mut Ui) -> Response {
         self.show(ui).response

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -409,7 +409,7 @@ impl<'t> TextEdit<'t> {
 
 impl Widget for TextEdit<'_> {
     fn ui(self, ui: &mut Ui) -> Response {
-        self.show(ui).response
+        self.show(ui).response.response
     }
 }
 
@@ -563,7 +563,7 @@ impl TextEdit<'_> {
         // so we can clip it to the available size. Thus, extract it from the atom closure here.
         let mut get_galley = None;
         let inner_rect_id = Id::new("text_edit_rect");
-        let atom_response = {
+        let mut response = {
             let any_shrink = hint_text.any_shrink();
             // Ideally we could just do `let mut atoms = prefix` here, but that won't compile
             // but due to servo/rust-smallvec#146 (also see the comment below).
@@ -716,8 +716,7 @@ impl TextEdit<'_> {
             allocated.paint(ui)
         };
 
-        let inner_rect = atom_response.rect(inner_rect_id).unwrap_or(Rect::ZERO);
-        let mut response = atom_response.response;
+        let inner_rect = response.rect(inner_rect_id).unwrap_or(Rect::ZERO);
 
         // Our atom closure was now called, so the galley should always be available here
         let mut galley = get_galley.expect("Galley should be available here");

--- a/crates/egui/src/widgets/text_edit/output.rs
+++ b/crates/egui/src/widgets/text_edit/output.rs
@@ -5,7 +5,7 @@ use crate::text::CCursorRange;
 /// The output from a [`TextEdit`](crate::TextEdit).
 pub struct TextEditOutput {
     /// The interaction response.
-    pub response: crate::Response,
+    pub response: crate::AtomLayoutResponse,
 
     /// How the text was displayed.
     pub galley: Arc<crate::Galley>,


### PR DESCRIPTION
This is necessary to add e.g. buttons as prefix/suffix within the textedit (so you can read the rect and place the button).

I'm not sure if deref on the AtomLayoutResponse is the right call but it should make the migration easier and is generally convenient (but might lead to some confusion).