### PR TITLE
Adds an optional feature to use the `portable-atomic` crate for atomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,6 +1248,7 @@ dependencies = [
  "epaint",
  "log",
  "nohash-hasher",
+ "portable-atomic",
  "profiling",
  "ron",
  "serde",
@@ -1355,6 +1356,7 @@ dependencies = [
  "jiff",
  "log",
  "mime_guess2",
+ "portable-atomic",
  "profiling",
  "resvg",
  "serde",
@@ -1543,6 +1545,7 @@ dependencies = [
  "mimalloc",
  "nohash-hasher",
  "parking_lot",
+ "portable-atomic",
  "profiling",
  "rayon",
  "self_cell",
@@ -3488,9 +3491,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ parking_lot = "0.12.5"
 percent-encoding = "2.3.2"
 poll-promise = { version = "0.3.0", default-features = false }
 pollster = "0.4.0"
+portable-atomic = "1.13.1"
 profiling = { version = "1.0.17", default-features = false }
 puffin = "0.19.1"
 puffin_http = "0.16.1"

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -62,6 +62,11 @@ glow = ["dep:egui_glow", "dep:glow", "dep:glutin-winit", "dep:glutin"]
 ## Enable saving app state to disk.
 persistence = ["dep:home", "egui-winit/serde", "egui/persistence", "ron", "serde"]
 
+## Uses the [`portable-atomic`](https://docs.rs/portable-atomic) crate instead of `std::sync::atomic`.
+##
+## This is useful for platforms that may lack certain types of atomics, i.e 32-bit platforms lacking `AtomicU64`.
+portable-atomic = ["egui/portable-atomic"]
+
 ## Enables wayland support and fixes clipboard issue.
 ##
 ## If you are compiling for Linux (or want to test on a CI system using Linux), you should enable this feature.

--- a/crates/egui/Cargo.toml
+++ b/crates/egui/Cargo.toml
@@ -66,6 +66,10 @@ unity = ["epaint/unity"]
 ## This exists, so that when testing with --all-features, snapshots render correctly.
 _override_unity = ["epaint/_override_unity"]
 
+## Uses the [`portable-atomic`](https://docs.rs/portable-atomic) crate instead of `std::sync::atomic`.
+##
+## This is useful for platforms that may lack certain types of atomics, i.e 32-bit platforms lacking `AtomicU64`.
+portable-atomic = ["dep:portable-atomic", "epaint/portable-atomic"]
 
 [dependencies]
 emath = { workspace = true, default-features = false }
@@ -89,3 +93,5 @@ document-features = { workspace = true, optional = true }
 
 ron = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive", "rc"] }
+
+portable-atomic = { workspace = true, optional = true }

--- a/crates/egui/src/containers/close_tag.rs
+++ b/crates/egui/src/containers/close_tag.rs
@@ -1,5 +1,9 @@
 #[expect(unused_imports)]
 use crate::{Ui, UiBuilder};
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic::AtomicBool;
+#[cfg(not(feature = "portable-atomic"))]
 use std::sync::atomic::AtomicBool;
 
 /// A tag to mark a container as closable.

--- a/crates/egui/src/load/texture_loader.rs
+++ b/crates/egui/src/load/texture_loader.rs
@@ -1,4 +1,9 @@
-use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
+use std::sync::atomic::Ordering::Relaxed;
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic::AtomicU64;
+#[cfg(not(feature = "portable-atomic"))]
+use std::sync::atomic::AtomicU64;
 
 use emath::Vec2;
 

--- a/crates/egui_demo_app/Cargo.toml
+++ b/crates/egui_demo_app/Cargo.toml
@@ -41,6 +41,12 @@ wgpu = ["eframe/wgpu", "bytemuck"]
 wayland = ["eframe/wayland"]
 x11 = ["eframe/x11"]
 
+portable-atomic = [
+  "egui/portable-atomic",
+  "egui_demo_lib/portable-atomic",
+  "egui_extras/portable-atomic",
+]
+
 [dependencies]
 eframe = { workspace = true, default-features = false, features = ["web_screen_reader"] }
 egui = { workspace = true, features = ["callstack", "default"] }
@@ -68,7 +74,6 @@ poll-promise = { workspace = true, optional = true }
 
 # feature "persistence":
 serde = { workspace = true, optional = true }
-
 
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/egui_demo_lib/Cargo.toml
+++ b/crates/egui_demo_lib/Cargo.toml
@@ -37,6 +37,10 @@ serde = ["egui/serde", "dep:serde", "egui_extras/serde"]
 ## Enable better syntax highlighting using [`syntect`](https://docs.rs/syntect).
 syntect = ["egui_extras/syntect"]
 
+## Uses the [`portable-atomic`](https://docs.rs/portable-atomic) crate instead of `std::sync::atomic`.
+##
+## This is useful for platforms that may lack certain types of atomics, i.e 32-bit platforms lacking `AtomicU64`.
+portable-atomic = ["egui/portable-atomic", "egui_extras/portable-atomic"]
 
 [dependencies]
 egui = { workspace = true, default-features = false, features = ["color-hex"] }

--- a/crates/egui_extras/Cargo.toml
+++ b/crates/egui_extras/Cargo.toml
@@ -68,6 +68,10 @@ svg_text = ["svg", "resvg/text", "resvg/system-fonts"]
 ## Enable better syntax highlighting using [`syntect`](https://docs.rs/syntect).
 syntect = ["dep:syntect"]
 
+## Uses the [`portable-atomic`](https://docs.rs/portable-atomic) crate instead of `std::sync::atomic`.
+##
+## This is useful for platforms that may lack certain types of atomics, i.e 32-bit platforms lacking `AtomicU64`.
+portable-atomic = ["dep:portable-atomic", "egui/portable-atomic"]
 
 [dependencies]
 egui = { workspace = true, default-features = false }
@@ -101,3 +105,5 @@ resvg = { workspace = true, optional = true }
 
 # http feature
 ehttp = { workspace = true, optional = true }
+
+portable-atomic = { workspace = true, optional = true }

--- a/crates/egui_extras/src/loaders/svg_loader.rs
+++ b/crates/egui_extras/src/loaders/svg_loader.rs
@@ -1,10 +1,12 @@
 use std::{
     mem::size_of,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering::Relaxed},
-    },
+    sync::{Arc, atomic::Ordering::Relaxed},
 };
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic::AtomicU64;
+#[cfg(not(feature = "portable-atomic"))]
+use std::sync::atomic::AtomicU64;
 
 use ahash::HashMap;
 

--- a/crates/epaint/Cargo.toml
+++ b/crates/epaint/Cargo.toml
@@ -47,6 +47,11 @@ mint = ["emath/mint"]
 ## This can help performance for graphics-intense applications.
 rayon = ["dep:rayon"]
 
+## Uses the [`portable-atomic`](https://docs.rs/portable-atomic) crate instead of `std::sync::atomic`.
+##
+## This is useful for platforms that may lack certain types of atomics, i.e 32-bit platforms lacking `AtomicU64`.
+portable-atomic = ["dep:portable-atomic"]
+
 ## Allow serialization using [`serde`](https://docs.rs/serde).
 serde = [
   "dep:serde",
@@ -94,6 +99,8 @@ rayon = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive", "rc"] }
 
 epaint_default_fonts = { workspace = true, optional = true }
+
+portable-atomic = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -1,11 +1,13 @@
 use std::{
     borrow::Cow,
     collections::BTreeMap,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::{Arc, atomic::Ordering},
 };
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic::AtomicU64;
+#[cfg(not(feature = "portable-atomic"))]
+use std::sync::atomic::AtomicU64;
 
 use crate::{
     TextureAtlas,


### PR DESCRIPTION
this adds a new feature (off by default) to `egui`, `epaint`, `eframe`, and `egui_extras`: `portable-atomic`

This feature makes it so that any use of atomics (these crates use `AtomicU64` or `AtomicBool`) will use the implementation from the [`portable-atomic` crate](https://docs.rs/portable-atomic), instead of the native `std::sync::atomic` version, which some platforms may not have.

I implemented this while porting egui to the 3DS - as it seems that it lacks a `AtomicU64` (albeit it has `AtomicUsize` and such), and refactoring the `AtomicU64` stuff to use `usize`s instead would likely be a breaking change, so this seems like a better solution - especially as it's optional, so you'd only enable the feature if you actually need it.