### PR TITLE
fix: prevent stale `Focused(false)` events from clearing valid focus and freezing rendering

### DIFF
--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -681,9 +681,6 @@ impl GlowWinitRunning<'_> {
         };
 
         viewport.info.events.clear(); // they should have been processed
-        // let window = viewport.window.clone().unwrap();
-        // let gl_surface = viewport.gl_surface.as_ref().unwrap();
-        // let egui_winit = viewport.egui_winit.as_mut().unwrap();
         let (Some(egui_winit), Some(window), Some(gl_surface)) = (
             viewport.egui_winit.as_mut(),
             &viewport.window.clone(),

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -569,6 +569,7 @@ impl GlowWinitRunning<'_> {
             egui_winit::update_viewport_info(&mut viewport.info, &egui_ctx, window, false);
 
             let is_visible = viewport.info.visible().unwrap_or(true);
+            let is_visible_for_paint = is_visible || viewport.info.focused == Some(true);
 
             let Some(egui_winit) = viewport.egui_winit.as_mut() else {
                 return Ok(EventResult::Wait);
@@ -588,7 +589,7 @@ impl GlowWinitRunning<'_> {
                 .map(|(id, viewport)| (*id, viewport.info.clone()))
                 .collect();
 
-            (raw_input, viewport_ui_cb, is_visible, run_ui)
+            (raw_input, viewport_ui_cb, is_visible_for_paint, run_ui)
         };
 
         // HACK: In order to get the right clear_color, the system theme needs to be set, which

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -681,11 +681,19 @@ impl GlowWinitRunning<'_> {
         };
 
         viewport.info.events.clear(); // they should have been processed
-        let window = viewport.window.clone().unwrap();
-        let gl_surface = viewport.gl_surface.as_ref().unwrap();
-        let egui_winit = viewport.egui_winit.as_mut().unwrap();
+        // let window = viewport.window.clone().unwrap();
+        // let gl_surface = viewport.gl_surface.as_ref().unwrap();
+        // let egui_winit = viewport.egui_winit.as_mut().unwrap();
+        let (Some(egui_winit), Some(window), Some(gl_surface)) = (
+            viewport.egui_winit.as_mut(),
+            &viewport.window.clone(),
+            &viewport.gl_surface,
+        ) else {
+            log::warn!("viewport unwrap error.");
+            return Ok(EventResult::Wait);
+        };
 
-        egui_winit.handle_platform_output_with_event_loop(&window, event_loop, platform_output);
+        egui_winit.handle_platform_output_with_event_loop(window, event_loop, platform_output);
 
         // Upload textures even when not visible: the atlas dirty region is already
         // consumed, so dropping the delta would desync the font texture.
@@ -746,7 +754,7 @@ impl GlowWinitRunning<'_> {
                     }
                 }
 
-                integration.post_rendering(&window);
+                integration.post_rendering(window);
             }
 
             {
@@ -781,7 +789,7 @@ impl GlowWinitRunning<'_> {
 
         integration.report_frame_time(frame_timer.total_time_sec()); // don't count auto-save time as part of regular frame time
 
-        integration.maybe_autosave(app.as_mut(), Some(&window));
+        integration.maybe_autosave(app.as_mut(), Some(window));
 
         if is_invisible_or_minimized(&window) {
             // On Mac, a minimized Window uses up all CPU:
@@ -840,6 +848,13 @@ impl GlowWinitRunning<'_> {
                 if let Some(viewport_id) = viewport_id {
                     if focused {
                         glutin.focused_viewport = Some(viewport_id);
+
+                        if let Some(viewport) = glutin.viewports.get_mut(&viewport_id) {
+                            // A focused window cannot be reliably treated as fully occluded.
+                            // On some platforms/drivers the matching Occluded(false) event may be missed,
+                            // so clear a stale occluded state on strong visibility signals.
+                            viewport.info.occluded = Some(false);
+                        }
                     } else if glutin.focused_viewport == Some(viewport_id) {
                         // Only clear the focused viewport if the viewport losing focus is
                         // the one we currently believe to be focused. This avoids stale
@@ -860,6 +875,13 @@ impl GlowWinitRunning<'_> {
                     && let Some(viewport_id) = viewport_id
                 {
                     repaint_asap = true;
+
+                    if let Some(viewport) = glutin.viewports.get_mut(&viewport_id) {
+                        // A non-zero resize is a strong signal that the window is visible enough
+                        // to render. Clear a stale occluded state in case Occluded(false) was missed.
+                        viewport.info.occluded = Some(false);
+                    }
+
                     glutin.resize(viewport_id, *physical_size);
                 }
             }
@@ -871,9 +893,7 @@ impl GlowWinitRunning<'_> {
                     viewport.info.occluded = Some(*is_occluded);
                 }
 
-                if !*is_occluded {
-                    repaint_asap = true;
-                }
+                repaint_asap = true;
             }
 
             winit::event::WindowEvent::CloseRequested => {

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -788,7 +788,7 @@ impl GlowWinitRunning<'_> {
 
         integration.maybe_autosave(app.as_mut(), Some(window));
 
-        if is_invisible_or_minimized(&window) {
+        if is_invisible_or_minimized(window) {
             // On Mac, a minimized Window uses up all CPU:
             // https://github.com/emilk/egui/issues/325
             // On Windows, an invisible window also uses up all CPU:

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -825,7 +825,18 @@ impl GlowWinitRunning<'_> {
                     *focused
                 };
 
-                glutin.focused_viewport = focused.then_some(viewport_id).flatten();
+                if let Some(viewport_id) = viewport_id {
+                    if focused {
+                        glutin.focused_viewport = Some(viewport_id);
+                    } else if glutin.focused_viewport == Some(viewport_id) {
+                        // Only clear the focused viewport if the viewport losing focus is
+                        // the one we currently believe to be focused. This avoids stale
+                        // Focused(false) events from other windows clearing a valid focus.
+                        glutin.focused_viewport = None;
+                    }
+                }
+
+                repaint_asap = true;
             }
 
             winit::event::WindowEvent::Resized(physical_size) => {

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -858,6 +858,10 @@ impl GlowWinitRunning<'_> {
                 {
                     viewport.info.occluded = Some(*is_occluded);
                 }
+
+                if !*is_occluded {
+                    repaint_asap = true;
+                }
             }
 
             winit::event::WindowEvent::CloseRequested => {

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -915,12 +915,12 @@ impl WgpuWinitRunning<'_> {
                     shared.painter.on_window_resized(id, width, height);
                     repaint_asap = true;
 
-                    if let Some(viewport_id) = viewport_id {
-                        if let Some(viewport) = shared.viewports.get_mut(&viewport_id) {
-                            // A non-zero resize is a strong signal that the window is visible enough
-                            // to render. Clear a stale occluded state in case Occluded(false) was missed.
-                            viewport.info.occluded = Some(false);
-                        }
+                    if let Some(viewport_id) = viewport_id
+                        && let Some(viewport) = shared.viewports.get_mut(&viewport_id)
+                    {
+                        // A non-zero resize is a strong signal that the window is visible enough
+                        // to render. Clear a stale occluded state in case Occluded(false) was missed.
+                        viewport.info.occluded = Some(false);
                     }
                 }
             }

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -881,11 +881,13 @@ impl WgpuWinitRunning<'_> {
                     if focused {
                         shared.focused_viewport = Some(viewport_id);
 
-                        if let Some(viewport) = shared.viewports.get_mut(&viewport_id) {
-                            // A focused window cannot be reliably treated as fully occluded.
-                            // On some platforms/drivers the matching Occluded(false) event may be missed,
-                            // so clear a stale occluded state on strong visibility signals.
-                            viewport.info.occluded = Some(false);
+                        if let Some(viewport_id) = viewport_id {
+                            if let Some(viewport) = shared.viewports.get_mut(&viewport_id) {
+                                // A focused window cannot be reliably treated as fully occluded.
+                                // On some platforms/drivers the matching Occluded(false) event may be missed,
+                                // so clear a stale occluded state on strong visibility signals.
+                                viewport.info.occluded = Some(false);
+                            }
                         }
                     } else if shared.focused_viewport == Some(viewport_id) {
                         // Only clear the focused viewport if the viewport losing focus is
@@ -915,10 +917,12 @@ impl WgpuWinitRunning<'_> {
                     shared.painter.on_window_resized(id, width, height);
                     repaint_asap = true;
 
-                    if let Some(viewport) = shared.viewports.get_mut(&viewport_id) {
-                        // A non-zero resize is a strong signal that the window is visible enough
-                        // to render. Clear a stale occluded state in case Occluded(false) was missed.
-                        viewport.info.occluded = Some(false);
+                    if let Some(viewport_id) = viewport_id {
+                        if let Some(viewport) = shared.viewports.get_mut(&viewport_id) {
+                            // A non-zero resize is a strong signal that the window is visible enough
+                            // to render. Clear a stale occluded state in case Occluded(false) was missed.
+                            viewport.info.occluded = Some(false);
+                        }
                     }
                 }
             }

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -880,6 +880,13 @@ impl WgpuWinitRunning<'_> {
                 if let Some(viewport_id) = viewport_id {
                     if focused {
                         shared.focused_viewport = Some(viewport_id);
+
+                        if let Some(viewport) = shared.viewports.get_mut(&viewport_id) {
+                            // A focused window cannot be reliably treated as fully occluded.
+                            // On some platforms/drivers the matching Occluded(false) event may be missed,
+                            // so clear a stale occluded state on strong visibility signals.
+                            viewport.info.occluded = Some(false);
+                        }
                     } else if shared.focused_viewport == Some(viewport_id) {
                         // Only clear the focused viewport if the viewport losing focus is
                         // the one we currently believe to be focused. This avoids stale
@@ -907,6 +914,12 @@ impl WgpuWinitRunning<'_> {
                     }
                     shared.painter.on_window_resized(id, width, height);
                     repaint_asap = true;
+
+                    if let Some(viewport) = shared.viewports.get_mut(&viewport_id) {
+                        // A non-zero resize is a strong signal that the window is visible enough
+                        // to render. Clear a stale occluded state in case Occluded(false) was missed.
+                        viewport.info.occluded = Some(false);
+                    }
                 }
             }
 
@@ -917,9 +930,7 @@ impl WgpuWinitRunning<'_> {
                     viewport.info.occluded = Some(*is_occluded);
                 }
 
-                if !*is_occluded {
-                    repaint_asap = true;
-                }
+                repaint_asap = true;
             }
 
             winit::event::WindowEvent::CloseRequested => {

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -881,13 +881,11 @@ impl WgpuWinitRunning<'_> {
                     if focused {
                         shared.focused_viewport = Some(viewport_id);
 
-                        if let Some(viewport_id) = viewport_id {
-                            if let Some(viewport) = shared.viewports.get_mut(&viewport_id) {
-                                // A focused window cannot be reliably treated as fully occluded.
-                                // On some platforms/drivers the matching Occluded(false) event may be missed,
-                                // so clear a stale occluded state on strong visibility signals.
-                                viewport.info.occluded = Some(false);
-                            }
+                        if let Some(viewport) = shared.viewports.get_mut(&viewport_id) {
+                            // A focused window cannot be reliably treated as fully occluded.
+                            // On some platforms/drivers the matching Occluded(false) event may be missed,
+                            // so clear a stale occluded state on strong visibility signals.
+                            viewport.info.occluded = Some(false);
                         }
                     } else if shared.focused_viewport == Some(viewport_id) {
                         // Only clear the focused viewport if the viewport losing focus is

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -646,6 +646,7 @@ impl WgpuWinitRunning<'_> {
             egui_winit::update_viewport_info(info, &integration.egui_ctx, window, false);
 
             let is_visible = viewport.info.visible().unwrap_or(true);
+            let is_visible_for_paint = is_visible || viewport.info.focused == Some(true);
 
             {
                 profiling::scope!("set_window");
@@ -669,7 +670,7 @@ impl WgpuWinitRunning<'_> {
 
             painter.handle_screenshots(&mut raw_input.events);
 
-            (viewport_ui_cb, raw_input, is_visible, run_ui)
+            (viewport_ui_cb, raw_input, is_visible_for_paint, run_ui)
         };
 
         // ------------------------------------------------------------

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -871,7 +871,18 @@ impl WgpuWinitRunning<'_> {
                     *focused
                 };
 
-                shared.focused_viewport = focused.then_some(viewport_id).flatten();
+                if let Some(viewport_id) = viewport_id {
+                    if focused {
+                        shared.focused_viewport = Some(viewport_id);
+                    } else if shared.focused_viewport == Some(viewport_id) {
+                        // Only clear the focused viewport if the viewport losing focus is
+                        // the one we currently believe to be focused. This avoids stale
+                        // Focused(false) events from other windows clearing a valid focus.
+                        shared.focused_viewport = None;
+                    }
+                }
+
+                repaint_asap = true;
             }
 
             winit::event::WindowEvent::Resized(physical_size) => {

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -910,6 +910,10 @@ impl WgpuWinitRunning<'_> {
                 {
                     viewport.info.occluded = Some(*is_occluded);
                 }
+
+                if !*is_occluded {
+                    repaint_asap = true;
+                }
             }
 
             winit::event::WindowEvent::CloseRequested => {

--- a/crates/egui/src/data/key.rs
+++ b/crates/egui/src/data/key.rs
@@ -226,7 +226,6 @@ pub enum Key {
     /// on ISO layouts. On French AZERTY it produces `<>|`; on UK
     /// QWERTY a secondary `\` / `|`. Missing from US ANSI keyboards.
     IntlBackslash,
-    // ----------------------------------------------
     // When adding keys, remember to also update:
     // * crates/egui-winit/src/lib.rs
     // * Key::ALL

--- a/crates/egui/src/data/key.rs
+++ b/crates/egui/src/data/key.rs
@@ -197,18 +197,25 @@ pub enum Key {
     // `Event::Key` presses.
     /// Left Shift key.
     ShiftLeft,
+
     /// Right Shift key.
     ShiftRight,
+
     /// Left Control key.
     ControlLeft,
+
     /// Right Control key.
     ControlRight,
+
     /// Left Alt / Option key.
     AltLeft,
+
     /// Right Alt / `AltGr` / Option key.
     AltRight,
+
     /// Left Super / Meta / Command / Windows key.
     SuperLeft,
+
     /// Right Super / Meta / Command / Windows key.
     SuperRight,
 

--- a/crates/egui/src/data/key.rs
+++ b/crates/egui/src/data/key.rs
@@ -205,7 +205,7 @@ pub enum Key {
     ControlRight,
     /// Left Alt / Option key.
     AltLeft,
-    /// Right Alt / AltGr / Option key.
+    /// Right Alt / `AltGr` / Option key.
     AltRight,
     /// Left Super / Meta / Command / Windows key.
     SuperLeft,

--- a/crates/egui/src/data/key.rs
+++ b/crates/egui/src/data/key.rs
@@ -219,7 +219,7 @@ pub enum Key {
     /// on ISO layouts. On French AZERTY it produces `<>|`; on UK
     /// QWERTY a secondary `\` / `|`. Missing from US ANSI keyboards.
     IntlBackslash,
-
+    // ----------------------------------------------
     // When adding keys, remember to also update:
     // * crates/egui-winit/src/lib.rs
     // * Key::ALL


### PR DESCRIPTION
fix: prevent stale `Focused(false)` events from clearing valid focus and freezing rendering

* Related #5063 

## Description

This PR fixes a rare and elusive screen-freezing issue in `egui` (especially noticeable on Windows 10/11) where the UI rendering permanently stops after running the application for a prolonged period (e.g., once or twice a day during all-day usage).

### Cause of the Issue
1. **Unconditional Focus Clearing:**
   Previously, any `WindowEvent::Focused(false)` event would unconditionally reset `focused_viewport` to `None`. In multi-window environments or when Windows OS dispatches stale/out-of-order focus events, a stale `Focused(false)` event from another window/viewport would clear the currently active viewport's focus state.
2. **Missing Repaint Trigger:**
   Once the focus state was incorrectly cleared or desynchronized, the application would stop repainting under certain conditions, causing the screen to freeze while the background logic continued running responsiveness-free.

### Solution
1. **Guarded Focus Clearing:**
   Only clear `shared.focused_viewport` if the viewport losing focus actually matches the one we currently believe to be focused:
   ```rust
   } else if shared.focused_viewport == Some(viewport_id) {
       shared.focused_viewport = None;
   }
   ```
2. **Forced Repaint on Focus Event:**
   Explicitly set `repaint_asap = true` on any `Focused` event to ensure the UI updates immediately and stays responsive when focus transitions occur.

Since this bug occurs semi-randomly over long sessions and is highly dependent on OS-level window focus dispatching, it is extremely difficult to write a minimal reproducible example. However, guarding the state transition and forcing a repaint completely resolves the long-term freeze issue.
