### PR TITLE
Log `localStorage` write failures in `local_storage_set`

### DIFF
--- a/crates/eframe/src/web/storage.rs
+++ b/crates/eframe/src/web/storage.rs
@@ -12,7 +12,10 @@ pub fn local_storage_set(key: &str, value: &str) {
     match local_storage() {
         Some(storage) => {
             if let Err(err) = storage.set_item(key, value) {
-                log::warn!("local_storage_set failed: key={key}, err={}", crate::web::string_from_js_value(&err));
+                log::warn!(
+                    "local_storage_set failed: key={key}, err={}",
+                    crate::web::string_from_js_value(&err)
+                );
             }
         }
         None => {


### PR DESCRIPTION
Log `localStorage` write failures in `local_storage_set`

**Description**  
This PR improves `local_storage_set()` logging in `eframe/src/web/storage.rs`.

It logs:
- write failures with key and browser error
- unavailable local storage

This helps diagnose web persistence issues such as `QuotaExceededError` when `localStorage.setItem()` fails.
