### PR TITLE
perf: remove redundant clone in about.rs demo

### DIFF
--- a/crates/egui_demo_lib/src/demo/about.rs
+++ b/crates/egui_demo_lib/src/demo/about.rs
@@ -29,9 +29,8 @@ impl crate::View for About {
 
         ui.vertical_centered(|ui| {
             ui.add_space(4.0);
-            let egui_icon = egui::include_image!("../../data/egui-logo.svg");
             ui.add(
-                egui::Image::new(egui_icon.clone())
+                egui::Image::new(egui::include_image!("../../data/egui-logo.svg"))
                     .max_height(30.0)
                     .tint(ui.visuals().strong_text_color()),
             );


### PR DESCRIPTION
As shown in the commit, this is exactly what it contains. There was a redundant and seemingly meaningless `.clone()` in `about.rs`, which I removed. Was it because the function signature of `Image::new()` was different in older versions of egui?
