### PR TITLE
Get text method for Buttons, Checkboxes, DragValues, and RadioButton

### DIFF
--- a/crates/egui/src/atomics/get_atoms.rs
+++ b/crates/egui/src/atomics/get_atoms.rs
@@ -1,0 +1,3 @@
+pub trait GetAtoms {
+  pub fn text(self) -> Atom<'a>;
+}

--- a/crates/egui/src/atomics/get_atoms.rs
+++ b/crates/egui/src/atomics/get_atoms.rs
@@ -1,3 +1,28 @@
 pub trait GetAtoms<'a> {
-  pub fn text(self) -> Atom<'a>;
+  pub fn text(self) -> Atoms<'a>;
+}
+
+impl<'a> GetAtoms<'a> for Button<'a> {
+  pub fn text(self) -> Atoms<'a> {
+    self.layout.atoms
+  }
+}
+
+impl<'a> GetAtoms<'a> for Checkbox<'a> {
+  pub fn text(self) -> Atoms<'a> {
+    self.atoms
+  }
+}
+
+impl<'a> GetAtoms<'a> for DragValue<'a> {
+  pub fn text(self) -> Atoms<'a> {
+    self.atoms
+  }
+}
+
+
+impl<'a> GetAtoms<'a> for RadioButton<'a> {
+  pub fn text(self) -> Atoms<'a> {
+    self.atoms
+  }
 }

--- a/crates/egui/src/atomics/get_atoms.rs
+++ b/crates/egui/src/atomics/get_atoms.rs
@@ -1,3 +1,3 @@
-pub trait GetAtoms {
+pub trait GetAtoms<'a> {
   pub fn text(self) -> Atom<'a>;
 }

--- a/crates/egui/src/atomics/mod.rs
+++ b/crates/egui/src/atomics/mod.rs
@@ -5,6 +5,7 @@ mod atom_layout;
 mod atoms;
 mod sized_atom;
 mod sized_atom_kind;
+mod get_atoms;
 
 pub use atom::*;
 pub use atom_ext::*;
@@ -13,3 +14,4 @@ pub use atom_layout::*;
 pub use atoms::*;
 pub use sized_atom::*;
 pub use sized_atom_kind::*;
+pub use get_atoms::*;


### PR DESCRIPTION
Might not even be useful to everyone, but I wanted to sort based an atom I put on a button (specifically the sort_by method using the image) and simply couldn't, so I thought I'd kill some time.