### PR TITLE
Always enable windows undecorated shadows

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1680,7 +1680,14 @@ fn process_viewport_command(
         ViewportCommand::Fullscreen(v) => {
             window.set_fullscreen(v.then_some(winit::window::Fullscreen::Borderless(None)));
         }
-        ViewportCommand::Decorations(v) => window.set_decorations(v),
+        ViewportCommand::Decorations(v) => {
+            window.set_decorations(v);
+            #[cfg(target_os = "windows")]
+            {
+                use winit::platform::windows::WindowExtWindows as _;
+                window.set_undecorated_shadow(!v);
+            }
+        }
         ViewportCommand::WindowLevel(l) => window.set_window_level(match l {
             egui::viewport::WindowLevel::AlwaysOnBottom => WindowLevel::AlwaysOnBottom,
             egui::viewport::WindowLevel::AlwaysOnTop => WindowLevel::AlwaysOnTop,
@@ -1960,6 +1967,7 @@ pub fn create_winit_window_attributes(
         if let Some(show) = _taskbar {
             window_attributes = window_attributes.with_skip_taskbar(!show);
         }
+        window_attributes = window_attributes.with_undecorated_shadow(!decorations.unwrap_or(true));
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
I wanted to do this in a backwards compatible way so it can go into a patch. That said, it's arguably very much a breaking change as it changes behavior. Alternatively we could also expose this as an option on the ViewportCommand.

What does this actually do? Easily described with pictures rather than words:

Before:
<img width="402" height="199" alt="image" src="https://github.com/user-attachments/assets/d8aace08-3d1d-426c-a441-3f4e6ebf71ee" />


After:
<img width="377" height="236" alt="image" src="https://github.com/user-attachments/assets/d483e798-7497-4623-ba59-f151e90c2291" />


I figured one would always want it as it enables the native shadow, but winit's doc warns `Enabling the shadow causes a thin 1px line to appear on the top of the window.`. Not sure whether it means the thin line visible here already because it looks rather natural to me but also isn't just on top but all around 🤷 