### PR TITLE
Add `subpixel_binning` to `TextOptions` and `FontTweak`

### DIFF
--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -2344,11 +2344,13 @@ impl Visuals {
                 max_texture_side: _,
                 alpha_from_coverage,
                 font_hinting,
+                subpixel_binning,
             } = text_options;
 
             text_alpha_from_coverage_ui(ui, alpha_from_coverage);
 
-            ui.checkbox(font_hinting, "Enable font hinting");
+            ui.checkbox(font_hinting, "Font hinting (sharper text)");
+            ui.checkbox(subpixel_binning, "Sub-pixel binning (more even kerning)");
         });
 
         ui.collapsing("Text cursor", |ui| {
@@ -2913,10 +2915,11 @@ impl Widget for &mut FontTweak {
                     scale,
                     y_offset_factor,
                     y_offset,
-                    hinting_override,
+                    hinting,
                     coords,
                     thin_space_width,
                     tab_size,
+                    subpixel_binning,
                 } = self;
 
                 ui.label("Scale");
@@ -2932,18 +2935,20 @@ impl Widget for &mut FontTweak {
                 ui.add(DragValue::new(y_offset).speed(-0.02));
                 ui.end_row();
 
-                ui.label("hinting_override");
-                ComboBox::from_id_salt("hinting_override")
-                    .selected_text(match hinting_override {
-                        None => "None",
-                        Some(true) => "Enable",
-                        Some(false) => "Disable",
-                    })
-                    .show_ui(ui, |ui| {
-                        ui.selectable_value(hinting_override, None, "None");
-                        ui.selectable_value(hinting_override, Some(true), "Enable");
-                        ui.selectable_value(hinting_override, Some(false), "Disable");
-                    });
+                ui.label("hinting");
+                ui.horizontal(|ui| {
+                    ui.radio_value(hinting, Some(true), "on");
+                    ui.radio_value(hinting, Some(false), "off");
+                    ui.radio_value(hinting, None, "default");
+                });
+                ui.end_row();
+
+                ui.label("subpixel_binning");
+                ui.horizontal(|ui| {
+                    ui.radio_value(subpixel_binning, Some(true), "on");
+                    ui.radio_value(subpixel_binning, Some(false), "off");
+                    ui.radio_value(subpixel_binning, None, "default");
+                });
                 ui.end_row();
 
                 ui.label("coords");

--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -316,6 +316,7 @@ pub struct FontFace {
     name: String,
     font: FontCell,
     tweak: FontTweak,
+    subpixel_binning: bool,
 
     /// Cached `harfrust` shaper data (parsed GSUB/GPOS tables).
     /// `ShaperData` is `Copy` — lives outside the `self_cell`.
@@ -352,7 +353,7 @@ impl FontFace {
                 skrifa::instance::LocationRef::default(),
             );
 
-            let hinting_enabled = tweak.hinting_override.unwrap_or(options.font_hinting);
+            let hinting_enabled = tweak.hinting.unwrap_or(options.font_hinting);
             let hinting_instance = hinting_enabled
                 .then(|| {
                     // It doesn't really matter what we put here for options. Since the size is `unscaled()`, we will
@@ -379,10 +380,13 @@ impl FontFace {
 
         let shaper_data = harfrust::ShaperData::new(&font.borrow_dependent().skrifa);
 
+        let subpixel_binning = tweak.subpixel_binning.unwrap_or(options.subpixel_binning);
+
         Ok(Self {
             name,
             font,
             tweak,
+            subpixel_binning,
             shaper_data,
             glyph_info_cache: Default::default(),
             glyph_alloc_cache: Default::default(),
@@ -551,12 +555,12 @@ impl FontFace {
             return (GlyphAllocation::default(), h_pos.round() as i32);
         }
 
-        let (h_pos_round, bin) = if is_cjk {
+        let (h_pos_round, bin) = if self.subpixel_binning && !is_cjk {
+            SubpixelBin::new(h_pos)
+        } else {
             // CJK scripts contain a lot of characters and could hog the glyph atlas
             // if we stored 4 subpixel offsets per glyph.
             (h_pos.round() as i32, SubpixelBin::Zero)
-        } else {
-            SubpixelBin::new(h_pos)
         };
 
         let cache_key = GlyphCacheKey::new(glyph_id, metrics, bin);

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -188,8 +188,13 @@ pub struct FontTweak {
 
     /// Override the global font hinting setting for this specific font.
     ///
-    /// `None` means use the global setting.
-    pub hinting_override: Option<bool>,
+    /// `None` means use the global setting in [`TextOptions::font_hinting`].
+    pub hinting: Option<bool>,
+
+    /// Override the global sub-pixel binning setting for this specific font.
+    ///
+    /// `None` means use the global setting in [`TextOptions::subpixel_binning`].
+    pub subpixel_binning: Option<bool>,
 
     /// Override the font's default variation coordinates.
     pub coords: VariationCoords,
@@ -214,7 +219,8 @@ impl Default for FontTweak {
             scale: 1.0,
             y_offset_factor: 0.0,
             y_offset: 0.0,
-            hinting_override: None,
+            hinting: None,
+            subpixel_binning: None,
             coords: VariationCoords::default(),
             thin_space_width: 0.5,
             tab_size: 4.0,

--- a/crates/epaint/src/text/mod.rs
+++ b/crates/epaint/src/text/mod.rs
@@ -34,6 +34,20 @@ pub struct TextOptions {
     ///
     /// Default is `true`.
     pub font_hinting: bool,
+
+    /// Enable sub-pixel binning for glyphs.
+    ///
+    /// Sub-pixel binning renders each glyph at up to four fractional horizontal offsets,
+    /// giving more even kerning at the cost of more atlas space.
+    ///
+    /// It also lead to text looking more blurry.
+    ///
+    /// This is always disabled for CJK characters (which have too many unique glyphs).
+    ///
+    /// Can be overridden per font with [`FontTweak::subpixel_binning`].
+    ///
+    /// Default: `true`.
+    pub subpixel_binning: bool,
 }
 
 impl Default for TextOptions {
@@ -42,6 +56,7 @@ impl Default for TextOptions {
             max_texture_side: 2048, // Small but portable
             alpha_from_coverage: crate::AlphaFromCoverage::default(),
             font_hinting: true,
+            subpixel_binning: true,
         }
     }
 }


### PR DESCRIPTION
This lets you turn off subpixel horizontal binning of glyphs. The option is a trade-off between even kerning and sharp text.

* Closes https://github.com/emilk/egui/issues/8034