### PR TITLE
Group `glow` config in a `struct`

### DIFF
--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -259,22 +259,6 @@ pub trait App {
     fn raw_input_hook(&mut self, _ctx: &egui::Context, _raw_input: &mut egui::RawInput) {}
 }
 
-/// Selects the level of hardware graphics acceleration.
-#[cfg(not(target_arch = "wasm32"))]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum HardwareAcceleration {
-    /// Require graphics acceleration.
-    Required,
-
-    /// Prefer graphics acceleration, but fall back to software.
-    Preferred,
-
-    /// Do NOT use graphics acceleration.
-    ///
-    /// On some platforms (macOS) this is ignored and treated the same as [`Self::Preferred`].
-    Off,
-}
-
 /// Options controlling the behavior of a native window.
 ///
 /// Additional windows can be opened using (egui viewports)[`egui::viewport`].
@@ -298,13 +282,6 @@ pub struct NativeOptions {
     /// To avoid this, set the icon to [`egui::IconData::default`].
     pub viewport: egui::ViewportBuilder,
 
-    /// Turn on vertical syncing, limiting the FPS to the display refresh rate.
-    ///
-    /// The default is `true`.
-    ///
-    /// Only affects the `glow` backend.
-    pub glow_vsync: bool,
-
     /// Set the level of the multisampling anti-aliasing (MSAA).
     ///
     /// Must be a power-of-two. Higher = more smooth 3D.
@@ -325,13 +302,6 @@ pub struct NativeOptions {
     ///
     /// `egui` doesn't need the stencil buffer, so the default value is 0.
     pub stencil_buffer: u8,
-
-    /// Specify whether or not hardware acceleration is preferred, required, or not.
-    ///
-    /// Default: [`HardwareAcceleration::Preferred`].
-    ///
-    /// Only affects the `glow` backend.
-    pub hardware_acceleration: HardwareAcceleration,
 
     /// What rendering backend to use.
     #[cfg(any(feature = "glow", feature = "wgpu_no_default_features"))]
@@ -369,19 +339,16 @@ pub struct NativeOptions {
     #[cfg(any(feature = "glow", feature = "wgpu_no_default_features"))]
     pub window_builder: Option<WindowBuilderHook>,
 
-    #[cfg(feature = "glow")]
-    /// Needed for cross compiling for VirtualBox VMSVGA driver with OpenGL ES 2.0 and OpenGL 2.1 which doesn't support SRGB texture.
-    /// See <https://github.com/emilk/egui/pull/1993>.
-    ///
-    /// For OpenGL ES 2.0: set this to [`egui_glow::ShaderVersion::Es100`] to solve blank texture problem (by using the "fallback shader").
-    pub shader_version: Option<egui_glow::ShaderVersion>,
-
     /// On desktop: make the window position to be centered at initialization.
     ///
     /// Platform specific:
     ///
     /// Wayland desktop currently not supported.
     pub centered: bool,
+
+    /// Configures glow instance.
+    #[cfg(feature = "glow")]
+    pub glow_options: egui_glow::GlowConfiguration,
 
     /// Configures wgpu instance/device/adapter/surface creation and renderloop.
     #[cfg(feature = "wgpu_no_default_features")]
@@ -427,6 +394,9 @@ impl Clone for NativeOptions {
             #[cfg(any(feature = "glow", feature = "wgpu_no_default_features"))]
             window_builder: None, // Skip any builder callbacks if cloning
 
+            #[cfg(feature = "glow")]
+            glow_options: self.glow_options.clone(),
+
             #[cfg(feature = "wgpu_no_default_features")]
             wgpu_options: self.wgpu_options.clone(),
 
@@ -446,11 +416,9 @@ impl Default for NativeOptions {
         Self {
             viewport: Default::default(),
 
-            glow_vsync: true,
             multisampling: 0,
             depth_buffer: 0,
             stencil_buffer: 0,
-            hardware_acceleration: HardwareAcceleration::Preferred,
 
             #[cfg(any(feature = "glow", feature = "wgpu_no_default_features"))]
             renderer: Renderer::default(),
@@ -463,10 +431,10 @@ impl Default for NativeOptions {
             #[cfg(any(feature = "glow", feature = "wgpu_no_default_features"))]
             window_builder: None,
 
-            #[cfg(feature = "glow")]
-            shader_version: None,
-
             centered: false,
+
+            #[cfg(feature = "glow")]
+            glow_options: egui_glow::GlowConfiguration::default(),
 
             #[cfg(feature = "wgpu_no_default_features")]
             wgpu_options: egui_wgpu::WgpuConfiguration::default()

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -473,6 +473,10 @@ pub struct WebOptions {
     #[cfg(feature = "glow")]
     pub webgl_context_option: WebGlContextOption,
 
+    /// Configures glow instance.
+    #[cfg(feature = "glow")]
+    pub glow_options: egui_glow::GlowConfiguration,
+
     /// Configures wgpu instance/device/adapter/surface creation and renderloop.
     #[cfg(feature = "wgpu_no_default_features")]
     pub wgpu_options: egui_wgpu::WgpuConfiguration,
@@ -516,6 +520,9 @@ impl Default for WebOptions {
 
             #[cfg(feature = "glow")]
             webgl_context_option: WebGlContextOption::BestFirst,
+
+            #[cfg(feature = "glow")]
+            glow_options: egui_glow::GlowConfiguration::default(),
 
             #[cfg(feature = "wgpu_no_default_features")]
             wgpu_options: egui_wgpu::WgpuConfiguration::default(),

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -303,7 +303,7 @@ pub struct NativeOptions {
     /// The default is `true`.
     ///
     /// Only affects the `glow` backend.
-    pub vsync: bool,
+    pub glow_vsync: bool,
 
     /// Set the level of the multisampling anti-aliasing (MSAA).
     ///
@@ -446,7 +446,7 @@ impl Default for NativeOptions {
         Self {
             viewport: Default::default(),
 
-            vsync: true,
+            glow_vsync: true,
             multisampling: 0,
             depth_buffer: 0,
             stencil_buffer: 0,

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -184,7 +184,7 @@ impl<'app> GlowWinitApp<'app> {
         let painter = egui_glow::Painter::new(
             gl,
             "",
-            native_options.shader_version,
+            native_options.glow_options.shader_version,
             native_options.dithering,
         )?;
 
@@ -952,12 +952,12 @@ impl GlutinWindowContext {
 
         use glutin::prelude::*;
         // convert native options to glutin options
-        let hardware_acceleration = match native_options.hardware_acceleration {
-            crate::HardwareAcceleration::Required => Some(true),
-            crate::HardwareAcceleration::Preferred => None,
-            crate::HardwareAcceleration::Off => Some(false),
+        let hardware_acceleration = match native_options.glow_options.hardware_acceleration {
+            egui_glow::HardwareAcceleration::Required => Some(true),
+            egui_glow::HardwareAcceleration::Preferred => None,
+            egui_glow::HardwareAcceleration::Off => Some(false),
         };
-        let swap_interval = if native_options.glow_vsync {
+        let swap_interval = if native_options.glow_options.vsync {
             glutin::surface::SwapInterval::Wait(NonZeroU32::MIN)
         } else {
             glutin::surface::SwapInterval::DontWait

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -957,7 +957,7 @@ impl GlutinWindowContext {
             crate::HardwareAcceleration::Preferred => None,
             crate::HardwareAcceleration::Off => Some(false),
         };
-        let swap_interval = if native_options.vsync {
+        let swap_interval = if native_options.glow_vsync {
             glutin::surface::SwapInterval::Wait(NonZeroU32::MIN)
         } else {
             glutin::surface::SwapInterval::DontWait

--- a/crates/eframe/src/web/web_painter_glow.rs
+++ b/crates/eframe/src/web/web_painter_glow.rs
@@ -31,7 +31,7 @@ impl WebPainterGlow {
         #[allow(clippy::allow_attributes, clippy::arc_with_non_send_sync)] // For wasm
         let gl = std::sync::Arc::new(gl);
 
-        let painter = egui_glow::Painter::new(gl, shader_prefix, None, options.dithering)
+        let painter = egui_glow::Painter::new(gl, shader_prefix, options.glow_options.shader_version, options.dithering)
             .map_err(|err| format!("Error starting glow painter: {err}"))?;
 
         Ok(Self {

--- a/crates/eframe/src/web/web_painter_glow.rs
+++ b/crates/eframe/src/web/web_painter_glow.rs
@@ -31,8 +31,13 @@ impl WebPainterGlow {
         #[allow(clippy::allow_attributes, clippy::arc_with_non_send_sync)] // For wasm
         let gl = std::sync::Arc::new(gl);
 
-        let painter = egui_glow::Painter::new(gl, shader_prefix, options.glow_options.shader_version, options.dithering)
-            .map_err(|err| format!("Error starting glow painter: {err}"))?;
+        let painter = egui_glow::Painter::new(
+            gl,
+            shader_prefix,
+            options.glow_options.shader_version,
+            options.dithering,
+        )
+        .map_err(|err| format!("Error starting glow painter: {err}"))?;
 
         Ok(Self {
             canvas,

--- a/crates/egui_glow/src/lib.rs
+++ b/crates/egui_glow/src/lib.rs
@@ -97,6 +97,7 @@ pub fn check_for_gl_error_impl(gl: &glow::Context, file: &str, line: u32, contex
 }
 
 /// Selects the level of hardware graphics acceleration.
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum HardwareAcceleration {
     /// Require graphics acceleration.
@@ -118,11 +119,13 @@ pub struct GlowConfiguration {
     /// Turn on vertical syncing, limiting the FPS to the display refresh rate.
     ///
     /// The default is `true`.
+    #[cfg(not(target_arch = "wasm32"))]
     pub vsync: bool,
 
     /// Specify whether or not hardware acceleration is preferred, required, or not.
     ///
     /// Default: [`HardwareAcceleration::Preferred`].
+    #[cfg(not(target_arch = "wasm32"))]
     pub hardware_acceleration: HardwareAcceleration,
 
     /// Needed for cross compiling for VirtualBox VMSVGA driver with OpenGL ES 2.0 and OpenGL 2.1 which doesn't support SRGB texture.
@@ -135,7 +138,9 @@ pub struct GlowConfiguration {
 impl Default for GlowConfiguration {
     fn default() -> Self {
         Self {
+            #[cfg(not(target_arch = "wasm32"))]
             vsync: true,
+            #[cfg(not(target_arch = "wasm32"))]
             hardware_acceleration: HardwareAcceleration::Preferred,
             shader_version: None,
         }

--- a/crates/egui_glow/src/lib.rs
+++ b/crates/egui_glow/src/lib.rs
@@ -112,7 +112,6 @@ pub enum HardwareAcceleration {
     Off,
 }
 
-
 /// Configuration for using glow with eframe or the egui-glow winit feature.
 #[derive(Clone)]
 pub struct GlowConfiguration {

--- a/crates/egui_glow/src/lib.rs
+++ b/crates/egui_glow/src/lib.rs
@@ -134,6 +134,7 @@ pub struct GlowConfiguration {
     pub shader_version: Option<ShaderVersion>,
 }
 
+#[cfg_attr(target_arch = "wasm32", expect(clippy::derivable_impls))]
 impl Default for GlowConfiguration {
     fn default() -> Self {
         Self {

--- a/crates/egui_glow/src/lib.rs
+++ b/crates/egui_glow/src/lib.rs
@@ -95,3 +95,55 @@ pub fn check_for_gl_error_impl(gl: &glow::Context, file: &str, line: u32, contex
         }
     }
 }
+
+/// Selects the level of hardware graphics acceleration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum HardwareAcceleration {
+    /// Require graphics acceleration.
+    Required,
+
+    /// Prefer graphics acceleration, but fall back to software.
+    Preferred,
+
+    /// Do NOT use graphics acceleration.
+    ///
+    /// On some platforms (macOS) this is ignored and treated the same as [`Self::Preferred`].
+    Off,
+}
+
+
+/// Configuration for using glow with eframe or the egui-glow winit feature.
+#[derive(Clone)]
+pub struct GlowConfiguration {
+    /// Turn on vertical syncing, limiting the FPS to the display refresh rate.
+    ///
+    /// The default is `true`.
+    pub vsync: bool,
+
+    /// Specify whether or not hardware acceleration is preferred, required, or not.
+    ///
+    /// Default: [`HardwareAcceleration::Preferred`].
+    pub hardware_acceleration: HardwareAcceleration,
+
+    /// Needed for cross compiling for VirtualBox VMSVGA driver with OpenGL ES 2.0 and OpenGL 2.1 which doesn't support SRGB texture.
+    /// See <https://github.com/emilk/egui/pull/1993>.
+    ///
+    /// For OpenGL ES 2.0: set this to [`ShaderVersion::Es100`] to solve blank texture problem (by using the "fallback shader").
+    pub shader_version: Option<ShaderVersion>,
+}
+
+impl Default for GlowConfiguration {
+    fn default() -> Self {
+        Self {
+            vsync: true,
+            hardware_acceleration: HardwareAcceleration::Preferred,
+            shader_version: None,
+        }
+    }
+}
+
+#[test]
+fn glow_config_impl_send_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<GlowConfiguration>();
+}


### PR DESCRIPTION
This is a breaking public API change, but is otherwise trivial due to it not changing any actual runtime behaviour.

This renames eframe's NativeOptions `vsync` option to `glow_vsync` to make clear without even looking at docs fully that this is specific to the `glow` backend.

While I think a better option would actually be to change the wgpu creation options to match the vsync option if not specified (either to `AutoVsync` or `AutoNoVsync` depending on setting) this would require this be made an `Option<PresentMode>`, which would be confusing - and the `WgpuConfiguration` should probably take priority over other options here, as there's more than 2 present modes that are relevant. So I think this is a suitable way to go.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* This does not close an issue - this was a trivial amount of code to change, so I might as well just make it a PR on the spot.
* [x] I have followed the instructions in the PR template
