### PR TITLE
Improve `UiBuilder` docs

### DIFF
--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2178,11 +2178,16 @@ impl Ui {
     /// });
     /// # });
     /// ```
+    ///
+    /// See also [`Self::scope_builder`] for more options.
     pub fn scope<R>(&mut self, add_contents: impl FnOnce(&mut Ui) -> R) -> InnerResponse<R> {
         self.scope_dyn(UiBuilder::new(), Box::new(add_contents))
     }
 
-    /// Create a child, add content to it, and then allocate only what was used in the parent `Ui`.
+    /// Create a scoped child ui, inheriting properties from the parent as specified by the [`UiBuilder`].
+    /// In contrast to [`Self::new_child`], this allocates the space used by the child.
+    ///
+    /// See also [`Self::scope`] and [`Self::scope_dyn`].
     pub fn scope_builder<R>(
         &mut self,
         ui_builder: UiBuilder,
@@ -2191,7 +2196,7 @@ impl Ui {
         self.scope_dyn(ui_builder, Box::new(add_contents))
     }
 
-    /// Create a child, add content to it, and then allocate only what was used in the parent `Ui`.
+    /// [`Self::scope_builder`] but with dynamic dispatch.
     pub fn scope_dyn<'c, R>(
         &mut self,
         ui_builder: UiBuilder,

--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -5,11 +5,13 @@ use crate::ClosableTag;
 use crate::Ui;
 use crate::{Id, LayerId, Layout, Rect, Sense, Style, UiStackInfo};
 
-/// Build a [`Ui`] as the child of another [`Ui`].
+/// The properties specified when creating a top-level or child [`Ui`].
 ///
 /// By default, everything is inherited from the parent,
 /// except for `max_rect` which by default is set to
 /// the parent [`Ui::available_rect_before_wrap`].
+///
+/// See also [`Ui::new`] and [`Ui::new_child`] for uses.
 #[must_use]
 #[derive(Clone, Default)]
 pub struct UiBuilder {


### PR DESCRIPTION
Previously, the doc for `Ui::scope_builder` read

> Create a child, add content to it, and then allocate only what was used in the parent `Ui`.

which I understood as meaning that "only what was used in the parent `UI`" would be allocated (in the child or parent), which makes no sense (in either case).

I rewrote it and some related docs.