### PR TITLE
Automation for eframe apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "automation_demo"
+version = "0.1.0"
+dependencies = [
+ "eframe",
+ "env_logger",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3813,6 +3821,15 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "remote_kittest"
+version = "0.1.0"
+dependencies = [
+ "eframe",
+ "egui_kittest",
+ "env_logger",
+]
 
 [[package]]
 name = "renderdoc-sys"

--- a/crates/eframe/src/automation.rs
+++ b/crates/eframe/src/automation.rs
@@ -1,0 +1,192 @@
+//! Programmatic automation channel for a running eframe application.
+//!
+//! [`AutomationHandle`] lets code running outside the winit event loop
+//! (typically a test thread) feed synthetic [`egui::Event`]s into the next
+//! frame and observe the AccessKit [`accesskit::TreeUpdate`]s produced by
+//! egui. This is the building block used by `egui_kittest`'s remote harness
+//! to drive a real eframe app the same way it drives the in-process test
+//! harness.
+//!
+//! Enable it by attaching an [`AutomationHandle`] to
+//! [`crate::NativeOptions::automation`] before calling [`crate::run_native`].
+
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+
+use egui::accesskit;
+
+/// Shared automation channel between a running eframe app and an external
+/// controller (e.g. a test thread).
+///
+/// Construct one with [`AutomationHandle::new`], hand a `clone` of the `Arc`
+/// to [`crate::NativeOptions::automation`], and keep another `Arc` in the
+/// controller for [`AutomationHandle::push_event`] /
+/// [`AutomationHandle::wait_for_tree_update`].
+pub struct AutomationHandle {
+    /// Events pushed by the controller. Drained into [`egui::RawInput`] each
+    /// frame by `egui_winit::State::take_egui_input`.
+    pub(crate) events: Arc<Mutex<Vec<egui::Event>>>,
+
+    /// Queue of AccessKit updates emitted by egui this frame and earlier,
+    /// in arrival order. Tree updates are *incremental* — consumers must
+    /// apply them in order to a `kittest::State` (or equivalent) to track
+    /// the current accessibility tree.
+    tree_updates: Mutex<Vec<accesskit::TreeUpdate>>,
+
+    /// Signalled whenever a new tree update lands in `tree_updates`.
+    tree_update_signal: Condvar,
+
+    /// The egui context of the running app. Populated by eframe on the first
+    /// frame. The controller uses this to request repaints between input
+    /// pushes.
+    ctx: OnceLock<egui::Context>,
+}
+
+impl AutomationHandle {
+    /// Create a fresh automation handle. Wrap in an `Arc` and pass via
+    /// [`crate::NativeOptions::automation`].
+    pub fn new() -> Self {
+        Self {
+            events: Arc::new(Mutex::new(Vec::new())),
+            tree_updates: Mutex::new(Vec::new()),
+            tree_update_signal: Condvar::new(),
+            ctx: OnceLock::new(),
+        }
+    }
+
+    /// Queue a synthetic event to be delivered on the next frame, then
+    /// request a repaint so the running app picks it up.
+    pub fn push_event(&self, event: egui::Event) {
+        self.events
+            .lock()
+            .expect("events lock poisoned")
+            .push(event);
+        if let Some(ctx) = self.ctx.get() {
+            ctx.request_repaint();
+        }
+    }
+
+    /// Queue multiple events in a single batch (cheaper than calling
+    /// [`Self::push_event`] in a loop).
+    pub fn push_events(&self, events: impl IntoIterator<Item = egui::Event>) {
+        let mut queue = self.events.lock().expect("events lock poisoned");
+        queue.extend(events);
+        drop(queue);
+        if let Some(ctx) = self.ctx.get() {
+            ctx.request_repaint();
+        }
+    }
+
+    /// Drain and return all AccessKit tree updates that have been produced
+    /// since the last drain, in arrival order. Returns an empty `Vec` if
+    /// none are pending.
+    pub fn drain_tree_updates(&self) -> Vec<accesskit::TreeUpdate> {
+        std::mem::take(&mut *self.tree_updates.lock().expect("tree lock poisoned"))
+    }
+
+    /// Block the calling thread until at least one tree update is available,
+    /// then drain and return all queued updates in order.
+    ///
+    /// Returns `None` if `timeout` elapses with no update.
+    pub fn wait_for_tree_update(
+        &self,
+        timeout: std::time::Duration,
+    ) -> Option<Vec<accesskit::TreeUpdate>> {
+        let mut updates = self.tree_updates.lock().expect("tree lock poisoned");
+        if !updates.is_empty() {
+            return Some(std::mem::take(&mut *updates));
+        }
+        let (mut updates, wait) = self
+            .tree_update_signal
+            .wait_timeout(updates, timeout)
+            .expect("tree lock poisoned");
+        if wait.timed_out() && updates.is_empty() {
+            None
+        } else {
+            Some(std::mem::take(&mut *updates))
+        }
+    }
+
+    /// Returns the running app's [`egui::Context`], if the first frame has
+    /// already run. Use this to call [`egui::Context::request_repaint`] or
+    /// inspect input/output state directly.
+    pub fn ctx(&self) -> Option<egui::Context> {
+        self.ctx.get().cloned()
+    }
+
+    /// Block until the eframe app has rendered its first frame and the
+    /// [`egui::Context`] is available. Returns `None` on timeout.
+    pub fn wait_for_ctx(&self, timeout: std::time::Duration) -> Option<egui::Context> {
+        let deadline = std::time::Instant::now() + timeout;
+        // The context is populated alongside the first tree update, so we
+        // can piggyback on the same condvar.
+        let mut updates = self.tree_updates.lock().expect("tree lock poisoned");
+        while self.ctx.get().is_none() {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                return None;
+            }
+            let (next, wait) = self
+                .tree_update_signal
+                .wait_timeout(updates, remaining)
+                .expect("tree lock poisoned");
+            updates = next;
+            if wait.timed_out() && self.ctx.get().is_none() {
+                return None;
+            }
+        }
+        self.ctx.get().cloned()
+    }
+
+    /// Wire this handle to an `egui_winit::State`: share the event queue so
+    /// pushed events reach the next frame's [`egui::RawInput`], install an
+    /// AccessKit observer that forwards every tree update back here, and
+    /// attach the running [`egui::Context`] so the controller can request
+    /// repaints.
+    pub(crate) fn install(
+        self: &Arc<Self>,
+        egui_winit: &mut egui_winit::State,
+        egui_ctx: &egui::Context,
+    ) {
+        egui_winit.set_external_event_sink(Arc::clone(&self.events));
+        let observer = Arc::clone(self);
+        egui_winit.set_accesskit_observer(Some(Box::new(move |update| {
+            observer._push_tree_update(update.clone());
+        })));
+        let _ = self.ctx.set(egui_ctx.clone());
+        // Wake any thread blocked in `wait_for_ctx`.
+        self.tree_update_signal.notify_all();
+    }
+
+    /// Called by eframe internals on every frame that produces an AccessKit
+    /// update. Not part of the public API.
+    #[doc(hidden)]
+    pub fn _push_tree_update(&self, update: accesskit::TreeUpdate) {
+        self.tree_updates
+            .lock()
+            .expect("tree lock poisoned")
+            .push(update);
+        self.tree_update_signal.notify_all();
+    }
+}
+
+impl Default for AutomationHandle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for AutomationHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AutomationHandle")
+            .field(
+                "queued_events",
+                &self.events.lock().map(|q| q.len()).unwrap_or(0),
+            )
+            .field(
+                "queued_tree_updates",
+                &self.tree_updates.lock().map(|q| q.len()).unwrap_or(0),
+            )
+            .field("ctx_attached", &self.ctx.get().is_some())
+            .finish()
+    }
+}

--- a/crates/eframe/src/automation.rs
+++ b/crates/eframe/src/automation.rs
@@ -10,9 +10,12 @@
 //! Enable it by attaching an [`AutomationHandle`] to
 //! [`crate::NativeOptions::automation`] before calling [`crate::run_native`].
 
-use std::sync::{Arc, Condvar, Mutex, OnceLock};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
 
 use egui::accesskit;
+use egui::mutex::Mutex;
+use parking_lot::Condvar;
 
 /// Shared automation channel between a running eframe app and an external
 /// controller (e.g. a test thread).
@@ -56,10 +59,7 @@ impl AutomationHandle {
     /// Queue a synthetic event to be delivered on the next frame, then
     /// request a repaint so the running app picks it up.
     pub fn push_event(&self, event: egui::Event) {
-        self.events
-            .lock()
-            .expect("events lock poisoned")
-            .push(event);
+        self.events.lock().push(event);
         if let Some(ctx) = self.ctx.get() {
             ctx.request_repaint();
         }
@@ -68,9 +68,7 @@ impl AutomationHandle {
     /// Queue multiple events in a single batch (cheaper than calling
     /// [`Self::push_event`] in a loop).
     pub fn push_events(&self, events: impl IntoIterator<Item = egui::Event>) {
-        let mut queue = self.events.lock().expect("events lock poisoned");
-        queue.extend(events);
-        drop(queue);
+        self.events.lock().extend(events);
         if let Some(ctx) = self.ctx.get() {
             ctx.request_repaint();
         }
@@ -80,25 +78,19 @@ impl AutomationHandle {
     /// since the last drain, in arrival order. Returns an empty `Vec` if
     /// none are pending.
     pub fn drain_tree_updates(&self) -> Vec<accesskit::TreeUpdate> {
-        std::mem::take(&mut *self.tree_updates.lock().expect("tree lock poisoned"))
+        std::mem::take(&mut *self.tree_updates.lock())
     }
 
     /// Block the calling thread until at least one tree update is available,
     /// then drain and return all queued updates in order.
     ///
     /// Returns `None` if `timeout` elapses with no update.
-    pub fn wait_for_tree_update(
-        &self,
-        timeout: std::time::Duration,
-    ) -> Option<Vec<accesskit::TreeUpdate>> {
-        let mut updates = self.tree_updates.lock().expect("tree lock poisoned");
+    pub fn wait_for_tree_update(&self, timeout: Duration) -> Option<Vec<accesskit::TreeUpdate>> {
+        let mut updates = self.tree_updates.lock();
         if !updates.is_empty() {
             return Some(std::mem::take(&mut *updates));
         }
-        let (mut updates, wait) = self
-            .tree_update_signal
-            .wait_timeout(updates, timeout)
-            .expect("tree lock poisoned");
+        let wait = self.tree_update_signal.wait_for(&mut updates, timeout);
         if wait.timed_out() && updates.is_empty() {
             None
         } else {
@@ -115,21 +107,17 @@ impl AutomationHandle {
 
     /// Block until the eframe app has rendered its first frame and the
     /// [`egui::Context`] is available. Returns `None` on timeout.
-    pub fn wait_for_ctx(&self, timeout: std::time::Duration) -> Option<egui::Context> {
-        let deadline = std::time::Instant::now() + timeout;
+    pub fn wait_for_ctx(&self, timeout: Duration) -> Option<egui::Context> {
+        let deadline = Instant::now() + timeout;
         // The context is populated alongside the first tree update, so we
         // can piggyback on the same condvar.
-        let mut updates = self.tree_updates.lock().expect("tree lock poisoned");
+        let mut updates = self.tree_updates.lock();
         while self.ctx.get().is_none() {
-            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
                 return None;
             }
-            let (next, wait) = self
-                .tree_update_signal
-                .wait_timeout(updates, remaining)
-                .expect("tree lock poisoned");
-            updates = next;
+            let wait = self.tree_update_signal.wait_for(&mut updates, remaining);
             if wait.timed_out() && self.ctx.get().is_none() {
                 return None;
             }
@@ -161,10 +149,7 @@ impl AutomationHandle {
     /// update. Not part of the public API.
     #[doc(hidden)]
     pub fn _push_tree_update(&self, update: accesskit::TreeUpdate) {
-        self.tree_updates
-            .lock()
-            .expect("tree lock poisoned")
-            .push(update);
+        self.tree_updates.lock().push(update);
         self.tree_update_signal.notify_all();
     }
 }
@@ -178,15 +163,9 @@ impl Default for AutomationHandle {
 impl std::fmt::Debug for AutomationHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AutomationHandle")
-            .field(
-                "queued_events",
-                &self.events.lock().map(|q| q.len()).unwrap_or(0),
-            )
-            .field(
-                "queued_tree_updates",
-                &self.tree_updates.lock().map(|q| q.len()).unwrap_or(0),
-            )
+            .field("queued_events", &self.events.lock().len())
+            .field("queued_tree_updates", &self.tree_updates.lock().len())
             .field("ctx_attached", &self.ctx.get().is_some())
-            .finish()
+            .finish_non_exhaustive()
     }
 }

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -381,7 +381,7 @@ pub struct NativeOptions {
     #[cfg(target_os = "android")]
     pub android_app: Option<winit::platform::android::activity::AndroidApp>,
 
-    /// Optional handle for programmatic automation (e.g. test harnesses).
+    /// Optional handle for programmatic app control.
     ///
     /// When set, the running app will:
     /// - drain [`egui::Event`]s pushed via
@@ -389,9 +389,6 @@ pub struct NativeOptions {
     ///   [`egui::RawInput`], and
     /// - forward every AccessKit [`egui::accesskit::TreeUpdate`] it produces
     ///   to the handle so an external controller can observe the UI state.
-    ///
-    /// Hand the same `Arc<AutomationHandle>` to your controller thread to
-    /// drive the app from outside the winit event loop.
     #[cfg(feature = "accesskit")]
     pub automation: Option<std::sync::Arc<crate::automation::AutomationHandle>>,
 }

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -380,6 +380,20 @@ pub struct NativeOptions {
     /// [`with_android_app`]: winit::platform::android::EventLoopBuilderExtAndroid::with_android_app
     #[cfg(target_os = "android")]
     pub android_app: Option<winit::platform::android::activity::AndroidApp>,
+
+    /// Optional handle for programmatic automation (e.g. test harnesses).
+    ///
+    /// When set, the running app will:
+    /// - drain [`egui::Event`]s pushed via
+    ///   [`crate::AutomationHandle::push_event`] into the next frame's
+    ///   [`egui::RawInput`], and
+    /// - forward every AccessKit [`egui::accesskit::TreeUpdate`] it produces
+    ///   to the handle so an external controller can observe the UI state.
+    ///
+    /// Hand the same `Arc<AutomationHandle>` to your controller thread to
+    /// drive the app from outside the winit event loop.
+    #[cfg(feature = "accesskit")]
+    pub automation: Option<std::sync::Arc<crate::automation::AutomationHandle>>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -404,6 +418,9 @@ impl Clone for NativeOptions {
 
             #[cfg(target_os = "android")]
             android_app: self.android_app.clone(),
+
+            #[cfg(feature = "accesskit")]
+            automation: self.automation.clone(),
 
             ..*self
         }
@@ -448,6 +465,9 @@ impl Default for NativeOptions {
 
             #[cfg(target_os = "android")]
             android_app: None,
+
+            #[cfg(feature = "accesskit")]
+            automation: None,
         }
     }
 }

--- a/crates/eframe/src/lib.rs
+++ b/crates/eframe/src/lib.rs
@@ -166,6 +166,12 @@ mod epi;
 // Re-export everything in `epi` so `eframe` users don't have to care about what `epi` is:
 pub use epi::*;
 
+#[cfg(all(not(target_arch = "wasm32"), feature = "accesskit"))]
+pub mod automation;
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "accesskit"))]
+pub use automation::AutomationHandle;
+
 pub(crate) mod stopwatch;
 
 // ----------------------------------------------------------------------------
@@ -191,6 +197,7 @@ pub use web::{WebLogger, WebRunner};
 mod native;
 
 #[cfg(target_os = "macos")]
+#[cfg(any(feature = "glow", feature = "wgpu_no_default_features"))]
 pub use native::macos::WindowChromeMetrics;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -283,6 +283,10 @@ impl<'app> GlowWinitApp<'app> {
             } = viewport
             {
                 egui_winit.init_accesskit(event_loop, window, event_loop_proxy);
+
+                if let Some(automation) = self.native_options.automation.as_ref() {
+                    automation.install(egui_winit, &integration.egui_ctx);
+                }
             }
         }
 

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -287,6 +287,10 @@ impl<'app> WgpuWinitApp<'app> {
         {
             let event_loop_proxy = self.repaint_proxy.lock().clone();
             egui_winit.init_accesskit(event_loop, &window, event_loop_proxy);
+
+            if let Some(automation) = self.native_options.automation.as_ref() {
+                automation.install(&mut egui_winit, &egui_ctx);
+            }
         }
 
         let app_creator = std::mem::take(&mut self.app_creator)

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -11,6 +11,7 @@
 
 #[cfg(target_os = "windows")]
 use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "accesskit")]
 pub use accesskit_winit;
@@ -19,6 +20,13 @@ pub use egui;
 use egui::accesskit;
 use egui::{Pos2, Rect, Theme, Vec2, ViewportBuilder, ViewportCommand, ViewportId, ViewportInfo};
 pub use winit;
+
+/// Callback invoked with every AccessKit [`accesskit::TreeUpdate`] produced by egui.
+///
+/// Used by [`State`] to expose the AccessKit tree to external automation
+/// consumers in addition to the platform accessibility adapter.
+#[cfg(feature = "accesskit")]
+pub type AccessKitObserver = Box<dyn Fn(&accesskit::TreeUpdate) + Send>;
 
 pub mod clipboard;
 mod safe_area;
@@ -112,6 +120,16 @@ pub struct State {
     /// for details.
     #[cfg(target_os = "windows")]
     pressed_processed_physical_keys: HashSet<winit::keyboard::PhysicalKey>,
+
+    /// Shared queue of events pushed by automation/test code outside the
+    /// winit loop. Drained into [`egui::RawInput::events`] each frame by
+    /// [`State::take_egui_input`].
+    external_events: Arc<Mutex<Vec<egui::Event>>>,
+
+    /// Optional observer called with every AccessKit tree update produced by
+    /// egui, in addition to forwarding the update to the platform adapter.
+    #[cfg(feature = "accesskit")]
+    accesskit_observer: Option<AccessKitObserver>,
 }
 
 impl State {
@@ -156,6 +174,10 @@ impl State {
             ime_rect_px: None,
             #[cfg(target_os = "windows")]
             pressed_processed_physical_keys: HashSet::new(),
+
+            external_events: Arc::new(Mutex::new(Vec::new())),
+            #[cfg(feature = "accesskit")]
+            accesskit_observer: None,
         };
 
         slf.egui_input
@@ -264,7 +286,47 @@ impl State {
             .or_default()
             .native_pixels_per_point = Some(window.scale_factor() as f32);
 
+        // Drain any events that automation/test code pushed via the
+        // external event sink (see [`State::external_event_sink`]).
+        if let Ok(mut external) = self.external_events.lock()
+            && !external.is_empty()
+        {
+            self.egui_input.events.append(&mut external);
+        }
+
         self.egui_input.take()
+    }
+
+    /// Handle to a shared queue of [`egui::Event`]s. Events pushed here from
+    /// any thread are appended to [`egui::RawInput::events`] the next time
+    /// [`State::take_egui_input`] is called, before the input is handed to
+    /// egui for the frame.
+    ///
+    /// This is the splice point used by automation/test harnesses to inject
+    /// synthetic input into a running app.
+    #[inline]
+    pub fn external_event_sink(&self) -> Arc<Mutex<Vec<egui::Event>>> {
+        Arc::clone(&self.external_events)
+    }
+
+    /// Replace the external event sink (see [`Self::external_event_sink`])
+    /// with a queue supplied by the caller. Allows an automation handle to
+    /// share its `Arc<Mutex<Vec<Event>>>` with this viewport.
+    #[inline]
+    pub fn set_external_event_sink(&mut self, sink: Arc<Mutex<Vec<egui::Event>>>) {
+        self.external_events = sink;
+    }
+
+    /// Install (or remove) a callback that observes every AccessKit
+    /// [`accesskit::TreeUpdate`] produced by egui for this viewport.
+    ///
+    /// The callback runs on the UI thread inside
+    /// [`State::handle_platform_output`], in addition to the update being
+    /// routed to the platform accessibility adapter (if any). Keep work in
+    /// the callback short — e.g. clone the update onto a queue.
+    #[cfg(feature = "accesskit")]
+    pub fn set_accesskit_observer(&mut self, observer: Option<AccessKitObserver>) {
+        self.accesskit_observer = observer;
     }
 
     /// Call this when there is a new event.
@@ -1100,11 +1162,15 @@ impl State {
         }
 
         #[cfg(feature = "accesskit")]
-        if let Some(accesskit) = self.accesskit.as_mut()
-            && let Some(update) = accesskit_update
-        {
-            profiling::scope!("accesskit");
-            accesskit.update_if_active(|| update);
+        if let Some(update) = accesskit_update {
+            if let Some(observer) = self.accesskit_observer.as_ref() {
+                profiling::scope!("accesskit_observer");
+                observer(&update);
+            }
+            if let Some(accesskit) = self.accesskit.as_mut() {
+                profiling::scope!("accesskit");
+                accesskit.update_if_active(|| update);
+            }
         }
 
         #[cfg(not(feature = "accesskit"))]

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -11,13 +11,14 @@
 
 #[cfg(target_os = "windows")]
 use std::collections::HashSet;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 #[cfg(feature = "accesskit")]
 pub use accesskit_winit;
 pub use egui;
 #[cfg(feature = "accesskit")]
 use egui::accesskit;
+use egui::mutex::Mutex;
 use egui::{Pos2, Rect, Theme, Vec2, ViewportBuilder, ViewportCommand, ViewportId, ViewportInfo};
 pub use winit;
 
@@ -288,9 +289,8 @@ impl State {
 
         // Drain any events that automation/test code pushed via the
         // external event sink (see [`State::external_event_sink`]).
-        if let Ok(mut external) = self.external_events.lock()
-            && !external.is_empty()
-        {
+        let mut external = self.external_events.lock();
+        if !external.is_empty() {
             self.egui_input.events.append(&mut external);
         }
 

--- a/crates/egui_kittest/Cargo.toml
+++ b/crates/egui_kittest/Cargo.toml
@@ -27,7 +27,7 @@ wgpu = ["dep:egui-wgpu", "dep:pollster", "dep:image", "dep:wgpu", "eframe?/wgpu"
 snapshot = ["dep:dify", "dep:image", "dep:open", "dep:tempfile", "image/png"]
 
 ## Allows testing eframe::App
-eframe = ["dep:eframe", "eframe/accesskit"]
+eframe = ["dep:eframe", "eframe/accesskit", "eframe/wgpu"]
 
 # This is just so it compiles with `--all-features` on Linux
 x11 = ["eframe?/x11"]

--- a/crates/egui_kittest/src/lib.rs
+++ b/crates/egui_kittest/src/lib.rs
@@ -14,9 +14,9 @@ pub use crate::snapshot::*;
 mod app_kind;
 mod config;
 mod node;
-mod renderer;
 #[cfg(feature = "eframe")]
 mod remote;
+mod renderer;
 #[cfg(feature = "wgpu")]
 mod texture_to_image;
 #[cfg(feature = "wgpu")]

--- a/crates/egui_kittest/src/lib.rs
+++ b/crates/egui_kittest/src/lib.rs
@@ -29,7 +29,7 @@ pub use {
 };
 
 #[cfg(feature = "eframe")]
-pub use crate::remote::{RemoteHarness, RemoteHarnessError};
+pub use crate::remote::{AutomationHarness, AutomationHarnessError};
 
 use std::{
     fmt::{Debug, Display, Formatter},

--- a/crates/egui_kittest/src/lib.rs
+++ b/crates/egui_kittest/src/lib.rs
@@ -15,6 +15,8 @@ mod app_kind;
 mod config;
 mod node;
 mod renderer;
+#[cfg(feature = "eframe")]
+mod remote;
 #[cfg(feature = "wgpu")]
 mod texture_to_image;
 #[cfg(feature = "wgpu")]
@@ -25,6 +27,9 @@ pub use {
     self::{builder::*, node::*, renderer::*},
     kittest,
 };
+
+#[cfg(feature = "eframe")]
+pub use crate::remote::{RemoteHarness, RemoteHarnessError};
 
 use std::{
     fmt::{Debug, Display, Formatter},

--- a/crates/egui_kittest/src/remote.rs
+++ b/crates/egui_kittest/src/remote.rs
@@ -106,12 +106,21 @@ impl AutomationHarness {
     ///
     /// Blocks until the app has produced its first AccessKit tree update or
     /// [`AutomationHarness::frame_timeout`] elapses.
+    ///
+    /// # Errors
+    /// Returns [`AutomationHarnessError::TimedOut`] if the remote app does
+    /// not produce its first AccessKit tree update within the default
+    /// timeout.
     pub fn attach(handle: Arc<AutomationHandle>) -> Result<Self, AutomationHarnessError> {
         Self::attach_with_timeout(handle, DEFAULT_FRAME_TIMEOUT)
     }
 
     /// Like [`Self::attach`], but with a caller-supplied timeout for the
     /// initial wait.
+    ///
+    /// # Errors
+    /// Returns [`AutomationHarnessError::TimedOut`] if the remote app does
+    /// not produce its first AccessKit tree update within `timeout`.
     pub fn attach_with_timeout(
         handle: Arc<AutomationHandle>,
         timeout: Duration,

--- a/crates/egui_kittest/src/remote.rs
+++ b/crates/egui_kittest/src/remote.rs
@@ -1,0 +1,287 @@
+//! Drive a real eframe app through [`eframe::AutomationHandle`].
+//!
+//! Where [`crate::Harness`] owns its own [`egui::Context`] and runs the
+//! frame loop itself, [`RemoteHarness`] talks to an eframe app running on
+//! another thread (typically the main thread) via an automation channel.
+//! The query API is the same — `harness.get_by_label("Save").click()` etc.
+//! — but every event is sent to the live app and every observation comes
+//! from real AccessKit tree updates the app produced.
+//!
+//! See `examples/remote_kittest/` for an end-to-end usage.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use eframe::AutomationHandle;
+use egui::mutex::Mutex;
+use kittest::Queryable;
+
+use crate::node::{EventQueue, EventType, Node};
+
+/// Default deadline used to wait for tree updates produced by the remote
+/// app. Frames are typically delivered within a few milliseconds; the
+/// generous deadline tolerates the OS scheduler and the first-frame setup.
+const DEFAULT_FRAME_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Idle interval used by [`RemoteHarness::run`] to decide that the remote
+/// app has settled. If no new tree updates arrive within this window after
+/// the last one, the run loop returns.
+const DEFAULT_SETTLE_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Errors returned by [`RemoteHarness::attach`] and friends.
+#[derive(Debug)]
+pub enum RemoteHarnessError {
+    /// The remote app never produced its first AccessKit tree update within
+    /// the timeout, so the harness has nothing to query.
+    TimedOut,
+}
+
+impl std::fmt::Display for RemoteHarnessError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TimedOut => write!(
+                f,
+                "Timed out waiting for the remote eframe app to produce its first AccessKit tree"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RemoteHarnessError {}
+
+/// Harness that drives a running eframe app through an
+/// [`eframe::AutomationHandle`].
+///
+/// Build one by handing the same `Arc<AutomationHandle>` to both
+/// [`eframe::NativeOptions::automation`] and [`RemoteHarness::attach`]:
+///
+/// ```no_run
+/// # use std::sync::Arc;
+/// # use eframe::AutomationHandle;
+/// # use egui_kittest::{RemoteHarness, kittest::Queryable as _};
+/// let automation = Arc::new(AutomationHandle::new());
+/// let controller = Arc::clone(&automation);
+///
+/// // Spawn the app on another thread (or run it on the main thread and
+/// // drive it from a worker — eframe must be on the main thread on macOS).
+/// std::thread::spawn(move || {
+///     let opts = eframe::NativeOptions {
+///         automation: Some(controller),
+///         ..Default::default()
+///     };
+///     eframe::run_native(
+///         "my app",
+///         opts,
+///         Box::new(|_cc| Ok(Box::<MyApp>::default())),
+///     ).unwrap();
+/// });
+///
+/// let mut harness = RemoteHarness::attach(automation).unwrap();
+/// harness.get_by_label("Click me").click();
+/// harness.run();
+/// assert!(harness.query_by_label("Clicked!").is_some());
+/// # #[derive(Default)] struct MyApp;
+/// # impl eframe::App for MyApp {
+/// #     fn ui(&mut self, _: &mut eframe::egui::Ui, _: &mut eframe::Frame) {}
+/// # }
+/// ```
+pub struct RemoteHarness {
+    handle: Arc<AutomationHandle>,
+    ctx: egui::Context,
+    kittest: kittest::State,
+    queue: EventQueue,
+    frame_timeout: Duration,
+    settle_timeout: Duration,
+    max_steps: u32,
+}
+
+impl std::fmt::Debug for RemoteHarness {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.kittest.fmt(f)
+    }
+}
+
+impl RemoteHarness {
+    /// Attach to a running eframe app via the shared automation handle.
+    ///
+    /// Blocks until the app has produced its first AccessKit tree update or
+    /// [`RemoteHarness::frame_timeout`] elapses.
+    pub fn attach(handle: Arc<AutomationHandle>) -> Result<Self, RemoteHarnessError> {
+        Self::attach_with_timeout(handle, DEFAULT_FRAME_TIMEOUT)
+    }
+
+    /// Like [`Self::attach`], but with a caller-supplied timeout for the
+    /// initial wait.
+    pub fn attach_with_timeout(
+        handle: Arc<AutomationHandle>,
+        timeout: Duration,
+    ) -> Result<Self, RemoteHarnessError> {
+        let deadline = Instant::now() + timeout;
+        let ctx = handle
+            .wait_for_ctx(timeout)
+            .ok_or(RemoteHarnessError::TimedOut)?;
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let updates = handle
+            .wait_for_tree_update(remaining)
+            .ok_or(RemoteHarnessError::TimedOut)?;
+        let mut iter = updates.into_iter();
+        let first = iter.next().ok_or(RemoteHarnessError::TimedOut)?;
+        let mut kittest = kittest::State::new(first);
+        for update in iter {
+            kittest.update(update);
+        }
+        Ok(Self {
+            handle,
+            ctx,
+            kittest,
+            queue: Mutex::new(Vec::new()),
+            frame_timeout: DEFAULT_FRAME_TIMEOUT,
+            settle_timeout: DEFAULT_SETTLE_TIMEOUT,
+            max_steps: 32,
+        })
+    }
+
+    /// How long each [`Self::step`] waits for the remote app to deliver at
+    /// least one tree update after the injected events. Default: 2s.
+    #[inline]
+    pub fn frame_timeout(&self) -> Duration {
+        self.frame_timeout
+    }
+
+    /// Configure the per-step frame timeout (see [`Self::frame_timeout`]).
+    #[inline]
+    pub fn set_frame_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.frame_timeout = timeout;
+        self
+    }
+
+    /// How long [`Self::run`] waits for further tree updates after the last
+    /// one before declaring the app settled. Default: 100ms.
+    #[inline]
+    pub fn settle_timeout(&self) -> Duration {
+        self.settle_timeout
+    }
+
+    /// Configure the settle timeout (see [`Self::settle_timeout`]).
+    #[inline]
+    pub fn set_settle_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.settle_timeout = timeout;
+        self
+    }
+
+    /// Maximum frames [`Self::run`] will pull before giving up. Default: 32.
+    #[inline]
+    pub fn max_steps(&self) -> u32 {
+        self.max_steps
+    }
+
+    /// Configure the maximum number of frames [`Self::run`] will pull.
+    #[inline]
+    pub fn set_max_steps(&mut self, max_steps: u32) -> &mut Self {
+        self.max_steps = max_steps;
+        self
+    }
+
+    /// Returns the remote app's [`egui::Context`].
+    #[inline]
+    pub fn ctx(&self) -> &egui::Context {
+        &self.ctx
+    }
+
+    /// Returns the automation handle this harness drives.
+    #[inline]
+    pub fn handle(&self) -> &Arc<AutomationHandle> {
+        &self.handle
+    }
+
+    /// Returns the underlying [`kittest::State`].
+    #[inline]
+    pub fn kittest_state(&self) -> &kittest::State {
+        &self.kittest
+    }
+
+    /// The root node of the remote AccessKit tree. Returned [`Node`]s push
+    /// events into this harness's queue, the same way they do for
+    /// [`crate::Harness`].
+    pub fn root(&self) -> Node<'_> {
+        Node {
+            accesskit_node: self.kittest.root(),
+            queue: &self.queue,
+        }
+    }
+
+    /// Drain queued events, deliver them to the remote app, and pull the
+    /// resulting tree updates back into [`Self::kittest_state`].
+    ///
+    /// Returns the number of tree updates that landed during this step.
+    pub fn step(&mut self) -> usize {
+        let pending = std::mem::take(&mut *self.queue.lock());
+        let mut events: Vec<egui::Event> = Vec::with_capacity(pending.len());
+        for entry in pending {
+            match entry {
+                EventType::Event(e) => events.push(e),
+                // Standalone modifier updates are a Harness-only concept
+                // (they mutate `RawInput.modifiers` directly). The remote
+                // egui-winit derives modifier state from real key events,
+                // and every modifier-flavored event we ship (e.g. an
+                // `Event::Key` with `modifiers: COMMAND`) carries the
+                // modifiers in its own field, so we can safely drop these.
+                EventType::Modifiers(_) => {}
+            }
+        }
+        if !events.is_empty() {
+            self.handle.push_events(events);
+        }
+        // Make sure the remote loop wakes up — push_events also calls this,
+        // but call it explicitly so a no-event step still forces a frame.
+        self.ctx.request_repaint();
+
+        let Some(updates) = self.handle.wait_for_tree_update(self.frame_timeout) else {
+            return 0;
+        };
+        let count = updates.len();
+        for update in updates {
+            self.kittest.update(update);
+        }
+        count
+    }
+
+    /// Run [`Self::step`] until the remote app stops emitting tree updates
+    /// for [`Self::settle_timeout`], or [`Self::max_steps`] is exhausted.
+    ///
+    /// Returns the number of steps that ran.
+    pub fn run(&mut self) -> u32 {
+        let mut steps = 0;
+        // First step: deliver any queued events.
+        let first_count = self.step();
+        steps += 1;
+        if first_count == 0 {
+            return steps;
+        }
+        // Subsequent steps: drain follow-up frames the app produces on its
+        // own (animations, async load completions, etc.). Stop when the
+        // app stops talking back.
+        while steps < self.max_steps {
+            let Some(updates) = self.handle.wait_for_tree_update(self.settle_timeout) else {
+                break;
+            };
+            if updates.is_empty() {
+                break;
+            }
+            for update in updates {
+                self.kittest.update(update);
+            }
+            steps += 1;
+        }
+        steps
+    }
+}
+
+impl<'tree, 'node> Queryable<'tree, 'node, Node<'tree>> for RemoteHarness
+where
+    'node: 'tree,
+{
+    fn queryable_node(&'node self) -> Node<'tree> {
+        self.root()
+    }
+}

--- a/crates/egui_kittest/src/remote.rs
+++ b/crates/egui_kittest/src/remote.rs
@@ -1,7 +1,7 @@
 //! Drive a real eframe app through [`eframe::AutomationHandle`].
 //!
 //! Where [`crate::Harness`] owns its own [`egui::Context`] and runs the
-//! frame loop itself, [`RemoteHarness`] talks to an eframe app running on
+//! frame loop itself, [`AutomationHarness`] talks to an eframe app running on
 //! another thread (typically the main thread) via an automation channel.
 //! The query API is the same — `harness.get_by_label("Save").click()` etc.
 //! — but every event is sent to the live app and every observation comes
@@ -23,20 +23,20 @@ use crate::node::{EventQueue, EventType, Node};
 /// generous deadline tolerates the OS scheduler and the first-frame setup.
 const DEFAULT_FRAME_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// Idle interval used by [`RemoteHarness::run`] to decide that the remote
+/// Idle interval used by [`AutomationHarness::run`] to decide that the remote
 /// app has settled. If no new tree updates arrive within this window after
 /// the last one, the run loop returns.
 const DEFAULT_SETTLE_TIMEOUT: Duration = Duration::from_millis(100);
 
-/// Errors returned by [`RemoteHarness::attach`] and friends.
+/// Errors returned by [`AutomationHarness::attach`] and friends.
 #[derive(Debug)]
-pub enum RemoteHarnessError {
+pub enum AutomationHarnessError {
     /// The remote app never produced its first AccessKit tree update within
     /// the timeout, so the harness has nothing to query.
     TimedOut,
 }
 
-impl std::fmt::Display for RemoteHarnessError {
+impl std::fmt::Display for AutomationHarnessError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::TimedOut => write!(
@@ -47,18 +47,18 @@ impl std::fmt::Display for RemoteHarnessError {
     }
 }
 
-impl std::error::Error for RemoteHarnessError {}
+impl std::error::Error for AutomationHarnessError {}
 
 /// Harness that drives a running eframe app through an
 /// [`eframe::AutomationHandle`].
 ///
 /// Build one by handing the same `Arc<AutomationHandle>` to both
-/// [`eframe::NativeOptions::automation`] and [`RemoteHarness::attach`]:
+/// [`eframe::NativeOptions::automation`] and [`AutomationHarness::attach`]:
 ///
 /// ```no_run
 /// # use std::sync::Arc;
 /// # use eframe::AutomationHandle;
-/// # use egui_kittest::{RemoteHarness, kittest::Queryable as _};
+/// # use egui_kittest::{AutomationHarness, kittest::Queryable as _};
 /// let automation = Arc::new(AutomationHandle::new());
 /// let controller = Arc::clone(&automation);
 ///
@@ -76,7 +76,7 @@ impl std::error::Error for RemoteHarnessError {}
 ///     ).unwrap();
 /// });
 ///
-/// let mut harness = RemoteHarness::attach(automation).unwrap();
+/// let mut harness = AutomationHarness::attach(automation).unwrap();
 /// harness.get_by_label("Click me").click();
 /// harness.run();
 /// assert!(harness.query_by_label("Clicked!").is_some());
@@ -85,7 +85,7 @@ impl std::error::Error for RemoteHarnessError {}
 /// #     fn ui(&mut self, _: &mut eframe::egui::Ui, _: &mut eframe::Frame) {}
 /// # }
 /// ```
-pub struct RemoteHarness {
+pub struct AutomationHarness {
     handle: Arc<AutomationHandle>,
     ctx: egui::Context,
     kittest: kittest::State,
@@ -95,18 +95,18 @@ pub struct RemoteHarness {
     max_steps: u32,
 }
 
-impl std::fmt::Debug for RemoteHarness {
+impl std::fmt::Debug for AutomationHarness {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.kittest.fmt(f)
     }
 }
 
-impl RemoteHarness {
+impl AutomationHarness {
     /// Attach to a running eframe app via the shared automation handle.
     ///
     /// Blocks until the app has produced its first AccessKit tree update or
-    /// [`RemoteHarness::frame_timeout`] elapses.
-    pub fn attach(handle: Arc<AutomationHandle>) -> Result<Self, RemoteHarnessError> {
+    /// [`AutomationHarness::frame_timeout`] elapses.
+    pub fn attach(handle: Arc<AutomationHandle>) -> Result<Self, AutomationHarnessError> {
         Self::attach_with_timeout(handle, DEFAULT_FRAME_TIMEOUT)
     }
 
@@ -115,17 +115,17 @@ impl RemoteHarness {
     pub fn attach_with_timeout(
         handle: Arc<AutomationHandle>,
         timeout: Duration,
-    ) -> Result<Self, RemoteHarnessError> {
+    ) -> Result<Self, AutomationHarnessError> {
         let deadline = Instant::now() + timeout;
         let ctx = handle
             .wait_for_ctx(timeout)
-            .ok_or(RemoteHarnessError::TimedOut)?;
+            .ok_or(AutomationHarnessError::TimedOut)?;
         let remaining = deadline.saturating_duration_since(Instant::now());
         let updates = handle
             .wait_for_tree_update(remaining)
-            .ok_or(RemoteHarnessError::TimedOut)?;
+            .ok_or(AutomationHarnessError::TimedOut)?;
         let mut iter = updates.into_iter();
-        let first = iter.next().ok_or(RemoteHarnessError::TimedOut)?;
+        let first = iter.next().ok_or(AutomationHarnessError::TimedOut)?;
         let mut kittest = kittest::State::new(first);
         for update in iter {
             kittest.update(update);
@@ -250,6 +250,7 @@ impl RemoteHarness {
     /// for [`Self::settle_timeout`], or [`Self::max_steps`] is exhausted.
     ///
     /// Returns the number of steps that ran.
+    // TODO: find a way to wait for the app to settle even if it renders continuously
     pub fn run(&mut self) -> u32 {
         let mut steps = 0;
         // First step: deliver any queued events.
@@ -277,7 +278,7 @@ impl RemoteHarness {
     }
 }
 
-impl<'tree, 'node> Queryable<'tree, 'node, Node<'tree>> for RemoteHarness
+impl<'tree, 'node> Queryable<'tree, 'node, Node<'tree>> for AutomationHarness
 where
     'node: 'tree,
 {

--- a/examples/automation_demo/Cargo.toml
+++ b/examples/automation_demo/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "automation_demo"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+edition = "2024"
+rust-version = "1.92"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+eframe = { workspace = true, features = ["default"] }
+env_logger = { workspace = true, features = ["auto-color", "humantime"] }

--- a/examples/automation_demo/src/main.rs
+++ b/examples/automation_demo/src/main.rs
@@ -6,7 +6,7 @@
 //! frame. After a few seconds it requests the app to close.
 
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
-#![expect(rustdoc::missing_crate_level_docs)]
+#![expect(clippy::print_stderr)]
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -20,7 +20,10 @@ fn main() -> eframe::Result {
     let controller_handle = Arc::clone(&automation);
 
     // The controller drives the app from outside the winit event loop.
-    let controller = std::thread::spawn(move || run_controller(controller_handle));
+    let controller = std::thread::Builder::new()
+        .name("controller".into())
+        .spawn(move || run_controller(&controller_handle))
+        .expect("failed to spawn controller thread");
 
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default().with_inner_size([320.0, 200.0]),
@@ -59,7 +62,7 @@ impl eframe::App for DemoApp {
     }
 }
 
-fn run_controller(handle: Arc<AutomationHandle>) {
+fn run_controller(handle: &AutomationHandle) {
     let Some(ctx) = handle.wait_for_ctx(Duration::from_secs(5)) else {
         eprintln!("controller: timed out waiting for app to start");
         return;
@@ -103,10 +106,7 @@ fn run_controller(handle: Arc<AutomationHandle>) {
         // Wait until the app paints the frame that consumed our events.
         if let Some(updates) = handle.wait_for_tree_update(Duration::from_secs(1)) {
             let nodes: usize = updates.iter().map(|u| u.nodes.len()).sum();
-            eprintln!(
-                "controller: press #{presses} delivered, observed {} node update(s)",
-                nodes
-            );
+            eprintln!("controller: press #{presses} delivered, observed {nodes} node update(s)");
         }
     }
 

--- a/examples/automation_demo/src/main.rs
+++ b/examples/automation_demo/src/main.rs
@@ -78,7 +78,7 @@ fn run_controller(handle: Arc<AutomationHandle>) {
 
     let started = Instant::now();
     let mut presses = 0;
-    while started.elapsed() < Duration::from_secs(5) {
+    while started.elapsed() < Duration::from_secs(20) {
         std::thread::sleep(Duration::from_millis(700));
 
         // Push a synthetic Space press + release.

--- a/examples/automation_demo/src/main.rs
+++ b/examples/automation_demo/src/main.rs
@@ -1,0 +1,115 @@
+//! Minimal end-to-end demo of [`eframe::AutomationHandle`].
+//!
+//! Runs a tiny eframe app on the main thread and a controller on a spawned
+//! thread. The controller injects synthetic `Space` key presses into the
+//! running app and prints how many AccessKit nodes the app exposes each
+//! frame. After a few seconds it requests the app to close.
+
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+#![expect(rustdoc::missing_crate_level_docs)]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use eframe::{AutomationHandle, egui};
+
+fn main() -> eframe::Result {
+    env_logger::init();
+
+    let automation = Arc::new(AutomationHandle::new());
+    let controller_handle = Arc::clone(&automation);
+
+    // The controller drives the app from outside the winit event loop.
+    let controller = std::thread::spawn(move || run_controller(controller_handle));
+
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([320.0, 200.0]),
+        automation: Some(automation),
+        ..Default::default()
+    };
+    let result = eframe::run_native(
+        "Automation demo",
+        options,
+        Box::new(|_cc| Ok(Box::<DemoApp>::default())),
+    );
+
+    // Make sure we wait for the controller to finish even on error so its log
+    // lines don't get cut off.
+    controller.join().ok();
+    result
+}
+
+#[derive(Default)]
+struct DemoApp {
+    counter: u32,
+}
+
+impl eframe::App for DemoApp {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        // Increment whenever Space is pressed — including events the
+        // controller pushed via AutomationHandle.
+        if ui.input(|i| i.key_pressed(egui::Key::Space)) {
+            self.counter += 1;
+        }
+        egui::CentralPanel::default().show_inside(ui, |ui| {
+            ui.heading("Automation demo");
+            ui.label(format!("Space presses received: {}", self.counter));
+            ui.label("Press Space (or wait for the controller).");
+        });
+    }
+}
+
+fn run_controller(handle: Arc<AutomationHandle>) {
+    let Some(ctx) = handle.wait_for_ctx(Duration::from_secs(5)) else {
+        eprintln!("controller: timed out waiting for app to start");
+        return;
+    };
+    eprintln!("controller: app started; ctx attached");
+
+    // Drain the initial tree update(s).
+    if let Some(updates) = handle.wait_for_tree_update(Duration::from_secs(2)) {
+        let total_nodes: usize = updates.iter().map(|u| u.nodes.len()).sum();
+        eprintln!(
+            "controller: first {} tree update(s) carried {} node(s)",
+            updates.len(),
+            total_nodes
+        );
+    }
+
+    let started = Instant::now();
+    let mut presses = 0;
+    while started.elapsed() < Duration::from_secs(5) {
+        std::thread::sleep(Duration::from_millis(700));
+
+        // Push a synthetic Space press + release.
+        handle.push_events([
+            egui::Event::Key {
+                key: egui::Key::Space,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: egui::Modifiers::NONE,
+            },
+            egui::Event::Key {
+                key: egui::Key::Space,
+                physical_key: None,
+                pressed: false,
+                repeat: false,
+                modifiers: egui::Modifiers::NONE,
+            },
+        ]);
+        presses += 1;
+
+        // Wait until the app paints the frame that consumed our events.
+        if let Some(updates) = handle.wait_for_tree_update(Duration::from_secs(1)) {
+            let nodes: usize = updates.iter().map(|u| u.nodes.len()).sum();
+            eprintln!(
+                "controller: press #{presses} delivered, observed {} node update(s)",
+                nodes
+            );
+        }
+    }
+
+    eprintln!("controller: done, asking app to close");
+    ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+}

--- a/examples/remote_kittest/Cargo.toml
+++ b/examples/remote_kittest/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "remote_kittest"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+edition = "2024"
+rust-version = "1.92"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+eframe = { workspace = true, features = ["default"] }
+egui_kittest = { workspace = true, features = ["eframe"] }
+env_logger = { workspace = true, features = ["auto-color", "humantime"] }

--- a/examples/remote_kittest/src/main.rs
+++ b/examples/remote_kittest/src/main.rs
@@ -6,7 +6,7 @@
 //! — all against the live, visible app rather than a test-only harness.
 
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
-#![expect(rustdoc::missing_crate_level_docs)]
+#![expect(clippy::print_stderr)]
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -20,7 +20,10 @@ fn main() -> eframe::Result {
     let automation = Arc::new(AutomationHandle::new());
     let controller_handle = Arc::clone(&automation);
 
-    let controller = std::thread::spawn(move || run_controller(controller_handle));
+    let controller = std::thread::Builder::new()
+        .name("controller".into())
+        .spawn(move || run_controller(controller_handle))
+        .expect("failed to spawn controller thread");
 
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default().with_inner_size([320.0, 200.0]),

--- a/examples/remote_kittest/src/main.rs
+++ b/examples/remote_kittest/src/main.rs
@@ -1,0 +1,87 @@
+//! End-to-end demo of [`egui_kittest::RemoteHarness`] driving a real eframe app.
+//!
+//! The eframe app runs on the main thread (required on macOS). A controller
+//! thread attaches a [`RemoteHarness`] to the running app, queries the
+//! AccessKit tree by label, clicks a button, and asserts the counter went up
+//! — all against the live, visible app rather than a test-only harness.
+
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+#![expect(rustdoc::missing_crate_level_docs)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use eframe::{AutomationHandle, egui};
+use egui_kittest::{RemoteHarness, kittest::Queryable as _};
+
+fn main() -> eframe::Result {
+    env_logger::init();
+
+    let automation = Arc::new(AutomationHandle::new());
+    let controller_handle = Arc::clone(&automation);
+
+    let controller = std::thread::spawn(move || run_controller(controller_handle));
+
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([320.0, 200.0]),
+        automation: Some(automation),
+        ..Default::default()
+    };
+    let result = eframe::run_native(
+        "RemoteHarness demo",
+        options,
+        Box::new(|_cc| Ok(Box::<DemoApp>::default())),
+    );
+
+    controller.join().ok();
+    result
+}
+
+#[derive(Default)]
+struct DemoApp {
+    counter: u32,
+}
+
+impl eframe::App for DemoApp {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show_inside(ui, |ui| {
+            ui.heading("RemoteHarness demo");
+            ui.label(format!("Counter: {}", self.counter));
+            if ui.button("Increment").clicked() {
+                self.counter += 1;
+            }
+        });
+    }
+}
+
+fn run_controller(handle: Arc<AutomationHandle>) {
+    let mut harness = match RemoteHarness::attach(handle) {
+        Ok(h) => h,
+        Err(err) => {
+            eprintln!("controller: attach failed: {err}");
+            return;
+        }
+    };
+    eprintln!("controller: attached to remote app");
+
+    // The Increment button uses AccessKit click, which works without
+    // synthesizing pointer coordinates (and is robust to layout changes).
+    for i in 1..=3 {
+        harness.get_by_label("Increment").click_accesskit();
+        harness.run();
+        eprintln!("controller: click #{i} delivered");
+    }
+
+    // Verify via the AccessKit tree that the label updated to "Counter: 3".
+    if harness.query_by_label("Counter: 3").is_some() {
+        eprintln!("controller: ✓ AccessKit reports Counter: 3");
+    } else {
+        eprintln!("controller: ✗ expected label not found; dumping tree:\n{harness:#?}");
+    }
+
+    std::thread::sleep(Duration::from_millis(500));
+    eprintln!("controller: done, asking app to close");
+    harness
+        .ctx()
+        .send_viewport_cmd(egui::ViewportCommand::Close);
+}

--- a/examples/remote_kittest/src/main.rs
+++ b/examples/remote_kittest/src/main.rs
@@ -1,7 +1,7 @@
-//! End-to-end demo of [`egui_kittest::RemoteHarness`] driving a real eframe app.
+//! End-to-end demo of [`egui_kittest::AutomationHarness`] driving a real eframe app.
 //!
 //! The eframe app runs on the main thread (required on macOS). A controller
-//! thread attaches a [`RemoteHarness`] to the running app, queries the
+//! thread attaches a [`AutomationHarness`] to the running app, queries the
 //! AccessKit tree by label, clicks a button, and asserts the counter went up
 //! — all against the live, visible app rather than a test-only harness.
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use eframe::{AutomationHandle, egui};
-use egui_kittest::{RemoteHarness, kittest::Queryable as _};
+use egui_kittest::{AutomationHarness, kittest::Queryable as _};
 
 fn main() -> eframe::Result {
     env_logger::init();
@@ -28,7 +28,7 @@ fn main() -> eframe::Result {
         ..Default::default()
     };
     let result = eframe::run_native(
-        "RemoteHarness demo",
+        "AutomationHarness demo",
         options,
         Box::new(|_cc| Ok(Box::<DemoApp>::default())),
     );
@@ -45,7 +45,7 @@ struct DemoApp {
 impl eframe::App for DemoApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show_inside(ui, |ui| {
-            ui.heading("RemoteHarness demo");
+            ui.heading("AutomationHarness demo");
             ui.label(format!("Counter: {}", self.counter));
             if ui.button("Increment").clicked() {
                 self.counter += 1;
@@ -55,24 +55,27 @@ impl eframe::App for DemoApp {
 }
 
 fn run_controller(handle: Arc<AutomationHandle>) {
-    let mut harness = match RemoteHarness::attach(handle) {
-        Ok(h) => h,
-        Err(err) => {
-            eprintln!("controller: attach failed: {err}");
-            return;
-        }
+    let Ok(mut harness) = AutomationHarness::attach(handle) else {
+        eprintln!("controller: attach failed: timed out");
+        return;
     };
     eprintln!("controller: attached to remote app");
 
     // The Increment button uses AccessKit click, which works without
     // synthesizing pointer coordinates (and is robust to layout changes).
-    for i in 1..=3 {
-        harness.get_by_label("Increment").click_accesskit();
+    for i in 1..=10 {
+        let Some(button) = harness.query_by_label("Increment") else {
+            eprintln!("controller: increment button not found");
+            return;
+        };
+        button.click_accesskit();
         harness.run();
+        std::thread::sleep(Duration::from_millis(500));
         eprintln!("controller: click #{i} delivered");
     }
 
     // Verify via the AccessKit tree that the label updated to "Counter: 3".
+    // TODO: this will fail.
     if harness.query_by_label("Counter: 3").is_some() {
         eprintln!("controller: ✓ AccessKit reports Counter: 3");
     } else {


### PR DESCRIPTION
Programmatic control support for eframe apps. Think Kittest, but for the actual app.

- Adds `AutomationHandle` which exposes ways to inject events and get AccessKit updates.
- Adds `AutomationHarness` which looks like Kittest.

TODO:
- [ ] The AutomationHarness is fully vibed and needs serious review for timeout-based functions



<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

