### PR TITLE
Configure wgpu to be low-latency by default

### DIFF
--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -87,7 +87,6 @@ impl SurfaceConfig {
     pub const LOW_LATENCY: Self = Self {
         present_mode: wgpu::PresentMode::AutoVsync,
 
-        #[expect(clippy::branches_sharing_code)]
         desired_maximum_frame_latency: if cfg!(target_os = "ios") {
             None // The default is good on iOS, while `Some(1)` cuts FPS in half
         } else {

--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -91,9 +91,7 @@ impl SurfaceConfig {
         desired_maximum_frame_latency: if cfg!(target_os = "ios") {
             None // The default is good on iOS, while `Some(1)` cuts FPS in half
         } else {
-            // TODO(emilk): We would like yo use `Some(1)` here, but
-            // that causes bugs when resizing the window on macOS.
-            None
+            Some(1)
         },
     };
 

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -414,20 +414,27 @@ impl Painter {
         // See https://github.com/emilk/egui/issues/903
         #[cfg(all(target_os = "macos", feature = "macos-window-resize-jitter-fix"))]
         {
-            // SAFETY: The cast is checked with if condition. If the used backend is not metal
-            // it gracefully fails.
-            unsafe {
-                if let Some(hal_surface) = state.surface.as_hal::<wgpu::hal::api::Metal>() {
-                    hal_surface
-                        .render_layer()
-                        .lock()
-                        .setPresentsWithTransaction(resizing);
+            // setPresentsWithTransaction causes hangs when desired_maximum_frame_latency == 1
+            let is_low_latency = self
+                .render_state
+                .as_ref()
+                .is_some_and(|rs| rs.surface_config.desired_maximum_frame_latency == Some(1));
+            if !is_low_latency {
+                // SAFETY: The cast is checked with if condition. If the used backend is not metal
+                // it gracefully fails.
+                unsafe {
+                    if let Some(hal_surface) = state.surface.as_hal::<wgpu::hal::api::Metal>() {
+                        hal_surface
+                            .render_layer()
+                            .lock()
+                            .setPresentsWithTransaction(resizing);
 
-                    Self::configure_surface(
-                        state,
-                        self.render_state.as_ref().unwrap(),
-                        &self.config.surface,
-                    );
+                        Self::configure_surface(
+                            state,
+                            self.render_state.as_ref().unwrap(),
+                            &self.config.surface,
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
* initially done in https://github.com/emilk/egui/pull/8103, reverted in #8167 due to resize hangs
* Related: https://github.com/emilk/egui/issues/8043 (maybe closes??)

Turns out the resize hangs were caused by the present_with_transaction call. Disabling that when `desired_maximum_frame_latency == 1` causes the window to resize smoothly.

Thanks @krisdigital for noticing that connection: https://github.com/emilk/egui/issues/8043#issuecomment-4154440382