### PR TITLE
Bump version to 0.34.2 and update changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.34.2 - 2026-05-04
+### ⭐ Added
+* Add regression test for O(n²) word boundary scan [#8077](https://github.com/emilk/egui/pull/8077) by [@hallyhaa](https://github.com/hallyhaa)
+
+### 🐛 Fixed
+* Fix wrong color of last glyph of selected text [#8075](https://github.com/emilk/egui/pull/8075) by [@emilk](https://github.com/emilk)
+* Fix text selection of centered and right-aligned text [#8076](https://github.com/emilk/egui/pull/8076) by [@emilk](https://github.com/emilk)
+* Fix `Context::is_pointer_over_egui` and `Context::egui_wants_pointer_input` [#8081](https://github.com/emilk/egui/pull/8081) by [@emilk](https://github.com/emilk)
+* Fix centered & right aligned `TextEdit` [#8082](https://github.com/emilk/egui/pull/8082) by [@lucasmerlin](https://github.com/lucasmerlin)
+
+### 🚀 Performance
+* Optimize text selection performance for large documents [#7917](https://github.com/emilk/egui/pull/7917) by [@rustbasic](https://github.com/rustbasic)
+
+
 ## 0.34.1 - 2026-03-27
 Nothing new
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "ecolor"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "bytemuck",
  "cint",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "egui_demo_app"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "egui_demo_lib"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "criterion",
  "document-features",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "ahash",
  "document-features",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "egui_kittest"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "dify",
  "document-features",
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "egui_tests"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "egui",
  "egui_extras",
@@ -1430,7 +1430,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "emath"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.34.1"
+version = "0.34.2"
 
 [[package]]
 name = "equivalent"
@@ -3480,7 +3480,7 @@ checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "popups"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "eframe",
  "env_logger",
@@ -5819,7 +5819,7 @@ checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "xtask"
-version = "0.34.1"
+version = "0.34.2"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.92"
-version = "0.34.1"
+version = "0.34.2"
 
 
 [profile.release]
@@ -55,18 +55,18 @@ opt-level = 2
 
 
 [workspace.dependencies]
-emath = { version = "0.34.1", path = "crates/emath", default-features = false }
-ecolor = { version = "0.34.1", path = "crates/ecolor", default-features = false }
-epaint = { version = "0.34.1", path = "crates/epaint", default-features = false }
-epaint_default_fonts = { version = "0.34.1", path = "crates/epaint_default_fonts" }
-egui = { version = "0.34.1", path = "crates/egui", default-features = false }
-egui-winit = { version = "0.34.1", path = "crates/egui-winit", default-features = false }
-egui_extras = { version = "0.34.1", path = "crates/egui_extras", default-features = false }
-egui-wgpu = { version = "0.34.1", path = "crates/egui-wgpu", default-features = false }
-egui_demo_lib = { version = "0.34.1", path = "crates/egui_demo_lib", default-features = false }
-egui_glow = { version = "0.34.1", path = "crates/egui_glow", default-features = false }
-egui_kittest = { version = "0.34.1", path = "crates/egui_kittest", default-features = false }
-eframe = { version = "0.34.1", path = "crates/eframe", default-features = false }
+emath = { version = "0.34.2", path = "crates/emath", default-features = false }
+ecolor = { version = "0.34.2", path = "crates/ecolor", default-features = false }
+epaint = { version = "0.34.2", path = "crates/epaint", default-features = false }
+epaint_default_fonts = { version = "0.34.2", path = "crates/epaint_default_fonts" }
+egui = { version = "0.34.2", path = "crates/egui", default-features = false }
+egui-winit = { version = "0.34.2", path = "crates/egui-winit", default-features = false }
+egui_extras = { version = "0.34.2", path = "crates/egui_extras", default-features = false }
+egui-wgpu = { version = "0.34.2", path = "crates/egui-wgpu", default-features = false }
+egui_demo_lib = { version = "0.34.2", path = "crates/egui_demo_lib", default-features = false }
+egui_glow = { version = "0.34.2", path = "crates/egui_glow", default-features = false }
+egui_kittest = { version = "0.34.2", path = "crates/egui_kittest", default-features = false }
+eframe = { version = "0.34.2", path = "crates/eframe", default-features = false }
 
 accesskit = "0.24.0"
 accesskit_consumer = "0.35.0"

--- a/crates/ecolor/CHANGELOG.md
+++ b/crates/ecolor/CHANGELOG.md
@@ -6,6 +6,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.34.2 - 2026-05-04
+Nothing new
+
+
 ## 0.34.1 - 2026-03-27
 Nothing new
 

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -7,6 +7,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.34.2 - 2026-05-04
+* Document glow-only fields in `NativeOptions` [#8104](https://github.com/emilk/egui/pull/8104) by [@emilk](https://github.com/emilk)
+
+
 ## 0.34.1 - 2026-03-27
 * `wgpu` backend: Enable WebGL fallback [#8038](https://github.com/emilk/egui/pull/8038) by [@emilk](https://github.com/emilk)
 * Only apply cursor style to the `<canvas>` [#8036](https://github.com/emilk/egui/pull/8036) by [@mkeeter](https://github.com/mkeeter)

--- a/crates/egui-wgpu/CHANGELOG.md
+++ b/crates/egui-wgpu/CHANGELOG.md
@@ -6,6 +6,11 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.34.2 - 2026-05-04
+* Update to wgpu 29.0.1 [#8073](https://github.com/emilk/egui/pull/8073) by [@emilk](https://github.com/emilk)
+* Warn if using a software rasterizer [#8101](https://github.com/emilk/egui/pull/8101) by [@emilk](https://github.com/emilk)
+
+
 ## 0.34.1 - 2026-03-27
 * `wgpu` backend: Enable WebGL fallback [#8038](https://github.com/emilk/egui/pull/8038) by [@emilk](https://github.com/emilk)
 

--- a/crates/egui-winit/CHANGELOG.md
+++ b/crates/egui-winit/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.34.2 - 2026-05-04
+Nothing new
+
+
 ## 0.34.1 - 2026-03-27
 Nothing new
 

--- a/crates/egui_extras/CHANGELOG.md
+++ b/crates/egui_extras/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.34.2 - 2026-05-04
+Nothing new
+
+
 ## 0.34.1 - 2026-03-27
 Nothing new
 

--- a/crates/egui_glow/CHANGELOG.md
+++ b/crates/egui_glow/CHANGELOG.md
@@ -6,6 +6,10 @@ Changes since the last release can be found at <https://github.com/emilk/egui/co
 
 
 
+## 0.34.2 - 2026-05-04
+Nothing new
+
+
 ## 0.34.1 - 2026-03-27
 Nothing new
 

--- a/crates/egui_kittest/CHANGELOG.md
+++ b/crates/egui_kittest/CHANGELOG.md
@@ -6,6 +6,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.34.2 - 2026-05-04
+Nothing new
+
+
 ## 0.34.1 - 2026-03-27
 Nothing new
 

--- a/crates/emath/CHANGELOG.md
+++ b/crates/emath/CHANGELOG.md
@@ -6,6 +6,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.34.2 - 2026-05-04
+Nothing new
+
+
 ## 0.34.1 - 2026-03-27
 Nothing new
 

--- a/crates/epaint/CHANGELOG.md
+++ b/crates/epaint/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.34.2 - 2026-05-04
+* Fix text layout bugs in wrapped texts [#8137](https://github.com/emilk/egui/pull/8137) by [@lucasmerlin](https://github.com/lucasmerlin)
+
+
 ## 0.34.1 - 2026-03-27
 Nothing new
 

--- a/crates/epaint_default_fonts/CHANGELOG.md
+++ b/crates/epaint_default_fonts/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.34.2 - 2026-05-04
+Nothing new
+
+
 ## 0.34.1 - 2026-03-27
 Nothing new
 


### PR DESCRIPTION
Brings the 0.34.2 release commit back to `main` so it tracks the latest published version and has updated changelogs.
