### PR TITLE
Add error message when calling `.render()` without `.update_buffers()`

### DIFF
--- a/crates/egui-wgpu/src/renderer.rs
+++ b/crates/egui-wgpu/src/renderer.rs
@@ -960,6 +960,7 @@ impl Renderer {
             let index_buffer_staging = queue.write_buffer_with(
                 &self.index_buffer.buffer,
                 0,
+                #[expect(clippy::unwrap_used)] // Checked above
                 NonZeroU64::new(required_index_buffer_size).unwrap(),
             );
 
@@ -1004,6 +1005,7 @@ impl Renderer {
             let vertex_buffer_staging = queue.write_buffer_with(
                 &self.vertex_buffer.buffer,
                 0,
+                #[expect(clippy::unwrap_used)] // Checked above
                 NonZeroU64::new(required_vertex_buffer_size).unwrap(),
             );
 


### PR DESCRIPTION
* Closes https://github.com/emilk/egui/issues/7968