### PR TITLE
Remove text refocus on input to fix mobile keyboard layout resetting

### DIFF
--- a/crates/eframe/src/web/text_agent.rs
+++ b/crates/eframe/src/web/text_agent.rs
@@ -56,12 +56,6 @@ impl TextAgent {
             let input = input.clone();
             move |event: web_sys::InputEvent, runner: &mut AppRunner| {
                 let text = input.value();
-                // Fix android virtual keyboard Gboard
-                // This removes the virtual keyboard's suggestion.
-                if !event.is_composing() {
-                    input.blur().ok();
-                    input.focus().ok();
-                }
                 // if `is_composing` is true, then user is using IME, for example: emoji, pinyin, kanji, hangul, etc.
                 // In that case, the browser emits both `input` and `compositionupdate` events,
                 // and we need to ignore the `input` event.


### PR DESCRIPTION
Fixes #8046

I don't know what the original code was supposed to fix, but removing that code fixes the issue linked above,