### PR TITLE
Create a function for making Vec2s via Iterators

### DIFF
--- a/crates/emath/src/vec2.rs
+++ b/crates/emath/src/vec2.rs
@@ -149,18 +149,15 @@ impl Vec2 {
         Self { x, y }
     }
 
-    /// Create a Vec2 from something
-    /// that implements the Iterator trait.
-
-    /// Returns a None value if the iterator is either too long
-    /// or too short.
+	/// Create a Vec2 from an iterator with f32 values.
+    /// Returns a None value if the iterator length is not 2. The first should be is x and the second should be y.
     #[inline]
     #[must_use]
-    pub fn from_iter(iter: impl Iterator<Item = f32>) -> Option<Vec2> {
-        let x = iter.next()?;
-        let y = iter.next()?;
-        if iter.next() != None { return None };
-        Some(Self { x, y })
+    pub fn from_iter(mut iter: impl Iterator<Item = f32>) -> Option<Vec2> {	
+		let x = iter.next()?;
+		let y = iter.next()?;
+		if iter.next() != None { return None; }
+		return Some(Self { x, y });
     }
 
     /// Set both `x` and `y` to the same value.

--- a/crates/emath/src/vec2.rs
+++ b/crates/emath/src/vec2.rs
@@ -157,11 +157,9 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub fn from_iter(iter: impl Iterator<Item = f32>) -> Option<Vec2> {
-        if iter.len() != 2 {
-            return None;
-        }
-        let x = iter.next();
-        let y = iter.next();
+        let x = iter.next()?;
+        let y = iter.next()?;
+        if iter.next() != None { return None };
         Some(Self { x, y })
     }
 

--- a/crates/emath/src/vec2.rs
+++ b/crates/emath/src/vec2.rs
@@ -149,6 +149,22 @@ impl Vec2 {
         Self { x, y }
     }
 
+    /// Create a Vec2 from something
+    /// that implements the Iterator trait.
+
+    /// Returns a None value if the iterator is either too long
+    /// or too short.
+    #[inline]
+    #[must_use]
+    pub fn from_iter(iter: impl Iterator<Item = f32>) -> Option<Vec2> {
+        if iter.len() != 2 {
+            return None;
+        }
+        let x = iter.next();
+        let y = iter.next();
+        Some(Self { x, y })
+    }
+
     /// Set both `x` and `y` to the same value.
     #[inline(always)]
     pub const fn splat(v: f32) -> Self {


### PR DESCRIPTION
This would be a quality of life feature, as neither `Vec2` nor `f32` implements Hash, making it difficult to store. This could lead to cleaner code in the codebase of the user using the egui crate. 
