### PR TITLE
Call `pre_present_notify` before presenting

### DIFF
--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -722,6 +722,7 @@ impl WgpuWinitRunning<'_> {
                 &clipped_primitives,
                 &textures_delta,
                 screenshot_commands,
+                window,
             );
 
             for action in viewport.actions_requested.drain(..) {
@@ -1111,6 +1112,7 @@ fn render_immediate_viewport(
         &clipped_primitives,
         &textures_delta,
         vec![],
+        window,
     );
 
     egui_winit.handle_platform_output(window, platform_output);

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -411,6 +411,7 @@ impl Painter {
     /// and the captures captured screenshot if it was requested.
     ///
     /// If `capture_data` isn't empty, a screenshot will be captured.
+    #[expect(clippy::too_many_arguments)]
     pub fn paint_and_update_textures(
         &mut self,
         viewport_id: ViewportId,
@@ -419,6 +420,7 @@ impl Painter {
         clipped_primitives: &[epaint::ClippedPrimitive],
         textures_delta: &epaint::textures::TexturesDelta,
         capture_data: Vec<UserData>,
+        window: &winit::window::Window,
     ) -> f32 {
         profiling::function_scope!();
 
@@ -653,6 +655,8 @@ impl Painter {
                 viewport_id,
             );
         }
+
+        window.pre_present_notify();
 
         {
             profiling::scope!("present");


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->
Add a call to [`Window::pre_present_notify`](https://docs.rs/winit/0.30.13/winit/window/struct.Window.html#method.pre_present_notify) before wgpu presents the output frame.

I noticed egui not looking as smooth after switching to wgpu. Lowering my refresh rate revealed more ugliness.

I'm a graphics noob but my guess is that on Wayland with Vulkan some funny synchronization stuff is happening. I can't try wgpu with OpenGL because of https://github.com/gfx-rs/wgpu/issues/4751. On glow this wasn't needed because under the hood it calls `eglSwapBuffers` which (according to https://emersion.fr/blog/2018/wayland-rendering-loop/) does the equivalent of calling `window.pre_present_notify()` automatically.

Below is a before and after of this PR. Before, dragged stuff lag behind the cursor and resizing the window is really slow. After, everything is normal.

https://github.com/user-attachments/assets/60ca0378-4d1b-4013-ac98-54cc1753389b

A side effect of this is that `logic` is no longer called if the app is minimized. I guess it was a happy accident.

* [x] I have followed the instructions in the PR template
