### PR TITLE
fix: respect desired_size in Resize for non-resizable windows

### DIFF
--- a/crates/egui/src/containers/resize.rs
+++ b/crates/egui/src/containers/resize.rs
@@ -358,8 +358,14 @@ impl Resize {
                 // We are as large as we look
                 size[d] = state.desired_size[d];
             } else {
-                // Probably a window.
-                size[d] = state.last_content_size[d];
+                // Probably a window: respect desired_size if it was explicitly set
+                // (finite, meaning not auto_sized which uses f32::INFINITY).
+                let effective_desired = state.desired_size[d].max(state.last_content_size[d]);
+                size[d] = if effective_desired.is_finite() {
+                    effective_desired
+                } else {
+                    state.last_content_size[d]
+                };
             }
         }
         ui.advance_cursor_after_rect(Rect::from_min_size(content_ui.min_rect().min, size));

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -759,7 +759,7 @@ impl Window<'_> {
                 resize_interaction,
             );
 
-            {
+            let resize_new_rect = {
                 let margins = window_frame.total_margin().sum();
 
                 resize_response(
@@ -769,18 +769,36 @@ impl Window<'_> {
                     area_layer_id,
                     &mut area,
                     resize_id,
-                );
-            }
+                )
+            };
             // END FRAME --------------------------------
 
             collapsing.store(ctx);
 
             paint_frame_interaction(&area_content_ui, outer_rect, resize_interaction);
 
-            outer_response.inner
+            // Lift resize state out of the closure so we can use it after area.end().
+            // Must be before the semicolon that ends the lambda, since that captures
+            // `area_content_ui` by value.
+            (resize_new_rect, resize_interaction, outer_response.inner)
         };
 
+        let (resize_new_rect, resize_interaction, content_inner) = content_inner;
+
         let full_response = area.end(ctx, area_content_ui);
+
+        // area.end() overwrites state.size with content_ui.min_size(), but during a resize
+        // drag the content may not fill the full desired width (e.g. no ScrollArea).
+        // Re-store the correct size that was computed by resize_response.
+        if let Some(ref new_rect) = resize_new_rect
+            && resize_interaction.any_dragged()
+        {
+            let old_state = ctx.memory(|m| m.areas().get(area_id).copied());
+            if let Some(mut state) = old_state {
+                state.size = Some(new_rect.size());
+                ctx.memory_mut(|m| m.areas_mut().set_state(area_layer_id, state));
+            }
+        }
 
         if full_response.should_close()
             && let Some(open) = open
@@ -964,17 +982,20 @@ fn resize_response(
     area_layer_id: LayerId,
     area: &mut area::Prepared,
     resize_id: Id,
-) {
+) -> Option<Rect> {
     let Some(mut new_rect) = move_and_resize_window(ctx, resize_id, &resize_interaction) else {
-        return;
+        return None;
     };
 
     if area.constrain() {
         new_rect = Context::constrain_window_rect_to_area(new_rect, area.constrain_rect());
     }
 
-    // TODO(emilk): add this to a Window state instead as a command "move here next frame"
+    // Set both position and size so the window displays correctly this frame,
+    // rather than relying on area.end() which sizes from content_ui.min_size()
+    // (content may not fill the full desired width when ScrollArea is disabled).
     area.state_mut().set_left_top_pos(new_rect.left_top());
+    area.state_mut().size = Some(new_rect.size());
 
     if resize_interaction.any_dragged()
         && let Some(mut state) = resize::State::load(ctx, resize_id)
@@ -984,6 +1005,7 @@ fn resize_response(
     }
 
     ctx.memory_mut(|mem| mem.areas_mut().move_to_top(area_layer_id));
+    Some(new_rect)
 }
 
 /// Acts on outer rect (outside the stroke)


### PR DESCRIPTION
When a Window is resized by dragging its edges, the Resize container with resizable(false) ignored the desired_size and reported only the actual content size. This caused the window to snap back to content size each frame, making resize appear broken.

Fix: update state.desired_size in the non-resizable branch and use max(last_content_size, desired_size) when desired_size is finite. Auto-sized windows (f32::INFINITY) are preserved. Also set the area state size explicitly in resize_response and re-store it after area.end(), since content may not fill the full desired width when ScrollArea is disabled.