### PR TITLE
Fix eframe inspection for glow

### DIFF
--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -299,7 +299,6 @@ impl<'app> GlowWinitApp<'app> {
         let app_creator = std::mem::take(&mut self.app_creator)
             .expect("Single-use AppCreator has unexpectedly already been taken");
 
-        #[cfg(all(not(feature = "inspection"), not(target_arch = "wasm32")))]
         crate::maybe_attach_inspection_plugin(&integration.egui_ctx, Some(self.app_name.clone()));
 
         let app: Box<dyn 'app + App> = {


### PR DESCRIPTION
Removed wrong `cfg` attribute that broke inspection with the glow backend.