### PR TITLE
Add viewport rotation (0°/90°/180°/270°)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## Unreleased
+
+### Added
+* Viewport rotation support (0°/90°/180°/270°) via `ViewportBuilder::with_rotation()` and `Context::set_viewport_rotation()` ([#4130](https://github.com/emilk/egui/issues/4130), [#2054](https://github.com/emilk/egui/issues/2054))
+  * Entire UI is rendered rotated with all input coordinates automatically remapped
+  * Software cursor with rotated movement direction, capture/release on window edges
+  * Cursor icons adapt to rotation (e.g. `ResizeHorizontal` ↔ `ResizeVertical` at 90°/270°)
+  * Configurable cursor scale via `Context::set_software_cursor_scale()`
+  * Works on all backends: glow, wgpu, and web (via `Context::set_viewport_rotation()`)
+  * `ViewportRotation` enum added to `emath` with coordinate transform methods
+
+
 ## 0.34.1 - 2026-03-27
 Nothing new
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,6 +1326,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_demo_app_90"
+version = "0.34.1"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "bytemuck",
+ "eframe",
+ "egui",
+ "egui_demo_lib",
+ "egui_extras",
+ "egui_kittest",
+ "ehttp",
+ "env_logger",
+ "image",
+ "jiff",
+ "log",
+ "mimalloc",
+ "poll-promise",
+ "profiling",
+ "puffin",
+ "puffin_http",
+ "rfd",
+ "serde",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "egui_demo_lib"
 version = "0.34.1"
 dependencies = [
@@ -2083,6 +2112,24 @@ dependencies = [
 
 [[package]]
 name = "hello_world"
+version = "0.1.0"
+dependencies = [
+ "eframe",
+ "egui_extras",
+ "env_logger",
+]
+
+[[package]]
+name = "hello_world_90_glow"
+version = "0.1.0"
+dependencies = [
+ "eframe",
+ "egui_extras",
+ "env_logger",
+]
+
+[[package]]
+name = "hello_world_90_wgpu"
 version = "0.1.0"
 dependencies = [
  "eframe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
   "crates/ecolor",
   "crates/egui_demo_app",
+  "crates/egui_demo_app_90",
   "crates/egui_demo_lib",
   "crates/egui_extras",
   "crates/egui_glow",

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -7,6 +7,9 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## Unreleased
+* Propagate `ViewportBuilder::rotation` to `Context` at init for glow and wgpu backends
+
 ## 0.34.1 - 2026-03-27
 * `wgpu` backend: Enable WebGL fallback [#8038](https://github.com/emilk/egui/pull/8038) by [@emilk](https://github.com/emilk)
 * Only apply cursor style to the `<canvas>` [#8036](https://github.com/emilk/egui/pull/8036) by [@mkeeter](https://github.com/mkeeter)

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -678,7 +678,9 @@ impl GlowWinitRunning<'_> {
         egui_winit.handle_platform_output(&window, platform_output);
 
         if is_visible {
-            let clipped_primitives = integration.egui_ctx.tessellate(shapes, pixels_per_point);
+            let clipped_primitives = integration
+                .egui_ctx
+                .tessellate_for_viewport(viewport_id, shapes, pixels_per_point);
 
             {
                 // We may need to switch contexts again, because of immediate viewports:
@@ -1533,7 +1535,8 @@ fn render_immediate_viewport(
 
     // ---------------------------------------------------
 
-    let clipped_primitives = egui_ctx.tessellate(shapes, pixels_per_point);
+    let clipped_primitives =
+        egui_ctx.tessellate_for_viewport(viewport_id, shapes, pixels_per_point);
 
     let mut glutin = glutin.borrow_mut();
 

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -277,6 +277,11 @@ impl<'app> GlowWinitApp<'app> {
             }
         }
 
+        // Apply viewport rotation from builder
+        if let Some(rotation) = self.native_options.viewport.rotation {
+            integration.egui_ctx.set_viewport_rotation(rotation);
+        }
+
         if self
             .native_options
             .viewport

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -709,7 +709,8 @@ impl WgpuWinitRunning<'_> {
         egui_winit.handle_platform_output(window, platform_output);
 
         let vsync_secs = if is_visible {
-            let clipped_primitives = egui_ctx.tessellate(shapes, pixels_per_point);
+            let clipped_primitives =
+                egui_ctx.tessellate_for_viewport(viewport_id, shapes, pixels_per_point);
 
             let mut screenshot_commands = vec![];
             viewport.actions_requested.retain(|cmd| {
@@ -1109,7 +1110,7 @@ fn render_immediate_viewport(
         }
     }
 
-    let clipped_primitives = egui_ctx.tessellate(shapes, pixels_per_point);
+    let clipped_primitives = egui_ctx.tessellate_for_viewport(ids.this, shapes, pixels_per_point);
     painter.paint_and_update_textures(
         ids.this,
         pixels_per_point,

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -330,6 +330,11 @@ impl<'app> WgpuWinitApp<'app> {
             resized_viewport: None,
         }));
 
+        // Apply viewport rotation from builder
+        if let Some(rotation) = self.native_options.viewport.rotation {
+            shared.borrow().egui_ctx.set_viewport_rotation(rotation);
+        }
+
         {
             // Create a weak pointer so that we don't keep state alive for too long.
             let shared = Rc::downgrade(&shared);

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1828,6 +1828,7 @@ pub fn create_winit_window_attributes(
 
         mouse_passthrough: _, // handled in `apply_viewport_builder_to_window`
         clamp_size_to_monitor_size: _, // Handled in `viewport_builder` in `epi_integration.rs`
+        rotation: _, // Handled by egui Context (input/output transform)
     } = viewport_builder;
 
     let mut window_attributes = winit::window::WindowAttributes::default()

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2577,6 +2577,12 @@ impl ContextImpl {
 
         let mut platform_output: PlatformOutput = std::mem::take(&mut viewport.output);
 
+        // Rotate cursor icon to match viewport rotation
+        let rotation = viewport.viewport_rotation;
+        if !rotation.is_none() {
+            platform_output.cursor_icon = platform_output.cursor_icon.rotate(rotation);
+        }
+
         if self.memory.should_interrupt_ime()
             && let Some(ime) = &mut platform_output.ime
         {

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -243,6 +243,9 @@ pub struct ViewportState {
     // ----------------------
     // Cross-frame statistics:
     pub num_multipass_in_row: usize,
+
+    /// Viewport rotation (0/90/180/270 degrees).
+    pub viewport_rotation: emath::ViewportRotation,
 }
 
 /// What called [`Context::request_repaint`] or [`Context::request_discard`]?
@@ -441,6 +444,36 @@ impl ContextImpl {
             // We should really scale everything else in the input too,
             // but the `screen_rect` is the most important part.
         }
+        // Apply viewport rotation to input coordinates
+        let rotation = viewport.viewport_rotation;
+        if !rotation.is_none() {
+            if let Some(physical_rect) = &new_raw_input.screen_rect {
+                let physical_size = physical_rect.size();
+                new_raw_input.screen_rect = Some(rotation.transform_screen_rect(*physical_rect));
+
+                for event in &mut new_raw_input.events {
+                    match event {
+                        crate::Event::PointerMoved(pos) => {
+                            *pos = rotation.transform_pos(*pos, physical_size);
+                        }
+                        crate::Event::PointerButton { pos, .. } => {
+                            *pos = rotation.transform_pos(*pos, physical_size);
+                        }
+                        crate::Event::Touch { pos, .. } => {
+                            *pos = rotation.transform_pos(*pos, physical_size);
+                        }
+                        crate::Event::MouseWheel { delta, .. } => {
+                            *delta = rotation.transform_vec(*delta);
+                        }
+                        crate::Event::MouseMoved(delta) => {
+                            *delta = rotation.transform_vec(*delta);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
         let native_pixels_per_point = new_raw_input
             .viewport()
             .native_pixels_per_point
@@ -2224,6 +2257,22 @@ impl Context {
         });
     }
 
+    /// Get the current viewport rotation.
+    pub fn viewport_rotation(&self) -> emath::ViewportRotation {
+        self.write(|ctx| ctx.viewport().viewport_rotation)
+    }
+
+    /// Set the viewport rotation for the current viewport.
+    ///
+    /// This rotates the entire UI by the given angle (0/90/180/270 degrees).
+    /// Input coordinates are automatically remapped, so application code
+    /// works in a normal coordinate space.
+    pub fn set_viewport_rotation(&self, rotation: emath::ViewportRotation) {
+        self.write(|ctx| {
+            ctx.viewport().viewport_rotation = rotation;
+        });
+    }
+
     /// Allocate a texture.
     ///
     /// This is for advanced users.
@@ -2724,7 +2773,7 @@ impl Context {
             };
 
             let paint_stats = PaintStats::from_shapes(&shapes);
-            let clipped_primitives = {
+            let mut clipped_primitives = {
                 profiling::scope!("tessellator::tessellate_shapes");
                 tessellator::Tessellator::new(
                     pixels_per_point,
@@ -2735,6 +2784,36 @@ impl Context {
                 .tessellate_shapes(shapes)
             };
             ctx.paint_stats = paint_stats.with_clipped_primitives(&clipped_primitives);
+
+            // Apply viewport rotation: transform from logical UI space back to physical screen space
+            let rotation = ctx.viewport().viewport_rotation;
+            if !rotation.is_none() {
+                let logical_size = ctx.viewport().input.viewport_rect().size();
+                for primitive in &mut clipped_primitives {
+                    // Rotate clip_rect back to physical space
+                    let min = rotation.inverse_transform_pos(
+                        primitive.clip_rect.min,
+                        logical_size,
+                    );
+                    let max = rotation.inverse_transform_pos(
+                        primitive.clip_rect.max,
+                        logical_size,
+                    );
+                    primitive.clip_rect = Rect::from_two_pos(min, max);
+
+                    // Rotate mesh vertices back to physical space
+                    if let epaint::Primitive::Mesh(mesh) = &mut primitive.primitive {
+                        for vertex in &mut mesh.vertices {
+                            let pos = rotation.inverse_transform_pos(
+                                Pos2::new(vertex.pos.x, vertex.pos.y),
+                                logical_size,
+                            );
+                            vertex.pos = pos;
+                        }
+                    }
+                }
+            }
+
             clipped_primitives
         })
     }

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -246,6 +246,20 @@ pub struct ViewportState {
 
     /// Viewport rotation (0/90/180/270 degrees).
     pub viewport_rotation: emath::ViewportRotation,
+
+    /// Previous physical mouse position (for computing deltas in rotated mode).
+    pub prev_physical_pointer_pos: Option<Pos2>,
+
+    /// Virtual cursor position in logical space (used when rotation is active).
+    pub virtual_cursor_pos: Option<Pos2>,
+
+    /// Whether the software cursor is currently captured (OS cursor hidden, warp active).
+    /// Set to false when the virtual cursor reaches the window edge.
+    pub cursor_captured: bool,
+
+    /// When releasing capture, warp the OS cursor to this physical position.
+    pub release_cursor_to: Option<Pos2>,
+
 }
 
 /// What called [`Context::request_repaint`] or [`Context::request_discard`]?
@@ -449,23 +463,90 @@ impl ContextImpl {
         if !rotation.is_none() {
             if let Some(physical_rect) = &new_raw_input.screen_rect {
                 let physical_size = physical_rect.size();
-                new_raw_input.screen_rect = Some(rotation.transform_screen_rect(*physical_rect));
+                let logical_rect = rotation.transform_screen_rect(*physical_rect);
+                new_raw_input.screen_rect = Some(logical_rect);
+                let logical_size = logical_rect.size();
 
+                let edge_margin = 1.0;
+
+                // First pass: update virtual cursor and capture state
+                for event in &new_raw_input.events {
+                    match event {
+                        crate::Event::MouseMoved(delta) => {
+                            if viewport.cursor_captured {
+                                let virtual_pos = viewport.virtual_cursor_pos
+                                    .unwrap_or_else(|| logical_rect.center());
+                                let new_x = virtual_pos.x + delta.x;
+                                let new_y = virtual_pos.y + delta.y;
+
+                                // Check if we hit an edge → release
+                                let at_edge = new_x <= 0.0
+                                    || new_x >= logical_size.x
+                                    || new_y <= 0.0
+                                    || new_y >= logical_size.y;
+
+                                if at_edge {
+                                    // Release: warp OS cursor 3px outside the window edge
+                                    let overshoot = 3.0;
+                                    let edge_pos = Pos2::new(
+                                        if new_x <= 0.0 { -overshoot }
+                                        else if new_x >= logical_size.x { logical_size.x + overshoot }
+                                        else { new_x },
+                                        if new_y <= 0.0 { -overshoot }
+                                        else if new_y >= logical_size.y { logical_size.y + overshoot }
+                                        else { new_y },
+                                    );
+                                    viewport.release_cursor_to = Some(
+                                        rotation.inverse_transform_pos(edge_pos, logical_size),
+                                    );
+                                    viewport.cursor_captured = false;
+                                    viewport.virtual_cursor_pos = None;
+                                } else {
+                                    let new_virtual_pos = Pos2::new(
+                                        new_x.clamp(edge_margin, logical_size.x - edge_margin),
+                                        new_y.clamp(edge_margin, logical_size.y - edge_margin),
+                                    );
+                                    viewport.virtual_cursor_pos = Some(new_virtual_pos);
+                                }
+                            }
+                        }
+                        crate::Event::PointerMoved(pos) => {
+                            // Pointer entered or is in window — capture at entry point
+                            if !viewport.cursor_captured && viewport.virtual_cursor_pos.is_none() {
+                                let entry_pos = rotation.transform_pos(*pos, physical_size);
+                                viewport.cursor_captured = true;
+                                viewport.virtual_cursor_pos = Some(entry_pos);
+                            }
+                        }
+                        crate::Event::PointerGone => {
+                            viewport.cursor_captured = false;
+                            viewport.virtual_cursor_pos = None;
+                        }
+                        _ => {}
+                    }
+                }
+
+                // Second pass: remap all position-based events
                 for event in &mut new_raw_input.events {
                     match event {
                         crate::Event::PointerMoved(pos) => {
-                            *pos = rotation.transform_pos(*pos, physical_size);
+                            if let Some(virtual_pos) = viewport.virtual_cursor_pos {
+                                *pos = virtual_pos;
+                            } else {
+                                *pos = rotation.transform_pos(*pos, physical_size);
+                            }
                         }
                         crate::Event::PointerButton { pos, .. } => {
-                            *pos = rotation.transform_pos(*pos, physical_size);
+                            if let Some(virtual_pos) = viewport.virtual_cursor_pos {
+                                *pos = virtual_pos;
+                            } else {
+                                *pos = rotation.transform_pos(*pos, physical_size);
+                            }
                         }
                         crate::Event::Touch { pos, .. } => {
                             *pos = rotation.transform_pos(*pos, physical_size);
                         }
                         crate::Event::MouseWheel { delta, .. } => {
-                            *delta = rotation.transform_vec(*delta);
-                        }
-                        crate::Event::MouseMoved(delta) => {
                             *delta = rotation.transform_vec(*delta);
                         }
                         _ => {}
@@ -2577,10 +2658,35 @@ impl ContextImpl {
 
         let mut platform_output: PlatformOutput = std::mem::take(&mut viewport.output);
 
-        // Rotate cursor icon to match viewport rotation
+        // Rotate cursor icon and draw software cursor when viewport is rotated
         let rotation = viewport.viewport_rotation;
         if !rotation.is_none() {
-            platform_output.cursor_icon = platform_output.cursor_icon.rotate(rotation);
+            // Save the original cursor before hiding it
+            let original_cursor = platform_output.cursor_icon;
+            if viewport.cursor_captured {
+                // Captured: hide OS cursor, warp to center, draw software cursor
+                platform_output.cursor_icon = CursorIcon::None;
+                let logical_vp = viewport.input.viewport_rect();
+                let physical_center = if rotation.swaps_axes() {
+                    Pos2::new(logical_vp.height() / 2.0, logical_vp.width() / 2.0)
+                } else {
+                    logical_vp.center()
+                };
+                viewport.commands.push(ViewportCommand::CursorPosition(physical_center));
+
+                if let Some(pos) = viewport.virtual_cursor_pos {
+                    let cursor_layer = LayerId::new(Order::Debug, Id::new("software_cursor"));
+                    paint_software_cursor(
+                        viewport.graphics.entry(cursor_layer),
+                        original_cursor,
+                        pos,
+                    );
+                }
+            }
+            // When releasing, warp OS cursor to the edge position
+            if let Some(release_pos) = viewport.release_cursor_to.take() {
+                viewport.commands.push(ViewportCommand::CursorPosition(release_pos));
+            }
         }
 
         if self.memory.should_interrupt_ime()
@@ -4445,5 +4551,118 @@ mod test {
                 "The request should have been cleared when fulfilled"
             );
         }
+    }
+}
+
+/// Paint a software cursor on the given paint list.
+///
+/// This is used when viewport rotation is active: the OS cursor is hidden
+/// and we draw our own cursor in logical (rotated) space.
+fn paint_software_cursor(
+    paint_list: &mut crate::layers::PaintList,
+    cursor: CursorIcon,
+    pos: Pos2,
+) {
+    use epaint::{Color32, PathShape, Shape, Stroke};
+
+    let (shapes, clip_rect) = match cursor {
+        CursorIcon::None => return,
+
+        CursorIcon::Text => {
+            // Vertical text caret bar
+            let half_h = 8.0;
+            let shapes = vec![
+                Shape::line_segment(
+                    [pos + vec2(0.0, -half_h), pos + vec2(0.0, half_h)],
+                    Stroke::new(2.0, Color32::WHITE),
+                ),
+                Shape::line_segment(
+                    [pos + vec2(-3.0, -half_h), pos + vec2(3.0, -half_h)],
+                    Stroke::new(1.5, Color32::WHITE),
+                ),
+                Shape::line_segment(
+                    [pos + vec2(-3.0, half_h), pos + vec2(3.0, half_h)],
+                    Stroke::new(1.5, Color32::WHITE),
+                ),
+            ];
+            (shapes, Rect::from_center_size(pos, vec2(20.0, 24.0)))
+        }
+
+        CursorIcon::VerticalText => {
+            // Horizontal text caret bar
+            let half_w = 8.0;
+            let shapes = vec![
+                Shape::line_segment(
+                    [pos + vec2(-half_w, 0.0), pos + vec2(half_w, 0.0)],
+                    Stroke::new(2.0, Color32::WHITE),
+                ),
+                Shape::line_segment(
+                    [pos + vec2(-half_w, -3.0), pos + vec2(-half_w, 3.0)],
+                    Stroke::new(1.5, Color32::WHITE),
+                ),
+                Shape::line_segment(
+                    [pos + vec2(half_w, -3.0), pos + vec2(half_w, 3.0)],
+                    Stroke::new(1.5, Color32::WHITE),
+                ),
+            ];
+            (shapes, Rect::from_center_size(pos, vec2(24.0, 20.0)))
+        }
+
+        CursorIcon::PointingHand | CursorIcon::Grab | CursorIcon::Grabbing => {
+            // Simple filled circle for hand-like cursors
+            let shapes = vec![
+                Shape::circle_filled(pos, 6.0, Color32::WHITE),
+                Shape::circle_stroke(pos, 6.0, Stroke::new(1.5, Color32::BLACK)),
+            ];
+            (shapes, Rect::from_center_size(pos, vec2(20.0, 20.0)))
+        }
+
+        CursorIcon::Crosshair => {
+            let s = 8.0;
+            let shapes = vec![
+                Shape::line_segment(
+                    [pos + vec2(-s, 0.0), pos + vec2(s, 0.0)],
+                    Stroke::new(1.5, Color32::WHITE),
+                ),
+                Shape::line_segment(
+                    [pos + vec2(0.0, -s), pos + vec2(0.0, s)],
+                    Stroke::new(1.5, Color32::WHITE),
+                ),
+            ];
+            (shapes, Rect::from_center_size(pos, vec2(24.0, 24.0)))
+        }
+
+        CursorIcon::NotAllowed | CursorIcon::NoDrop => {
+            // Circle with a line through it
+            let shapes = vec![
+                Shape::circle_stroke(pos, 8.0, Stroke::new(2.0, Color32::RED)),
+                Shape::line_segment(
+                    [pos + vec2(-5.0, -5.0), pos + vec2(5.0, 5.0)],
+                    Stroke::new(2.0, Color32::RED),
+                ),
+            ];
+            (shapes, Rect::from_center_size(pos, vec2(24.0, 24.0)))
+        }
+
+        _ => {
+            // Default arrow cursor: a triangle pointing up-left
+            let tip = pos;
+            let left = pos + vec2(0.0, 16.0);
+            let right = pos + vec2(11.0, 11.0);
+
+            let arrow = PathShape::convex_polygon(
+                vec![tip, left, right],
+                Color32::WHITE,
+                Stroke::new(1.5, Color32::BLACK),
+            );
+            (
+                vec![Shape::Path(arrow)],
+                Rect::from_min_size(pos, vec2(16.0, 20.0)),
+            )
+        }
+    };
+
+    for shape in shapes {
+        paint_list.add(clip_rect, shape);
     }
 }

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2884,6 +2884,23 @@ impl Context {
         shapes: Vec<ClippedShape>,
         pixels_per_point: f32,
     ) -> Vec<ClippedPrimitive> {
+        self.tessellate_for_viewport(ViewportId::ROOT, shapes, pixels_per_point)
+    }
+
+    /// Same as [`Self::tessellate`] but applies the viewport rotation of the
+    /// given `viewport_id` instead of the currently-active viewport.
+    ///
+    /// Required because [`Self::tessellate`] is typically called by the
+    /// integration **after** the viewport pass has ended (so `viewport_stack`
+    /// is already popped). Without explicit targeting, the current-viewport
+    /// fallback resolves to `ROOT`, which causes the root's rotation to leak
+    /// into all other viewports' rendering.
+    pub fn tessellate_for_viewport(
+        &self,
+        viewport_id: ViewportId,
+        shapes: Vec<ClippedShape>,
+        pixels_per_point: f32,
+    ) -> Vec<ClippedPrimitive> {
         profiling::function_scope!();
 
         // A tempting optimization is to reuse the tessellation from last frame if the
@@ -2917,9 +2934,10 @@ impl Context {
             ctx.paint_stats = paint_stats.with_clipped_primitives(&clipped_primitives);
 
             // Apply viewport rotation: transform from logical UI space back to physical screen space
-            let rotation = ctx.viewport().viewport_rotation;
+            let viewport = ctx.viewport_for(viewport_id);
+            let rotation = viewport.viewport_rotation;
             if !rotation.is_none() {
-                let logical_size = ctx.viewport().input.viewport_rect().size();
+                let logical_size = viewport.input.viewport_rect().size();
                 for primitive in &mut clipped_primitives {
                     // Rotate clip_rect back to physical space
                     let min = rotation.inverse_transform_pos(

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -257,6 +257,9 @@ pub struct ViewportState {
     /// Set to false when the virtual cursor reaches the window edge.
     pub cursor_captured: bool,
 
+    /// Scale factor for the software cursor (default: 1.0).
+    pub software_cursor_scale: f32,
+
     /// When releasing capture, warp the OS cursor to this physical position.
     pub release_cursor_to: Option<Pos2>,
 
@@ -2354,6 +2357,15 @@ impl Context {
         });
     }
 
+    /// Set the scale factor for the software cursor (default: 1.0).
+    ///
+    /// Only has an effect when viewport rotation is active.
+    pub fn set_software_cursor_scale(&self, scale: f32) {
+        self.write(|ctx| {
+            ctx.viewport().software_cursor_scale = scale;
+        });
+    }
+
     /// Allocate a texture.
     ///
     /// This is for advanced users.
@@ -2676,15 +2688,22 @@ impl ContextImpl {
 
                 if let Some(pos) = viewport.virtual_cursor_pos {
                     let cursor_layer = LayerId::new(Order::Debug, Id::new("software_cursor"));
+                    let scale = if viewport.software_cursor_scale <= 0.0 {
+                        1.0
+                    } else {
+                        viewport.software_cursor_scale
+                    };
                     paint_software_cursor(
                         viewport.graphics.entry(cursor_layer),
                         original_cursor,
                         pos,
+                        scale,
                     );
                 }
             }
-            // When releasing, warp OS cursor to the edge position
+            // When releasing, restore OS cursor and warp to the edge position
             if let Some(release_pos) = viewport.release_cursor_to.take() {
+                platform_output.cursor_icon = CursorIcon::Default;
                 viewport.commands.push(ViewportCommand::CursorPosition(release_pos));
             }
         }
@@ -4562,102 +4581,106 @@ fn paint_software_cursor(
     paint_list: &mut crate::layers::PaintList,
     cursor: CursorIcon,
     pos: Pos2,
+    scale: f32,
 ) {
     use epaint::{Color32, PathShape, Shape, Stroke};
+
+    let s = scale;
 
     let (shapes, clip_rect) = match cursor {
         CursorIcon::None => return,
 
         CursorIcon::Text => {
-            // Vertical text caret bar
-            let half_h = 8.0;
+            let half_h = 8.0 * s;
+            let sw = 3.0 * s;
             let shapes = vec![
                 Shape::line_segment(
                     [pos + vec2(0.0, -half_h), pos + vec2(0.0, half_h)],
-                    Stroke::new(2.0, Color32::WHITE),
+                    Stroke::new(2.0 * s, Color32::WHITE),
                 ),
                 Shape::line_segment(
-                    [pos + vec2(-3.0, -half_h), pos + vec2(3.0, -half_h)],
-                    Stroke::new(1.5, Color32::WHITE),
+                    [pos + vec2(-sw, -half_h), pos + vec2(sw, -half_h)],
+                    Stroke::new(1.5 * s, Color32::WHITE),
                 ),
                 Shape::line_segment(
-                    [pos + vec2(-3.0, half_h), pos + vec2(3.0, half_h)],
-                    Stroke::new(1.5, Color32::WHITE),
+                    [pos + vec2(-sw, half_h), pos + vec2(sw, half_h)],
+                    Stroke::new(1.5 * s, Color32::WHITE),
                 ),
             ];
-            (shapes, Rect::from_center_size(pos, vec2(20.0, 24.0)))
+            (shapes, Rect::from_center_size(pos, vec2(20.0 * s, 24.0 * s)))
         }
 
         CursorIcon::VerticalText => {
-            // Horizontal text caret bar
-            let half_w = 8.0;
+            let half_w = 8.0 * s;
+            let sw = 3.0 * s;
             let shapes = vec![
                 Shape::line_segment(
                     [pos + vec2(-half_w, 0.0), pos + vec2(half_w, 0.0)],
-                    Stroke::new(2.0, Color32::WHITE),
+                    Stroke::new(2.0 * s, Color32::WHITE),
                 ),
                 Shape::line_segment(
-                    [pos + vec2(-half_w, -3.0), pos + vec2(-half_w, 3.0)],
-                    Stroke::new(1.5, Color32::WHITE),
+                    [pos + vec2(-half_w, -sw), pos + vec2(-half_w, sw)],
+                    Stroke::new(1.5 * s, Color32::WHITE),
                 ),
                 Shape::line_segment(
-                    [pos + vec2(half_w, -3.0), pos + vec2(half_w, 3.0)],
-                    Stroke::new(1.5, Color32::WHITE),
+                    [pos + vec2(half_w, -sw), pos + vec2(half_w, sw)],
+                    Stroke::new(1.5 * s, Color32::WHITE),
                 ),
             ];
-            (shapes, Rect::from_center_size(pos, vec2(24.0, 20.0)))
+            (shapes, Rect::from_center_size(pos, vec2(24.0 * s, 20.0 * s)))
         }
 
         CursorIcon::PointingHand | CursorIcon::Grab | CursorIcon::Grabbing => {
-            // Simple filled circle for hand-like cursors
+            let r = 6.0 * s;
             let shapes = vec![
-                Shape::circle_filled(pos, 6.0, Color32::WHITE),
-                Shape::circle_stroke(pos, 6.0, Stroke::new(1.5, Color32::BLACK)),
+                Shape::circle_filled(pos, r, Color32::WHITE),
+                Shape::circle_stroke(pos, r, Stroke::new(1.5 * s, Color32::BLACK)),
             ];
-            (shapes, Rect::from_center_size(pos, vec2(20.0, 20.0)))
+            (shapes, Rect::from_center_size(pos, vec2(20.0 * s, 20.0 * s)))
         }
 
         CursorIcon::Crosshair => {
-            let s = 8.0;
+            let h = 8.0 * s;
             let shapes = vec![
                 Shape::line_segment(
-                    [pos + vec2(-s, 0.0), pos + vec2(s, 0.0)],
-                    Stroke::new(1.5, Color32::WHITE),
+                    [pos + vec2(-h, 0.0), pos + vec2(h, 0.0)],
+                    Stroke::new(1.5 * s, Color32::WHITE),
                 ),
                 Shape::line_segment(
-                    [pos + vec2(0.0, -s), pos + vec2(0.0, s)],
-                    Stroke::new(1.5, Color32::WHITE),
+                    [pos + vec2(0.0, -h), pos + vec2(0.0, h)],
+                    Stroke::new(1.5 * s, Color32::WHITE),
                 ),
             ];
-            (shapes, Rect::from_center_size(pos, vec2(24.0, 24.0)))
+            (shapes, Rect::from_center_size(pos, vec2(24.0 * s, 24.0 * s)))
         }
 
         CursorIcon::NotAllowed | CursorIcon::NoDrop => {
-            // Circle with a line through it
+            let r = 8.0 * s;
+            let d = 5.0 * s;
             let shapes = vec![
-                Shape::circle_stroke(pos, 8.0, Stroke::new(2.0, Color32::RED)),
+                Shape::circle_stroke(pos, r, Stroke::new(2.0 * s, Color32::RED)),
                 Shape::line_segment(
-                    [pos + vec2(-5.0, -5.0), pos + vec2(5.0, 5.0)],
-                    Stroke::new(2.0, Color32::RED),
+                    [pos + vec2(-d, -d), pos + vec2(d, d)],
+                    Stroke::new(2.0 * s, Color32::RED),
                 ),
             ];
-            (shapes, Rect::from_center_size(pos, vec2(24.0, 24.0)))
+            (shapes, Rect::from_center_size(pos, vec2(24.0 * s, 24.0 * s)))
         }
 
         _ => {
-            // Default arrow cursor: a triangle pointing up-left
+            // Default arrow cursor
             let tip = pos;
-            let left = pos + vec2(0.0, 16.0);
-            let right = pos + vec2(11.0, 11.0);
+            let left = pos + vec2(0.0, 16.0 * s);
+            let right = pos + vec2(11.0 * s, 11.0 * s);
 
             let arrow = PathShape::convex_polygon(
                 vec![tip, left, right],
                 Color32::WHITE,
-                Stroke::new(1.5, Color32::BLACK),
+                Stroke::new(1.5 * s, Color32::BLACK),
             );
             (
                 vec![Shape::Path(arrow)],
-                Rect::from_min_size(pos, vec2(16.0, 20.0)),
+                Rect::from_min_size(pos, vec2(16.0 * s, 20.0 * s)),
             )
         }
     };

--- a/crates/egui/src/data/output.rs
+++ b/crates/egui/src/data/output.rs
@@ -428,6 +428,110 @@ impl CursorIcon {
         Self::ZoomIn,
         Self::ZoomOut,
     ];
+
+    /// Rotate a cursor icon to match a [`emath::ViewportRotation`].
+    ///
+    /// Directional cursors (resize arrows, etc.) are remapped so they
+    /// visually point in the correct direction after rotation.
+    pub fn rotate(self, rotation: emath::ViewportRotation) -> Self {
+        use emath::ViewportRotation;
+        if rotation.is_none() {
+            return self;
+        }
+
+        match self {
+            // Bidirectional resize cursors
+            Self::ResizeHorizontal => match rotation {
+                ViewportRotation::CW90 | ViewportRotation::CW270 => Self::ResizeVertical,
+                _ => self,
+            },
+            Self::ResizeVertical => match rotation {
+                ViewportRotation::CW90 | ViewportRotation::CW270 => Self::ResizeHorizontal,
+                _ => self,
+            },
+            Self::ResizeNeSw => match rotation {
+                ViewportRotation::CW90 | ViewportRotation::CW270 => Self::ResizeNwSe,
+                _ => self,
+            },
+            Self::ResizeNwSe => match rotation {
+                ViewportRotation::CW90 | ViewportRotation::CW270 => Self::ResizeNeSw,
+                _ => self,
+            },
+
+            // Column/Row resize
+            Self::ResizeColumn => match rotation {
+                ViewportRotation::CW90 | ViewportRotation::CW270 => Self::ResizeRow,
+                _ => self,
+            },
+            Self::ResizeRow => match rotation {
+                ViewportRotation::CW90 | ViewportRotation::CW270 => Self::ResizeColumn,
+                _ => self,
+            },
+
+            // Text cursors
+            Self::Text => match rotation {
+                ViewportRotation::CW90 | ViewportRotation::CW270 => Self::VerticalText,
+                _ => self,
+            },
+            Self::VerticalText => match rotation {
+                ViewportRotation::CW90 | ViewportRotation::CW270 => Self::Text,
+                _ => self,
+            },
+
+            // Directional (single-direction) resize cursors: rotate clockwise
+            Self::ResizeEast => match rotation {
+                ViewportRotation::CW90 => Self::ResizeSouth,
+                ViewportRotation::CW180 => Self::ResizeWest,
+                ViewportRotation::CW270 => Self::ResizeNorth,
+                _ => self,
+            },
+            Self::ResizeSouthEast => match rotation {
+                ViewportRotation::CW90 => Self::ResizeSouthWest,
+                ViewportRotation::CW180 => Self::ResizeNorthWest,
+                ViewportRotation::CW270 => Self::ResizeNorthEast,
+                _ => self,
+            },
+            Self::ResizeSouth => match rotation {
+                ViewportRotation::CW90 => Self::ResizeWest,
+                ViewportRotation::CW180 => Self::ResizeNorth,
+                ViewportRotation::CW270 => Self::ResizeEast,
+                _ => self,
+            },
+            Self::ResizeSouthWest => match rotation {
+                ViewportRotation::CW90 => Self::ResizeNorthWest,
+                ViewportRotation::CW180 => Self::ResizeNorthEast,
+                ViewportRotation::CW270 => Self::ResizeSouthEast,
+                _ => self,
+            },
+            Self::ResizeWest => match rotation {
+                ViewportRotation::CW90 => Self::ResizeNorth,
+                ViewportRotation::CW180 => Self::ResizeEast,
+                ViewportRotation::CW270 => Self::ResizeSouth,
+                _ => self,
+            },
+            Self::ResizeNorthWest => match rotation {
+                ViewportRotation::CW90 => Self::ResizeNorthEast,
+                ViewportRotation::CW180 => Self::ResizeSouthEast,
+                ViewportRotation::CW270 => Self::ResizeSouthWest,
+                _ => self,
+            },
+            Self::ResizeNorth => match rotation {
+                ViewportRotation::CW90 => Self::ResizeEast,
+                ViewportRotation::CW180 => Self::ResizeSouth,
+                ViewportRotation::CW270 => Self::ResizeWest,
+                _ => self,
+            },
+            Self::ResizeNorthEast => match rotation {
+                ViewportRotation::CW90 => Self::ResizeSouthEast,
+                ViewportRotation::CW180 => Self::ResizeSouthWest,
+                ViewportRotation::CW270 => Self::ResizeNorthWest,
+                _ => self,
+            },
+
+            // All other cursors are rotation-invariant
+            _ => self,
+        }
+    }
 }
 
 /// Things that happened during this frame that the integration may be interested in.

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -333,6 +333,12 @@ pub struct ViewportBuilder {
     // X11
     pub window_type: Option<X11WindowType>,
     pub override_redirect: Option<bool>,
+
+    /// Viewport rotation in 90-degree increments.
+    ///
+    /// When set, the entire UI is rendered rotated and all input coordinates
+    /// are automatically remapped. The application sees a normal coordinate space.
+    pub rotation: Option<crate::emath::ViewportRotation>,
 }
 
 impl ViewportBuilder {
@@ -680,6 +686,16 @@ impl ViewportBuilder {
         self
     }
 
+    /// Sets the viewport rotation in 90-degree increments.
+    ///
+    /// When set, the entire UI is rendered rotated and all input coordinates
+    /// are automatically remapped. The application sees a normal coordinate space.
+    #[inline]
+    pub fn with_rotation(mut self, rotation: crate::emath::ViewportRotation) -> Self {
+        self.rotation = Some(rotation);
+        self
+    }
+
     /// Update this `ViewportBuilder` with a delta,
     /// returning a list of commands and a bool indicating if the window needs to be recreated.
     #[must_use]
@@ -717,6 +733,7 @@ impl ViewportBuilder {
             taskbar: new_taskbar,
             window_type: new_window_type,
             override_redirect: new_override_redirect,
+            rotation: new_rotation,
         } = new_vp_builder;
 
         let mut commands = Vec::new();
@@ -917,6 +934,11 @@ impl ViewportBuilder {
         if new_override_redirect.is_some() && self.override_redirect != new_override_redirect {
             self.override_redirect = new_override_redirect;
             recreate_window = true;
+        }
+
+        // Rotation is handled by egui (input/output transform), no window command needed.
+        if new_rotation.is_some() && self.rotation != new_rotation {
+            self.rotation = new_rotation;
         }
 
         (commands, recreate_window)

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -65,6 +65,30 @@
 //! * To support immediate viewports you need to call [`Context::set_immediate_viewport_renderer`].
 //! * If you support viewports, you need to call [`Context::set_embed_viewports`] with `false`, or all new viewports will be embedded (the default behavior).
 //!
+//! ## Viewport rotation
+//! Viewports support rotation in 90-degree increments (0°, 90°, 180°, 270°).
+//! When enabled, the entire UI is rendered rotated and all input coordinates
+//! (mouse, touch) are automatically remapped. Application code sees a normal
+//! coordinate space — rotation is transparent.
+//!
+//! A software cursor is automatically drawn in the rotated space, with mouse
+//! movement direction matching the rotation. The OS cursor is captured on entry
+//! and released when the software cursor reaches a window edge.
+//!
+//! ```no_run
+//! let options = eframe::NativeOptions {
+//!     viewport: egui::ViewportBuilder::default()
+//!         .with_inner_size([800.0, 480.0])
+//!         .with_rotation(eframe::emath::ViewportRotation::CW90),
+//!     ..Default::default()
+//! };
+//! ```
+//!
+//! You can also set rotation at runtime via [`Context::set_viewport_rotation`],
+//! and adjust the software cursor size with [`Context::set_software_cursor_scale`].
+//!
+//! Use cases: pinball cabinet displays, kiosks, embedded screens, industrial panels.
+//!
 //! ## Future work
 //! There are several more things related to viewports that we want to add.
 //! Read more at <https://github.com/emilk/egui/issues/3556>.

--- a/crates/egui_demo_app_90/Cargo.toml
+++ b/crates/egui_demo_app_90/Cargo.toml
@@ -1,0 +1,86 @@
+[package]
+name = "egui_demo_app_90"
+version.workspace = true
+authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+default-run = "egui_demo_app_90"
+
+[package.metadata.cargo-shear]
+ignored = ["image", "profiling", "wasm-bindgen-futures"]
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--generate-link-to-definition"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+
+[features]
+default = ["wgpu", "persistence", "wayland", "x11"]
+
+web_app = ["http", "persistence"]
+
+accessibility_inspector = ["dep:accesskit", "dep:accesskit_consumer", "eframe/accesskit"]
+easymark = [] # easymark is off by default, because it a pretty shitty markup language
+http = ["ehttp", "image/jpeg", "poll-promise", "egui_extras/image"]
+image_viewer = ["image/jpeg", "egui_extras/all_loaders", "rfd"]
+persistence = ["eframe/persistence", "egui_extras/serde", "egui/persistence", "serde"]
+puffin = ["dep:puffin", "dep:puffin_http", "profiling/profile-with-puffin"]
+serde = ["dep:serde", "egui_demo_lib/serde", "egui/serde"]
+syntect = ["egui_demo_lib/syntect"]
+
+glow = ["eframe/glow"]
+wgpu = ["eframe/wgpu", "bytemuck"]
+wayland = ["eframe/wayland"]
+x11 = ["eframe/x11"]
+
+[dependencies]
+eframe = { workspace = true, default-features = false, features = ["web_screen_reader"] }
+egui = { workspace = true, features = ["callstack", "default"] }
+egui_demo_lib = { workspace = true, features = ["default", "jiff"] }
+egui_extras = { workspace = true, features = ["default", "image"] }
+image = { workspace = true, default-features = false, features = [
+  # Ensure we can display the test images
+  "png",
+] }
+jiff = { workspace = true, features = ["std", "tz-system", "js"] }
+log.workspace = true
+profiling.workspace = true
+
+# Optional dependencies:
+accesskit = { workspace = true, optional = true }
+accesskit_consumer = { workspace = true, optional = true }
+bytemuck = { workspace = true, optional = true }
+puffin = { workspace = true, optional = true }
+puffin_http = { workspace = true, optional = true }
+
+
+# feature "http":
+ehttp = { workspace = true, optional = true }
+poll-promise = { workspace = true, optional = true }
+
+# feature "persistence":
+serde = { workspace = true, optional = true }
+
+
+# native:
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+env_logger = { workspace = true, features = ["auto-color", "humantime"] }
+mimalloc.workspace = true
+rfd = { workspace = true, optional = true }
+
+# web:
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen.workspace = true
+wasm-bindgen-futures.workspace = true
+web-sys.workspace = true
+
+[dev-dependencies]
+egui_kittest = { workspace = true, features = ["eframe", "snapshot", "wgpu"] }

--- a/crates/egui_demo_app_90/README.md
+++ b/crates/egui_demo_app_90/README.md
@@ -1,0 +1,19 @@
+# egui demo app
+This app demonstrates [`egui`](https://github.com/emilk/egui/) and [`eframe`](https://github.com/emilk/egui/tree/main/crates/eframe).
+
+View the demo app online at <https://egui.rs>.
+
+Run it locally with `cargo run --release -p egui_demo_app`.
+
+`egui_demo_app` can be compiled to WASM and viewed in a browser locally with:
+
+```sh
+./scripts/start_server.sh &
+./scripts/build_demo_web.sh --open
+```
+
+`egui_demo_app` uses [`egui_demo_lib`](https://github.com/emilk/egui/tree/main/crates/egui_demo_lib).
+
+
+## Running with `wgpu` backend
+`(cd egui_demo_app && cargo r --features wgpu)`

--- a/crates/egui_demo_app_90/src/accessibility_inspector.rs
+++ b/crates/egui_demo_app_90/src/accessibility_inspector.rs
@@ -1,0 +1,259 @@
+use std::mem;
+
+use accesskit::{Action, ActionRequest};
+use accesskit_consumer::{FilterResult, Node, NodeId, Tree, TreeChangeHandler};
+
+use eframe::epaint::text::TextWrapMode;
+use egui::{
+    Button, Color32, Event, Frame, FullOutput, Id, Key, KeyboardShortcut, Label, Modifiers, Panel,
+    RawInput, RichText, ScrollArea, Ui, collapsing_header::CollapsingState,
+};
+
+/// This [`egui::Plugin`] adds an inspector panel.
+///
+/// It can be opened with the `(Cmd/Ctrl)+Alt+I`. It shows the current AccessKit tree and details
+/// for the selected node.
+/// Useful when debugging accessibility issues or trying to understand the structure of the Ui.
+///
+/// Add via
+/// ```
+/// # use egui_demo_app::accessibility_inspector::AccessibilityInspectorPlugin;
+/// # let ctx = egui::Context::default();
+/// ctx.add_plugin(AccessibilityInspectorPlugin::default());
+/// ```
+#[derive(Default, Debug)]
+pub struct AccessibilityInspectorPlugin {
+    pub open: bool,
+    tree: Option<accesskit_consumer::Tree>,
+    selected_node: Option<NodeId>,
+    queued_action: Option<ActionRequest>,
+}
+
+struct ChangeHandler;
+
+impl TreeChangeHandler for ChangeHandler {
+    fn node_added(&mut self, _node: &Node<'_>) {}
+
+    fn node_updated(&mut self, _old_node: &Node<'_>, _new_node: &Node<'_>) {}
+
+    fn focus_moved(&mut self, _old_node: Option<&Node<'_>>, _new_node: Option<&Node<'_>>) {}
+
+    fn node_removed(&mut self, _node: &Node<'_>) {}
+}
+
+impl egui::Plugin for AccessibilityInspectorPlugin {
+    fn debug_name(&self) -> &'static str {
+        "Accessibility Inspector"
+    }
+
+    fn input_hook(&mut self, input: &mut RawInput) {
+        if let Some(queued_action) = self.queued_action.take() {
+            input
+                .events
+                .push(Event::AccessKitActionRequest(queued_action));
+        }
+    }
+
+    fn output_hook(&mut self, output: &mut FullOutput) {
+        if let Some(update) = output.platform_output.accesskit_update.clone() {
+            self.tree = match mem::take(&mut self.tree) {
+                None => {
+                    // Create a new tree if it doesn't exist
+                    Some(Tree::new(update, true))
+                }
+                Some(mut tree) => {
+                    // Update the tree with the latest accesskit data
+                    tree.update_and_process_changes(update, &mut ChangeHandler);
+
+                    Some(tree)
+                }
+            }
+        }
+    }
+
+    fn on_begin_pass(&mut self, ui: &mut Ui) {
+        if ui.input_mut(|i| {
+            i.consume_shortcut(&KeyboardShortcut::new(
+                Modifiers::COMMAND | Modifiers::ALT,
+                Key::I,
+            ))
+        }) {
+            self.open = !self.open;
+        }
+
+        if !self.open {
+            return;
+        }
+
+        ui.enable_accesskit();
+
+        Panel::right(Self::id()).show_inside(ui, |ui| {
+            ui.heading("🔎 AccessKit Inspector");
+            if let Some(selected_node) = self.selected_node {
+                Panel::bottom(Self::id().with("details_panel"))
+                    .frame(Frame::new())
+                    .show_separator_line(false)
+                    .show_inside(ui, |ui| {
+                        self.selection_ui(ui, selected_node);
+                    });
+            }
+
+            ui.style_mut().wrap_mode = Some(TextWrapMode::Truncate);
+            ScrollArea::vertical().show(ui, |ui| {
+                if let Some(tree) = &self.tree {
+                    Self::node_ui(ui, &tree.state().root(), &mut self.selected_node);
+                }
+            });
+        });
+    }
+}
+
+impl AccessibilityInspectorPlugin {
+    fn id() -> Id {
+        Id::new("Accessibility Inspector")
+    }
+
+    fn selection_ui(&mut self, ui: &mut Ui, selected_node: NodeId) {
+        ui.separator();
+
+        if let Some(tree) = &self.tree
+            && let Some(node) = tree.state().node_by_id(selected_node)
+        {
+            // Safety: This is safe since the `accesskit::NodeId` was created from an `egui::Id`.
+            #[expect(unsafe_code)]
+            let egui_node_id = unsafe { Id::from_high_entropy_bits(node.locate().0.0) };
+
+            let node_response = ui.ctx().read_response(egui_node_id);
+
+            if let Some(widget_response) = node_response {
+                ui.debug_painter().debug_rect(
+                    widget_response.rect,
+                    ui.style_mut().visuals.selection.bg_fill,
+                    "",
+                );
+            }
+
+            egui::Grid::new("node_details_grid")
+                .num_columns(2)
+                .show(ui, |ui| {
+                    ui.label("Node ID");
+                    ui.strong(format!("{selected_node:?}"));
+                    ui.end_row();
+
+                    ui.label("Role");
+                    ui.strong(format!("{:?}", node.role()));
+                    ui.end_row();
+
+                    ui.label("Label");
+                    ui.add(
+                        Label::new(RichText::new(node.label().unwrap_or_default()).strong())
+                            .truncate(),
+                    );
+                    ui.end_row();
+
+                    ui.label("Value");
+                    ui.add(
+                        Label::new(RichText::new(node.value().unwrap_or_default()).strong())
+                            .truncate(),
+                    );
+                    ui.end_row();
+
+                    ui.label("Children");
+                    ui.label(RichText::new(node.children().len().to_string()).strong());
+
+                    ui.end_row();
+                });
+
+            ui.label("Actions");
+            ui.horizontal_wrapped(|ui| {
+                // Iterate through all possible actions via the `Action::n` helper.
+                let mut current_action = 0;
+                let all_actions = std::iter::from_fn(|| {
+                    let action = Action::n(current_action);
+                    current_action += 1;
+                    action
+                });
+
+                for action in all_actions {
+                    if node.supports_action(action, &|_node| FilterResult::Include)
+                        && ui.button(format!("{action:?}")).clicked()
+                    {
+                        let (target_node, target_tree) = node.locate();
+                        let action_request = ActionRequest {
+                            target_node,
+                            target_tree,
+                            action,
+                            data: None,
+                        };
+                        self.queued_action = Some(action_request);
+                    }
+                }
+            });
+        } else {
+            ui.label("Node not found");
+        }
+    }
+
+    fn node_ui(ui: &mut Ui, node: &Node<'_>, selected_node: &mut Option<NodeId>) {
+        if node.locate() == (Self::id().value().into(), accesskit::TreeId::ROOT)
+            || node
+                .value()
+                .as_deref()
+                .is_some_and(|l| l.contains("AccessKit Inspector"))
+        {
+            return;
+        }
+        let label = node
+            .label()
+            .or_else(|| node.value())
+            .unwrap_or_else(|| node.locate().0.0.to_string());
+        let label = format!("({:?}) {}", node.role(), label);
+
+        // Safety: This is safe since the `accesskit::NodeId` was created from an `egui::Id`.
+        #[expect(unsafe_code)]
+        let egui_node_id = unsafe { Id::from_high_entropy_bits(node.locate().0.0) };
+
+        ui.push_id(node.id(), |ui| {
+            let child_count = node.children().len();
+            let has_children = child_count > 0;
+            let default_open = child_count == 1 && node.role() != accesskit::Role::Label;
+
+            let mut collapsing = CollapsingState::load_with_default_open(
+                ui.ctx(),
+                egui_node_id.with("ak_collapse"),
+                default_open,
+            );
+
+            let header_response = ui.horizontal(|ui| {
+                let text = if collapsing.is_open() { "⏷" } else { "⏵" };
+
+                if ui
+                    .add_visible(has_children, Button::new(text).frame_when_inactive(false))
+                    .clicked()
+                {
+                    collapsing.set_open(!collapsing.is_open());
+                }
+                let label_response =
+                    ui.selectable_value(selected_node, Some(node.id()), label.clone());
+                if label_response.hovered() {
+                    let widget_response = ui.ctx().read_response(egui_node_id);
+
+                    if let Some(widget_response) = widget_response {
+                        ui.debug_painter()
+                            .debug_rect(widget_response.rect, Color32::RED, "");
+                    }
+                }
+            });
+
+            if has_children {
+                collapsing.show_body_indented(&header_response.response, ui, |ui| {
+                    node.children().for_each(|c| {
+                        Self::node_ui(ui, &c, selected_node);
+                    });
+                });
+            }
+
+            collapsing.store(ui.ctx());
+        });
+    }
+}

--- a/crates/egui_demo_app_90/src/apps/custom3d_glow.rs
+++ b/crates/egui_demo_app_90/src/apps/custom3d_glow.rs
@@ -1,0 +1,203 @@
+#![expect(clippy::undocumented_unsafe_blocks)]
+
+use std::sync::Arc;
+
+use eframe::egui_glow;
+use egui::mutex::Mutex;
+use egui_glow::glow;
+
+pub struct Custom3d {
+    /// Behind an `Arc<Mutex<…>>` so we can pass it to [`egui::PaintCallback`] and paint later.
+    rotating_triangle: Arc<Mutex<RotatingTriangle>>,
+    angle: f32,
+}
+
+impl Custom3d {
+    pub fn new<'a>(cc: &'a eframe::CreationContext<'a>) -> Option<Self> {
+        let gl = cc.gl.as_ref()?;
+        Some(Self {
+            rotating_triangle: Arc::new(Mutex::new(RotatingTriangle::new(gl)?)),
+            angle: 0.0,
+        })
+    }
+}
+
+impl crate::DemoApp for Custom3d {
+    fn demo_ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        // TODO(emilk): Use `ScrollArea::inner_margin`
+        egui::CentralPanel::default().show_inside(ui, |ui| {
+            egui::ScrollArea::both().auto_shrink(false).show(ui, |ui| {
+                ui.horizontal(|ui| {
+                    ui.spacing_mut().item_spacing.x = 0.0;
+                    ui.label("The triangle is being painted using ");
+                    ui.hyperlink_to("glow", "https://github.com/grovesNL/glow");
+                    ui.label(" (OpenGL).");
+                });
+                ui.label(
+                    "It's not a very impressive demo, but it shows you can embed 3D inside of egui.",
+                );
+
+                egui::Frame::canvas(ui.style()).show(ui, |ui| {
+                    self.custom_painting(ui);
+                });
+                ui.label("Drag to rotate!");
+                ui.add(egui_demo_lib::egui_github_link_file!());
+            });
+        });
+    }
+
+    fn on_exit(&mut self, gl: Option<&glow::Context>) {
+        if let Some(gl) = gl {
+            self.rotating_triangle.lock().destroy(gl);
+        }
+    }
+}
+
+impl Custom3d {
+    fn custom_painting(&mut self, ui: &mut egui::Ui) {
+        let (rect, response) =
+            ui.allocate_exact_size(egui::Vec2::splat(300.0), egui::Sense::drag());
+
+        self.angle += response.drag_motion().x * 0.01;
+
+        // Clone locals so we can move them into the paint callback:
+        let angle = self.angle;
+        let rotating_triangle = self.rotating_triangle.clone();
+
+        let cb = egui_glow::CallbackFn::new(move |_info, painter| {
+            rotating_triangle.lock().paint(painter.gl(), angle);
+        });
+
+        let callback = egui::PaintCallback {
+            rect,
+            callback: Arc::new(cb),
+        };
+        ui.painter().add(callback);
+    }
+}
+
+struct RotatingTriangle {
+    program: glow::Program,
+    vertex_array: glow::VertexArray,
+}
+
+#[expect(unsafe_code)] // we need unsafe code to use glow
+impl RotatingTriangle {
+    fn new(gl: &glow::Context) -> Option<Self> {
+        use glow::HasContext as _;
+
+        let shader_version = egui_glow::ShaderVersion::get(gl);
+
+        unsafe {
+            let program = gl.create_program().expect("Cannot create program");
+
+            if !shader_version.is_new_shader_interface() {
+                log::warn!("Custom 3D painting hasn't been ported to {shader_version:?}");
+                return None;
+            }
+
+            let (vertex_shader_source, fragment_shader_source) = (
+                r#"
+                    const vec2 verts[3] = vec2[3](
+                        vec2(0.0, 1.0),
+                        vec2(-1.0, -1.0),
+                        vec2(1.0, -1.0)
+                    );
+                    const vec4 colors[3] = vec4[3](
+                        vec4(1.0, 0.0, 0.0, 1.0),
+                        vec4(0.0, 1.0, 0.0, 1.0),
+                        vec4(0.0, 0.0, 1.0, 1.0)
+                    );
+                    out vec4 v_color;
+                    uniform float u_angle;
+                    void main() {
+                        v_color = colors[gl_VertexID];
+                        gl_Position = vec4(verts[gl_VertexID], 0.0, 1.0);
+                        gl_Position.x *= cos(u_angle);
+                    }
+                "#,
+                r#"
+                    precision mediump float;
+                    in vec4 v_color;
+                    out vec4 out_color;
+                    void main() {
+                        out_color = v_color;
+                    }
+                "#,
+            );
+
+            let shader_sources = [
+                (glow::VERTEX_SHADER, vertex_shader_source),
+                (glow::FRAGMENT_SHADER, fragment_shader_source),
+            ];
+
+            let shaders: Vec<_> = shader_sources
+                .iter()
+                .map(|(shader_type, shader_source)| {
+                    let shader = gl
+                        .create_shader(*shader_type)
+                        .expect("Cannot create shader");
+                    gl.shader_source(
+                        shader,
+                        &format!(
+                            "{}\n{}",
+                            shader_version.version_declaration(),
+                            shader_source
+                        ),
+                    );
+                    gl.compile_shader(shader);
+                    assert!(
+                        gl.get_shader_compile_status(shader),
+                        "Failed to compile custom_3d_glow {shader_type}: {}",
+                        gl.get_shader_info_log(shader)
+                    );
+
+                    gl.attach_shader(program, shader);
+                    shader
+                })
+                .collect();
+
+            gl.link_program(program);
+            assert!(
+                gl.get_program_link_status(program),
+                "{}",
+                gl.get_program_info_log(program)
+            );
+
+            for shader in shaders {
+                gl.detach_shader(program, shader);
+                gl.delete_shader(shader);
+            }
+
+            let vertex_array = gl
+                .create_vertex_array()
+                .expect("Cannot create vertex array");
+
+            Some(Self {
+                program,
+                vertex_array,
+            })
+        }
+    }
+
+    fn destroy(&self, gl: &glow::Context) {
+        use glow::HasContext as _;
+        unsafe {
+            gl.delete_program(self.program);
+            gl.delete_vertex_array(self.vertex_array);
+        }
+    }
+
+    fn paint(&self, gl: &glow::Context, angle: f32) {
+        use glow::HasContext as _;
+        unsafe {
+            gl.use_program(Some(self.program));
+            gl.uniform_1_f32(
+                gl.get_uniform_location(self.program, "u_angle").as_ref(),
+                angle,
+            );
+            gl.bind_vertex_array(Some(self.vertex_array));
+            gl.draw_arrays(glow::TRIANGLES, 0, 3);
+        }
+    }
+}

--- a/crates/egui_demo_app_90/src/apps/custom3d_wgpu.rs
+++ b/crates/egui_demo_app_90/src/apps/custom3d_wgpu.rs
@@ -1,0 +1,212 @@
+#![expect(clippy::unwrap_used)] // TODO(emilk): avoid unwraps
+
+use std::num::NonZeroU64;
+
+use eframe::{
+    egui_wgpu::wgpu::util::DeviceExt as _,
+    egui_wgpu::{self, wgpu},
+};
+
+pub struct Custom3d {
+    angle: f32,
+}
+
+impl Custom3d {
+    pub fn new<'a>(cc: &'a eframe::CreationContext<'a>) -> Option<Self> {
+        // Get the WGPU render state from the eframe creation context. This can also be retrieved
+        // from `eframe::Frame` when you don't have a `CreationContext` available.
+        let wgpu_render_state = cc.wgpu_render_state.as_ref()?;
+
+        let device = &wgpu_render_state.device;
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("custom3d"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("./custom3d_wgpu_shader.wgsl").into()),
+        });
+
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("custom3d"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(16),
+                },
+                count: None,
+            }],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("custom3d"),
+            bind_group_layouts: &[Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("custom3d"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: None,
+                buffers: &[],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu_render_state.target_format.into())],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview_mask: None,
+            cache: None,
+        });
+
+        let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("custom3d"),
+            contents: bytemuck::cast_slice(&[0.0_f32; 4]), // 16 bytes aligned!
+            // Mapping at creation (as done by the create_buffer_init utility) doesn't require us to to add the MAP_WRITE usage
+            // (this *happens* to workaround this bug )
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("custom3d"),
+            layout: &bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buffer.as_entire_binding(),
+            }],
+        });
+
+        // Because the graphics pipeline must have the same lifetime as the egui render pass,
+        // instead of storing the pipeline in our `Custom3D` struct, we insert it into the
+        // `paint_callback_resources` type map, which is stored alongside the render pass.
+        wgpu_render_state
+            .renderer
+            .write()
+            .callback_resources
+            .insert(TriangleRenderResources {
+                pipeline,
+                bind_group,
+                uniform_buffer,
+            });
+
+        Some(Self { angle: 0.0 })
+    }
+}
+
+impl crate::DemoApp for Custom3d {
+    fn demo_ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        // TODO(emilk): Use `ScrollArea::inner_margin`
+        egui::CentralPanel::default().show_inside(ui, |ui| {
+            egui::ScrollArea::both().auto_shrink(false).show(ui, |ui| {
+                ui.horizontal(|ui| {
+                    ui.spacing_mut().item_spacing.x = 0.0;
+                    ui.label("The triangle is being painted using ");
+                    ui.hyperlink_to("WGPU", "https://wgpu.rs");
+                    ui.label(" (Portable Rust graphics API awesomeness)");
+                });
+                ui.label(
+                    "It's not a very impressive demo, but it shows you can embed 3D inside of egui.",
+                );
+
+                egui::Frame::canvas(ui.style()).show(ui, |ui| {
+                    self.custom_painting(ui);
+                });
+                ui.label("Drag to rotate!");
+                ui.add(egui_demo_lib::egui_github_link_file!());
+            });
+        });
+    }
+}
+
+// Callbacks in egui_wgpu have 3 stages:
+// * prepare (per callback impl)
+// * finish_prepare (once)
+// * paint (per callback impl)
+//
+// The prepare callback is called every frame before paint and is given access to the wgpu
+// Device and Queue, which can be used, for instance, to update buffers and uniforms before
+// rendering.
+// If [`egui_wgpu::Renderer`] has [`egui_wgpu::FinishPrepareCallback`] registered,
+// it will be called after all `prepare` callbacks have been called.
+// You can use this to update any shared resources that need to be updated once per frame
+// after all callbacks have been processed.
+//
+// On both prepare methods you can use the main `CommandEncoder` that is passed-in,
+// return an arbitrary number of user-defined `CommandBuffer`s, or both.
+// The main command buffer, as well as all user-defined ones, will be submitted together
+// to the GPU in a single call.
+//
+// The paint callback is called after finish prepare and is given access to egui's main render pass,
+// which can be used to issue draw commands.
+struct CustomTriangleCallback {
+    angle: f32,
+}
+
+impl egui_wgpu::CallbackTrait for CustomTriangleCallback {
+    fn prepare(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        _screen_descriptor: &egui_wgpu::ScreenDescriptor,
+        _egui_encoder: &mut wgpu::CommandEncoder,
+        resources: &mut egui_wgpu::CallbackResources,
+    ) -> Vec<wgpu::CommandBuffer> {
+        let resources: &TriangleRenderResources = resources.get().unwrap();
+        resources.prepare(device, queue, self.angle);
+        Vec::new()
+    }
+
+    fn paint(
+        &self,
+        _info: egui::PaintCallbackInfo,
+        render_pass: &mut wgpu::RenderPass<'static>,
+        resources: &egui_wgpu::CallbackResources,
+    ) {
+        let resources: &TriangleRenderResources = resources.get().unwrap();
+        resources.paint(render_pass);
+    }
+}
+
+impl Custom3d {
+    fn custom_painting(&mut self, ui: &mut egui::Ui) {
+        let (rect, response) =
+            ui.allocate_exact_size(egui::Vec2::splat(300.0), egui::Sense::drag());
+
+        self.angle += response.drag_motion().x * 0.01;
+        ui.painter().add(egui_wgpu::Callback::new_paint_callback(
+            rect,
+            CustomTriangleCallback { angle: self.angle },
+        ));
+    }
+}
+
+struct TriangleRenderResources {
+    pipeline: wgpu::RenderPipeline,
+    bind_group: wgpu::BindGroup,
+    uniform_buffer: wgpu::Buffer,
+}
+
+impl TriangleRenderResources {
+    fn prepare(&self, _device: &wgpu::Device, queue: &wgpu::Queue, angle: f32) {
+        // Update our uniform buffer with the angle from the UI
+        queue.write_buffer(
+            &self.uniform_buffer,
+            0,
+            bytemuck::cast_slice(&[angle, 0.0, 0.0, 0.0]),
+        );
+    }
+
+    fn paint(&self, render_pass: &mut wgpu::RenderPass<'_>) {
+        // Draw our triangle!
+        render_pass.set_pipeline(&self.pipeline);
+        render_pass.set_bind_group(0, &self.bind_group, &[]);
+        render_pass.draw(0..3, 0..1);
+    }
+}

--- a/crates/egui_demo_app_90/src/apps/custom3d_wgpu_shader.wgsl
+++ b/crates/egui_demo_app_90/src/apps/custom3d_wgpu_shader.wgsl
@@ -1,0 +1,39 @@
+struct VertexOut {
+    @location(0) color: vec4<f32>,
+    @builtin(position) position: vec4<f32>,
+};
+
+struct Uniforms {
+    @size(16) angle: f32, // pad to 16 bytes
+};
+
+@group(0) @binding(0)
+var<uniform> uniforms: Uniforms;
+
+var<private> v_positions: array<vec2<f32>, 3> = array<vec2<f32>, 3>(
+    vec2<f32>(0.0, 1.0),
+    vec2<f32>(1.0, -1.0),
+    vec2<f32>(-1.0, -1.0),
+);
+
+var<private> v_colors: array<vec4<f32>, 3> = array<vec4<f32>, 3>(
+    vec4<f32>(1.0, 0.0, 0.0, 1.0),
+    vec4<f32>(0.0, 1.0, 0.0, 1.0),
+    vec4<f32>(0.0, 0.0, 1.0, 1.0),
+);
+
+@vertex
+fn vs_main(@builtin(vertex_index) v_idx: u32) -> VertexOut {
+    var out: VertexOut;
+
+    out.position = vec4<f32>(v_positions[v_idx], 0.0, 1.0);
+    out.position.x = out.position.x * cos(uniforms.angle);
+    out.color = v_colors[v_idx];
+
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
+    return in.color;
+}

--- a/crates/egui_demo_app_90/src/apps/fractal_clock.rs
+++ b/crates/egui_demo_app_90/src/apps/fractal_clock.rs
@@ -1,0 +1,210 @@
+use egui::{
+    Color32, Painter, Pos2, Rect, Shape, Stroke, Ui, Vec2,
+    containers::{CollapsingHeader, Frame},
+    emath, pos2,
+    widgets::Slider,
+};
+use std::f32::consts::TAU;
+
+#[derive(PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(default))]
+pub struct FractalClock {
+    paused: bool,
+    time: f64,
+    zoom: f32,
+    start_line_width: f32,
+    depth: usize,
+    length_factor: f32,
+    luminance_factor: f32,
+    width_factor: f32,
+    line_count: usize,
+}
+
+impl Default for FractalClock {
+    fn default() -> Self {
+        Self {
+            paused: false,
+            time: 0.0,
+            zoom: 0.25,
+            start_line_width: 2.5,
+            depth: 9,
+            length_factor: 0.8,
+            luminance_factor: 0.8,
+            width_factor: 0.9,
+            line_count: 0,
+        }
+    }
+}
+
+impl FractalClock {
+    pub fn ui(&mut self, ui: &mut Ui, seconds_since_midnight: Option<f64>) {
+        if !self.paused {
+            self.time = seconds_since_midnight.unwrap_or_else(|| ui.input(|i| i.time));
+            ui.request_repaint();
+        }
+
+        let painter = Painter::new(
+            ui.ctx().clone(),
+            ui.layer_id(),
+            ui.available_rect_before_wrap(),
+        );
+        self.paint(&painter);
+        // Make sure we allocate what we used (everything)
+        ui.expand_to_include_rect(painter.clip_rect());
+
+        Frame::popup(ui.style())
+            .stroke(Stroke::NONE)
+            .show(ui, |ui| {
+                ui.set_max_width(270.0);
+                CollapsingHeader::new("Settings")
+                    .show(ui, |ui| self.options_ui(ui, seconds_since_midnight));
+            });
+    }
+
+    fn options_ui(&mut self, ui: &mut Ui, seconds_since_midnight: Option<f64>) {
+        if seconds_since_midnight.is_some() {
+            ui.label(format!(
+                "Local time: {:02}:{:02}:{:02}.{:03}",
+                (self.time % (24.0 * 60.0 * 60.0) / 3600.0).floor(),
+                (self.time % (60.0 * 60.0) / 60.0).floor(),
+                (self.time % 60.0).floor(),
+                (self.time % 1.0 * 100.0).floor()
+            ));
+        } else {
+            ui.label("The fractal_clock clock is not showing the correct time");
+        }
+        ui.label(format!("Painted line count: {}", self.line_count));
+
+        ui.checkbox(&mut self.paused, "Paused");
+        ui.add(Slider::new(&mut self.zoom, 0.0..=1.0).text("zoom"));
+        ui.add(Slider::new(&mut self.start_line_width, 0.0..=5.0).text("Start line width"));
+        ui.add(Slider::new(&mut self.depth, 0..=14).text("depth"));
+        ui.add(Slider::new(&mut self.length_factor, 0.0..=1.0).text("length factor"));
+        ui.add(Slider::new(&mut self.luminance_factor, 0.0..=1.0).text("luminance factor"));
+        ui.add(Slider::new(&mut self.width_factor, 0.0..=1.0).text("width factor"));
+
+        egui::reset_button(ui, self, "Reset");
+
+        ui.hyperlink_to(
+            "Inspired by a screensaver by Rob Mayoff",
+            "http://www.dqd.com/~mayoff/programs/FractalClock/",
+        );
+        ui.add(egui_demo_lib::egui_github_link_file!());
+    }
+
+    fn paint(&mut self, painter: &Painter) {
+        struct Hand {
+            length: f32,
+            angle: f32,
+            vec: Vec2,
+        }
+
+        impl Hand {
+            fn from_length_angle(length: f32, angle: f32) -> Self {
+                Self {
+                    length,
+                    angle,
+                    vec: length * Vec2::angled(angle),
+                }
+            }
+        }
+
+        let angle_from_period =
+            |period| TAU * (self.time.rem_euclid(period) / period) as f32 - TAU / 4.0;
+
+        let hands = [
+            // Second hand:
+            Hand::from_length_angle(self.length_factor, angle_from_period(60.0)),
+            // Minute hand:
+            Hand::from_length_angle(self.length_factor, angle_from_period(60.0 * 60.0)),
+            // Hour hand:
+            Hand::from_length_angle(0.5, angle_from_period(12.0 * 60.0 * 60.0)),
+        ];
+
+        let mut shapes: Vec<Shape> = Vec::new();
+
+        let rect = painter.clip_rect();
+        let to_screen = emath::RectTransform::from_to(
+            Rect::from_center_size(Pos2::ZERO, rect.square_proportions() / self.zoom),
+            rect,
+        );
+
+        let mut paint_line = |points: [Pos2; 2], color: Color32, width: f32| {
+            let line = [to_screen * points[0], to_screen * points[1]];
+
+            // culling
+            if rect.intersects(Rect::from_two_pos(line[0], line[1])) {
+                shapes.push(Shape::line_segment(line, (width, color)));
+            }
+        };
+
+        let hand_rotations = [
+            hands[0].angle - hands[2].angle + TAU / 2.0,
+            hands[1].angle - hands[2].angle + TAU / 2.0,
+        ];
+
+        let hand_rotors = [
+            hands[0].length * emath::Rot2::from_angle(hand_rotations[0]),
+            hands[1].length * emath::Rot2::from_angle(hand_rotations[1]),
+        ];
+
+        #[derive(Clone, Copy)]
+        struct Node {
+            pos: Pos2,
+            dir: Vec2,
+        }
+
+        let mut nodes = Vec::new();
+
+        let mut width = self.start_line_width;
+
+        for (i, hand) in hands.iter().enumerate() {
+            let center = pos2(0.0, 0.0);
+            let end = center + hand.vec;
+            paint_line([center, end], Color32::from_additive_luminance(255), width);
+            if i < 2 {
+                nodes.push(Node {
+                    pos: end,
+                    dir: hand.vec,
+                });
+            }
+        }
+
+        let mut luminance = 0.7; // Start dimmer than main hands
+
+        let mut new_nodes = Vec::new();
+        for _ in 0..self.depth {
+            new_nodes.clear();
+            new_nodes.reserve(nodes.len() * 2);
+
+            luminance *= self.luminance_factor;
+            width *= self.width_factor;
+
+            let luminance_u8 = (255.0 * luminance).round() as u8;
+            if luminance_u8 == 0 {
+                break;
+            }
+
+            for &rotor in &hand_rotors {
+                for a in &nodes {
+                    let new_dir = rotor * a.dir;
+                    let b = Node {
+                        pos: a.pos + new_dir,
+                        dir: new_dir,
+                    };
+                    paint_line(
+                        [a.pos, b.pos],
+                        Color32::from_additive_luminance(luminance_u8),
+                        width,
+                    );
+                    new_nodes.push(b);
+                }
+            }
+
+            std::mem::swap(&mut nodes, &mut new_nodes);
+        }
+        self.line_count = shapes.len();
+        painter.extend(shapes);
+    }
+}

--- a/crates/egui_demo_app_90/src/apps/http_app.rs
+++ b/crates/egui_demo_app_90/src/apps/http_app.rs
@@ -1,0 +1,244 @@
+use egui::Image;
+use poll_promise::Promise;
+
+struct Resource {
+    /// HTTP response
+    response: ehttp::Response,
+
+    text: Option<String>,
+
+    /// If set, the response was an image.
+    image: Option<Image<'static>>,
+
+    /// If set, the response was text with some supported syntax highlighting (e.g. ".rs" or ".md").
+    colored_text: Option<ColoredText>,
+}
+
+impl Resource {
+    fn from_response(ctx: &egui::Context, response: ehttp::Response) -> Self {
+        let content_type = response.content_type().unwrap_or_default();
+        if content_type.starts_with("image/") {
+            ctx.include_bytes(response.url.clone(), response.bytes.clone());
+            let image = Image::from_uri(response.url.clone());
+
+            Self {
+                response,
+                text: None,
+                colored_text: None,
+                image: Some(image),
+            }
+        } else {
+            let text = response.text();
+            let colored_text = text.and_then(|text| syntax_highlighting(ctx, &response, text));
+            let text = text.map(|text| text.to_owned());
+
+            Self {
+                response,
+                text,
+                colored_text,
+                image: None,
+            }
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct HttpApp {
+    url: String,
+
+    #[cfg_attr(feature = "serde", serde(skip))]
+    promise: Option<Promise<ehttp::Result<Resource>>>,
+}
+
+impl Default for HttpApp {
+    fn default() -> Self {
+        Self {
+            url: "https://raw.githubusercontent.com/emilk/egui/main/README.md".to_owned(),
+            promise: Default::default(),
+        }
+    }
+}
+
+impl crate::DemoApp for HttpApp {
+    fn demo_ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
+        egui::Panel::bottom("http_bottom").show_inside(ui, |ui| {
+            let layout = egui::Layout::top_down(egui::Align::Center).with_main_justify(true);
+            ui.allocate_ui_with_layout(ui.available_size(), layout, |ui| {
+                ui.add(egui_demo_lib::egui_github_link_file!())
+            })
+        });
+
+        egui::CentralPanel::default().show_inside(ui, |ui| {
+            let prev_url = self.url.clone();
+            let trigger_fetch = ui_url(ui, frame, &mut self.url);
+
+            ui.horizontal_wrapped(|ui| {
+                ui.spacing_mut().item_spacing.x = 0.0;
+                ui.label("HTTP requests made using ");
+                ui.hyperlink_to("ehttp", "https://www.github.com/emilk/ehttp");
+                ui.label(".");
+            });
+
+            if trigger_fetch {
+                let ctx = ui.ctx().clone();
+                let (sender, promise) = Promise::new();
+                let request = ehttp::Request::get(&self.url);
+                ehttp::fetch(request, move |response| {
+                    ctx.forget_image(&prev_url);
+                    ctx.request_repaint(); // wake up UI thread
+                    let resource = response.map(|response| Resource::from_response(&ctx, response));
+                    sender.send(resource);
+                });
+                self.promise = Some(promise);
+            }
+
+            ui.separator();
+
+            if let Some(promise) = &self.promise {
+                if let Some(result) = promise.ready() {
+                    match result {
+                        Ok(resource) => {
+                            ui_resource(ui, resource);
+                        }
+                        Err(error) => {
+                            // This should only happen if the fetch API isn't available or something similar.
+                            ui.colored_label(
+                                ui.visuals().error_fg_color,
+                                if error.is_empty() { "Error" } else { error },
+                            );
+                        }
+                    }
+                } else {
+                    ui.spinner();
+                }
+            }
+        });
+    }
+}
+
+fn ui_url(ui: &mut egui::Ui, frame: &eframe::Frame, url: &mut String) -> bool {
+    let mut trigger_fetch = false;
+
+    ui.horizontal(|ui| {
+        ui.label("URL:");
+        trigger_fetch |= ui
+            .add(egui::TextEdit::singleline(url).desired_width(f32::INFINITY))
+            .lost_focus();
+    });
+
+    if frame.is_web() {
+        ui.label("HINT: paste the url of this page into the field above!");
+    }
+
+    ui.horizontal(|ui| {
+        if ui.button("Source code for this example").clicked() {
+            *url = format!(
+                "https://raw.githubusercontent.com/emilk/egui/main/{}",
+                file!()
+            );
+            trigger_fetch = true;
+        }
+        if ui.button("Random image").clicked() {
+            let seed = ui.input(|i| i.time);
+            let side = 640;
+            *url = format!("https://picsum.photos/seed/{seed}/{side}");
+            trigger_fetch = true;
+        }
+    });
+
+    trigger_fetch
+}
+
+fn ui_resource(ui: &mut egui::Ui, resource: &Resource) {
+    let Resource {
+        response,
+        text,
+        image,
+        colored_text,
+    } = resource;
+
+    ui.monospace(format!("url:          {}", response.url));
+    ui.monospace(format!(
+        "status:       {} ({})",
+        response.status, response.status_text
+    ));
+    ui.monospace(format!(
+        "content-type: {}",
+        response.content_type().unwrap_or_default()
+    ));
+    ui.monospace(format!(
+        "size:         {:.1} kB",
+        response.bytes.len() as f32 / 1000.0
+    ));
+
+    ui.separator();
+
+    egui::ScrollArea::vertical()
+        .auto_shrink(false)
+        .show(ui, |ui| {
+            egui::CollapsingHeader::new("Response headers")
+                .default_open(false)
+                .show(ui, |ui| {
+                    egui::Grid::new("response_headers")
+                        .spacing(egui::vec2(ui.spacing().item_spacing.x * 2.0, 0.0))
+                        .show(ui, |ui| {
+                            for (k, v) in &response.headers {
+                                ui.label(k);
+                                ui.label(v);
+                                ui.end_row();
+                            }
+                        })
+                });
+
+            ui.separator();
+
+            if let Some(text) = &text {
+                let tooltip = "Click to copy the response body";
+                if ui.button("📋").on_hover_text(tooltip).clicked() {
+                    ui.copy_text(text.clone());
+                }
+                ui.separator();
+            }
+
+            if let Some(image) = image {
+                ui.add(image.clone());
+            } else if let Some(colored_text) = colored_text {
+                colored_text.ui(ui);
+            } else if let Some(text) = &text {
+                ui.add(egui::Label::new(text).selectable(true));
+            } else {
+                ui.monospace("[binary]");
+            }
+        });
+}
+
+// ----------------------------------------------------------------------------
+// Syntax highlighting:
+
+fn syntax_highlighting(
+    ctx: &egui::Context,
+    response: &ehttp::Response,
+    text: &str,
+) -> Option<ColoredText> {
+    let extension_and_rest: Vec<&str> = response.url.rsplitn(2, '.').collect();
+    let extension = extension_and_rest.first()?;
+    let theme = egui_extras::syntax_highlighting::CodeTheme::from_style(&ctx.global_style());
+    Some(ColoredText(egui_extras::syntax_highlighting::highlight(
+        ctx,
+        &ctx.global_style(),
+        &theme,
+        text,
+        extension,
+    )))
+}
+
+struct ColoredText(egui::text::LayoutJob);
+
+impl ColoredText {
+    pub fn ui(&self, ui: &mut egui::Ui) {
+        let mut job = self.0.clone();
+        job.wrap.max_width = ui.available_width();
+        let galley = ui.fonts_mut(|f| f.layout_job(job));
+        ui.add(egui::Label::new(galley).selectable(true));
+    }
+}

--- a/crates/egui_demo_app_90/src/apps/image_viewer.rs
+++ b/crates/egui_demo_app_90/src/apps/image_viewer.rs
@@ -1,0 +1,228 @@
+use egui::ImageFit;
+use egui::Slider;
+use egui::Vec2;
+use egui::emath::Rot2;
+
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct ImageViewer {
+    current_uri: String,
+    uri_edit_text: String,
+    image_options: egui::ImageOptions,
+    chosen_fit: ChosenFit,
+    fit: ImageFit,
+    maintain_aspect_ratio: bool,
+    max_size: Vec2,
+    alt_text: String,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+enum ChosenFit {
+    ExactSize,
+    Fraction,
+    OriginalSize,
+}
+
+impl ChosenFit {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::ExactSize => "exact size",
+            Self::Fraction => "fraction",
+            Self::OriginalSize => "original size",
+        }
+    }
+}
+
+impl Default for ImageViewer {
+    fn default() -> Self {
+        Self {
+            current_uri: "https://picsum.photos/seed/1.759706314/1024".to_owned(),
+            uri_edit_text: "https://picsum.photos/seed/1.759706314/1024".to_owned(),
+            image_options: egui::ImageOptions::default(),
+            chosen_fit: ChosenFit::Fraction,
+            fit: ImageFit::Fraction(Vec2::splat(1.0)),
+            maintain_aspect_ratio: true,
+            max_size: Vec2::splat(2048.0),
+            alt_text: "My Image".to_owned(),
+        }
+    }
+}
+
+impl crate::DemoApp for ImageViewer {
+    fn demo_ui(&mut self, ui: &mut egui::Ui, _: &mut eframe::Frame) {
+        egui::Panel::top("url bar").show_inside(ui, |ui| {
+            ui.horizontal_centered(|ui| {
+                let label = ui.label("URI:");
+                ui.text_edit_singleline(&mut self.uri_edit_text)
+                    .labelled_by(label.id);
+                if ui.small_button("✔").clicked() {
+                    ui.ctx().forget_image(&self.current_uri);
+                    self.uri_edit_text = self.uri_edit_text.trim().to_owned();
+                    self.current_uri = self.uri_edit_text.clone();
+                }
+
+                #[cfg(not(target_arch = "wasm32"))]
+                if ui.button("file…").clicked()
+                    && let Some(path) = rfd::FileDialog::new().pick_file()
+                {
+                    self.uri_edit_text = format!("file://{}", path.display());
+                    self.current_uri = self.uri_edit_text.clone();
+                }
+            });
+        });
+
+        egui::Panel::left("controls").show_inside(ui, |ui| {
+            // uv
+            ui.label("UV");
+            ui.add(Slider::new(&mut self.image_options.uv.min.x, 0.0..=1.0).text("min x"));
+            ui.add(Slider::new(&mut self.image_options.uv.min.y, 0.0..=1.0).text("min y"));
+            ui.add(Slider::new(&mut self.image_options.uv.max.x, 0.0..=1.0).text("max x"));
+            ui.add(Slider::new(&mut self.image_options.uv.max.y, 0.0..=1.0).text("max y"));
+
+            // rotation
+            ui.add_space(2.0);
+            let had_rotation = self.image_options.rotation.is_some();
+            let mut has_rotation = had_rotation;
+            ui.checkbox(&mut has_rotation, "Rotation");
+            match (had_rotation, has_rotation) {
+                (true, false) => self.image_options.rotation = None,
+                (false, true) => {
+                    self.image_options.rotation =
+                        Some((Rot2::from_angle(0.0), Vec2::new(0.5, 0.5)));
+                }
+                (true, true) | (false, false) => {}
+            }
+
+            if let Some((rot, origin)) = self.image_options.rotation.as_mut() {
+                let mut angle = rot.angle();
+
+                ui.label("angle");
+                ui.drag_angle(&mut angle);
+                *rot = Rot2::from_angle(angle);
+
+                ui.add(Slider::new(&mut origin.x, 0.0..=1.0).text("origin x"));
+                ui.add(Slider::new(&mut origin.y, 0.0..=1.0).text("origin y"));
+            }
+
+            // bg_fill
+            ui.add_space(2.0);
+            ui.horizontal(|ui| {
+                ui.color_edit_button_srgba(&mut self.image_options.bg_fill);
+                ui.label("Background color");
+            });
+
+            // tint
+            ui.add_space(2.0);
+            ui.horizontal(|ui| {
+                ui.color_edit_button_srgba(&mut self.image_options.tint);
+                ui.label("Tint");
+            });
+
+            // fit
+            ui.add_space(10.0);
+            ui.label(
+                "The chosen fit will determine how the image tries to fill the available space",
+            );
+            egui::ComboBox::from_label("Fit")
+                .selected_text(self.chosen_fit.as_str())
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(
+                        &mut self.chosen_fit,
+                        ChosenFit::ExactSize,
+                        ChosenFit::ExactSize.as_str(),
+                    );
+                    ui.selectable_value(
+                        &mut self.chosen_fit,
+                        ChosenFit::Fraction,
+                        ChosenFit::Fraction.as_str(),
+                    );
+                    ui.selectable_value(
+                        &mut self.chosen_fit,
+                        ChosenFit::OriginalSize,
+                        ChosenFit::OriginalSize.as_str(),
+                    );
+                });
+
+            match self.chosen_fit {
+                ChosenFit::ExactSize => {
+                    if !matches!(self.fit, ImageFit::Exact(_)) {
+                        self.fit = ImageFit::Exact(Vec2::splat(128.0));
+                    }
+                    let ImageFit::Exact(size) = &mut self.fit else {
+                        unreachable!()
+                    };
+                    ui.add(Slider::new(&mut size.x, 0.0..=2048.0).text("width"));
+                    ui.add(Slider::new(&mut size.y, 0.0..=2048.0).text("height"));
+                }
+                ChosenFit::Fraction => {
+                    if !matches!(self.fit, ImageFit::Fraction(_)) {
+                        self.fit = ImageFit::Fraction(Vec2::splat(1.0));
+                    }
+                    let ImageFit::Fraction(fract) = &mut self.fit else {
+                        unreachable!()
+                    };
+                    ui.add(Slider::new(&mut fract.x, 0.0..=1.0).text("width"));
+                    ui.add(Slider::new(&mut fract.y, 0.0..=1.0).text("height"));
+                }
+                ChosenFit::OriginalSize => {
+                    if !matches!(self.fit, ImageFit::Original { .. }) {
+                        self.fit = ImageFit::Original { scale: 1.0 };
+                    }
+                    let ImageFit::Original { scale } = &mut self.fit else {
+                        unreachable!()
+                    };
+                    ui.add(Slider::new(scale, 0.1..=4.0).text("scale"));
+                }
+            }
+
+            // max size
+            ui.add_space(5.0);
+            ui.label("The calculated size will not exceed the maximum size");
+            ui.add(Slider::new(&mut self.max_size.x, 0.0..=2048.0).text("width"));
+            ui.add(Slider::new(&mut self.max_size.y, 0.0..=2048.0).text("height"));
+
+            // aspect ratio
+            ui.add_space(5.0);
+            ui.label("Aspect ratio is maintained by scaling both sides as necessary");
+            ui.checkbox(&mut self.maintain_aspect_ratio, "Maintain aspect ratio");
+
+            // alt text
+            ui.add_space(5.0);
+            ui.label("Alt text");
+            ui.text_edit_singleline(&mut self.alt_text);
+
+            // forget all images
+            if ui.button("Forget all images").clicked() {
+                ui.ctx().forget_all_images();
+            }
+        });
+
+        egui::CentralPanel::default().show_inside(ui, |ui| {
+            egui::ScrollArea::both().show(ui, |ui| {
+                let mut image = egui::Image::from_uri(&self.current_uri);
+                image = image.uv(self.image_options.uv);
+                image = image.bg_fill(self.image_options.bg_fill);
+                image = image.tint(self.image_options.tint);
+                let (angle, origin) = self
+                    .image_options
+                    .rotation
+                    .map_or((0.0, Vec2::splat(0.5)), |(rot, origin)| {
+                        (rot.angle(), origin)
+                    });
+                image = image.rotate(angle, origin);
+                match self.fit {
+                    ImageFit::Original { scale } => image = image.fit_to_original_size(scale),
+                    ImageFit::Fraction(fract) => image = image.fit_to_fraction(fract),
+                    ImageFit::Exact(size) => image = image.fit_to_exact_size(size),
+                }
+                image = image.maintain_aspect_ratio(self.maintain_aspect_ratio);
+                image = image.max_size(self.max_size);
+                if !self.alt_text.is_empty() {
+                    image = image.alt_text(&self.alt_text);
+                }
+
+                ui.add_sized(ui.available_size(), image);
+            });
+        });
+    }
+}

--- a/crates/egui_demo_app_90/src/apps/mod.rs
+++ b/crates/egui_demo_app_90/src/apps/mod.rs
@@ -1,0 +1,27 @@
+#[cfg(all(feature = "glow", not(feature = "wgpu")))]
+mod custom3d_glow;
+
+#[cfg(feature = "wgpu")]
+mod custom3d_wgpu;
+
+mod fractal_clock;
+
+#[cfg(feature = "http")]
+mod http_app;
+
+#[cfg(feature = "image_viewer")]
+mod image_viewer;
+
+#[cfg(feature = "image_viewer")]
+pub use image_viewer::ImageViewer;
+
+#[cfg(all(feature = "glow", not(feature = "wgpu")))]
+pub use custom3d_glow::Custom3d;
+
+#[cfg(feature = "wgpu")]
+pub use custom3d_wgpu::Custom3d;
+
+pub use fractal_clock::FractalClock;
+
+#[cfg(feature = "http")]
+pub use http_app::HttpApp;

--- a/crates/egui_demo_app_90/src/backend_panel.rs
+++ b/crates/egui_demo_app_90/src/backend_panel.rs
@@ -1,0 +1,497 @@
+/// How often we repaint the demo app by default
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RunMode {
+    /// This is the default for the demo.
+    ///
+    /// If this is selected, egui is only updated if are input events
+    /// (like mouse movements) or there are some animations in the GUI.
+    ///
+    /// Reactive mode saves CPU.
+    ///
+    /// The downside is that the UI can become out-of-date if something it is supposed to monitor changes.
+    /// For instance, a GUI for a thermostat need to repaint each time the temperature changes.
+    /// To ensure the UI is up to date you need to call `egui::Context::request_repaint()` each
+    /// time such an event happens. You can also chose to call `request_repaint()` once every second
+    /// or after every single frame - this is called [`Continuous`](RunMode::Continuous) mode,
+    /// and for games and interactive tools that need repainting every frame anyway, this should be the default.
+    Reactive,
+
+    /// This will call `egui::Context::request_repaint()` at the end of each frame
+    /// to request the backend to repaint as soon as possible.
+    ///
+    /// On most platforms this will mean that egui will run at the display refresh rate of e.g. 60 Hz.
+    ///
+    /// For this demo it is not any reason to do so except to
+    /// demonstrate how quickly egui runs.
+    ///
+    /// For games or other interactive apps, this is probably what you want to do.
+    /// It will guarantee that egui is always up-to-date.
+    Continuous,
+}
+
+/// Default for demo is Reactive since
+/// 1) We want to use minimal CPU
+/// 2) There are no external events that could invalidate the UI
+///    so there are no events to miss.
+impl Default for RunMode {
+    fn default() -> Self {
+        Self::Reactive
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+#[derive(Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(default))]
+pub struct BackendPanel {
+    pub open: bool,
+
+    #[cfg_attr(feature = "serde", serde(skip))]
+    // go back to [`RunMode::Reactive`] mode each time we start
+    run_mode: RunMode,
+
+    #[cfg_attr(feature = "serde", serde(skip))]
+    frame_history: crate::frame_history::FrameHistory,
+
+    egui_windows: EguiWindows,
+}
+
+impl BackendPanel {
+    pub fn update(&mut self, ctx: &egui::Context, frame: &eframe::Frame) {
+        self.frame_history
+            .on_new_frame(ctx.input(|i| i.time), frame.info().cpu_usage);
+
+        match self.run_mode {
+            RunMode::Continuous => {
+                // Tell the backend to repaint as soon as possible
+                ctx.request_repaint();
+            }
+            RunMode::Reactive => {
+                // let the computer rest for a bit
+            }
+        }
+    }
+
+    pub fn end_of_frame(&mut self, ctx: &egui::Context) {
+        self.egui_windows.windows(ctx);
+    }
+
+    pub fn ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
+        integration_ui(ui, frame);
+
+        ui.separator();
+
+        self.run_mode_ui(ui);
+
+        ui.separator();
+
+        self.frame_history.ui(ui);
+
+        ui.separator();
+
+        ui.label("egui windows:");
+        self.egui_windows.checkboxes(ui);
+
+        #[cfg(debug_assertions)]
+        if ui.global_style().debug.debug_on_hover_with_all_modifiers {
+            ui.separator();
+            ui.label("Press down all modifiers and hover a widget to see a callstack for it");
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            ui.separator();
+            let mut screen_reader = ui.options(|o| o.screen_reader);
+            ui.checkbox(&mut screen_reader, "🔈 Screen reader").on_hover_text("Experimental feature: checking this will turn on the screen reader on supported platforms");
+            ui.options_mut(|o| o.screen_reader = screen_reader);
+        }
+
+        if cfg!(debug_assertions) && cfg!(target_arch = "wasm32") {
+            ui.separator();
+            // For testing panic handling on web:
+            #[expect(clippy::manual_assert)]
+            if ui.button("panic!()").clicked() {
+                panic!("intentional panic!");
+            }
+        }
+
+        if !cfg!(target_arch = "wasm32") {
+            ui.separator();
+            if ui.button("Quit").clicked() {
+                ui.send_viewport_cmd(egui::ViewportCommand::Close);
+            }
+        }
+    }
+
+    fn run_mode_ui(&mut self, ui: &mut egui::Ui) {
+        ui.horizontal(|ui| {
+            let run_mode = &mut self.run_mode;
+            ui.label("Mode:");
+            ui.radio_value(run_mode, RunMode::Reactive, "Reactive")
+                .on_hover_text("Repaint when there are animations or input (e.g. mouse movement)");
+            ui.radio_value(run_mode, RunMode::Continuous, "Continuous")
+                .on_hover_text("Repaint everything each frame");
+        });
+
+        if self.run_mode == RunMode::Continuous {
+            ui.label(format!(
+                "Repainting the UI each frame. FPS: {:.1}",
+                self.frame_history.fps()
+            ));
+        } else {
+            ui.label("Only running UI code when there are animations or input.");
+
+            // Add a test for `request_repaint_after`, but only in debug
+            // builds to keep the noise down in the official demo.
+            if cfg!(debug_assertions) {
+                ui.collapsing("More…", |ui| {
+                    ui.horizontal(|ui| {
+                        ui.label("Total ui frames:");
+                        ui.monospace(ui.ctx().cumulative_frame_nr().to_string());
+                    });
+                    ui.horizontal(|ui| {
+                        ui.label("Total ui passes:");
+                        ui.monospace(ui.ctx().cumulative_pass_nr().to_string());
+                    });
+                    if ui
+                        .button("Wait 2s, then request repaint after another 3s")
+                        .clicked()
+                    {
+                        log::info!("Waiting 2s before requesting repaint…");
+                        let ctx = ui.ctx().clone();
+                        call_after_delay(std::time::Duration::from_secs(2), move || {
+                            log::info!("Request a repaint in 3s…");
+                            ctx.request_repaint_after(std::time::Duration::from_secs(3));
+                        });
+                    }
+
+                    ui.horizontal(|ui| {
+                        if ui.button("Request discard").clicked() {
+                            ui.request_discard("Manual button click");
+
+                            if !ui.ctx().will_discard() {
+                                ui.label("Discard denied!");
+                            }
+                        }
+                    });
+                });
+            }
+        }
+    }
+}
+
+fn integration_ui(ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 0.0;
+        ui.label("egui running inside ");
+        ui.hyperlink_to(
+            "eframe",
+            "https://github.com/emilk/egui/tree/main/crates/eframe",
+        );
+        ui.label(".");
+    });
+
+    #[cfg(target_arch = "wasm32")]
+    ui.collapsing("Web info (location)", |ui| {
+        ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+        ui.monospace(format!("{:#?}", _frame.info().web_info.location));
+    });
+
+    #[cfg(feature = "glow")]
+    if _frame.gl().is_some() {
+        ui.horizontal(|ui| {
+            ui.label("Renderer:");
+            ui.hyperlink_to("glow", "https://github.com/grovesNL/glow");
+        });
+    }
+
+    #[cfg(feature = "wgpu")]
+    if let Some(render_state) = _frame.wgpu_render_state() {
+        let wgpu_adapter_details_ui = |ui: &mut egui::Ui, adapter: &eframe::wgpu::Adapter| {
+            let info = &adapter.get_info();
+
+            let eframe::wgpu::AdapterInfo {
+                name,
+                vendor,
+                device,
+                device_type,
+                driver,
+                driver_info,
+                backend,
+                device_pci_bus_id,
+                subgroup_min_size,
+                subgroup_max_size,
+                transient_saves_memory,
+            } = &info;
+
+            // Example values:
+            // > name: "llvmpipe (LLVM 16.0.6, 256 bits)", device_type: Cpu, backend: Vulkan, driver: "llvmpipe", driver_info: "Mesa 23.1.6-arch1.4 (LLVM 16.0.6)"
+            // > name: "Apple M1 Pro", device_type: IntegratedGpu, backend: Metal, driver: "", driver_info: ""
+            // > name: "ANGLE (Apple, Apple M1 Pro, OpenGL 4.1)", device_type: IntegratedGpu, backend: Gl, driver: "", driver_info: ""
+
+            egui::Grid::new("adapter_info").show(ui, |ui| {
+                ui.label("Backend:");
+                ui.label(format!("{backend:?}"));
+                ui.end_row();
+
+                ui.label("Device Type:");
+                ui.label(format!("{device_type:?}"));
+                ui.end_row();
+
+                if !name.is_empty() {
+                    ui.label("Name:");
+                    ui.label(format!("{name:?}"));
+                    ui.end_row();
+                }
+                if !driver.is_empty() {
+                    ui.label("Driver:");
+                    ui.label(format!("{driver:?}"));
+                    ui.end_row();
+                }
+                if !driver_info.is_empty() {
+                    ui.label("Driver info:");
+                    ui.label(format!("{driver_info:?}"));
+                    ui.end_row();
+                }
+                if *vendor != 0 {
+                    // TODO(emilk): decode using https://github.com/gfx-rs/wgpu/blob/767ac03245ee937d3dc552edc13fe7ab0a860eec/wgpu-hal/src/auxil/mod.rs#L7
+                    ui.label("Vendor:");
+                    ui.label(format!("0x{vendor:04X}"));
+                    ui.end_row();
+                }
+                if *device != 0 {
+                    ui.label("Device:");
+                    ui.label(format!("0x{device:02X}"));
+                    ui.end_row();
+                }
+                if !device_pci_bus_id.is_empty() {
+                    ui.label("PCI Bus ID:");
+                    ui.label(device_pci_bus_id.as_str());
+                    ui.end_row();
+                }
+                if *subgroup_min_size != 0 || *subgroup_max_size != 0 {
+                    ui.label("Subgroup size:");
+                    ui.label(format!("{subgroup_min_size}..={subgroup_max_size}"));
+                    ui.end_row();
+                }
+                ui.label("Transient saves memory:");
+                ui.label(format!("{transient_saves_memory}"));
+                ui.end_row();
+            });
+        };
+
+        let wgpu_adapter_ui = |ui: &mut egui::Ui, adapter: &eframe::wgpu::Adapter| {
+            let info = &adapter.get_info();
+            ui.label(format!("{:?}", info.backend)).on_hover_ui(|ui| {
+                wgpu_adapter_details_ui(ui, adapter);
+            });
+        };
+
+        egui::Grid::new("wgpu_info").num_columns(2).show(ui, |ui| {
+            ui.label("Renderer:");
+            ui.hyperlink_to("wgpu", "https://wgpu.rs/");
+            ui.end_row();
+
+            ui.label("Backend:");
+            wgpu_adapter_ui(ui, &render_state.adapter);
+            ui.end_row();
+
+            #[cfg(not(target_arch = "wasm32"))]
+            if 1 < render_state.available_adapters.len() {
+                ui.label("Others:");
+                ui.vertical(|ui| {
+                    for adapter in &*render_state.available_adapters {
+                        if adapter.get_info() != render_state.adapter.get_info() {
+                            wgpu_adapter_ui(ui, adapter);
+                        }
+                    }
+                });
+                ui.end_row();
+            }
+        });
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        ui.horizontal(|ui| {
+            {
+                let mut fullscreen = ui.input(|i| i.viewport().fullscreen.unwrap_or(false));
+                if ui
+                    .checkbox(&mut fullscreen, "🗖 Fullscreen (F11)")
+                    .on_hover_text("Fullscreen the window")
+                    .changed()
+                {
+                    ui.send_viewport_cmd(egui::ViewportCommand::Fullscreen(fullscreen));
+                }
+            }
+
+            let mut size = None;
+            egui::ComboBox::from_id_salt("viewport-size-combo")
+                .selected_text("Resize to…")
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(
+                        &mut size,
+                        Some(egui::vec2(375.0, 667.0)),
+                        "📱 iPhone SE 2nd Gen",
+                    );
+                    ui.selectable_value(&mut size, Some(egui::vec2(393.0, 852.0)), "📱 iPhone 15");
+                    ui.selectable_value(
+                        &mut size,
+                        Some(egui::vec2(1280.0, 720.0)),
+                        "🖥 Desktop 720p",
+                    );
+                    ui.selectable_value(
+                        &mut size,
+                        Some(egui::vec2(1920.0, 1080.0)),
+                        "🖥 Desktop 1080p",
+                    );
+                });
+
+            if let Some(size) = size {
+                ui.send_viewport_cmd(egui::ViewportCommand::InnerSize(size));
+                ui.send_viewport_cmd(egui::ViewportCommand::Fullscreen(false));
+                ui.close();
+            }
+        });
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+struct EguiWindows {
+    // egui stuff:
+    settings: bool,
+    inspection: bool,
+    memory: bool,
+    output_events: bool,
+
+    #[cfg_attr(feature = "serde", serde(skip))]
+    output_event_history: std::collections::VecDeque<egui::output::OutputEvent>,
+}
+
+impl Default for EguiWindows {
+    fn default() -> Self {
+        Self::none()
+    }
+}
+
+impl EguiWindows {
+    fn none() -> Self {
+        Self {
+            settings: false,
+            inspection: false,
+            memory: false,
+            output_events: false,
+            output_event_history: Default::default(),
+        }
+    }
+
+    fn checkboxes(&mut self, ui: &mut egui::Ui) {
+        let Self {
+            settings,
+            inspection,
+            memory,
+            output_events,
+            output_event_history: _,
+        } = self;
+
+        ui.checkbox(settings, "🔧 Settings");
+        ui.checkbox(inspection, "🔍 Inspection");
+        ui.checkbox(memory, "📝 Memory");
+        ui.checkbox(output_events, "📤 Output Events");
+    }
+
+    fn windows(&mut self, ctx: &egui::Context) {
+        let Self {
+            settings,
+            inspection,
+            memory,
+            output_events,
+            output_event_history,
+        } = self;
+
+        ctx.output(|o| {
+            for event in &o.events {
+                output_event_history.push_back(event.clone());
+            }
+        });
+        while output_event_history.len() > 1000 {
+            output_event_history.pop_front();
+        }
+
+        egui::Window::new("🔧 Settings")
+            .open(settings)
+            .vscroll(true)
+            .show(ctx, |ui| {
+                ctx.settings_ui(ui);
+            });
+
+        egui::Window::new("🔍 Inspection")
+            .open(inspection)
+            .vscroll(true)
+            .show(ctx, |ui| {
+                ctx.inspection_ui(ui);
+            });
+
+        egui::Window::new("📝 Memory")
+            .open(memory)
+            .resizable(false)
+            .show(ctx, |ui| {
+                ctx.memory_ui(ui);
+            });
+
+        egui::Window::new("📤 Output Events")
+            .open(output_events)
+            .resizable(true)
+            .default_width(520.0)
+            .show(ctx, |ui| {
+                ui.label(
+                    "Recent output events from egui. \
+            These are emitted when you interact with widgets, or move focus between them with TAB. \
+            They can be hooked up to a screen reader on supported platforms.",
+                );
+
+                ui.separator();
+
+                egui::ScrollArea::vertical()
+                    .stick_to_bottom(true)
+                    .show(ui, |ui| {
+                        for event in output_event_history {
+                            ui.label(format!("{event:?}"));
+                        }
+                    });
+            });
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+#[cfg(not(target_arch = "wasm32"))]
+fn call_after_delay(delay: std::time::Duration, f: impl FnOnce() + Send + 'static) {
+    std::thread::Builder::new()
+        .name("call_after_delay".to_owned())
+        .spawn(move || {
+            std::thread::sleep(delay);
+            f();
+        })
+        .expect("Failed to spawn a thread");
+}
+
+#[cfg(target_arch = "wasm32")]
+fn call_after_delay(delay: std::time::Duration, f: impl FnOnce() + Send + 'static) {
+    #![expect(clippy::unwrap_used)]
+
+    use wasm_bindgen::prelude::*;
+    let window = web_sys::window().unwrap();
+    let closure = Closure::once(f);
+    let delay_ms = delay.as_millis() as _;
+    window
+        .set_timeout_with_callback_and_timeout_and_arguments_0(
+            closure.as_ref().unchecked_ref(),
+            delay_ms,
+        )
+        .unwrap();
+    closure.forget(); // We must forget it, or else the callback is canceled on drop
+}

--- a/crates/egui_demo_app_90/src/frame_history.rs
+++ b/crates/egui_demo_app_90/src/frame_history.rs
@@ -1,0 +1,127 @@
+use egui::util::History;
+
+pub struct FrameHistory {
+    frame_times: History<f32>,
+}
+
+impl Default for FrameHistory {
+    fn default() -> Self {
+        let max_age: f32 = 1.0;
+        let max_len = (max_age * 300.0).round() as usize;
+        Self {
+            frame_times: History::new(0..max_len, max_age),
+        }
+    }
+}
+
+impl FrameHistory {
+    // Called first
+    pub fn on_new_frame(&mut self, now: f64, previous_frame_time: Option<f32>) {
+        let previous_frame_time = previous_frame_time.unwrap_or_default();
+        if let Some(latest) = self.frame_times.latest_mut() {
+            *latest = previous_frame_time; // rewrite history now that we know
+        }
+        self.frame_times.add(now, previous_frame_time); // projected
+    }
+
+    pub fn mean_frame_time(&self) -> f32 {
+        self.frame_times.average().unwrap_or_default()
+    }
+
+    pub fn fps(&self) -> f32 {
+        1.0 / self.frame_times.mean_time_interval().unwrap_or_default()
+    }
+
+    pub fn ui(&self, ui: &mut egui::Ui) {
+        ui.label(format!(
+            "Mean CPU usage: {:.2} ms / frame",
+            1e3 * self.mean_frame_time()
+        ))
+        .on_hover_text(
+            "Includes all app logic, egui layout, tessellation, and rendering.\n\
+            Does not include waiting for vsync.",
+        );
+        egui::warn_if_debug_build(ui);
+
+        if !cfg!(target_arch = "wasm32") {
+            egui::CollapsingHeader::new("📊 CPU usage history")
+                .default_open(false)
+                .show(ui, |ui| {
+                    self.graph(ui);
+                });
+        }
+    }
+
+    fn graph(&self, ui: &mut egui::Ui) -> egui::Response {
+        use egui::{Pos2, Rect, Sense, Shape, Stroke, TextStyle, emath, epaint, pos2, vec2};
+
+        ui.label("egui CPU usage history");
+
+        let history = &self.frame_times;
+
+        // TODO(emilk): we should not use `slider_width` as default graph width.
+        let height = ui.spacing().slider_width;
+        let size = vec2(ui.available_size_before_wrap().x, height);
+        let (rect, response) = ui.allocate_at_least(size, Sense::hover());
+        let style = ui.style().noninteractive();
+
+        let graph_top_cpu_usage = 0.010;
+        let graph_rect = Rect::from_x_y_ranges(history.max_age()..=0.0, graph_top_cpu_usage..=0.0);
+        let to_screen = emath::RectTransform::from_to(graph_rect, rect);
+
+        let mut shapes = Vec::with_capacity(3 + 2 * history.len());
+        shapes.push(Shape::Rect(epaint::RectShape::new(
+            rect,
+            style.corner_radius,
+            ui.visuals().extreme_bg_color,
+            ui.style().noninteractive().bg_stroke,
+            egui::StrokeKind::Inside,
+        )));
+
+        let rect = rect.shrink(4.0);
+        let color = ui.visuals().text_color();
+        let line_stroke = Stroke::new(1.0, color);
+
+        if let Some(pointer_pos) = response.hover_pos() {
+            let y = pointer_pos.y;
+            shapes.push(Shape::line_segment(
+                [pos2(rect.left(), y), pos2(rect.right(), y)],
+                line_stroke,
+            ));
+            let cpu_usage = to_screen.inverse().transform_pos(pointer_pos).y;
+            let text = format!("{:.1} ms", 1e3 * cpu_usage);
+            shapes.push(ui.fonts_mut(|f| {
+                Shape::text(
+                    f,
+                    pos2(rect.left(), y),
+                    egui::Align2::LEFT_BOTTOM,
+                    text,
+                    TextStyle::Monospace.resolve(ui.style()),
+                    color,
+                )
+            }));
+        }
+
+        let circle_color = color;
+        let radius = 2.0;
+        let right_side_time = ui.input(|i| i.time); // Time at right side of screen
+
+        for (time, cpu_usage) in history.iter() {
+            let age = (right_side_time - time) as f32;
+            let pos = to_screen.transform_pos_clamped(Pos2::new(age, cpu_usage));
+
+            shapes.push(Shape::line_segment(
+                [pos2(pos.x, rect.bottom()), pos],
+                line_stroke,
+            ));
+
+            if cpu_usage < graph_top_cpu_usage {
+                shapes.push(Shape::circle_filled(pos, radius, circle_color));
+            }
+        }
+
+        ui.painter().extend(shapes);
+
+        response
+    }
+}

--- a/crates/egui_demo_app_90/src/lib.rs
+++ b/crates/egui_demo_app_90/src/lib.rs
@@ -1,0 +1,33 @@
+//! Demo app for egui
+
+mod apps;
+mod backend_panel;
+mod frame_history;
+mod wrap_app;
+
+pub use wrap_app::{Anchor, WrapApp};
+
+/// Time of day as seconds since midnight. Used for clock in demo app.
+pub(crate) fn seconds_since_midnight() -> f64 {
+    jiff::Zoned::now()
+        .time()
+        .duration_since(jiff::civil::Time::midnight())
+        .as_secs_f64()
+}
+
+/// Trait that wraps different parts of the demo app.
+pub trait DemoApp {
+    fn demo_ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame);
+
+    #[cfg(feature = "glow")]
+    fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {}
+}
+
+// ----------------------------------------------------------------------------
+#[cfg(feature = "accessibility_inspector")]
+pub mod accessibility_inspector;
+#[cfg(target_arch = "wasm32")]
+mod web;
+
+#[cfg(target_arch = "wasm32")]
+pub use web::*;

--- a/crates/egui_demo_app_90/src/main.rs
+++ b/crates/egui_demo_app_90/src/main.rs
@@ -55,7 +55,8 @@ fn main() {
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_inner_size([1280.0, 1024.0])
-            .with_drag_and_drop(true),
+            .with_drag_and_drop(true)
+            .with_rotation(eframe::emath::ViewportRotation::CW90),
 
         #[cfg(feature = "wgpu")]
         renderer: eframe::Renderer::Wgpu,
@@ -66,7 +67,7 @@ fn main() {
     let result = eframe::run_native(
         "egui demo app",
         options,
-        Box::new(|cc| Ok(Box::new(egui_demo_app::WrapApp::new(cc)))),
+        Box::new(|cc| Ok(Box::new(egui_demo_app_90::WrapApp::new(cc)))),
     );
 
     match result {

--- a/crates/egui_demo_app_90/src/main.rs
+++ b/crates/egui_demo_app_90/src/main.rs
@@ -1,0 +1,112 @@
+//! Demo app for egui
+
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
+#![expect(rustdoc::missing_crate_level_docs)] // it's an example
+#![allow(clippy::allow_attributes, clippy::never_loop)]
+
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc; // Much faster allocator, can give 20% speedups: https://github.com/emilk/egui/pull/7029
+
+// When compiling natively:
+fn main() {
+    for arg in std::env::args().skip(1) {
+        match arg.as_str() {
+            "--profile" => {
+                #[cfg(feature = "puffin")]
+                start_puffin_server();
+
+                #[cfg(not(feature = "puffin"))]
+                panic!(
+                    "Unknown argument: {arg} - you need to enable the 'puffin' feature to use this."
+                );
+            }
+
+            _ => {
+                panic!("Unknown argument: {arg}");
+            }
+        }
+    }
+
+    {
+        // Silence wgpu log spam (https://github.com/gfx-rs/wgpu/issues/3206)
+        let mut rust_log = std::env::var("RUST_LOG").unwrap_or_else(|_| {
+            if cfg!(debug_assertions) {
+                "debug".to_owned()
+            } else {
+                "info".to_owned()
+            }
+        });
+        for loud_crate in ["naga", "wgpu_core", "wgpu_hal"] {
+            if !rust_log.contains(&format!("{loud_crate}=")) {
+                use std::fmt::Write as _;
+                write!(rust_log, ",{loud_crate}=warn").ok();
+            }
+        }
+
+        // SAFETY: we call this from the main thread without any other threads running.
+        #[expect(unsafe_code)]
+        unsafe {
+            std::env::set_var("RUST_LOG", rust_log);
+        }
+    }
+
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
+
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default()
+            .with_inner_size([1280.0, 1024.0])
+            .with_drag_and_drop(true),
+
+        #[cfg(feature = "wgpu")]
+        renderer: eframe::Renderer::Wgpu,
+
+        ..Default::default()
+    };
+
+    let result = eframe::run_native(
+        "egui demo app",
+        options,
+        Box::new(|cc| Ok(Box::new(egui_demo_app::WrapApp::new(cc)))),
+    );
+
+    match result {
+        Ok(()) => {}
+        Err(err) => {
+            // This produces a nicer error message than returning the `Result`:
+            print_error_and_exit(&err);
+        }
+    }
+}
+
+fn print_error_and_exit(err: &eframe::Error) -> ! {
+    #![expect(clippy::print_stderr)]
+    #![expect(clippy::exit)]
+
+    eprintln!("Error: {err}");
+    std::process::exit(1)
+}
+
+#[cfg(feature = "puffin")]
+fn start_puffin_server() {
+    puffin::set_scopes_on(true); // tell puffin to collect data
+
+    match puffin_http::Server::new("127.0.0.1:8585") {
+        Ok(puffin_server) => {
+            log::info!("Run:  cargo install puffin_viewer && puffin_viewer --url 127.0.0.1:8585");
+
+            std::process::Command::new("puffin_viewer")
+                .arg("--url")
+                .arg("127.0.0.1:8585")
+                .spawn()
+                .ok();
+
+            // We can store the server if we want, but in this case we just want
+            // it to keep running. Dropping it closes the server, so let's not drop it!
+            #[expect(clippy::mem_forget)]
+            std::mem::forget(puffin_server);
+        }
+        Err(err) => {
+            log::error!("Failed to start puffin server: {err}");
+        }
+    }
+}

--- a/crates/egui_demo_app_90/src/web.rs
+++ b/crates/egui_demo_app_90/src/web.rs
@@ -1,0 +1,80 @@
+use eframe::wasm_bindgen::{self, prelude::*};
+
+use crate::WrapApp;
+
+/// Our handle to the web app from JavaScript.
+#[derive(Clone)]
+#[wasm_bindgen]
+pub struct WebHandle {
+    runner: eframe::WebRunner,
+}
+
+#[wasm_bindgen]
+impl WebHandle {
+    /// Installs a panic hook, then returns.
+    #[allow(clippy::allow_attributes, clippy::new_without_default)]
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        // Redirect [`log`] message to `console.log` and friends:
+        let log_level = if cfg!(debug_assertions) {
+            log::LevelFilter::Trace
+        } else {
+            log::LevelFilter::Debug
+        };
+        eframe::WebLogger::init(log_level).ok();
+
+        Self {
+            runner: eframe::WebRunner::new(),
+        }
+    }
+
+    /// Call this once from JavaScript to start your app.
+    ///
+    /// # Errors
+    /// Returns an error if the app could not start.
+    #[wasm_bindgen]
+    pub async fn start(
+        &self,
+        canvas: web_sys::HtmlCanvasElement,
+    ) -> Result<(), wasm_bindgen::JsValue> {
+        self.runner
+            .start(
+                canvas,
+                eframe::WebOptions::default(),
+                Box::new(|cc| {
+                    cc.egui_ctx.set_viewport_rotation(eframe::emath::ViewportRotation::CW90);
+                    Ok(Box::new(WrapApp::new(cc)))
+                }),
+            )
+            .await
+    }
+
+    #[wasm_bindgen]
+    pub fn destroy(&self) {
+        self.runner.destroy();
+    }
+
+    /// Example on how to call into your app from JavaScript.
+    #[wasm_bindgen]
+    pub fn example(&self) {
+        if let Some(_app) = self.runner.app_mut::<WrapApp>() {
+            // _app.example();
+        }
+    }
+
+    /// The JavaScript can check whether or not your app has crashed:
+    #[wasm_bindgen]
+    pub fn has_panicked(&self) -> bool {
+        self.runner.has_panicked()
+    }
+
+    #[wasm_bindgen]
+    pub fn panic_message(&self) -> Option<String> {
+        self.runner.panic_summary().map(|s| s.message())
+    }
+
+    #[wasm_bindgen]
+    pub fn panic_callstack(&self) -> Option<String> {
+        self.runner.panic_summary().map(|s| s.callstack())
+    }
+}

--- a/crates/egui_demo_app_90/src/wrap_app.rs
+++ b/crates/egui_demo_app_90/src/wrap_app.rs
@@ -1,0 +1,547 @@
+use egui_demo_lib::{DemoWindows, is_mobile};
+
+#[cfg(feature = "glow")]
+use eframe::glow;
+
+#[cfg(target_arch = "wasm32")]
+use core::any::Any;
+
+use crate::DemoApp;
+
+#[cfg(feature = "easymark")]
+#[derive(Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+struct EasyMarkApp {
+    editor: egui_demo_lib::easy_mark::EasyMarkEditor,
+}
+
+#[cfg(feature = "easymark")]
+impl DemoApp for EasyMarkApp {
+    fn demo_ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        self.editor.panels(ui);
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+impl DemoApp for DemoWindows {
+    fn demo_ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        self.ui(ui);
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+#[derive(Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct FractalClockApp {
+    fractal_clock: crate::apps::FractalClock,
+    pub mock_time: Option<f64>,
+}
+
+impl DemoApp for FractalClockApp {
+    fn demo_ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        egui::Frame::dark_canvas(ui.style())
+            .stroke(egui::Stroke::NONE)
+            .corner_radius(0)
+            .show(ui, |ui| {
+                self.fractal_clock.ui(
+                    ui,
+                    self.mock_time
+                        .or_else(|| Some(crate::seconds_since_midnight())),
+                );
+            });
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+#[derive(Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct ColorTestApp {
+    color_test: egui_demo_lib::ColorTest,
+}
+
+impl DemoApp for ColorTestApp {
+    fn demo_ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show_inside(ui, |ui| {
+            if frame.is_web() {
+                ui.label(
+                        "NOTE: Some old browsers stuck on WebGL1 without sRGB support will not pass the color test.",
+                    );
+                ui.separator();
+            }
+            egui::ScrollArea::both().auto_shrink(false).show(ui, |ui| {
+                self.color_test.ui(ui);
+            });
+        });
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum Anchor {
+    #[default]
+    Demo,
+
+    EasyMarkEditor,
+
+    #[cfg(feature = "http")]
+    Http,
+
+    #[cfg(feature = "image_viewer")]
+    ImageViewer,
+
+    Clock,
+
+    #[cfg(any(feature = "glow", feature = "wgpu"))]
+    Custom3d,
+
+    /// Rendering test
+    Rendering,
+}
+
+impl Anchor {
+    #[cfg(target_arch = "wasm32")]
+    fn all() -> Vec<Self> {
+        vec![
+            Self::Demo,
+            Self::EasyMarkEditor,
+            #[cfg(feature = "http")]
+            Self::Http,
+            Self::Clock,
+            #[cfg(any(feature = "glow", feature = "wgpu"))]
+            Self::Custom3d,
+            Self::Rendering,
+        ]
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn from_str_case_insensitive(anchor: &str) -> Option<Self> {
+        let anchor = anchor.to_lowercase();
+        Self::all().into_iter().find(|x| x.to_string() == anchor)
+    }
+}
+
+impl std::fmt::Display for Anchor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut name = format!("{self:?}");
+        name.make_ascii_lowercase();
+        f.write_str(&name)
+    }
+}
+
+impl From<Anchor> for egui::WidgetText {
+    fn from(value: Anchor) -> Self {
+        Self::from(value.to_string())
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug)]
+#[must_use]
+enum Command {
+    Nothing,
+    ResetEverything,
+}
+
+// ----------------------------------------------------------------------------
+
+/// The state that we persist (serialize).
+#[derive(Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(default))]
+pub struct State {
+    demo: DemoWindows,
+
+    #[cfg(feature = "easymark")]
+    easy_mark_editor: EasyMarkApp,
+
+    #[cfg(feature = "http")]
+    http: crate::apps::HttpApp,
+
+    #[cfg(feature = "image_viewer")]
+    image_viewer: crate::apps::ImageViewer,
+
+    pub clock: FractalClockApp,
+
+    rendering_test: ColorTestApp,
+
+    selected_anchor: Anchor,
+    backend_panel: super::backend_panel::BackendPanel,
+}
+
+/// Wraps many demo/test apps into one.
+pub struct WrapApp {
+    pub state: State,
+
+    #[cfg(any(feature = "glow", feature = "wgpu"))]
+    custom3d: Option<crate::apps::Custom3d>,
+
+    dropped_files: Vec<egui::DroppedFile>,
+}
+
+impl WrapApp {
+    pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
+        // This gives us image support:
+        egui_extras::install_image_loaders(&cc.egui_ctx);
+
+        #[cfg(feature = "accessibility_inspector")]
+        cc.egui_ctx
+            .add_plugin(crate::accessibility_inspector::AccessibilityInspectorPlugin::default());
+
+        #[allow(clippy::allow_attributes, unused_mut)]
+        let mut slf = Self {
+            state: State::default(),
+
+            #[cfg(any(feature = "glow", feature = "wgpu"))]
+            custom3d: crate::apps::Custom3d::new(cc),
+
+            dropped_files: Default::default(),
+        };
+
+        #[cfg(feature = "persistence")]
+        if let Some(storage) = cc.storage
+            && let Some(state) = eframe::get_value(storage, eframe::APP_KEY)
+        {
+            slf.state = state;
+        }
+
+        slf
+    }
+
+    pub fn apps_iter_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (&'static str, Anchor, &mut dyn DemoApp)> {
+        let mut vec = vec![
+            (
+                "✨ Demos",
+                Anchor::Demo,
+                &mut self.state.demo as &mut dyn DemoApp,
+            ),
+            #[cfg(feature = "easymark")]
+            (
+                "🖹 EasyMark editor",
+                Anchor::EasyMarkEditor,
+                &mut self.state.easy_mark_editor as &mut dyn DemoApp,
+            ),
+            #[cfg(feature = "http")]
+            (
+                "⬇ HTTP",
+                Anchor::Http,
+                &mut self.state.http as &mut dyn DemoApp,
+            ),
+            (
+                "🕑 Fractal Clock",
+                Anchor::Clock,
+                &mut self.state.clock as &mut dyn DemoApp,
+            ),
+            #[cfg(feature = "image_viewer")]
+            (
+                "🖼 Image Viewer",
+                Anchor::ImageViewer,
+                &mut self.state.image_viewer as &mut dyn DemoApp,
+            ),
+        ];
+
+        #[cfg(any(feature = "glow", feature = "wgpu"))]
+        if let Some(custom3d) = &mut self.custom3d {
+            vec.push((
+                "🔺 3D painting",
+                Anchor::Custom3d,
+                custom3d as &mut dyn DemoApp,
+            ));
+        }
+
+        vec.push((
+            "🎨 Rendering test",
+            Anchor::Rendering,
+            &mut self.state.rendering_test as &mut dyn DemoApp,
+        ));
+
+        vec.into_iter()
+    }
+}
+
+impl eframe::App for WrapApp {
+    #[cfg(feature = "persistence")]
+    fn save(&mut self, storage: &mut dyn eframe::Storage) {
+        eframe::set_value(storage, eframe::APP_KEY, &self.state);
+    }
+
+    fn clear_color(&self, visuals: &egui::Visuals) -> [f32; 4] {
+        // Give the area behind the floating windows a different color, because it looks better:
+        let color = egui::lerp(
+            egui::Rgba::from(visuals.panel_fill)..=egui::Rgba::from(visuals.extreme_bg_color),
+            0.5,
+        );
+        let color = egui::Color32::from(color);
+        color.to_normalized_gamma_f32()
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
+        #[cfg(target_arch = "wasm32")]
+        if let Some(anchor) = frame
+            .info()
+            .web_info
+            .location
+            .hash
+            .strip_prefix('#')
+            .and_then(Anchor::from_str_case_insensitive)
+        {
+            self.state.selected_anchor = anchor;
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::F11)) {
+            let fullscreen = ui.input(|i| i.viewport().fullscreen.unwrap_or(false));
+            ui.send_viewport_cmd(egui::ViewportCommand::Fullscreen(!fullscreen));
+        }
+
+        let mut cmd = Command::Nothing;
+        egui::Panel::top("wrap_app_top_bar")
+            .frame(egui::Frame::new().inner_margin(4))
+            .show_inside(ui, |ui| {
+                ui.horizontal_wrapped(|ui| {
+                    ui.visuals_mut().button_frame = false;
+                    self.bar_contents(ui, frame, &mut cmd);
+                });
+            });
+
+        self.state.backend_panel.update(ui.ctx(), frame);
+
+        egui::CentralPanel::no_frame().show_inside(ui, |ui| {
+            if !is_mobile(ui.ctx()) {
+                cmd = self.backend_panel(ui, frame);
+            }
+
+            self.show_selected_app(ui, frame);
+        });
+
+        self.state.backend_panel.end_of_frame(ui.ctx());
+
+        self.ui_file_drag_and_drop(ui.ctx());
+
+        self.run_cmd(ui.ctx(), cmd);
+    }
+
+    #[cfg(feature = "glow")]
+    fn on_exit(&mut self, gl: Option<&glow::Context>) {
+        if let Some(custom3d) = &mut self.custom3d {
+            custom3d.on_exit(gl);
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn as_any_mut(&mut self) -> Option<&mut dyn Any> {
+        Some(&mut *self)
+    }
+}
+
+impl WrapApp {
+    fn backend_panel(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) -> Command {
+        // The backend-panel can be toggled on/off.
+        // We show a little animation when the user switches it.
+        let is_open = self.state.backend_panel.open || ui.memory(|mem| mem.everything_is_visible());
+
+        let mut cmd = Command::Nothing;
+
+        egui::Panel::left("backend_panel")
+            .resizable(false)
+            .show_animated_inside(ui, is_open, |ui| {
+                ui.add_space(4.0);
+                ui.vertical_centered(|ui| {
+                    ui.heading("💻 Backend");
+                });
+
+                ui.separator();
+                self.backend_panel_contents(ui, frame, &mut cmd);
+            });
+
+        cmd
+    }
+
+    fn run_cmd(&mut self, ctx: &egui::Context, cmd: Command) {
+        match cmd {
+            Command::Nothing => {}
+            Command::ResetEverything => {
+                self.state = Default::default();
+                ctx.memory_mut(|mem| *mem = Default::default());
+            }
+        }
+    }
+
+    fn backend_panel_contents(
+        &mut self,
+        ui: &mut egui::Ui,
+        frame: &mut eframe::Frame,
+        cmd: &mut Command,
+    ) {
+        self.state.backend_panel.ui(ui, frame);
+
+        ui.separator();
+
+        ui.horizontal(|ui| {
+            if ui
+                .button("Reset egui")
+                .on_hover_text("Forget scroll, positions, sizes etc")
+                .clicked()
+            {
+                ui.memory_mut(|mem| *mem = Default::default());
+                ui.close();
+            }
+
+            if ui.button("Reset everything").clicked() {
+                *cmd = Command::ResetEverything;
+                ui.close();
+            }
+        });
+    }
+
+    fn show_selected_app(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
+        let selected_anchor = self.state.selected_anchor;
+        for (_name, anchor, app) in self.apps_iter_mut() {
+            if anchor == selected_anchor || ui.memory(|mem| mem.everything_is_visible()) {
+                app.demo_ui(ui, frame);
+            }
+        }
+    }
+
+    fn bar_contents(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame, cmd: &mut Command) {
+        ui.add_space(8.0);
+
+        egui::widgets::global_theme_preference_switch(ui);
+
+        ui.separator();
+
+        if is_mobile(ui.ctx()) {
+            ui.menu_button("💻 Backend", |ui| {
+                ui.set_style(ui.global_style()); // ignore the "menu" style set by `menu_button`.
+                self.backend_panel_contents(ui, frame, cmd);
+            });
+        } else {
+            ui.toggle_value(&mut self.state.backend_panel.open, "💻 Backend");
+        }
+
+        ui.separator();
+
+        let mut selected_anchor = self.state.selected_anchor;
+        for (name, anchor, _app) in self.apps_iter_mut() {
+            if ui
+                .selectable_label(selected_anchor == anchor, name)
+                .clicked()
+            {
+                selected_anchor = anchor;
+                if frame.is_web() {
+                    ui.open_url(egui::OpenUrl::same_tab(format!("#{anchor}")));
+                }
+            }
+        }
+        self.state.selected_anchor = selected_anchor;
+
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            if false {
+                // TODO(emilk): fix the overlap on small screens
+                if clock_button(ui, crate::seconds_since_midnight()).clicked() {
+                    self.state.selected_anchor = Anchor::Clock;
+                    if frame.is_web() {
+                        ui.open_url(egui::OpenUrl::same_tab("#clock"));
+                    }
+                }
+            }
+
+            egui::warn_if_debug_build(ui);
+        });
+    }
+
+    fn ui_file_drag_and_drop(&mut self, ctx: &egui::Context) {
+        use egui::{Align2, Color32, Id, LayerId, Order, TextStyle};
+        use std::fmt::Write as _;
+
+        // Preview hovering files:
+        if !ctx.input(|i| i.raw.hovered_files.is_empty()) {
+            let text = ctx.input(|i| {
+                let mut text = "Dropping files:\n".to_owned();
+                for file in &i.raw.hovered_files {
+                    if let Some(path) = &file.path {
+                        write!(text, "\n{}", path.display()).ok();
+                    } else if file.mime.is_empty() {
+                        text += "\n???";
+                    } else {
+                        write!(text, "\n{}", file.mime).ok();
+                    }
+                }
+                text
+            });
+
+            let painter =
+                ctx.layer_painter(LayerId::new(Order::Foreground, Id::new("file_drop_target")));
+
+            let content_rect = ctx.content_rect();
+            painter.rect_filled(content_rect, 0.0, Color32::from_black_alpha(192));
+            painter.text(
+                content_rect.center(),
+                Align2::CENTER_CENTER,
+                text,
+                TextStyle::Heading.resolve(&ctx.global_style()),
+                Color32::WHITE,
+            );
+        }
+
+        // Collect dropped files:
+        ctx.input(|i| {
+            if !i.raw.dropped_files.is_empty() {
+                self.dropped_files.clone_from(&i.raw.dropped_files);
+            }
+        });
+
+        // Show dropped files (if any):
+        if !self.dropped_files.is_empty() {
+            let mut open = true;
+            egui::Window::new("Dropped files")
+                .open(&mut open)
+                .show(ctx, |ui| {
+                    for file in &self.dropped_files {
+                        let mut info = if let Some(path) = &file.path {
+                            path.display().to_string()
+                        } else if file.name.is_empty() {
+                            "???".to_owned()
+                        } else {
+                            file.name.clone()
+                        };
+
+                        let mut additional_info = vec![];
+                        if !file.mime.is_empty() {
+                            additional_info.push(format!("type: {}", file.mime));
+                        }
+                        if let Some(bytes) = &file.bytes {
+                            additional_info.push(format!("{} bytes", bytes.len()));
+                        }
+                        if !additional_info.is_empty() {
+                            use std::fmt::Write as _;
+                            write!(info, " ({})", additional_info.join(", ")).ok();
+                        }
+
+                        ui.label(info);
+                    }
+                });
+            if !open {
+                self.dropped_files.clear();
+            }
+        }
+    }
+}
+
+fn clock_button(ui: &mut egui::Ui, seconds_since_midnight: f64) -> egui::Response {
+    let time = seconds_since_midnight;
+    let time = format!(
+        "{:02}:{:02}:{:02}.{:02}",
+        (time % (24.0 * 60.0 * 60.0) / 3600.0).floor(),
+        (time % (60.0 * 60.0) / 60.0).floor(),
+        (time % 60.0).floor(),
+        (time % 1.0 * 100.0).floor()
+    );
+
+    ui.button(egui::RichText::new(time).monospace())
+}

--- a/crates/egui_demo_app_90/tests/snapshots/clock.png
+++ b/crates/egui_demo_app_90/tests/snapshots/clock.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:288e11a1fa684575155826a760d5aecc5855e1f4b68bc8954441bf3ac015ee84
+size 335175

--- a/crates/egui_demo_app_90/tests/snapshots/custom3d.png
+++ b/crates/egui_demo_app_90/tests/snapshots/custom3d.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d674918c635bfc865043f2123c0f5d4a671dd21ba7b878c056e817b19f2e8f00
+size 92770

--- a/crates/egui_demo_app_90/tests/snapshots/easymarkeditor.png
+++ b/crates/egui_demo_app_90/tests/snapshots/easymarkeditor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa67354cfe4d9cb8774c8de614be5975853a4a817ceaf96c3ec7a968de638d8d
+size 169740

--- a/crates/egui_demo_app_90/tests/snapshots/imageviewer.png
+++ b/crates/egui_demo_app_90/tests/snapshots/imageviewer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9f5204a9b8f15e0f144e66f0df8685e4e3ed90cd265474f2600fdd4cb5df390
+size 98934

--- a/crates/egui_demo_app_90/tests/test_demo_app.rs
+++ b/crates/egui_demo_app_90/tests/test_demo_app.rs
@@ -1,0 +1,77 @@
+use egui::Vec2;
+use egui::accesskit::Role;
+use egui_demo_app::{Anchor, WrapApp};
+use egui_kittest::SnapshotResults;
+use egui_kittest::kittest::Queryable as _;
+
+#[test]
+fn test_demo_app() {
+    let mut harness = egui_kittest::Harness::builder()
+        .with_size(Vec2::new(900.0, 600.0))
+        .wgpu()
+        .build_eframe(|cc| WrapApp::new(cc));
+
+    let app = harness.state_mut();
+
+    // Mock the fractal clock time so snapshots are consistent.
+    app.state.clock.mock_time = Some(36383.0);
+
+    let apps = app
+        .apps_iter_mut()
+        .map(|(name, anchor, _)| (name, anchor))
+        .collect::<Vec<_>>();
+
+    #[cfg(feature = "wgpu")]
+    assert!(
+        apps.iter()
+            .any(|(_, anchor)| matches!(anchor, Anchor::Custom3d)),
+        "Expected to find the Custom3d app.",
+    );
+
+    let mut results = SnapshotResults::new();
+
+    for (name, anchor) in apps {
+        harness.get_by_role_and_label(Role::Button, name).click();
+
+        match anchor {
+            // The widget gallery demo shows the current date, so we can't use it for snapshot testing
+            Anchor::Demo => {
+                continue;
+            }
+            // This is already tested extensively elsewhere
+            Anchor::Rendering => {
+                continue;
+            }
+            // We don't want to rely on a network connection for tests
+            #[cfg(feature = "http")]
+            Anchor::Http => {
+                continue;
+            }
+            // Load a local image where we know it exists and loads quickly
+            #[cfg(feature = "image_viewer")]
+            Anchor::ImageViewer => {
+                harness.step();
+
+                harness
+                    .get_by_role_and_label(Role::TextInput, "URI:")
+                    .focus();
+                harness.key_press_modifiers(egui::Modifiers::COMMAND, egui::Key::A);
+
+                harness
+                    .get_by_role_and_label(Role::TextInput, "URI:")
+                    .type_text("file://../eframe/data/icon.png");
+
+                harness.get_by_role_and_label(Role::Button, "✔").click();
+
+                // Wait for the image to load
+                harness.try_run_realtime().ok();
+            }
+            _ => {}
+        }
+
+        // Can't use Harness::run because fractal clock keeps requesting repaints
+        harness.run_steps(4);
+
+        results.add(harness.try_snapshot(anchor.to_string()));
+    }
+}

--- a/crates/emath/CHANGELOG.md
+++ b/crates/emath/CHANGELOG.md
@@ -6,6 +6,9 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## Unreleased
+* Added `ViewportRotation` enum with coordinate transform methods for 0°/90°/180°/270° rotation
+
 ## 0.34.1 - 2026-03-27
 Nothing new
 

--- a/crates/emath/src/lib.rs
+++ b/crates/emath/src/lib.rs
@@ -41,6 +41,7 @@ pub mod smart_aim;
 mod ts_transform;
 mod vec2;
 mod vec2b;
+mod viewport_rotation;
 
 pub use self::{
     align::{Align, Align2},
@@ -57,6 +58,7 @@ pub use self::{
     ts_transform::*,
     vec2::*,
     vec2b::*,
+    viewport_rotation::*,
 };
 
 // ----------------------------------------------------------------------------

--- a/crates/emath/src/viewport_rotation.rs
+++ b/crates/emath/src/viewport_rotation.rs
@@ -1,0 +1,192 @@
+use super::{Pos2, Rect, Vec2};
+
+/// Viewport rotation in 90-degree increments (clockwise).
+///
+/// When applied, the entire UI is rendered rotated and all input coordinates
+/// (mouse, touch) are automatically remapped. Application code sees a normal
+/// coordinate space — rotation is transparent.
+///
+/// Use cases: pinball cabinet displays, kiosks, embedded screens,
+/// industrial panels mounted in non-standard orientation.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum ViewportRotation {
+    /// No rotation (0 degrees).
+    #[default]
+    None,
+
+    /// 90 degrees clockwise.
+    CW90,
+
+    /// 180 degrees.
+    CW180,
+
+    /// 270 degrees clockwise (= 90 degrees counter-clockwise).
+    CW270,
+}
+
+impl ViewportRotation {
+    /// Returns `true` if width and height are swapped (90 or 270 degrees).
+    #[inline]
+    pub fn swaps_axes(self) -> bool {
+        matches!(self, Self::CW90 | Self::CW270)
+    }
+
+    /// Returns `true` if this is [`Self::None`].
+    #[inline]
+    pub fn is_none(self) -> bool {
+        self == Self::None
+    }
+
+    /// Transform a point from physical screen space to logical UI space.
+    ///
+    /// `physical_size` is the physical window size (before rotation).
+    #[inline]
+    pub fn transform_pos(self, pos: Pos2, physical_size: Vec2) -> Pos2 {
+        match self {
+            Self::None => pos,
+            Self::CW90 => Pos2::new(physical_size.y - pos.y, pos.x),
+            Self::CW180 => Pos2::new(
+                physical_size.x - pos.x,
+                physical_size.y - pos.y,
+            ),
+            Self::CW270 => Pos2::new(pos.y, physical_size.x - pos.x),
+        }
+    }
+
+    /// Transform a point from logical UI space back to physical screen space.
+    #[inline]
+    pub fn inverse_transform_pos(self, pos: Pos2, logical_size: Vec2) -> Pos2 {
+        match self {
+            Self::None => pos,
+            Self::CW90 => Pos2::new(pos.y, logical_size.x - pos.x),
+            Self::CW180 => Pos2::new(
+                logical_size.x - pos.x,
+                logical_size.y - pos.y,
+            ),
+            Self::CW270 => Pos2::new(logical_size.y - pos.y, pos.x),
+        }
+    }
+
+    /// Transform a delta/vector (no translation needed).
+    #[inline]
+    pub fn transform_vec(self, vec: Vec2) -> Vec2 {
+        match self {
+            Self::None => vec,
+            Self::CW90 => Vec2::new(-vec.y, vec.x),
+            Self::CW180 => Vec2::new(-vec.x, -vec.y),
+            Self::CW270 => Vec2::new(vec.y, -vec.x),
+        }
+    }
+
+    /// Logical screen rect after rotation.
+    ///
+    /// For 90/270 degree rotations, width and height are swapped.
+    #[inline]
+    pub fn transform_screen_rect(self, physical_rect: Rect) -> Rect {
+        if self.swaps_axes() {
+            Rect::from_min_size(
+                Pos2::ZERO,
+                Vec2::new(physical_rect.height(), physical_rect.width()),
+            )
+        } else {
+            physical_rect
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_none_is_identity() {
+        let pos = Pos2::new(10.0, 20.0);
+        let size = Vec2::new(800.0, 600.0);
+        assert_eq!(ViewportRotation::None.transform_pos(pos, size), pos);
+        assert_eq!(ViewportRotation::None.inverse_transform_pos(pos, size), pos);
+    }
+
+    #[test]
+    fn test_roundtrip_all_rotations() {
+        let physical_size = Vec2::new(800.0, 600.0);
+        let pos = Pos2::new(100.0, 200.0);
+
+        for rotation in [
+            ViewportRotation::None,
+            ViewportRotation::CW90,
+            ViewportRotation::CW180,
+            ViewportRotation::CW270,
+        ] {
+            let logical_size = if rotation.swaps_axes() {
+                Vec2::new(physical_size.y, physical_size.x)
+            } else {
+                physical_size
+            };
+
+            let transformed = rotation.transform_pos(pos, physical_size);
+            let back = rotation.inverse_transform_pos(transformed, logical_size);
+            assert!(
+                (back.x - pos.x).abs() < 1e-6 && (back.y - pos.y).abs() < 1e-6,
+                "Roundtrip failed for {rotation:?}: {pos:?} -> {transformed:?} -> {back:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cw90_transform() {
+        let physical_size = Vec2::new(800.0, 600.0);
+        // Physical top-left (0,0) should map to logical (600, 0) — bottom-left in physical
+        let pos = Pos2::new(0.0, 0.0);
+        let result = ViewportRotation::CW90.transform_pos(pos, physical_size);
+        assert_eq!(result, Pos2::new(600.0, 0.0));
+    }
+
+    #[test]
+    fn test_cw180_transform() {
+        let physical_size = Vec2::new(800.0, 600.0);
+        let pos = Pos2::new(0.0, 0.0);
+        let result = ViewportRotation::CW180.transform_pos(pos, physical_size);
+        assert_eq!(result, Pos2::new(800.0, 600.0));
+    }
+
+    #[test]
+    fn test_cw270_transform() {
+        let physical_size = Vec2::new(800.0, 600.0);
+        let pos = Pos2::new(0.0, 0.0);
+        let result = ViewportRotation::CW270.transform_pos(pos, physical_size);
+        assert_eq!(result, Pos2::new(0.0, 800.0));
+    }
+
+    #[test]
+    fn test_transform_screen_rect() {
+        let rect = Rect::from_min_size(Pos2::ZERO, Vec2::new(800.0, 600.0));
+
+        assert_eq!(ViewportRotation::None.transform_screen_rect(rect), rect);
+        assert_eq!(
+            ViewportRotation::CW90.transform_screen_rect(rect),
+            Rect::from_min_size(Pos2::ZERO, Vec2::new(600.0, 800.0))
+        );
+        assert_eq!(ViewportRotation::CW180.transform_screen_rect(rect), rect);
+        assert_eq!(
+            ViewportRotation::CW270.transform_screen_rect(rect),
+            Rect::from_min_size(Pos2::ZERO, Vec2::new(600.0, 800.0))
+        );
+    }
+
+    #[test]
+    fn test_transform_vec() {
+        let v = Vec2::new(1.0, 0.0);
+        assert_eq!(ViewportRotation::CW90.transform_vec(v), Vec2::new(0.0, 1.0));
+        assert_eq!(ViewportRotation::CW180.transform_vec(v), Vec2::new(-1.0, 0.0));
+        assert_eq!(ViewportRotation::CW270.transform_vec(v), Vec2::new(0.0, -1.0));
+    }
+
+    #[test]
+    fn test_swaps_axes() {
+        assert!(!ViewportRotation::None.swaps_axes());
+        assert!(ViewportRotation::CW90.swaps_axes());
+        assert!(!ViewportRotation::CW180.swaps_axes());
+        assert!(ViewportRotation::CW270.swaps_axes());
+    }
+}

--- a/examples/hello_world_90_glow/Cargo.toml
+++ b/examples/hello_world_90_glow/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "hello_world_90_glow"
+version = "0.1.0"
+authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
+license = "MIT OR Apache-2.0"
+edition = "2024"
+rust-version = "1.92"
+publish = false
+
+[lints]
+workspace = true
+
+
+[dependencies]
+eframe = { workspace = true, features = [
+  "default",
+  "glow",
+  "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
+] }
+
+# For image support:
+egui_extras = { workspace = true, features = ["default", "image"] }
+
+env_logger = { workspace = true, features = ["auto-color", "humantime"] }

--- a/examples/hello_world_90_glow/README.md
+++ b/examples/hello_world_90_glow/README.md
@@ -1,0 +1,7 @@
+Example showing some UI controls like `Label`, `TextEdit`, `Slider`, `Button`.
+
+```sh
+cargo run -p hello_world
+```
+
+![](screenshot.png)

--- a/examples/hello_world_90_glow/screenshot.png
+++ b/examples/hello_world_90_glow/screenshot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac6e85577844ba1e4cdaa6ee7db18a6538daa4fc75e5859c72d7da1a6cb8a934
+size 12799

--- a/examples/hello_world_90_glow/src/main.rs
+++ b/examples/hello_world_90_glow/src/main.rs
@@ -6,7 +6,7 @@ use eframe::egui;
 fn main() -> eframe::Result {
     env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
     let options = eframe::NativeOptions {
-        viewport: egui::ViewportBuilder::default().with_inner_size([320.0, 240.0]).with_rotation(eframe::emath::ViewportRotation::CW90),
+        viewport: egui::ViewportBuilder::default().with_inner_size([1024.0, 768.0]).with_rotation(eframe::emath::ViewportRotation::CW90),
         renderer: eframe::Renderer::Glow,
         ..Default::default()
     };
@@ -38,6 +38,7 @@ impl Default for MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+
         egui::CentralPanel::default().show_inside(ui, |ui| {
             ui.heading("My egui Application");
             ui.horizontal(|ui| {

--- a/examples/hello_world_90_glow/src/main.rs
+++ b/examples/hello_world_90_glow/src/main.rs
@@ -1,0 +1,59 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
+#![expect(rustdoc::missing_crate_level_docs)] // it's an example
+
+use eframe::egui;
+
+fn main() -> eframe::Result {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([320.0, 240.0]).with_rotation(eframe::emath::ViewportRotation::CW90),
+        renderer: eframe::Renderer::Glow,
+        ..Default::default()
+    };
+    eframe::run_native(
+        "My egui App (90° glow)",
+        options,
+        Box::new(|cc| {
+            // This gives us image support:
+            egui_extras::install_image_loaders(&cc.egui_ctx);
+
+            Ok(Box::<MyApp>::default())
+        }),
+    )
+}
+
+struct MyApp {
+    name: String,
+    age: u32,
+}
+
+impl Default for MyApp {
+    fn default() -> Self {
+        Self {
+            name: "Arthur".to_owned(),
+            age: 42,
+        }
+    }
+}
+
+impl eframe::App for MyApp {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show_inside(ui, |ui| {
+            ui.heading("My egui Application");
+            ui.horizontal(|ui| {
+                let name_label = ui.label("Your name: ");
+                ui.text_edit_singleline(&mut self.name)
+                    .labelled_by(name_label.id);
+            });
+            ui.add(egui::Slider::new(&mut self.age, 0..=120).text("age"));
+            if ui.button("Increment").clicked() {
+                self.age += 1;
+            }
+            ui.label(format!("Hello '{}', age {}", self.name, self.age));
+
+            ui.image(egui::include_image!(
+                "../../../crates/egui/assets/ferris.png"
+            ));
+        });
+    }
+}

--- a/examples/hello_world_90_wgpu/Cargo.toml
+++ b/examples/hello_world_90_wgpu/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "hello_world_90_wgpu"
+version = "0.1.0"
+authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
+license = "MIT OR Apache-2.0"
+edition = "2024"
+rust-version = "1.92"
+publish = false
+
+[lints]
+workspace = true
+
+
+[dependencies]
+eframe = { workspace = true, features = [
+  "default",
+  "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
+] }
+
+# For image support:
+egui_extras = { workspace = true, features = ["default", "image"] }
+
+env_logger = { workspace = true, features = ["auto-color", "humantime"] }

--- a/examples/hello_world_90_wgpu/README.md
+++ b/examples/hello_world_90_wgpu/README.md
@@ -1,0 +1,7 @@
+Example showing some UI controls like `Label`, `TextEdit`, `Slider`, `Button`.
+
+```sh
+cargo run -p hello_world
+```
+
+![](screenshot.png)

--- a/examples/hello_world_90_wgpu/screenshot.png
+++ b/examples/hello_world_90_wgpu/screenshot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac6e85577844ba1e4cdaa6ee7db18a6538daa4fc75e5859c72d7da1a6cb8a934
+size 12799

--- a/examples/hello_world_90_wgpu/src/main.rs
+++ b/examples/hello_world_90_wgpu/src/main.rs
@@ -1,0 +1,58 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
+#![expect(rustdoc::missing_crate_level_docs)] // it's an example
+
+use eframe::egui;
+
+fn main() -> eframe::Result {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([320.0, 240.0]).with_rotation(eframe::emath::ViewportRotation::CW90),
+        renderer: eframe::Renderer::Wgpu, ..Default::default()
+    };
+    eframe::run_native(
+        "My egui App (90° wgpu)",
+        options,
+        Box::new(|cc| {
+            // This gives us image support:
+            egui_extras::install_image_loaders(&cc.egui_ctx);
+
+            Ok(Box::<MyApp>::default())
+        }),
+    )
+}
+
+struct MyApp {
+    name: String,
+    age: u32,
+}
+
+impl Default for MyApp {
+    fn default() -> Self {
+        Self {
+            name: "Arthur".to_owned(),
+            age: 42,
+        }
+    }
+}
+
+impl eframe::App for MyApp {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show_inside(ui, |ui| {
+            ui.heading("My egui Application");
+            ui.horizontal(|ui| {
+                let name_label = ui.label("Your name: ");
+                ui.text_edit_singleline(&mut self.name)
+                    .labelled_by(name_label.id);
+            });
+            ui.add(egui::Slider::new(&mut self.age, 0..=120).text("age"));
+            if ui.button("Increment").clicked() {
+                self.age += 1;
+            }
+            ui.label(format!("Hello '{}', age {}", self.name, self.age));
+
+            ui.image(egui::include_image!(
+                "../../../crates/egui/assets/ferris.png"
+            ));
+        });
+    }
+}

--- a/rotated.png
+++ b/rotated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2f9b6a1633cb8a1bff984cc0a2aacb47bb62f8a230bce5f1bfa14ff49693217
+size 99747

--- a/scripts/build_demo_web_90.sh
+++ b/scripts/build_demo_web_90.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -eu
+script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+cd "$script_path/.."
+
+./scripts/setup_web.sh
+
+CRATE_NAME="egui_demo_app_90"
+
+FEATURES="web_app"
+
+OPEN=false
+OPTIMIZE=false
+BUILD=debug
+BUILD_FLAGS=""
+GLOW=false
+WASM_OPT_FLAGS="-O2 --fast-math"
+
+while test $# -gt 0; do
+  case "$1" in
+    -h|--help)
+      echo "build_demo_web_90.sh [--release] [--glow] [--open]"
+      echo ""
+      echo "  -g:        Keep debug symbols even with --release."
+      echo "             These are useful profiling and size trimming."
+      echo ""
+      echo "  --open:    Open the result in a browser."
+      echo ""
+      echo "  --release: Build with --release, and then run wasm-opt."
+      echo "             NOTE: --release also removes debug symbols, unless you also use -g."
+      echo ""
+      echo "  --glow:    Build a binary using glow instead of wgpu."
+      exit 0
+      ;;
+
+    -g)
+      shift
+      WASM_OPT_FLAGS="${WASM_OPT_FLAGS} -g"
+      ;;
+
+    --open)
+      shift
+      OPEN=true
+      ;;
+
+    --release)
+      shift
+      OPTIMIZE=true
+      BUILD="release"
+      BUILD_FLAGS="--release"
+      ;;
+
+    --glow)
+      shift
+      GLOW=true
+      ;;
+
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+OUT_FILE_NAME="egui_demo_app_90"
+
+if [[ "${GLOW}" == true ]]; then
+  FEATURES="${FEATURES},glow"
+else
+  FEATURES="${FEATURES},wgpu"
+fi
+
+FINAL_WASM_PATH=web_demo_90/${OUT_FILE_NAME}_bg.wasm
+
+# Clear output from old stuff:
+rm -f "${FINAL_WASM_PATH}"
+
+echo "Building rust…"
+
+(cd crates/$CRATE_NAME &&
+  cargo build \
+    ${BUILD_FLAGS} \
+    --quiet \
+    --lib \
+    --target wasm32-unknown-unknown \
+    --no-default-features \
+    --features ${FEATURES}
+)
+
+# Get the output directory (in the workspace it is in another location)
+# TARGET=`cargo metadata --format-version=1 | jq --raw-output .target_directory`
+TARGET="target"
+
+echo "Generating JS bindings for wasm…"
+TARGET_NAME="${CRATE_NAME}.wasm"
+WASM_PATH="${TARGET}/wasm32-unknown-unknown/$BUILD/$TARGET_NAME"
+mkdir -p web_demo_90
+wasm-bindgen "${WASM_PATH}" --out-dir web_demo_90 --out-name ${OUT_FILE_NAME} --no-modules --no-typescript
+
+# Copy and patch index.html from web_demo
+sed "s/egui_demo_app/egui_demo_app_90/g" web_demo/index.html > web_demo_90/index.html
+
+# if this fails with "error: cannot import from modules (`env`) with `--no-modules`", you can use:
+# wasm2wat target/wasm32-unknown-unknown/release/egui_demo_app_90.wasm | rg env
+# wasm2wat target/wasm32-unknown-unknown/release/egui_demo_app_90.wasm | rg "call .now\b" -B 20 # What calls `$now` (often a culprit)
+# Or use https://rustwasm.github.io/twiggy/usage/command-line-interface/paths.html#twiggy-paths
+
+# to get wasm-strip:  apt/brew/dnf install wabt
+# wasm-strip ${FINAL_WASM_PATH}
+
+if [[ "${OPTIMIZE}" = true ]]; then
+  echo "Optimizing wasm…"
+  # to get wasm-opt:  apt/brew/dnf install binaryen
+  wasm-opt "${FINAL_WASM_PATH}" $WASM_OPT_FLAGS -o "${FINAL_WASM_PATH}"
+fi
+
+echo "Finished ${FINAL_WASM_PATH}"
+
+if [[ "${OPEN}" == true ]]; then
+  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    # Linux, ex: Fedora
+    xdg-open http://localhost:8768/index.html
+  elif [[ "$OSTYPE" == "msys" ]]; then
+    # Windows
+    start http://localhost:8768/index.html
+  else
+    # Darwin/MacOS, or something else
+    open http://localhost:8768/index.html
+  fi
+fi

--- a/web_90.png
+++ b/web_90.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be38dd7e49f6247727da992b17d74cff048303233656b1ea62469fcd970d1f5d
+size 309693


### PR DESCRIPTION
## Summary

Adds **viewport rotation** (0° / 90° / 180° / 270°) to egui and eframe, with transparent input/output remapping and a rotated software cursor. Enables use cases where the physical display is mounted rotated — pinball cabinets, kiosks, embedded panels, industrial displays.

Resolves #4130 (rotation via GPU scissor conflict) and #2054 by bypassing the scissor rect limitation entirely: primitives are already in physical screen coordinates by the time they reach the GPU backend.

## What's in this PR

### 1. `ViewportRotation` in `emath`
New enum `{ None, CW90, CW180, CW270 }` with `transform_pos`, `inverse_transform_pos`, `transform_vec`, `transform_screen_rect`, and `swaps_axes` helpers. Applied with integer rotations so no floating-point drift.

### 2. Rotation applied transparently at the egui layer
- Input rotation in `Context::begin_pass` — mouse positions and deltas are transformed before the UI sees them. App code reads coordinates as if the viewport were un-rotated.
- Output rotation in `Context::tessellate_for_viewport(viewport_id, …)` — mesh vertices and clip rects are inverse-transformed back to physical screen space after layout. Painters see physical pixels.
- Per-viewport state: `ViewportState.viewport_rotation`, settable via `Context::set_viewport_rotation` at runtime, or via `ViewportBuilder::with_rotation` at creation (root only).

### 3. Rotated software cursor
When rotation is active, the OS cursor would move in physical space — disorienting in a rotated UI. This PR:
- Hides the OS cursor on entry into the rotated window, draws a software cursor in logical space.
- Follows raw mouse deltas (rotated appropriately) so direction matches the rotated UI.
- Rotates cursor icons (text caret, resize arrows, etc.) to match the viewport rotation.
- Releases the OS cursor cleanly 3px outside the window when the software cursor reaches an edge.
- Recaptures at the entry point when the cursor re-enters.
- Scalable via `Context::set_software_cursor_scale(f32)` — useful for large pincab playfields.
- Restores the OS cursor to `Default` on release (fixes invisible cursor bug).

### 4. `tessellate_for_viewport` — required correctness fix
A naive implementation of `tessellate` reads rotation from `ctx.viewport()` which resolves to the currently-active viewport via `viewport_stack`. But integrations (wgpu, glow) call `tessellate()` **after** the pass has ended — `viewport_stack` is already popped, and `ctx.viewport()` falls back to `ROOT`. Result: the root viewport's rotation leaks into every other viewport's rendering; secondary viewports' rotations are ignored entirely.

The fix: `tessellate_for_viewport(viewport_id, shapes, pixels_per_point)` takes the target viewport explicitly. `tessellate()` is kept as a thin wrapper calling `tessellate_for_viewport(ViewportId::ROOT, …)` for backwards compat. Both wgpu and glow integrations updated to pass the right `viewport_id`.

### 5. Validation — working examples on all three backends
- **Glow (native)**: `examples/hello_world_90_glow`
- **Wgpu (native)**: `examples/hello_world_90_wgpu`
- **Web (wasm)**: `crates/egui_demo_app_90` + `scripts/build_demo_web_90.sh`

### 6. Module-level docs and changelog
Updated `egui/src/viewport.rs` module docs with a usage example and section on the rotation feature. Changelog entries in `egui`, `eframe`, and `emath`.

## Usage

```rust
// At creation (root viewport)
let options = eframe::NativeOptions {
    viewport: egui::ViewportBuilder::default()
        .with_inner_size([800.0, 480.0])
        .with_rotation(eframe::emath::ViewportRotation::CW90),
    ..Default::default()
};

// At runtime (any viewport, per-viewport state)
ctx.set_viewport_rotation(eframe::emath::ViewportRotation::CW90);
ctx.set_software_cursor_scale(3.0); // big cursor for far-viewing displays
```

## Test plan

- [x] `cargo check --workspace` clean
- [x] Manual: hello_world_90_glow rotates, cursor behaves correctly in all 4 rotations, edge-release works
- [x] Manual: hello_world_90_wgpu same
- [x] Manual: web demo rotated
- [x] Downstream validation in a real multi-viewport kiosk app (pinball cabinet launcher) — confirms primary rotation works and secondaries are correctly isolated after the `tessellate_for_viewport` fix

---

Related follow-up PR (separate, orthogonal feature): adds `ViewportBuilder::with_monitor(index)` for targeting a specific output at window creation. Useful with rotation for multi-screen kiosk setups but independent of rotation.

🤖 Contributions from [Claude Code](https://claude.com/claude-code)