### PR TITLE
Add ViewportBuilder::with_monitor for targeting specific monitors

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1678,6 +1678,16 @@ fn process_viewport_command(
         ViewportCommand::Fullscreen(v) => {
             window.set_fullscreen(v.then_some(winit::window::Fullscreen::Borderless(None)));
         }
+        ViewportCommand::SetMonitor(idx) => {
+            if let Some(monitor) = window.available_monitors().nth(idx) {
+                window.set_fullscreen(Some(winit::window::Fullscreen::Borderless(Some(monitor))));
+            } else {
+                log::warn!(
+                    "ViewportCommand::SetMonitor({idx}): index out of range ({} monitors available)",
+                    window.available_monitors().count()
+                );
+            }
+        }
         ViewportCommand::Decorations(v) => window.set_decorations(v),
         ViewportCommand::WindowLevel(l) => window.set_window_level(match l {
             egui::viewport::WindowLevel::AlwaysOnBottom => WindowLevel::AlwaysOnBottom,
@@ -1776,7 +1786,26 @@ pub fn create_window(
 ) -> Result<Window, winit::error::OsError> {
     profiling::function_scope!();
 
-    let window_attributes = create_winit_window_attributes(egui_ctx, viewport_builder.clone());
+    let mut window_attributes = create_winit_window_attributes(egui_ctx, viewport_builder.clone());
+
+    // Resolve target monitor index → MonitorHandle, so the window is created
+    // directly in borderless fullscreen on the requested output. This is the
+    // only reliable way to target a specific monitor under Wayland, and also
+    // avoids the Mutter race where OuterPosition is ignored pre-mapping.
+    if let Some(idx) = viewport_builder.monitor {
+        let monitors: Vec<_> = event_loop.available_monitors().collect();
+        if let Some(monitor) = monitors.get(idx) {
+            window_attributes = window_attributes.with_fullscreen(Some(
+                winit::window::Fullscreen::Borderless(Some(monitor.clone())),
+            ));
+        } else {
+            log::warn!(
+                "ViewportBuilder::with_monitor({idx}): index out of range ({} monitors available)",
+                monitors.len()
+            );
+        }
+    }
+
     let window = event_loop.create_window(window_attributes)?;
     apply_viewport_builder_to_window(egui_ctx, &window, viewport_builder);
     Ok(window)
@@ -1828,6 +1857,7 @@ pub fn create_winit_window_attributes(
 
         mouse_passthrough: _, // handled in `apply_viewport_builder_to_window`
         clamp_size_to_monitor_size: _, // Handled in `viewport_builder` in `epi_integration.rs`
+        monitor: _, // Handled in `create_window` (needs ActiveEventLoop for monitor handle)
     } = viewport_builder;
 
     let mut window_attributes = winit::window::WindowAttributes::default()

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -333,6 +333,19 @@ pub struct ViewportBuilder {
     // X11
     pub window_type: Option<X11WindowType>,
     pub override_redirect: Option<bool>,
+
+    /// Target monitor index for borderless fullscreen.
+    ///
+    /// When set, the window is placed in borderless fullscreen on the monitor at
+    /// the given index in `available_monitors()` order (same order returned by
+    /// winit). Works on Windows, macOS, and Linux (X11 + Wayland).
+    ///
+    /// If the index is out of range, it is ignored and a warning is logged.
+    ///
+    /// Takes precedence over [`Self::with_position`] / [`Self::with_fullscreen`]
+    /// for monitor selection: if both are set, the window will be fullscreen on
+    /// the chosen monitor.
+    pub monitor: Option<usize>,
 }
 
 impl ViewportBuilder {
@@ -680,6 +693,21 @@ impl ViewportBuilder {
         self
     }
 
+    /// Place the window in borderless fullscreen on the monitor at `index`.
+    ///
+    /// The index refers to the order returned by winit's `available_monitors()`.
+    /// Works cross-platform (Windows, macOS, Linux X11 + Wayland). On Wayland
+    /// this is the only reliable way to target a specific output, since
+    /// absolute window positions are not exposed.
+    ///
+    /// If the index is out of range, the flag is ignored at window creation time.
+    #[inline]
+    pub fn with_monitor(mut self, index: usize) -> Self {
+        self.monitor = Some(index);
+        self
+    }
+
+
     /// Update this `ViewportBuilder` with a delta,
     /// returning a list of commands and a bool indicating if the window needs to be recreated.
     #[must_use]
@@ -717,6 +745,7 @@ impl ViewportBuilder {
             taskbar: new_taskbar,
             window_type: new_window_type,
             override_redirect: new_override_redirect,
+            monitor: new_monitor,
         } = new_vp_builder;
 
         let mut commands = Vec::new();
@@ -919,6 +948,13 @@ impl ViewportBuilder {
             recreate_window = true;
         }
 
+        if let Some(new_monitor) = new_monitor
+            && Some(new_monitor) != self.monitor
+        {
+            self.monitor = Some(new_monitor);
+            commands.push(ViewportCommand::SetMonitor(new_monitor));
+        }
+
         (commands, recreate_window)
     }
 }
@@ -1104,6 +1140,12 @@ pub enum ViewportCommand {
 
     /// Turn borderless fullscreen on/off.
     Fullscreen(bool),
+
+    /// Move the window to borderless fullscreen on the monitor at the given index.
+    ///
+    /// Index refers to winit's `available_monitors()` order. If out of range, the
+    /// command is ignored (logged as a warning).
+    SetMonitor(usize),
 
     /// Show window decorations, i.e. the chrome around the content
     /// with the title bar, close buttons, resize handles, etc.


### PR DESCRIPTION
## Summary

Adds `ViewportBuilder::with_monitor(index)` and `ViewportCommand::SetMonitor(index)` for targeting a specific monitor at viewport creation or at runtime.

This is useful whenever an app needs to open borderless fullscreen on a specific output — kiosks, pinball cabinets, digital signage, multi-monitor dashboards. It's also the **only portable way** to target a specific output under Wayland, since Wayland doesn't expose absolute window positions to clients; `with_position` is silently ignored there.

## Implementation

- **`egui/src/viewport.rs`**: adds `monitor: Option<usize>` to `ViewportBuilder`, `with_monitor(index)` setter, `ViewportCommand::SetMonitor(index)` variant, and diff detection in `patch()`.
- **`egui-winit/src/lib.rs`**:
  - In `create_window` (after building `WindowAttributes` but before `event_loop.create_window(...)`): resolves `event_loop.available_monitors().nth(index)` and calls `with_fullscreen(Some(Fullscreen::Borderless(Some(monitor.clone()))))` on the attributes.
  - In `process_viewport_command`: handles `SetMonitor(idx)` by resolving via `window.available_monitors().nth(idx)` + `window.set_fullscreen(Some(Fullscreen::Borderless(Some(monitor))))`.
  - Out-of-range index is logged as a warning and silently ignored (no panic, no state mutation).

## Usage

```rust
// Window opens in borderless fullscreen on monitor index 1
let options = eframe::NativeOptions {
    viewport: egui::ViewportBuilder::default()
        .with_title("kiosk")
        .with_decorations(false)
        .with_monitor(1),
    ..Default::default()
};

// At runtime, move the root viewport to monitor 2:
ctx.send_viewport_cmd(egui::ViewportCommand::SetMonitor(2));
```

## Why not just `with_position(monitor.position)`?

- **Wayland clients cannot read global positions** — `with_position` is effectively a no-op.
- **X11 + Mutter/GNOME** race: `OuterPosition` is dropped if set before the window is mapped. Even with repeat-send loops, the window sometimes lands on the monitor the cursor is on rather than the requested one.
- **macOS / Windows** `Fullscreen::Borderless(Some(handle))` is the OS-native API for borderless fullscreen on a specific screen.

Using winit's `MonitorHandle` explicitly sidesteps all of these — same API path as when users press F11 in apps.

## Relationship to viewport rotation (PR #8113)

Completely orthogonal — `with_monitor` doesn't depend on rotation and vice versa. They're submitted separately because they're independent features. In practice they combine well for cabinet/kiosk apps (rotate the root on a specific playfield output, non-rotated secondary viewports on other screens).

## Test plan

- [x] `cargo check --workspace` clean on Linux (X11 + Wayland)
- [x] Manual on X11 + Mutter (GNOME 46): window lands on the requested monitor in borderless fullscreen, no race with `OuterPosition`.
- [x] Manual downstream in a multi-monitor kiosk app (pinball cabinet launcher, 3 monitors) — `with_monitor(idx)` places each viewport on the correct screen deterministically.
- [x] Out-of-range index produces a warning log, app continues normally.
- [ ] Reviewer: any concerns on naming (`with_monitor` vs e.g. `with_monitor_index`) before final polish.

🤖 Contributions from [Claude Code](https://claude.com/claude-code)
