### PR TITLE
Revert #8103: low-latency by default

### DIFF
--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -86,10 +86,14 @@ impl SurfaceConfig {
     /// Good default for GUIs with very little (or no) extra GPU work.
     pub const LOW_LATENCY: Self = Self {
         present_mode: wgpu::PresentMode::AutoVsync,
+
+        #[expect(clippy::branches_sharing_code)]
         desired_maximum_frame_latency: if cfg!(target_os = "ios") {
             None // The default is good on iOS, while `Some(1)` cuts FPS in half
         } else {
-            Some(1) // Low-latency by default.
+            // TODO(emilk): We would like yo use `Some(1)` here, but
+            // that causes bugs when resizing the window on macOS.
+            None
         },
     };
 


### PR DESCRIPTION
## Related
* Related: https://github.com/emilk/egui/issues/8043
* Introduced in #8103



## What
I noticed resizing the native winit window was really choppy and bad on macOS, and this was the readon