### PR TITLE
Configure wgpu to be low-latency by default

### DIFF
--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -328,7 +328,11 @@ impl Default for WgpuConfiguration {
     fn default() -> Self {
         Self {
             present_mode: wgpu::PresentMode::AutoVsync,
-            desired_maximum_frame_latency: Some(1), // Low-latency by default.
+            desired_maximum_frame_latency: if cfg!(target_os = "ios") {
+                None // The default is good on iOS, while `Some(1)` cuts FPS in half
+            } else {
+                Some(1) // Low-latency by default.
+            },
 
             // No display handle available at this point — callers should replace this with
             // `WgpuSetup::from_display_handle(...)` before creating the instance if one is available.

--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -328,7 +328,8 @@ impl Default for WgpuConfiguration {
     fn default() -> Self {
         Self {
             present_mode: wgpu::PresentMode::AutoVsync,
-            desired_maximum_frame_latency: None,
+            desired_maximum_frame_latency: Some(1), // Low-latency by default.
+
             // No display handle available at this point — callers should replace this with
             // `WgpuSetup::from_display_handle(...)` before creating the instance if one is available.
             wgpu_setup: WgpuSetup::without_display_handle(),


### PR DESCRIPTION
This changes the default value of `WgpuConfiguration::desired_maximum_frame_latency` to `Some(1)`. For low-Hz displays, this results in significantly lower input latency.

* Closes https://github.com/emilk/egui/issues/5037 ?
* Related to https://github.com/emilk/egui/issues/7761