### PR TITLE
Add arbitrary request headers to `EhttpLoader`

### DIFF
--- a/crates/egui_extras/src/loaders/http_loader.rs
+++ b/crates/egui_extras/src/loaders/http_loader.rs
@@ -42,7 +42,7 @@ type Entry = Poll<Result<File, String>>;
 #[derive(Default)]
 pub struct EhttpLoader {
     cache: Arc<Mutex<HashMap<String, Entry>>>,
-    request_template: Option<Box<dyn Fn(&mut ehttp::Request)>>,
+    request_template: Option<Box<dyn Fn(ehttp::Request) -> ehttp::Request + Send + Sync>>,
 }
 
 impl EhttpLoader {
@@ -50,7 +50,9 @@ impl EhttpLoader {
 
     /// Provide a request template to modify requests before they're sent,
     /// e.g. to add headers.
-    pub fn with_request_template<F: Fn(&mut ehttp::Request) + 'static>(
+    pub fn with_request_template<
+        F: Fn(ehttp::Request) -> ehttp::Request + Send + Sync + 'static,
+    >(
         mut self,
         request_template: F,
     ) -> Self {
@@ -95,11 +97,7 @@ impl BytesLoader for EhttpLoader {
 
             ehttp::fetch(
                 match &self.request_template {
-                    Some(templ) => {
-                        let mut req = ehttp::Request::get(uri.clone());
-                        templ(&mut req);
-                        req
-                    }
+                    Some(templ) => templ(ehttp::Request::get(uri.clone())),
                     None => ehttp::Request::get(uri.clone()),
                 },
                 {

--- a/crates/egui_extras/src/loaders/http_loader.rs
+++ b/crates/egui_extras/src/loaders/http_loader.rs
@@ -41,16 +41,20 @@ type Entry = Poll<Result<File, String>>;
 
 #[derive(Default)]
 pub struct EhttpLoader {
-    headers: ehttp::Headers,
     cache: Arc<Mutex<HashMap<String, Entry>>>,
+    request_template: Option<Box<dyn Fn(&mut ehttp::Request)>>,
 }
 
 impl EhttpLoader {
     pub const ID: &'static str = egui::generate_loader_id!(EhttpLoader);
 
-    /// Add additional headers to be sent with each request.
-    pub fn with_headers(mut self, headers: &[(&str, &str)]) -> Self {
-        self.headers = ehttp::Headers::new(headers);
+    /// Provide a request template to modify requests before they're sent,
+    /// e.g. to add headers.
+    pub fn with_request_template<F: Fn(&mut ehttp::Request) + 'static>(
+        mut self,
+        request_template: F,
+    ) -> Self {
+        self.request_template = Some(Box::new(request_template));
         self
     }
 }
@@ -90,7 +94,14 @@ impl BytesLoader for EhttpLoader {
             drop(cache);
 
             ehttp::fetch(
-                ehttp::Request::get(uri.clone()).with_headers(self.headers.clone()),
+                match &self.request_template {
+                    Some(templ) => {
+                        let mut req = ehttp::Request::get(uri.clone());
+                        templ(&mut req);
+                        req
+                    }
+                    None => ehttp::Request::get(uri.clone()),
+                },
                 {
                     let ctx = ctx.clone();
                     let cache = Arc::clone(&self.cache);

--- a/crates/egui_extras/src/loaders/http_loader.rs
+++ b/crates/egui_extras/src/loaders/http_loader.rs
@@ -41,11 +41,17 @@ type Entry = Poll<Result<File, String>>;
 
 #[derive(Default)]
 pub struct EhttpLoader {
+    headers: ehttp::Headers,
     cache: Arc<Mutex<HashMap<String, Entry>>>,
 }
 
 impl EhttpLoader {
     pub const ID: &'static str = egui::generate_loader_id!(EhttpLoader);
+
+    pub fn with_headers(mut self, headers: &[(&str, &str)]) -> Self {
+        self.headers = ehttp::Headers::new(headers);
+        self
+    }
 }
 
 const PROTOCOLS: &[&str] = &["http://", "https://"];
@@ -82,41 +88,44 @@ impl BytesLoader for EhttpLoader {
             cache.insert(uri.clone(), Poll::Pending);
             drop(cache);
 
-            ehttp::fetch(ehttp::Request::get(uri.clone()), {
-                let ctx = ctx.clone();
-                let cache = Arc::clone(&self.cache);
-                move |response| {
-                    let result = match response {
-                        Ok(response) => File::from_response(&uri, response),
-                        Err(err) => {
-                            // Log details; return summary
-                            log::error!("Failed to load {uri:?}: {err}");
-                            Err(format!("Failed to load {uri:?}"))
+            ehttp::fetch(
+                ehttp::Request::get(uri.clone()).with_headers(self.headers.clone()),
+                {
+                    let ctx = ctx.clone();
+                    let cache = Arc::clone(&self.cache);
+                    move |response| {
+                        let result = match response {
+                            Ok(response) => File::from_response(&uri, response),
+                            Err(err) => {
+                                // Log details; return summary
+                                log::error!("Failed to load {uri:?}: {err}");
+                                Err(format!("Failed to load {uri:?}"))
+                            }
+                        };
+                        let repaint = {
+                            let mut cache = cache.lock();
+                            if let std::collections::hash_map::Entry::Occupied(mut entry) =
+                                cache.entry(uri.clone())
+                            {
+                                let entry = entry.get_mut();
+                                *entry = Poll::Ready(result);
+                                log::trace!("Finished loading {uri:?}");
+                                true
+                            } else {
+                                log::trace!(
+                                    "Canceled loading {uri:?}\nNote: This can happen if `forget_image` is called while the image is still loading."
+                                );
+                                false
+                            }
+                        };
+                        // We may not lock Context while the cache lock is held (see ImageLoader::load
+                        // for details).
+                        if repaint {
+                            ctx.request_repaint();
                         }
-                    };
-                    let repaint = {
-                        let mut cache = cache.lock();
-                        if let std::collections::hash_map::Entry::Occupied(mut entry) =
-                            cache.entry(uri.clone())
-                        {
-                            let entry = entry.get_mut();
-                            *entry = Poll::Ready(result);
-                            log::trace!("Finished loading {uri:?}");
-                            true
-                        } else {
-                            log::trace!(
-                                "Canceled loading {uri:?}\nNote: This can happen if `forget_image` is called while the image is still loading."
-                            );
-                            false
-                        }
-                    };
-                    // We may not lock Context while the cache lock is held (see ImageLoader::load
-                    // for details).
-                    if repaint {
-                        ctx.request_repaint();
                     }
-                }
-            });
+                },
+            );
 
             Ok(BytesPoll::Pending { size: None })
         }

--- a/crates/egui_extras/src/loaders/http_loader.rs
+++ b/crates/egui_extras/src/loaders/http_loader.rs
@@ -48,6 +48,7 @@ pub struct EhttpLoader {
 impl EhttpLoader {
     pub const ID: &'static str = egui::generate_loader_id!(EhttpLoader);
 
+    /// Add additional headers to be sent with each request.
     pub fn with_headers(mut self, headers: &[(&str, &str)]) -> Self {
         self.headers = ehttp::Headers::new(headers);
         self


### PR DESCRIPTION
* Closes <https://github.com/emilk/egui/issues/4491>
* [x] I have followed the instructions in the PR template

Lets you create an `EhttpLoader` with arbitrary headers like so:

```rust
cc.egui_ctx.add_bytes_loader(std::sync::Arc::new(
    egui_extras::loaders::http_loader::EhttpLoader::default().with_headers(&[
        ("User-Agent", "foo"),
    ])
));
```

I'm not sure if there are any problems with installing a second
`EhttpLoader` (in addition to the one installed by default when using
`egui_extras::install_image_loaders(&cc.egui_ctx)`. But I wasn't
sure how else to pass in configuration options to
`install_image_loaders`.