### PR TITLE
Exclude `take_app` from `wasm32` in `egui_kittest`

### DIFF
--- a/crates/egui_kittest/src/app_kind.rs
+++ b/crates/egui_kittest/src/app_kind.rs
@@ -10,6 +10,7 @@ type AppKindUi<'a> = Box<dyn FnMut(&mut egui::Ui) + 'a>;
 #[cfg(feature = "eframe")]
 pub(crate) struct AppKindEframe<State> {
     pub get_app: fn(&mut State) -> &mut dyn eframe::App,
+    #[cfg(not(target_arch = "wasm32"))]
     pub take_app: fn(State) -> Box<dyn eframe::App>,
     pub frame: eframe::Frame,
 }

--- a/crates/egui_kittest/src/builder.rs
+++ b/crates/egui_kittest/src/builder.rs
@@ -211,6 +211,7 @@ impl<State> HarnessBuilder<State> {
 
         let kind = AppKind::Eframe(AppKindEframe {
             get_app: |state| state,
+            #[cfg(not(target_arch = "wasm32"))]
             take_app: |state| Box::new(state),
             frame,
         });

--- a/crates/egui_kittest/src/lib.rs
+++ b/crates/egui_kittest/src/lib.rs
@@ -711,7 +711,7 @@ impl<'a, State> Harness<'a, State> {
     /// Then write a `fn main()` in the test file that invokes your test directly.
     ///
     /// See also: <https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-harness-field>
-    #[cfg(feature = "eframe")]
+    #[cfg(all(feature = "eframe", not(target_arch = "wasm32")))]
     #[deprecated = "Only for debugging, don't commit this."]
     pub fn spawn_eframe_app(self)
     where


### PR DESCRIPTION
Otherwise `egui` won't compile for `wasm32` targets anymore.

A bit odd that this was not caught in CI.