### PR TITLE
Support tablet pressure in the browser

### DIFF
--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -15,6 +15,27 @@ use web_sys::{Document, EventTarget, ShadowRoot};
 
 // ------------------------------------------------------------------------
 
+/// Returns `true` if the browser supports Pointer Events.
+/// If so, we can rely on `pointermove` instead of `mousemove`.
+fn pointer_events_supported() -> bool {
+    Reflect::get(&web_sys::window().unwrap(), &"PointerEvent".into())
+        .map(|v| !v.is_undefined())
+        .unwrap_or(false)
+}
+
+/// Returns pressure only for pen or touch pointer types.
+/// Mouse devices always report 0.0 pressure, which we treat as "not available".
+fn pointer_pressure(event: &web_sys::PointerEvent) -> Option<f32> {
+    let pointer_type = event.pointer_type();
+    if pointer_type == "pen" || pointer_type == "touch" {
+        Some(event.pressure())
+    } else {
+        None
+    }
+}
+
+// ------------------------------------------------------------------------
+
 /// Calls `request_animation_frame` to schedule repaint.
 ///
 /// It will only paint if needed, but will always call `request_animation_frame` immediately.
@@ -89,7 +110,12 @@ pub(crate) fn install_event_handlers(runner_ref: &WebRunner) -> Result<(), JsVal
 
     // Use `document` here to notice if the user releases a drag outside of the canvas:
     // See https://github.com/emilk/egui/issues/3157
-    install_mousemove(runner_ref, &document)?;
+    // If the browser supports Pointer Events, we rely on pointermove and skip mousemove
+    // to avoid duplicate PointerMoved events.
+    if !pointer_events_supported() {
+        install_mousemove(runner_ref, &document)?;
+    }
+    install_pointermove(runner_ref, &document)?;
     install_pointerup(runner_ref, &document)?;
     install_pointerdown(runner_ref, &canvas)?;
     install_mouseleave(runner_ref, &canvas)?;
@@ -520,11 +546,13 @@ fn install_pointerdown(runner_ref: &WebRunner, target: &EventTarget) -> Result<(
             if let Some(button) = button_from_mouse_event(&event) {
                 let pos = pos_from_mouse_event(runner.canvas(), &event, runner.egui_ctx());
                 let modifiers = runner.input.raw.modifiers;
+                let force = pointer_pressure(&event);
                 let egui_event = egui::Event::PointerButton {
                     pos,
                     button,
                     pressed: true,
                     modifiers,
+                    force,
                 };
                 should_stop_propagation = (runner.web_options.should_stop_propagation)(&egui_event);
                 runner.input.raw.events.push(egui_event);
@@ -562,11 +590,13 @@ fn install_pointerup(runner_ref: &WebRunner, target: &EventTarget) -> Result<(),
             ) && let Some(button) = button_from_mouse_event(&event)
             {
                 let modifiers = runner.input.raw.modifiers;
+                let force = pointer_pressure(&event);
                 let egui_event = egui::Event::PointerButton {
                     pos,
                     button,
                     pressed: false,
                     modifiers,
+                    force,
                 };
                 let should_stop_propagation =
                     (runner.web_options.should_stop_propagation)(&egui_event);
@@ -635,13 +665,42 @@ fn install_mousemove(runner_ref: &WebRunner, target: &EventTarget) -> Result<(),
             runner,
             egui::pos2(event.client_x() as f32, event.client_y() as f32),
         ) {
-            let egui_event = egui::Event::PointerMoved(pos);
+            let egui_event = egui::Event::PointerMoved { pos, force: None };
             let should_stop_propagation = (runner.web_options.should_stop_propagation)(&egui_event);
             let should_prevent_default = (runner.web_options.should_prevent_default)(&egui_event);
             runner.input.raw.events.push(egui_event);
             runner.needs_repaint.repaint();
 
             // Use web options to tell if the web event should be propagated to parent elements based on the egui event.
+            if should_stop_propagation {
+                event.stop_propagation();
+            }
+
+            if should_prevent_default {
+                event.prevent_default();
+            }
+        }
+    })
+}
+
+fn install_pointermove(runner_ref: &WebRunner, target: &EventTarget) -> Result<(), JsValue> {
+    runner_ref.add_event_listener(target, "pointermove", |event: web_sys::PointerEvent, runner| {
+        let modifiers = modifiers_from_mouse_event(&event);
+        runner.input.raw.modifiers = modifiers;
+
+        let pos = pos_from_mouse_event(runner.canvas(), &event, runner.egui_ctx());
+
+        if is_interested_in_pointer_event(
+            runner,
+            egui::pos2(event.client_x() as f32, event.client_y() as f32),
+        ) {
+            let force = pointer_pressure(&event);
+            let egui_event = egui::Event::PointerMoved { pos, force };
+            let should_stop_propagation = (runner.web_options.should_stop_propagation)(&egui_event);
+            let should_prevent_default = (runner.web_options.should_prevent_default)(&egui_event);
+            runner.input.raw.events.push(egui_event);
+            runner.needs_repaint.repaint();
+
             if should_stop_propagation {
                 event.stop_propagation();
             }
@@ -680,12 +739,14 @@ fn install_touchstart(runner_ref: &WebRunner, target: &EventTarget) -> Result<()
         |event: web_sys::TouchEvent, runner| {
             let mut should_stop_propagation = true;
             let mut should_prevent_default = true;
-            if let Some((pos, _)) = primary_touch_pos(runner, &event) {
+            if let Some((pos, touch)) = primary_touch_pos(runner, &event) {
+                let force = Some(touch.force());
                 let egui_event = egui::Event::PointerButton {
                     pos,
                     button: egui::PointerButton::Primary,
                     pressed: true,
                     modifiers: runner.input.raw.modifiers,
+                    force,
                 };
                 should_stop_propagation = (runner.web_options.should_stop_propagation)(&egui_event);
                 should_prevent_default = (runner.web_options.should_prevent_default)(&egui_event);
@@ -715,7 +776,8 @@ fn install_touchmove(runner_ref: &WebRunner, target: &EventTarget) -> Result<(),
                 egui::pos2(touch.client_x() as f32, touch.client_y() as f32),
             )
         {
-            let egui_event = egui::Event::PointerMoved(pos);
+            let force = Some(touch.force());
+            let egui_event = egui::Event::PointerMoved { pos, force };
             let should_stop_propagation = (runner.web_options.should_stop_propagation)(&egui_event);
             let should_prevent_default = (runner.web_options.should_prevent_default)(&egui_event);
             runner.input.raw.events.push(egui_event);
@@ -746,11 +808,13 @@ fn install_touchend(runner_ref: &WebRunner, target: &EventTarget) -> Result<(), 
             // First release mouse to click:
             let mut should_stop_propagation = true;
             let mut should_prevent_default = true;
+            let force = Some(touch.force());
             let egui_event = egui::Event::PointerButton {
                 pos,
                 button: egui::PointerButton::Primary,
                 pressed: false,
                 modifiers: runner.input.raw.modifiers,
+                force,
             };
             should_stop_propagation &= (runner.web_options.should_stop_propagation)(&egui_event);
             should_prevent_default &= (runner.web_options.should_prevent_default)(&egui_event);

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -751,6 +751,7 @@ impl State {
                 button,
                 pressed,
                 modifiers: self.egui_input.modifiers,
+                force: None,
             });
 
             if self.simulate_touch_screen {
@@ -796,9 +797,10 @@ impl State {
 
         if self.simulate_touch_screen {
             if self.any_pointer_button_down {
-                self.egui_input
-                    .events
-                    .push(egui::Event::PointerMoved(pos_in_points));
+                self.egui_input.events.push(egui::Event::PointerMoved {
+                    pos: pos_in_points,
+                    force: None,
+                });
 
                 self.egui_input.events.push(egui::Event::Touch {
                     device_id: egui::TouchDeviceId(0),
@@ -809,9 +811,10 @@ impl State {
                 });
             }
         } else {
-            self.egui_input
-                .events
-                .push(egui::Event::PointerMoved(pos_in_points));
+            self.egui_input.events.push(egui::Event::PointerMoved {
+                pos: pos_in_points,
+                force: None,
+            });
         }
     }
 

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -483,7 +483,15 @@ pub enum Event {
     },
 
     /// The mouse or touch moved to a new place.
-    PointerMoved(Pos2),
+    PointerMoved {
+        /// Where is the pointer?
+        pos: Pos2,
+
+        /// Describes how hard the pointer device was pressed. May always be `None` if the platform does
+        /// not support pressure sensitivity.
+        /// The value is in the range from 0.0 (no pressure) to 1.0 (maximum pressure).
+        force: Option<f32>,
+    },
 
     /// The mouse moved, the units are unspecified.
     /// Represents the actual movement of the mouse, without acceleration or clamped by screen edges.
@@ -504,6 +512,11 @@ pub enum Event {
 
         /// The state of the modifier keys at the time of the event.
         modifiers: Modifiers,
+
+        /// Describes how hard the pointer device was pressed. May always be `None` if the platform does
+        /// not support pressure sensitivity.
+        /// The value is in the range from 0.0 (no pressure) to 1.0 (maximum pressure).
+        force: Option<f32>,
     },
 
     /// The mouse left the screen, or the last/primary touch input disappeared.

--- a/crates/egui/src/input_state/mod.rs
+++ b/crates/egui/src/input_state/mod.rs
@@ -1054,6 +1054,10 @@ pub struct PointerState {
     /// Used for things like showing hover ui/tooltip with a delay.
     last_move_time: f64,
 
+    /// Current pressure of the pointer (0.0 to 1.0), if available.
+    /// Only available on devices that support pressure sensitivity (e.g. graphics tablets, touch screens).
+    pressure: Option<f32>,
+
     /// All button events that occurred this frame
     pub(crate) pointer_events: Vec<PointerEvent>,
 
@@ -1083,6 +1087,7 @@ impl Default for PointerState {
             last_click_time: f64::NEG_INFINITY,
             last_last_click_time: f64::NEG_INFINITY,
             last_move_time: f64::NEG_INFINITY,
+            pressure: None,
             pointer_events: vec![],
             options: Default::default(),
         }
@@ -1108,7 +1113,7 @@ impl PointerState {
         let mut clear_history_after_velocity_calculation = false;
         for event in &new.events {
             match event {
-                Event::PointerMoved(pos) => {
+                Event::PointerMoved { pos, force } => {
                     let pos = *pos;
 
                     self.latest_pos = Some(pos);
@@ -1120,6 +1125,9 @@ impl PointerState {
                     }
 
                     self.last_move_time = time;
+                    if force.is_some() {
+                        self.pressure = *force;
+                    }
                     self.pointer_events.push(PointerEvent::Moved(pos));
                 }
                 Event::PointerButton {
@@ -1127,6 +1135,7 @@ impl PointerState {
                     button,
                     pressed,
                     modifiers,
+                    force,
                 } => {
                     let pos = *pos;
                     let button = *button;
@@ -1135,6 +1144,9 @@ impl PointerState {
 
                     self.latest_pos = Some(pos);
                     self.interact_pos = Some(pos);
+                    if force.is_some() {
+                        self.pressure = *force;
+                    }
 
                     if pressed {
                         // Start of a drag: we want to track the velocity for during the drag
@@ -1199,6 +1211,7 @@ impl PointerState {
                 }
                 Event::PointerGone => {
                     self.latest_pos = None;
+                    self.pressure = None;
                     // When dragging a slider and the mouse leaves the viewport, we still want the drag to work,
                     // so we don't treat this as a `PointerEvent::Released`.
                     // NOTE: we do NOT clear `self.interact_pos` here. It will be cleared next frame.
@@ -1356,6 +1369,15 @@ impl PointerState {
     #[inline(always)]
     pub fn time_since_last_click(&self) -> f32 {
         (self.time - self.last_click_time) as f32
+    }
+
+    /// Current pressure of the pointer (0.0 to 1.0), if available.
+    ///
+    /// Returns `None` if the platform does not support pressure sensitivity.
+    /// Only available on devices like graphics tablets and touch screens.
+    #[inline(always)]
+    pub fn pressure(&self) -> Option<f32> {
+        self.pressure
     }
 
     /// Was any pointer button pressed (`!down -> down`) this frame?
@@ -1660,6 +1682,7 @@ impl PointerState {
             last_last_click_time,
             pointer_events,
             last_move_time,
+            pressure,
             options: _,
         } = self;
 
@@ -1685,6 +1708,7 @@ impl PointerState {
         ui.label(format!("last_click_time: {last_click_time:#?}"));
         ui.label(format!("last_last_click_time: {last_last_click_time:#?}"));
         ui.label(format!("last_move_time: {last_move_time:#?}"));
+        ui.label(format!("pressure: {pressure:?}"));
         ui.label(format!("pointer_events: {pointer_events:?}"));
     }
 }

--- a/crates/egui_demo_lib/src/demo/painting.rs
+++ b/crates/egui_demo_lib/src/demo/painting.rs
@@ -1,11 +1,25 @@
-use egui::{Color32, Frame, Pos2, Rect, Sense, Stroke, Ui, Window, emath, vec2};
+use egui::{Color32, Frame, Pos2, Rect, Sense, Shape, Stroke, Ui, Window, emath, vec2};
+
+/// A point in a stroke, optionally carrying pressure information.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+struct LinePoint {
+    pos: Pos2,
+    /// Pressure in the range [0.0, 1.0], or `None` for constant-width strokes.
+    pressure: Option<f32>,
+}
+
+/// A completed or in-progress stroke.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+struct Line {
+    points: Vec<LinePoint>,
+}
 
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct Painting {
-    /// in 0-1 normalized coordinates
-    lines: Vec<Vec<Pos2>>,
+    lines: Vec<Line>,
     stroke: Stroke,
+    use_pressure: bool,
 }
 
 impl Default for Painting {
@@ -13,6 +27,7 @@ impl Default for Painting {
         Self {
             lines: Default::default(),
             stroke: Stroke::new(1.0, Color32::from_rgb(25, 200, 100)),
+            use_pressure: false,
         }
     }
 }
@@ -40,35 +55,106 @@ impl Painting {
         );
         let from_screen = to_screen.inverse();
 
+        let pressure = ui.ctx().input(|i| i.pointer.pressure());
+        let has_pressure = pressure.is_some() && self.use_pressure;
+
+        self.paint_strokes(&mut response, &painter, &to_screen, &from_screen, if has_pressure { pressure } else { None });
+
+        response
+    }
+
+    fn paint_strokes(
+        &mut self,
+        response: &mut egui::Response,
+        painter: &egui::Painter,
+        to_screen: &emath::RectTransform,
+        from_screen: &emath::RectTransform,
+        pressure: Option<f32>,
+    ) {
         if self.lines.is_empty() {
-            self.lines.push(vec![]);
+            self.lines.push(Line { points: Vec::new() });
         }
 
         let current_line = self.lines.last_mut().unwrap();
 
         if let Some(pointer_pos) = response.interact_pointer_pos() {
             let canvas_pos = from_screen * pointer_pos;
-            if current_line.last() != Some(&canvas_pos) {
-                current_line.push(canvas_pos);
+            if current_line.points.last().map_or(true, |p| p.pos != canvas_pos) {
+                current_line.points.push(LinePoint { pos: canvas_pos, pressure });
                 response.mark_changed();
             }
-        } else if !current_line.is_empty() {
-            self.lines.push(vec![]);
+        } else if current_line.points.last().is_some() {
+            self.lines.push(Line { points: Vec::new() });
             response.mark_changed();
         }
 
-        let shapes = self
-            .lines
-            .iter()
-            .filter(|line| line.len() >= 2)
-            .map(|line| {
-                let points: Vec<Pos2> = line.iter().map(|p| to_screen * *p).collect();
-                egui::Shape::line(points, self.stroke)
-            });
+        for line in &self.lines {
+            if line.points.len() < 2 {
+                continue;
+            }
 
-        painter.extend(shapes);
+            let is_pressure = line.points.iter().any(|p| p.pressure.is_some());
+            if is_pressure {
+                self.paint_pressure_line(painter, line, to_screen);
+            } else {
+                self.paint_constant_line(painter, line, to_screen);
+            }
+        }
+    }
 
-        response
+    fn paint_constant_line(
+        &self,
+        painter: &egui::Painter,
+        line: &Line,
+        to_screen: &emath::RectTransform,
+    ) {
+        let points: Vec<Pos2> = line.points.iter().map(|p| to_screen * p.pos).collect();
+        painter.add(Shape::line(points, self.stroke));
+    }
+
+    fn paint_pressure_line(
+        &self,
+        painter: &egui::Painter,
+        line: &Line,
+        to_screen: &emath::RectTransform,
+    ) {
+        for i in 1..line.points.len() {
+            let from = to_screen * line.points[i - 1].pos;
+            let to = to_screen * line.points[i].pos;
+
+            let delta = to - from;
+            let len_sq = delta.length_sq();
+            if len_sq < 0.001 {
+                continue;
+            }
+
+            let pressure_from = line.points[i - 1].pressure.unwrap_or(0.5);
+            let pressure_to = line.points[i].pressure.unwrap_or(0.5);
+
+            let width_from = self.stroke.width * pressure_from * 2.0;
+            let width_to = self.stroke.width * pressure_to * 2.0;
+
+            let dir = delta.normalized();
+            let perp = egui::vec2(-dir.y, dir.x);
+
+            let p0 = from + perp * width_from / 2.0;
+            let p1 = from - perp * width_from / 2.0;
+            let p2 = to - perp * width_to / 2.0;
+            let p3 = to + perp * width_to / 2.0;
+
+            painter.add(Shape::convex_polygon(
+                vec![p0, p1, p2, p3],
+                self.stroke.color,
+                Stroke::NONE,
+            ));
+        }
+
+        for point in &line.points {
+            let pos = to_screen * point.pos;
+            let pressure = point.pressure.unwrap_or(0.5);
+            let radius = self.stroke.width * pressure;
+            painter.circle_filled(pos, radius, self.stroke.color);
+        }
     }
 }
 
@@ -94,7 +180,24 @@ impl crate::View for Painting {
             ui.add(crate::egui_github_link_file!());
         });
         self.ui_control(ui);
-        ui.label("Paint with your mouse/touch!");
+
+        let pressure_info = ui.ctx().input(|i| {
+            if let Some(pressure) = i.pointer.pressure() {
+                format!("Pressure: {:.2}", pressure)
+            } else {
+                "Pressure: not available".to_owned()
+            }
+        });
+
+        ui.horizontal(|ui| {
+            ui.checkbox(&mut self.use_pressure, "Use pressure sensitivity");
+            if self.use_pressure {
+                ui.separator();
+                ui.label(&pressure_info);
+            }
+        });
+
+        ui.label("Paint with your mouse/touch/stylus!");
         Frame::canvas(ui.style()).show(ui, |ui| {
             self.ui_content(ui);
         });

--- a/crates/egui_kittest/src/lib.rs
+++ b/crates/egui_kittest/src/lib.rs
@@ -595,7 +595,7 @@ impl<'a, State> Harness<'a, State> {
 
     /// Move mouse cursor to this position.
     pub fn hover_at(&self, pos: egui::Pos2) {
-        self.event(egui::Event::PointerMoved(pos));
+        self.event(egui::Event::PointerMoved { pos, force: None });
     }
 
     /// Start dragging from a position.
@@ -605,6 +605,7 @@ impl<'a, State> Harness<'a, State> {
             button: PointerButton::Primary,
             pressed: true,
             modifiers: Modifiers::NONE,
+            force: None,
         });
     }
 
@@ -615,6 +616,7 @@ impl<'a, State> Harness<'a, State> {
             button: PointerButton::Primary,
             pressed: false,
             modifiers: Modifiers::NONE,
+            force: None,
         });
         self.remove_cursor();
     }

--- a/crates/egui_kittest/src/node.rs
+++ b/crates/egui_kittest/src/node.rs
@@ -46,7 +46,10 @@ impl Node<'_> {
     }
 
     pub fn hover(&self) {
-        self.event(egui::Event::PointerMoved(self.rect().center()));
+        self.event(egui::Event::PointerMoved {
+            pos: self.rect().center(),
+            force: None,
+        });
     }
 
     /// Click at the node center with the primary button.
@@ -66,6 +69,7 @@ impl Node<'_> {
                 button,
                 pressed,
                 modifiers: Modifiers::default(),
+                force: None,
             });
         }
     }
@@ -83,6 +87,7 @@ impl Node<'_> {
                 button,
                 pressed,
                 modifiers,
+                force: None,
             });
         }
         self.modifiers(Modifiers::default());

--- a/crates/egui_kittest/tests/regression_tests.rs
+++ b/crates/egui_kittest/tests/regression_tests.rs
@@ -237,6 +237,7 @@ pub fn menus_should_close_even_if_submenu_disappears() {
             button: egui::PointerButton::Primary,
             pressed: true,
             modifiers: Modifiers::default(),
+            force: None,
         });
         harness.step();
 
@@ -252,6 +253,7 @@ pub fn menus_should_close_even_if_submenu_disappears() {
             button: egui::PointerButton::Primary,
             pressed: false,
             modifiers: Modifiers::default(),
+            force: None,
         });
 
         harness.run();

--- a/tests/egui_tests/tests/test_widgets.rs
+++ b/tests/egui_tests/tests/test_widgets.rs
@@ -335,6 +335,7 @@ impl<'a> VisualTests<'a> {
                 pos: rect.center(),
                 pressed: true,
                 modifiers: Default::default(),
+                force: None,
             });
         });
         self.add_node("focussed", |node| {


### PR DESCRIPTION
Initial work to support reading the pressure of a graphics tablet or touch screen.

This only works in the browser because it does not address lack of support in winit.

It also alters the demo painter application to allow for pressure sensitive drawing. I have taken some effort to preserve some of the behavior.

* Partly addresses #2104
* [x] I have followed the instructions in the PR template

