### PR TITLE
Rename `Panel` methods

### DIFF
--- a/crates/eframe/src/lib.rs
+++ b/crates/eframe/src/lib.rs
@@ -45,7 +45,7 @@
 //!
 //! impl eframe::App for MyEguiApp {
 //!    fn ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
-//!        egui::CentralPanel::default().show_inside(ui, |ui| {
+//!        egui::CentralPanel::default().show(ui, |ui| {
 //!            ui.heading("Hello World!");
 //!        });
 //!    }
@@ -244,7 +244,7 @@ pub mod icon_data;
 ///
 /// impl eframe::App for MyEguiApp {
 ///    fn ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
-///        egui::CentralPanel::default().show_inside(ui, |ui| {
+///        egui::CentralPanel::default().show(ui, |ui| {
 ///            ui.heading("Hello World!");
 ///        });
 ///    }
@@ -334,7 +334,7 @@ pub fn run_native_ext(
 ///
 /// impl eframe::App for MyEguiApp {
 ///    fn ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
-///        egui::CentralPanel::default().show_inside(ui, |ui| {
+///        egui::CentralPanel::default().show(ui, |ui| {
 ///            ui.heading("Hello World!");
 ///        });
 ///    }
@@ -425,7 +425,7 @@ fn init_native(app_name: &str, native_options: &mut NativeOptions) -> Renderer {
 ///     let options = eframe::NativeOptions::default();
 ///     eframe::run_ui_native("My egui App", options, move |ui, _frame| {
 ///         // Wrap everything in a CentralPanel so we get some margins and a background color:
-///         egui::CentralPanel::default().show_inside(ui, |ui| {
+///         egui::CentralPanel::default().show(ui, |ui| {
 ///             ui.heading("My egui Application");
 ///             ui.horizontal(|ui| {
 ///                 let name_label = ui.label("Your name: ");

--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -160,6 +160,15 @@ impl PanelSide {
 ///
 /// See the [module level docs](crate::containers::panel) for more details.
 ///
+/// # Showing the panel
+///
+/// Pick the variant that matches the behavior you want:
+///
+/// * [`Panel::show`]: always show the panel.
+/// * [`Panel::show_collapsible`]: show or hide the panel, with a slide animation in between.
+/// * [`Panel::show_switched`]: animate between two different panels:
+///   a thin/collapsed one and a thick/expanded one.
+///
 /// ```
 /// # egui::__run_test_ui(|ui| {
 /// egui::Panel::left("my_left_panel").show(ui, |ui| {

--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -162,12 +162,12 @@ impl PanelSide {
 ///
 /// ```
 /// # egui::__run_test_ui(|ui| {
-/// egui::Panel::left("my_left_panel").show_inside(ui, |ui| {
+/// egui::Panel::left("my_left_panel").show(ui, |ui| {
 ///    ui.label("Hello World!");
 /// });
 /// # });
 /// ```
-#[must_use = "You should call .show_inside()"]
+#[must_use = "You should call .show()"]
 pub struct Panel {
     side: PanelSide,
     id: Id,
@@ -186,13 +186,13 @@ pub struct Panel {
     /// `1.0` = panel fully visible (the normal case),
     /// `0.0` = panel fully slid off-screen toward its fixed edge.
     ///
-    /// Used by [`Self::show_animated_inside`] to animate a panel sliding in/out.
+    /// Used by [`Self::show_collapsible`] to animate a panel sliding in/out.
     /// While `slide_fraction != 1.0` the panel does _not_ persist its [`PanelState`].
     slide_fraction: f32,
 
     /// Override for the [`Id`] under which the resize-handle widget is registered.
     ///
-    /// Used by [`Self::show_animated_between_inside`] so the collapsed and
+    /// Used by [`Self::show_switched`] so the collapsed and
     /// expanded panels share a single resize widget — that way a drag on either
     /// one can flip `is_expanded` and the gesture survives the swap.
     resize_id_source: Option<Id>,
@@ -200,7 +200,7 @@ pub struct Panel {
     /// Size below which drag-to-collapse fires, when set.
     ///
     /// Defaults to `outer_size_range.min`. Used by
-    /// [`Self::show_animated_between_inside`] to set the threshold at the
+    /// [`Self::show_switched`] to set the threshold at the
     /// collapsed panel's size, so the swap happens exactly when the slide
     /// matches the collapsed size visually.
     collapse_threshold: Option<f32>,
@@ -351,12 +351,18 @@ impl Panel {
 // Public showing methods
 impl Panel {
     /// Show the panel inside a [`Ui`].
+    pub fn show<R>(self, ui: &mut Ui, add_contents: impl FnOnce(&mut Ui) -> R) -> InnerResponse<R> {
+        self.show_inside_dyn(ui, None, Box::new(add_contents))
+    }
+
+    /// Renamed to [`Self::show`].
+    #[deprecated = "Renamed to `show`"]
     pub fn show_inside<R>(
         self,
         ui: &mut Ui,
         add_contents: impl FnOnce(&mut Ui) -> R,
     ) -> InnerResponse<R> {
-        self.show_inside_dyn(ui, None, Box::new(add_contents))
+        self.show(ui, add_contents)
     }
 
     /// Show the panel if `*is_expanded` is `true`,
@@ -369,7 +375,7 @@ impl Panel {
     /// `is_expanded` is taken by `&mut` so the panel can flip it to `false` when
     /// the user drags the resize handle past the panel's minimum size, and back
     /// to `true` if the user drags the handle outward while the panel is closed.
-    pub fn show_animated_inside<R>(
+    pub fn show_collapsible<R>(
         self,
         ui: &mut Ui,
         is_expanded: &mut bool,
@@ -406,6 +412,17 @@ impl Panel {
         };
 
         Some(panel.show_inside_dyn(ui, Some(is_expanded), Box::new(add_contents)))
+    }
+
+    /// Renamed to [`Self::show_collapsible`].
+    #[deprecated = "Renamed to `show_collapsible`"]
+    pub fn show_animated_inside<R>(
+        self,
+        ui: &mut Ui,
+        is_expanded: &mut bool,
+        add_contents: impl FnOnce(&mut Ui) -> R,
+    ) -> Option<InnerResponse<R>> {
+        self.show_collapsible(ui, is_expanded, add_contents)
     }
 
     /// Show either a collapsed or expanded panel, with a nice slide animation between.
@@ -445,7 +462,7 @@ impl Panel {
     /// let expanded = egui::Panel::top("top_expanded")
     ///     .resizable(true)
     ///     .default_size(120.0);
-    /// egui::Panel::show_animated_between_inside(
+    /// egui::Panel::show_switched(
     ///     ui,
     ///     &mut is_expanded,
     ///     collapsed,
@@ -462,7 +479,7 @@ impl Panel {
     /// ui.toggle_value(&mut is_expanded, "Expand");
     /// # });
     /// ```
-    pub fn show_animated_between_inside<R>(
+    pub fn show_switched<R>(
         ui: &mut Ui,
         is_expanded: &mut bool,
         collapsed_panel: Self,
@@ -471,7 +488,7 @@ impl Panel {
     ) -> InnerResponse<R> {
         debug_assert!(
             collapsed_panel.id != expanded_panel.id,
-            "show_animated_between_inside: the collapsed and expanded panels must have distinct ids \
+            "show_switched: the collapsed and expanded panels must have distinct ids \
              (their persisted sizes are stored per-id, and sharing one id would let the collapsed \
              size overwrite the expanded size)."
         );
@@ -548,6 +565,24 @@ impl Panel {
             )
         }
     }
+
+    /// Renamed to [`Self::show_switched`].
+    #[deprecated = "Renamed to `show_switched`"]
+    pub fn show_animated_between_inside<R>(
+        ui: &mut Ui,
+        is_expanded: &mut bool,
+        collapsed_panel: Self,
+        expanded_panel: Self,
+        add_contents: impl FnOnce(&mut Ui, bool) -> R,
+    ) -> InnerResponse<R> {
+        Self::show_switched(
+            ui,
+            is_expanded,
+            collapsed_panel,
+            expanded_panel,
+            add_contents,
+        )
+    }
 }
 
 // Private methods to support the various show methods
@@ -555,7 +590,7 @@ impl Panel {
     /// Show the panel inside a [`Ui`].
     ///
     /// `is_expanded` is `Some` for the animated entry points
-    /// ([`Self::show_animated_inside`], [`Self::show_animated_between_inside`]);
+    /// ([`Self::show_collapsible`], [`Self::show_switched`]);
     /// when present, dragging the resize handle past the minimum size collapses
     /// the panel by setting `*is_expanded = false`.
     fn show_inside_dyn<'c, R>(
@@ -608,7 +643,7 @@ impl Panel {
                 if let Some(is_expanded) = is_expanded {
                     // Drag-to-collapse: shrink past the threshold → close.
                     // The threshold defaults to `min_size`, but
-                    // `show_animated_between_inside` overrides it to the
+                    // `show_switched` overrides it to the
                     // collapsed panel's size so the swap happens exactly when
                     // the drag visually crosses the collapsed size.
                     // Use `raw_outer_size` (pre-clamp) so a tight `exact_size`
@@ -620,7 +655,7 @@ impl Panel {
                     }
                     // Drag-to-expand: pointer pulled outward past `max_size` → open.
                     // Triggers when this panel is acting as the collapsed view of
-                    // `show_animated_between_inside`, with `resize_id_source` set
+                    // `show_switched`, with `resize_id_source` set
                     // to the expanded panel's id. `raw_outer_size` is required
                     // because `outer_size` is clamped to `max` and would never
                     // exceed it (so `exact_size` panels couldn't otherwise expand).
@@ -834,7 +869,7 @@ impl Panel {
         let amount = ui.style().interaction.resize_grab_radius_side * self.side.axis_unit();
 
         // Use `resize_id_source` so collapsed/expanded panels in
-        // `show_animated_between_inside` share one resize widget.
+        // `show_switched` share one resize widget.
         let resize_id = self.resize_id_source.unwrap_or(self.id).with("__resize");
         let resize_rect = Rect::from_x_y_ranges(resize_x, resize_y).expand2(amount);
         let resize_response = ui.interact(resize_rect, resize_id, Sense::drag());
@@ -843,7 +878,7 @@ impl Panel {
     }
 
     fn cursor_icon(&self, outer_size: f32) -> CursorIcon {
-        // When this panel is the collapsed view of `show_animated_between_inside`
+        // When this panel is the collapsed view of `show_switched`
         // (`resize_id_source` is set), dragging past `max_size` triggers
         // drag-to-expand — so the user can always grow further. Treat the cap
         // as `INFINITY` for cursor purposes, otherwise we'd advertise
@@ -889,7 +924,7 @@ impl Panel {
 
     /// Register the resize-handle widget under this `Id` instead of `self.id`.
     ///
-    /// Used by [`Self::show_animated_between_inside`] to share one widget across
+    /// Used by [`Self::show_switched`] to share one widget across
     /// the collapsed and expanded panels.
     #[inline]
     fn with_resize_id_source(mut self, id: Id) -> Self {
@@ -924,15 +959,15 @@ impl Panel {
 ///
 /// ```
 /// # egui::__run_test_ui(|ui| {
-/// egui::Panel::top("my_panel").show_inside(ui, |ui| {
+/// egui::Panel::top("my_panel").show(ui, |ui| {
 ///    ui.label("Hello World! From `Panel`, that must be before `CentralPanel`!");
 /// });
-/// egui::CentralPanel::default().show_inside(ui, |ui| {
+/// egui::CentralPanel::default().show(ui, |ui| {
 ///    ui.label("Hello World!");
 /// });
 /// # });
 /// ```
-#[must_use = "You should call .show_inside()"]
+#[must_use = "You should call .show()"]
 #[derive(Default)]
 pub struct CentralPanel {
     frame: Option<Frame>,
@@ -959,12 +994,18 @@ impl CentralPanel {
     }
 
     /// Show the panel inside a [`Ui`].
+    pub fn show<R>(self, ui: &mut Ui, add_contents: impl FnOnce(&mut Ui) -> R) -> InnerResponse<R> {
+        self.show_inside_dyn(ui, Box::new(add_contents))
+    }
+
+    /// Renamed to [`Self::show`].
+    #[deprecated = "Renamed to `show`"]
     pub fn show_inside<R>(
         self,
         ui: &mut Ui,
         add_contents: impl FnOnce(&mut Ui) -> R,
     ) -> InnerResponse<R> {
-        self.show_inside_dyn(ui, Box::new(add_contents))
+        self.show(ui, add_contents)
     }
 
     /// Show the panel inside a [`Ui`].

--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -424,14 +424,18 @@ impl Panel {
     }
 
     /// Renamed to [`Self::show_collapsible`].
+    ///
+    /// Note: [`Self::show_collapsible`] takes `is_expanded` by `&mut` so it can
+    /// flip it to `false` when the user drags the panel closed. To opt in,
+    /// migrate to the new name.
     #[deprecated = "Renamed to `show_collapsible`"]
     pub fn show_animated_inside<R>(
         self,
         ui: &mut Ui,
-        is_expanded: &mut bool,
+        mut is_expanded: bool,
         add_contents: impl FnOnce(&mut Ui) -> R,
     ) -> Option<InnerResponse<R>> {
-        self.show_collapsible(ui, is_expanded, add_contents)
+        self.show_collapsible(ui, &mut is_expanded, add_contents)
     }
 
     /// Show either a collapsed or expanded panel, with a nice slide animation between.
@@ -576,20 +580,26 @@ impl Panel {
     }
 
     /// Renamed to [`Self::show_switched`].
+    ///
+    /// Note: [`Self::show_switched`] takes `is_expanded` by `&mut` (to allow
+    /// drag-to-collapse / drag-to-expand to flip it) and passes a `bool` to
+    /// `add_contents` instead of an `f32` animation fraction. To opt in,
+    /// migrate to the new name.
     #[deprecated = "Renamed to `show_switched`"]
     pub fn show_animated_between_inside<R>(
         ui: &mut Ui,
-        is_expanded: &mut bool,
+        is_expanded: bool,
         collapsed_panel: Self,
         expanded_panel: Self,
-        add_contents: impl FnOnce(&mut Ui, bool) -> R,
+        add_contents: impl FnOnce(&mut Ui, f32) -> R,
     ) -> InnerResponse<R> {
+        let mut is_expanded = is_expanded;
         Self::show_switched(
             ui,
-            is_expanded,
+            &mut is_expanded,
             collapsed_panel,
             expanded_panel,
-            add_contents,
+            |ui, expanded| add_contents(ui, if expanded { 1.0 } else { 0.0 }),
         )
     }
 }

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -694,7 +694,7 @@ impl ContextImpl {
 /// loop {
 ///     let raw_input = egui::RawInput::default();
 ///     let full_output = ctx.run_ui(raw_input, |ui| {
-///         egui::CentralPanel::default().show_inside(ui, |ui| {
+///         egui::CentralPanel::default().show(ui, |ui| {
 ///             ui.label("Hello world!");
 ///             if ui.button("Click me").clicked() {
 ///                 // take some action here

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -113,7 +113,7 @@
 //!     let raw_input: egui::RawInput = gather_input();
 //!
 //!     let full_output = ctx.run_ui(raw_input, |ui| {
-//!         egui::CentralPanel::default().show_inside(ui, |ui| {
+//!         egui::CentralPanel::default().show(ui, |ui| {
 //!             ui.label("Hello world!");
 //!             if ui.button("Click me").clicked() {
 //!                 // take some action here

--- a/crates/egui_demo_app/src/accessibility_inspector.rs
+++ b/crates/egui_demo_app/src/accessibility_inspector.rs
@@ -87,13 +87,13 @@ impl egui::Plugin for AccessibilityInspectorPlugin {
 
         ui.enable_accesskit();
 
-        Panel::right(Self::id()).show_inside(ui, |ui| {
+        Panel::right(Self::id()).show(ui, |ui| {
             ui.heading("🔎 AccessKit Inspector");
             if let Some(selected_node) = self.selected_node {
                 Panel::bottom(Self::id().with("details_panel"))
                     .frame(Frame::new())
                     .show_separator_line(false)
-                    .show_inside(ui, |ui| {
+                    .show(ui, |ui| {
                         self.selection_ui(ui, selected_node);
                     });
             }

--- a/crates/egui_demo_app/src/apps/custom3d_glow.rs
+++ b/crates/egui_demo_app/src/apps/custom3d_glow.rs
@@ -25,7 +25,7 @@ impl Custom3d {
 impl crate::DemoApp for Custom3d {
     fn demo_ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         // TODO(emilk): Use `ScrollArea::content_margin`
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             egui::ScrollArea::both().auto_shrink(false).show(ui, |ui| {
                 ui.horizontal(|ui| {
                     ui.spacing_mut().item_spacing.x = 0.0;

--- a/crates/egui_demo_app/src/apps/custom3d_wgpu.rs
+++ b/crates/egui_demo_app/src/apps/custom3d_wgpu.rs
@@ -103,7 +103,7 @@ impl Custom3d {
 impl crate::DemoApp for Custom3d {
     fn demo_ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         // TODO(emilk): Use `ScrollArea::content_margin`
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             egui::ScrollArea::both().auto_shrink(false).show(ui, |ui| {
                 ui.horizontal(|ui| {
                     ui.spacing_mut().item_spacing.x = 0.0;

--- a/crates/egui_demo_app/src/apps/http_app.rs
+++ b/crates/egui_demo_app/src/apps/http_app.rs
@@ -61,14 +61,14 @@ impl Default for HttpApp {
 
 impl crate::DemoApp for HttpApp {
     fn demo_ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
-        egui::Panel::bottom("http_bottom").show_inside(ui, |ui| {
+        egui::Panel::bottom("http_bottom").show(ui, |ui| {
             let layout = egui::Layout::top_down(egui::Align::Center).with_main_justify(true);
             ui.allocate_ui_with_layout(ui.available_size(), layout, |ui| {
                 ui.add(egui_demo_lib::egui_github_link_file!())
             })
         });
 
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             let prev_url = self.url.clone();
             let trigger_fetch = ui_url(ui, frame, &mut self.url);
 

--- a/crates/egui_demo_app/src/apps/image_viewer.rs
+++ b/crates/egui_demo_app/src/apps/image_viewer.rs
@@ -50,7 +50,7 @@ impl Default for ImageViewer {
 
 impl crate::DemoApp for ImageViewer {
     fn demo_ui(&mut self, ui: &mut egui::Ui, _: &mut eframe::Frame) {
-        egui::Panel::top("url bar").show_inside(ui, |ui| {
+        egui::Panel::top("url bar").show(ui, |ui| {
             ui.horizontal_centered(|ui| {
                 let label = ui.label("URI:");
                 ui.text_edit_singleline(&mut self.uri_edit_text)
@@ -71,7 +71,7 @@ impl crate::DemoApp for ImageViewer {
             });
         });
 
-        egui::Panel::left("controls").show_inside(ui, |ui| {
+        egui::Panel::left("controls").show(ui, |ui| {
             // uv
             ui.label("UV");
             ui.add(Slider::new(&mut self.image_options.uv.min.x, 0.0..=1.0).text("min x"));
@@ -197,7 +197,7 @@ impl crate::DemoApp for ImageViewer {
             }
         });
 
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             egui::ScrollArea::both().show(ui, |ui| {
                 let mut image = egui::Image::from_uri(&self.current_uri);
                 image = image.uv(self.image_options.uv);

--- a/crates/egui_demo_app/src/wrap_app.rs
+++ b/crates/egui_demo_app/src/wrap_app.rs
@@ -64,7 +64,7 @@ pub struct ColorTestApp {
 
 impl DemoApp for ColorTestApp {
     fn demo_ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             if frame.is_web() {
                 ui.label(
                         "NOTE: Some old browsers stuck on WebGL1 without sRGB support will not pass the color test.",
@@ -302,7 +302,7 @@ impl eframe::App for WrapApp {
         let mut cmd = Command::Nothing;
         egui::Panel::top("wrap_app_top_bar")
             .frame(egui::Frame::new().inner_margin(4))
-            .show_inside(ui, |ui| {
+            .show(ui, |ui| {
                 ui.horizontal_wrapped(|ui| {
                     ui.visuals_mut().button_frame = false;
                     self.bar_contents(ui, frame, &mut cmd);
@@ -311,7 +311,7 @@ impl eframe::App for WrapApp {
 
         self.state.backend_panel.update(ui.ctx(), frame);
 
-        egui::CentralPanel::no_frame().show_inside(ui, |ui| {
+        egui::CentralPanel::no_frame().show(ui, |ui| {
             if !is_mobile(ui.ctx()) {
                 cmd = self.backend_panel(ui, frame);
             }
@@ -350,7 +350,7 @@ impl WrapApp {
 
         egui::Panel::left("backend_panel")
             .resizable(false)
-            .show_animated_inside(ui, &mut is_open, |ui| {
+            .show_collapsible(ui, &mut is_open, |ui| {
                 ui.add_space(4.0);
                 ui.vertical_centered(|ui| {
                     ui.heading("💻 Backend");

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -245,7 +245,7 @@ impl DemoWindows {
     }
 
     fn mobile_top_bar(&mut self, ui: &mut egui::Ui) {
-        egui::Panel::top("menu_bar").show_inside(ui, |ui| {
+        egui::Panel::top("menu_bar").show(ui, |ui| {
             menu::MenuBar::new()
                 .config(menu::MenuConfig::new().style(StyleModifier::default()))
                 .ui(ui, |ui| {
@@ -275,7 +275,7 @@ impl DemoWindows {
             .resizable(false)
             .default_size(160.0)
             .min_size(160.0)
-            .show_inside(ui, |ui| {
+            .show(ui, |ui| {
                 ui.vertical_centered_justified(|ui| {
                     ui.add_space(4.0);
                     ui.add(
@@ -296,7 +296,7 @@ impl DemoWindows {
                 self.demo_list_ui(ui);
             });
 
-        egui::Panel::top("menu_bar").show_inside(ui, |ui| {
+        egui::Panel::top("menu_bar").show(ui, |ui| {
             menu::MenuBar::new().ui(ui, |ui| {
                 file_menu_button(ui);
             });

--- a/crates/egui_demo_lib/src/demo/extra_viewport.rs
+++ b/crates/egui_demo_lib/src/demo/extra_viewport.rs
@@ -27,7 +27,7 @@ impl crate::Demo for ExtraViewport {
                     // Not a real viewport
                     ui.label("This egui integration does not support multiple viewports");
                 } else {
-                    egui::CentralPanel::default().show_inside(ui, |ui| {
+                    egui::CentralPanel::default().show(ui, |ui| {
                         viewport_content(ui, open);
                     });
                 }

--- a/crates/egui_demo_lib/src/demo/panels.rs
+++ b/crates/egui_demo_lib/src/demo/panels.rs
@@ -49,7 +49,7 @@ impl crate::View for Panels {
         egui::Panel::top("top_panel")
             .resizable(true)
             .min_size(32.0)
-            .show_animated_inside(ui, top, |ui| {
+            .show_collapsible(ui, top, |ui| {
                 egui::ScrollArea::vertical().show(ui, |ui| {
                     ui.vertical_centered(|ui| {
                         ui.heading("Expandable Upper Panel");
@@ -62,7 +62,7 @@ impl crate::View for Panels {
             .resizable(true)
             .default_size(150.0)
             .size_range(80.0..=200.0)
-            .show_animated_inside(ui, left, |ui| {
+            .show_collapsible(ui, left, |ui| {
                 ui.vertical_centered(|ui| {
                     ui.heading("Left Panel");
                 });
@@ -75,7 +75,7 @@ impl crate::View for Panels {
             .resizable(true)
             .default_size(150.0)
             .size_range(80.0..=200.0)
-            .show_animated_inside(ui, right, |ui| {
+            .show_collapsible(ui, right, |ui| {
                 ui.vertical_centered(|ui| {
                     ui.heading("Right Panel");
                 });
@@ -89,7 +89,7 @@ impl crate::View for Panels {
         // re-expand. Both panels are `.resizable(true)` so each one's edge accepts
         // the gesture; the collapsed panel uses `exact_size` so even a tiny
         // outward drag is enough to trigger the swap.
-        egui::Panel::show_animated_between_inside(
+        egui::Panel::show_switched(
             ui,
             bottom,
             egui::Panel::bottom("bottom_panel_collapsed")
@@ -115,7 +115,7 @@ impl crate::View for Panels {
         );
 
         // TODO(emilk): This extra panel is superfluous - just use what's left of `ui` instead
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.vertical_centered(|ui| {
                 ui.heading("Central Panel");
             });

--- a/crates/egui_demo_lib/src/demo/text_edit.rs
+++ b/crates/egui_demo_lib/src/demo/text_edit.rs
@@ -164,7 +164,7 @@ mod tests {
         let text = "Hello, world!".to_owned();
         let mut harness = Harness::new_ui_state(
             move |ui, text| {
-                CentralPanel::default().show_inside(ui, |ui| {
+                CentralPanel::default().show(ui, |ui| {
                     ui.text_edit_singleline(text);
                 });
             },

--- a/crates/egui_demo_lib/src/demo/tooltips.rs
+++ b/crates/egui_demo_lib/src/demo/tooltips.rs
@@ -36,7 +36,7 @@ impl crate::View for Tooltips {
             ui.add(crate::egui_github_link_file_line!());
         });
 
-        egui::Panel::right("scroll_test").show_inside(ui, |ui| {
+        egui::Panel::right("scroll_test").show(ui, |ui| {
             ui.label(
                 "The scroll area below has many labels with interactive tooltips. \
                  The purpose is to test that the tooltips close when you scroll.",
@@ -56,7 +56,7 @@ impl crate::View for Tooltips {
                 });
         });
 
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             self.misc_tests(ui);
         });
     }

--- a/crates/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
+++ b/crates/egui_demo_lib/src/easy_mark/easy_mark_editor.rs
@@ -33,14 +33,14 @@ impl Default for EasyMarkEditor {
 
 impl EasyMarkEditor {
     pub fn panels(&mut self, ui: &mut egui::Ui) {
-        egui::Panel::bottom("easy_mark_bottom").show_inside(ui, |ui| {
+        egui::Panel::bottom("easy_mark_bottom").show(ui, |ui| {
             let layout = egui::Layout::top_down(egui::Align::Center).with_main_justify(true);
             ui.allocate_ui_with_layout(ui.available_size(), layout, |ui| {
                 ui.add(crate::egui_github_link_file!())
             })
         });
 
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             self.ui(ui);
         });
     }

--- a/crates/egui_glow/examples/pure_glow.rs
+++ b/crates/egui_glow/examples/pure_glow.rs
@@ -219,7 +219,7 @@ impl winit::application::ApplicationHandler<UserEvent> for GlowApp {
                 .as_mut()
                 .unwrap()
                 .run(self.gl_window.as_mut().unwrap().window(), |ui| {
-                    egui::Panel::left("my_side_panel").show_inside(ui, |ui| {
+                    egui::Panel::left("my_side_panel").show(ui, |ui| {
                         ui.heading("Hello World!");
                         if ui.button("Quit").clicked() {
                             quit = true;

--- a/crates/egui_kittest/tests/accesskit.rs
+++ b/crates/egui_kittest/tests/accesskit.rs
@@ -43,7 +43,7 @@ fn button_node() {
     let button_text = "This is a test button!";
 
     let output = accesskit_output_single_egui_frame(|ui| {
-        CentralPanel::default().show_inside(ui, |ui| ui.button(button_text));
+        CentralPanel::default().show(ui, |ui| ui.button(button_text));
     });
 
     let (_, button) = output
@@ -61,7 +61,7 @@ fn disabled_button_node() {
     let button_text = "This is a test button!";
 
     let output = accesskit_output_single_egui_frame(|ui| {
-        CentralPanel::default().show_inside(ui, |ui| {
+        CentralPanel::default().show(ui, |ui| {
             ui.add_enabled(false, egui::Button::new(button_text))
         });
     });
@@ -82,7 +82,7 @@ fn toggle_button_node() {
 
     let mut selected = false;
     let output = accesskit_output_single_egui_frame(|ui| {
-        CentralPanel::default().show_inside(ui, |ui| ui.toggle_value(&mut selected, button_text));
+        CentralPanel::default().show(ui, |ui| ui.toggle_value(&mut selected, button_text));
     });
 
     let (_, toggle) = output
@@ -98,7 +98,7 @@ fn toggle_button_node() {
 #[test]
 fn multiple_disabled_widgets() {
     let output = accesskit_output_single_egui_frame(|ui| {
-        CentralPanel::default().show_inside(ui, |ui| {
+        CentralPanel::default().show(ui, |ui| {
             ui.add_enabled_ui(false, |ui| {
                 let _ = ui.button("Button 1");
                 let _ = ui.button("Button 2");

--- a/crates/egui_kittest/tests/regression_tests.rs
+++ b/crates/egui_kittest/tests/regression_tests.rs
@@ -271,7 +271,7 @@ fn keyboard_submenu_harness() -> Harness<'static, bool> {
         .with_size(Vec2::new(400.0, 240.0))
         .build_ui_state(
             |ui, checked| {
-                egui::Panel::top("menu_bar").show_inside(ui, |ui| {
+                egui::Panel::top("menu_bar").show(ui, |ui| {
                     egui::MenuBar::new().ui(ui, |ui| {
                         ui.menu_button("X", |ui| {
                             ui.menu_button("Y", |ui| {

--- a/examples/confirm_exit/src/main.rs
+++ b/examples/confirm_exit/src/main.rs
@@ -24,7 +24,7 @@ struct MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.heading("Try to close the window");
         });
 

--- a/examples/custom_3d_glow/src/main.rs
+++ b/examples/custom_3d_glow/src/main.rs
@@ -44,7 +44,7 @@ impl MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.horizontal(|ui| {
                 ui.spacing_mut().item_spacing.x = 0.0;
                 ui.label("The triangle is being painted using ");

--- a/examples/custom_font/src/main.rs
+++ b/examples/custom_font/src/main.rs
@@ -87,7 +87,7 @@ impl MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.heading("egui using custom fonts");
             ui.text_edit_multiline(&mut self.text);
         });

--- a/examples/custom_font_style/src/main.rs
+++ b/examples/custom_font_style/src/main.rs
@@ -66,7 +66,7 @@ impl MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, content);
+        egui::CentralPanel::default().show(ui, content);
     }
 }
 

--- a/examples/custom_style/src/main.rs
+++ b/examples/custom_style/src/main.rs
@@ -58,7 +58,7 @@ impl MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.heading("egui using a customized style");
             ui.label("Switch between dark and light mode to see the different styles in action.");
             global_theme_preference_buttons(ui);

--- a/examples/external_eventloop/src/main.rs
+++ b/examples/external_eventloop/src/main.rs
@@ -45,7 +45,7 @@ impl Default for MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.heading("My External Eventloop Application");
 
             ui.horizontal(|ui| {

--- a/examples/external_eventloop_async/src/app.rs
+++ b/examples/external_eventloop_async/src/app.rs
@@ -81,7 +81,7 @@ impl Default for MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.heading("My External Eventloop Application");
 
             ui.horizontal(|ui| {

--- a/examples/file_dialog/src/main.rs
+++ b/examples/file_dialog/src/main.rs
@@ -26,7 +26,7 @@ struct MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.label("Drag-and-drop files onto the window!");
 
             if ui.button("Open file…").clicked()

--- a/examples/font_variations/src/main.rs
+++ b/examples/font_variations/src/main.rs
@@ -77,7 +77,7 @@ impl MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.heading("Font Variations (Recursive)");
             ui.add_space(4.0);
 

--- a/examples/hello_android/src/lib.rs
+++ b/examples/hello_android/src/lib.rs
@@ -41,11 +41,11 @@ impl eframe::App for MyApp {
         // TODO(lucasmerlin): This is a pretty big hack, should be fixed once safe_area implemented
         // for android:
         // https://github.com/rust-windowing/winit/issues/3910
-        egui::Panel::top("status_bar_space").show_inside(ui, |ui| {
+        egui::Panel::top("status_bar_space").show(ui, |ui| {
             ui.set_height(32.0);
         });
 
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             self.demo.ui(ui);
         });
     }

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -37,7 +37,7 @@ impl Default for MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.heading("My egui Application");
             ui.horizontal(|ui| {
                 let name_label = ui.label("Your name: ");

--- a/examples/hello_world_simple/src/main.rs
+++ b/examples/hello_world_simple/src/main.rs
@@ -16,7 +16,7 @@ fn main() -> eframe::Result {
     let mut age = 42;
 
     eframe::run_ui_native("My egui App", options, move |ui, _frame| {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.heading("My egui Application");
             ui.horizontal(|ui| {
                 let name_label = ui.label("Your name: ");

--- a/examples/images/src/main.rs
+++ b/examples/images/src/main.rs
@@ -25,7 +25,7 @@ struct MyApp {}
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             egui::ScrollArea::both().show(ui, |ui| {
                 ui.image(egui::include_image!("cat.webp"))
                     .on_hover_text_at_pointer("WebP");

--- a/examples/keyboard_events/src/main.rs
+++ b/examples/keyboard_events/src/main.rs
@@ -21,7 +21,7 @@ struct Content {
 
 impl eframe::App for Content {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.heading("Press/Hold/Release example. Press A to test.");
             if ui.button("Clear").clicked() {
                 self.text.clear();

--- a/examples/multiple_viewports/src/main.rs
+++ b/examples/multiple_viewports/src/main.rs
@@ -36,7 +36,7 @@ struct MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.label("Hello from the root viewport");
 
             ui.checkbox(
@@ -72,7 +72,7 @@ impl eframe::App for MyApp {
                             "This viewport is embedded in the parent window, and cannot be moved outside of it.",
                         );
                     } else {
-                        egui::CentralPanel::default().show_inside(ui, |ui| {
+                        egui::CentralPanel::default().show(ui, |ui| {
                             ui.label("Hello from immediate viewport");
 
                             if ui.input(|i| i.viewport().close_requested()) {
@@ -98,7 +98,7 @@ impl eframe::App for MyApp {
                             "This viewport is embedded in the parent window, and cannot be moved outside of it.",
                         );
                     } else {
-                        egui::CentralPanel::default().show_inside(ui, |ui| {
+                        egui::CentralPanel::default().show(ui, |ui| {
                             ui.label("Hello from deferred viewport");
 
                             if ui.input(|i| i.viewport().close_requested()) {

--- a/examples/popups/src/main.rs
+++ b/examples/popups/src/main.rs
@@ -19,7 +19,7 @@ struct MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut eframe::egui::Ui, _frame: &mut eframe::Frame) {
-        CentralPanel::default().show_inside(ui, |ui| {
+        CentralPanel::default().show(ui, |ui| {
             ui.label("PopupCloseBehavior::CloseOnClick popup");
             ComboBox::from_label("ComboBox")
                 .selected_text(format!("{}", self.number))

--- a/examples/puffin_profiler/src/main.rs
+++ b/examples/puffin_profiler/src/main.rs
@@ -55,7 +55,7 @@ impl Default for MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.heading("Example of how to use the puffin profiler with egui");
             ui.separator();
 
@@ -116,7 +116,7 @@ impl eframe::App for MyApp {
                         "This egui backend doesn't support multiple viewports"
                     );
 
-                    egui::CentralPanel::default().show_inside(ui, |ui| {
+                    egui::CentralPanel::default().show(ui, |ui| {
                         ui.label("Hello from immediate viewport");
                     });
 
@@ -143,7 +143,7 @@ impl eframe::App for MyApp {
                         "This egui backend doesn't support multiple viewports"
                     );
 
-                    egui::CentralPanel::default().show_inside(ui, |ui| {
+                    egui::CentralPanel::default().show(ui, |ui| {
                         ui.label("Hello from deferred viewport");
                     });
                     if ui.input(|i| i.viewport().close_requested()) {

--- a/examples/screenshot/src/main.rs
+++ b/examples/screenshot/src/main.rs
@@ -28,7 +28,7 @@ struct MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             if let Some(screenshot) = self.screenshot.take() {
                 self.texture = Some(ui.ctx().load_texture(
                     "screenshot",

--- a/examples/serial_windows/src/main.rs
+++ b/examples/serial_windows/src/main.rs
@@ -44,7 +44,7 @@ struct MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             let label_text = if self.has_next {
                 "When this window is closed the next will be opened after a short delay"
             } else {

--- a/examples/user_attention/src/main.rs
+++ b/examples/user_attention/src/main.rs
@@ -76,7 +76,7 @@ impl eframe::App for Application {
             ));
         }
 
-        CentralPanel::default().show_inside(ui, |ui| {
+        CentralPanel::default().show(ui, |ui| {
             ui.vertical(|ui| {
                 ui.horizontal(|ui| {
                     ui.label("Attention type:");

--- a/tests/egui_tests/tests/test_panel_drag.rs
+++ b/tests/egui_tests/tests/test_panel_drag.rs
@@ -1,8 +1,8 @@
 //! Snapshot tests for `Panel`'s drag-to-close and drag-to-expand gestures.
 //!
 //! Covers:
-//! * [`Panel::show_animated_inside`] — drag-to-close on a `Left` panel.
-//! * [`Panel::show_animated_between_inside`] — drag-to-close on the expanded panel
+//! * [`Panel::show_collapsible`] — drag-to-close on a `Left` panel.
+//! * [`Panel::show_switched`] — drag-to-close on the expanded panel
 //!   followed by drag-to-expand on the collapsed panel, both via the shared
 //!   resize handle.
 
@@ -27,10 +27,10 @@ fn drag_to_close_animated_inside() {
                     .resizable(true)
                     .default_size(120.0)
                     .min_size(60.0)
-                    .show_animated_inside(ui, &mut state.is_expanded, |ui| {
+                    .show_collapsible(ui, &mut state.is_expanded, |ui| {
                         ui.label("Left panel content");
                     });
-                egui::CentralPanel::default().show_inside(ui, |ui| {
+                egui::CentralPanel::default().show(ui, |ui| {
                     ui.label("Central");
                 });
             },
@@ -83,7 +83,7 @@ fn drag_to_close_and_reopen_animated_between() {
                 let expanded = Panel::bottom("between_expanded")
                     .resizable(true)
                     .default_size(expanded_size);
-                Panel::show_animated_between_inside(
+                Panel::show_switched(
                     ui,
                     &mut state.is_expanded,
                     collapsed,
@@ -104,7 +104,7 @@ fn drag_to_close_and_reopen_animated_between() {
                         }
                     },
                 );
-                egui::CentralPanel::default().show_inside(ui, |ui| {
+                egui::CentralPanel::default().show(ui, |ui| {
                     ui.label("Central");
                 });
             },

--- a/tests/test_inline_glow_paint/src/main.rs
+++ b/tests/test_inline_glow_paint/src/main.rs
@@ -30,7 +30,7 @@ struct MyTestApp {}
 
 impl eframe::App for MyTestApp {
     fn ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
-        egui::Panel::top("top").show_inside(ui, |ui| {
+        egui::Panel::top("top").show(ui, |ui| {
             ui.label("This is a test of painting directly with glow.");
         });
 

--- a/tests/test_size_pass/src/main.rs
+++ b/tests/test_size_pass/src/main.rs
@@ -9,7 +9,7 @@ fn main() -> eframe::Result {
     let options = eframe::NativeOptions::default();
     eframe::run_ui_native("My egui App", options, move |ui, _frame| {
         // A bottom panel to force the tooltips to consider if the fit below or under the widget:
-        egui::Panel::bottom("bottom").show_inside(ui, |ui| {
+        egui::Panel::bottom("bottom").show(ui, |ui| {
             ui.horizontal(|ui| {
                 ui.vertical(|ui| {
                     ui.label("Single tooltips:");
@@ -33,7 +33,7 @@ fn main() -> eframe::Result {
             });
         });
 
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.horizontal(|ui| {
                 if ui.button("Reset egui memory").clicked() {
                     ui.memory_mut(|mem| *mem = Default::default());

--- a/tests/test_ui_stack/src/main.rs
+++ b/tests/test_ui_stack/src/main.rs
@@ -36,7 +36,7 @@ impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         ui.all_styles_mut(|style| style.interaction.tooltip_delay = 0.0);
 
-        egui::Panel::left("side_panel_left").show_inside(ui, |ui| {
+        egui::Panel::left("side_panel_left").show(ui, |ui| {
             ui.heading("Information");
             ui.label(
                 "This is a demo/test environment of the `UiStack` feature. The tables display \
@@ -84,7 +84,7 @@ impl eframe::App for MyApp {
             });
         });
 
-        egui::Panel::right("side_panel_right").show_inside(ui, |ui| {
+        egui::Panel::right("side_panel_right").show(ui, |ui| {
             egui::ScrollArea::both().auto_shrink(false).show(ui, |ui| {
                 stack_ui(ui);
 
@@ -94,7 +94,7 @@ impl eframe::App for MyApp {
             });
         });
 
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             egui::ScrollArea::both().auto_shrink(false).show(ui, |ui| {
                 ui.label("stack here:");
                 stack_ui(ui);
@@ -174,7 +174,7 @@ impl eframe::App for MyApp {
 
         egui::Panel::bottom("bottom_panel")
             .resizable(true)
-            .show_inside(ui, |ui| {
+            .show(ui, |ui| {
                 egui::ScrollArea::vertical()
                     .auto_shrink(false)
                     .show(ui, |ui| {

--- a/tests/test_viewports/src/main.rs
+++ b/tests/test_viewports/src/main.rs
@@ -154,7 +154,7 @@ impl Default for App {
 
 impl eframe::App for App {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.heading("Root viewport");
             {
                 let mut embed_viewports = ui.embed_viewports();
@@ -182,7 +182,7 @@ fn show_as_popup(
         // Not a real viewport - already has a frame
         content(ui);
     } else {
-        egui::CentralPanel::default().show_inside(ui, content);
+        egui::CentralPanel::default().show(ui, content);
     }
 }
 


### PR DESCRIPTION
The three methods for showing a `Panel` are now:

* `panel.show`: always show the panel.
* `panel.show_collapsible`: show or hide the panel, with a slide animation in between.
* `Panel::show_switched`: animate between two different panels: a thin/collapsed one and a thick/expanded one.