### PR TITLE
eframe: Add `App::transform_primitives` and `App::post_platform_output` hooks

### DIFF
--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -7,6 +7,12 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## Unreleased
+
+### ⭐ Added
+* Add `App::transform_primitives` and `App::post_platform_output` hooks to inspect/transform tessellated primitives and platform output before they are dispatched.
+
+
 ## 0.34.1 - 2026-03-27
 * `wgpu` backend: Enable WebGL fallback [#8038](https://github.com/emilk/egui/pull/8038) by [@emilk](https://github.com/emilk)
 * Only apply cursor style to the `<canvas>` [#8036](https://github.com/emilk/egui/pull/8036) by [@mkeeter](https://github.com/mkeeter)

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -257,6 +257,69 @@ pub trait App {
     ///
     /// This function does not return a value. Any changes to the input should be made directly to `_raw_input`.
     fn raw_input_hook(&mut self, _ctx: &egui::Context, _raw_input: &mut egui::RawInput) {}
+
+    /// A hook for inspecting or transforming tessellated primitives before they are
+    /// handed to the GPU painter, on every frame.
+    ///
+    /// This runs **after** [`egui::Context::tessellate`] and **before** the painter
+    /// (glow / wgpu) submits draw calls. The primitives are in the same coordinate
+    /// space the painter expects (logical pixels). You can rewrite vertex positions,
+    /// modify clip rects, replace meshes, or strip primitives entirely.
+    ///
+    /// Fires once per viewport per frame. Use `_viewport_id` to filter on the root
+    /// (`egui::ViewportId::ROOT`) or on a specific child viewport — `_ctx.viewport_id()`
+    /// is unreliable here because the viewport stack is already popped by the time
+    /// the hook fires.
+    ///
+    /// Use cases:
+    /// - viewport-level transforms applied uniformly to the whole frame (rotation,
+    ///   mirroring, custom projections) without touching individual widgets
+    /// - debugging / instrumentation: dump primitive counts, log overdraw, inject
+    ///   debug overlays
+    /// - custom render passes that need access to the final primitive list
+    ///
+    /// # Arguments
+    ///
+    /// * `_ctx` - The egui context, useful to read state such as `content_rect()`.
+    /// * `_viewport_id` - The viewport these primitives belong to.
+    /// * `_primitives` - The tessellated primitives. Mutate in place to alter what
+    ///   the painter draws.
+    fn transform_primitives(
+        &mut self,
+        _ctx: &egui::Context,
+        _viewport_id: egui::ViewportId,
+        _primitives: &mut Vec<egui::epaint::ClippedPrimitive>,
+    ) {
+    }
+
+    /// A hook for inspecting [`egui::PlatformOutput`] **after** the egui pass completes,
+    /// before it is consumed by the integration (cursor icon dispatch, IME state,
+    /// clipboard writes, accessibility updates).
+    ///
+    /// You can read fields such as `cursor_icon` or `ime`, or modify them to override
+    /// what the integration sees (e.g. force a cursor icon). Mutating the field in
+    /// place changes what is dispatched to the OS.
+    ///
+    /// Fires once per viewport per frame. Use `_viewport_id` to filter on the root
+    /// (`egui::ViewportId::ROOT`) or on a specific child viewport.
+    ///
+    /// Use cases:
+    /// - capture the cursor icon for a custom software cursor
+    /// - intercept clipboard writes for instrumentation
+    /// - override platform output for kiosk/embedded scenarios
+    ///
+    /// # Arguments
+    ///
+    /// * `_ctx` - The egui context.
+    /// * `_viewport_id` - The viewport this output belongs to.
+    /// * `_platform_output` - The platform output for this frame. May be mutated.
+    fn post_platform_output(
+        &mut self,
+        _ctx: &egui::Context,
+        _viewport_id: egui::ViewportId,
+        _platform_output: &mut egui::PlatformOutput,
+    ) {
+    }
 }
 
 /// Options controlling the behavior of a native window.

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -654,12 +654,16 @@ impl GlowWinitRunning<'_> {
         let mut painter = painter.borrow_mut();
 
         let egui::FullOutput {
-            platform_output,
+            mut platform_output,
             textures_delta,
             shapes,
             pixels_per_point,
             viewport_output,
         } = full_output;
+
+        // Hook: let the user inspect / mutate the platform output before it
+        // is dispatched to the OS (cursor icon, IME, clipboard, etc.).
+        app.post_platform_output(&integration.egui_ctx, viewport_id, &mut platform_output);
 
         glutin.remove_viewports_not_in(&viewport_output);
 
@@ -682,7 +686,11 @@ impl GlowWinitRunning<'_> {
         egui_winit.handle_platform_output(&window, platform_output);
 
         if is_visible {
-            let clipped_primitives = integration.egui_ctx.tessellate(shapes, pixels_per_point);
+            let mut clipped_primitives = integration.egui_ctx.tessellate(shapes, pixels_per_point);
+
+            // Hook: let the user inspect / transform the tessellated primitives
+            // before they are submitted to the GPU painter.
+            app.transform_primitives(&integration.egui_ctx, viewport_id, &mut clipped_primitives);
 
             {
                 // We may need to switch contexts again, because of immediate viewports:

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -686,12 +686,16 @@ impl WgpuWinitRunning<'_> {
         } = &mut *shared_mut;
 
         let FullOutput {
-            platform_output,
+            mut platform_output,
             textures_delta,
             shapes,
             pixels_per_point,
             viewport_output,
         } = full_output;
+
+        // Hook: let the user inspect / mutate the platform output before it
+        // is dispatched to the OS (cursor icon, IME, clipboard, etc.).
+        app.post_platform_output(egui_ctx, viewport_id, &mut platform_output);
 
         remove_viewports_not_in(viewports, painter, viewport_from_window, &viewport_output);
 
@@ -713,7 +717,11 @@ impl WgpuWinitRunning<'_> {
         egui_winit.handle_platform_output(window, platform_output);
 
         let vsync_secs = if is_visible {
-            let clipped_primitives = egui_ctx.tessellate(shapes, pixels_per_point);
+            let mut clipped_primitives = egui_ctx.tessellate(shapes, pixels_per_point);
+
+            // Hook: let the user inspect / transform the tessellated primitives
+            // before they are submitted to the GPU painter.
+            app.transform_primitives(egui_ctx, viewport_id, &mut clipped_primitives);
 
             let mut screenshot_commands = vec![];
             viewport.actions_requested.retain(|cmd| {


### PR DESCRIPTION
## Summary

Adds two optional methods on the `App` trait that give integrations a place to inspect or transform the per-frame egui pipeline output before it reaches the platform.

```rust
fn transform_primitives(
    &mut self,
    ctx: &egui::Context,
    primitives: &mut Vec<egui::epaint::ClippedPrimitive>,
) {}

fn post_platform_output(
    &mut self,
    ctx: &egui::Context,
    platform_output: &mut egui::PlatformOutput,
) {}
```

Both default to no-op, so existing apps are unaffected.

## Where they fire

| Hook | Fires after | Fires before |
|---|---|---|
| `transform_primitives` | `Context::tessellate` | painter `paint_and_update_textures` |
| `post_platform_output` | `Context::run_ui` returns | `egui_winit.handle_platform_output` consumes it |

Wired into both `glow_integration` and `wgpu_integration`. Web (wasm32) is not touched in this PR — could be a follow-up if there's interest.

## Use cases

These are general-purpose hooks, not tied to any specific feature. Examples that motivated them:

- **Viewport-level transforms**: rotation (e.g. for a 90°-mounted kiosk display), mirroring, custom projections — applied uniformly to the whole frame without touching individual widgets. The shipping companion crate [`egui-rotate`](https://crates.io/crates/egui-rotate) uses these hooks to integrate cleanly with eframe; without them it can only target custom winit/glow integrations.
- **Debugging / instrumentation**: dump primitive counts, log overdraw, inject debug overlays after the UI has been laid out.
- **Custom render passes**: anything that needs access to the final primitive list (e.g. injecting a post-processing pass on a subset of layers).
- **Software cursor capture**: read `PlatformOutput::cursor_icon` to drive a custom cursor (where the OS cursor is hidden, e.g. cabinet displays where the OS cursor cannot be rotated).
- **Output interception**: clipboard / IME / cursor-icon overrides for kiosk and embedded scenarios.

## Why not a single hook?

The two hooks fire at different points in the pipeline (tessellate→paint vs. run_ui→handle_platform_output) and target different data (primitives vs. platform output). Coalescing them would either add a hook that fires earlier than needed for one of the use cases, or split the work into one hook with two unrelated parameters.

## Why not extend `Context` instead?

These are integration-time concerns (post-tessellation, pre-paint; post-run, pre-OS-dispatch). They don't fit the egui `Context` API, which is mid-pass. The `App` trait is the natural place: it's already where `raw_input_hook` lives for the symmetric input side.

## Test plan

- [x] `cargo build -p eframe` clean
- [x] `cargo clippy -p eframe --all-features -- -D warnings` clean
- [x] `cargo fmt -p eframe --check` clean
- [x] `cargo test -p eframe --lib` passes
- [ ] Manual: drive a vendored `egui-rotate` integration through these hooks on a real eframe app, verify rotation + cursor work — done locally on my pinball cabinet launcher (`PinReady`), can share details if useful

## Background

This is a smaller, more general follow-up to [#8113](https://github.com/emilk/egui/pull/8113), which tried to integrate viewport rotation directly into egui+eframe and was declined as too niche / too much surface to maintain. That feedback was fair. The follow-up published the rotation logic as a standalone crate ([`egui-rotate`](https://crates.io/crates/egui-rotate)) which works fine with custom integrations (winit + glow / wgpu / SDL3 directly). However it cannot integrate with `eframe` because eframe owns the tessellate→paint pipeline with no hook in between.

These two hooks fix that — and stay generic. They're not specific to rotation; the doc-comments describe the broader use cases.

If preferred, I'm happy to:
- rename either method (`pre_paint` / `pre_handle_output`?)
- gate them behind a feature flag
- only add `transform_primitives` and drop `post_platform_output` (the cursor icon use case can be worked around with a fixed icon)
- wire them into the wasm integration too

🤖 Drafted with [Claude Code](https://claude.com/claude-code)