### PR TITLE
Slow down animation time from 0.1s to 0.2s

### DIFF
--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1401,7 +1401,7 @@ impl Default for Style {
             spacing: Spacing::default(),
             interaction: Interaction::default(),
             visuals: Visuals::default(),
-            animation_time: 6.0 / 60.0, // If we make this too slow, it will be too obvious that our panel animations look like shit :(
+            animation_time: 0.2,
             #[cfg(debug_assertions)]
             debug: Default::default(),
             explanation_tooltips: false,


### PR DESCRIPTION
We now have easings, and we have nice animations of panels. I think 100ms feels a bit rushed now. 200ms feels nicer.