### PR TITLE
Clamp panel rects to visible bounds

### DIFF
--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -693,6 +693,11 @@ impl Panel {
             add_contents(ui)
         });
 
+        let mut inner_response = inner_response;
+        inner_response.response.rect =
+            inner_response.response.rect.intersect(panel_sizer.panel_rect);
+        inner_response.response.interact_rect =
+            inner_response.response.interact_rect.intersect(panel_sizer.panel_rect);
         let rect = inner_response.response.rect;
 
         {
@@ -779,7 +784,7 @@ impl Panel {
             .widget_info(|| WidgetInfo::new(WidgetType::Panel));
 
         let inner_response = self.show_inside_dyn(&mut panel_ui, add_contents);
-        let rect = inner_response.response.rect;
+        let rect = inner_response.response.rect.intersect(available_rect);
 
         match side {
             PanelSide::Vertical(side) => match side {

--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -694,10 +694,14 @@ impl Panel {
         });
 
         let mut inner_response = inner_response;
-        inner_response.response.rect =
-            inner_response.response.rect.intersect(panel_sizer.panel_rect);
-        inner_response.response.interact_rect =
-            inner_response.response.interact_rect.intersect(panel_sizer.panel_rect);
+        inner_response.response.rect = inner_response
+            .response
+            .rect
+            .intersect(panel_sizer.panel_rect);
+        inner_response.response.interact_rect = inner_response
+            .response
+            .interact_rect
+            .intersect(panel_sizer.panel_rect);
         let rect = inner_response.response.rect;
 
         {

--- a/crates/egui_kittest/tests/regression_tests.rs
+++ b/crates/egui_kittest/tests/regression_tests.rs
@@ -374,8 +374,7 @@ fn panel_response_rect_clamped_to_panel_bounds() {
     let panel_height = 80.0_f32;
 
     // Use a RefCell so we can read the responses back after `harness.run()`.
-    let side_response: std::cell::RefCell<Option<egui::Response>> =
-        std::cell::RefCell::new(None);
+    let side_response: std::cell::RefCell<Option<egui::Response>> = std::cell::RefCell::new(None);
     let tb_response: std::cell::RefCell<Option<egui::Response>> = std::cell::RefCell::new(None);
 
     let mut harness = Harness::builder()

--- a/crates/egui_kittest/tests/regression_tests.rs
+++ b/crates/egui_kittest/tests/regression_tests.rs
@@ -360,3 +360,73 @@ pub fn pointer_click_on_open_submenu_button_should_not_close_it() {
         "Expected submenu to remain open on repeated pointer click"
     );
 }
+
+/// Regression test for https://github.com/emilk/egui/pull/8056
+///
+/// Panel `response.rect` and `response.interact_rect` must be clamped to the
+/// visible panel bounds even when the content inside the panel overflows.
+/// Before the fix only the cursor-advancement `rect` was clamped, so callers
+/// of `SidePanel::show` / `TopBottomPanel::show` received an oversized rect
+/// that broke pointer hit-testing and separator placement.
+#[test]
+fn panel_response_rect_clamped_to_panel_bounds() {
+    let panel_width = 100.0_f32;
+    let panel_height = 80.0_f32;
+
+    // Use a RefCell so we can read the responses back after `harness.run()`.
+    let side_response: std::cell::RefCell<Option<egui::Response>> =
+        std::cell::RefCell::new(None);
+    let tb_response: std::cell::RefCell<Option<egui::Response>> = std::cell::RefCell::new(None);
+
+    let mut harness = Harness::builder()
+        .with_size(Vec2::new(400.0, 300.0))
+        .build(|ctx| {
+            let sr = egui::SidePanel::left("left_panel")
+                .exact_width(panel_width)
+                .show(ctx, |ui| {
+                    // Allocate space that is far wider than the panel to trigger overflow.
+                    ui.allocate_space(Vec2::new(1000.0, 10.0));
+                });
+            *side_response.borrow_mut() = Some(sr.response);
+
+            let tbr = egui::TopBottomPanel::top("top_panel")
+                .exact_height(panel_height)
+                .show(ctx, |ui| {
+                    // Allocate space that is far taller than the panel to trigger overflow.
+                    ui.allocate_space(Vec2::new(10.0, 1000.0));
+                });
+            *tb_response.borrow_mut() = Some(tbr.response);
+        });
+
+    harness.run();
+
+    let sr = side_response.borrow();
+    let sr = sr.as_ref().unwrap();
+    assert!(
+        sr.rect.right() <= panel_width + 1.0,
+        "SidePanel response.rect.right() ({}) must not exceed panel width ({})",
+        sr.rect.right(),
+        panel_width,
+    );
+    assert!(
+        sr.interact_rect.right() <= panel_width + 1.0,
+        "SidePanel response.interact_rect.right() ({}) must not exceed panel width ({})",
+        sr.interact_rect.right(),
+        panel_width,
+    );
+
+    let tbr = tb_response.borrow();
+    let tbr = tbr.as_ref().unwrap();
+    assert!(
+        tbr.rect.bottom() <= panel_height + 1.0,
+        "TopBottomPanel response.rect.bottom() ({}) must not exceed panel height ({})",
+        tbr.rect.bottom(),
+        panel_height,
+    );
+    assert!(
+        tbr.interact_rect.bottom() <= panel_height + 1.0,
+        "TopBottomPanel response.interact_rect.bottom() ({}) must not exceed panel height ({})",
+        tbr.interact_rect.bottom(),
+        panel_height,
+    );
+}


### PR DESCRIPTION
Fixes #8055.

When panel contents overflow beyond the visible clamped bounds, the panel response can become larger than the actual visible panel. That oversized response was then reused by integrations for pointer hit-testing, and its rect was also reused internally for cursor advancement, stored panel state, separator painting, and top-level panel allocation.

This change clamps the outward-facing panel response back to the visible panel bounds with `intersect(panel_rect)`, for both `response.rect` and `response.interact_rect`. The fix is applied to both `SidePanel` and `TopBottomPanel`, so callers using the returned panel response do not inherit oversized clipped-child bounds.

I verified this against a Bevy + bevy_egui integration where a resizable panel with clipped overflow content incorrectly blocked scene interaction and displaced its effective boundary. After this change, the panel hit area and boundary stay aligned with the visible panel edge.