### PR TITLE
Make `Slider::new` take `impl Into<RangeInclusive`

### DIFF
--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -2963,7 +2963,7 @@ pub fn font_tweak_ui(ui: &mut Ui, tweak: &mut FontTweak, axes: &[FontVariationAx
                 let mut value = existing.map_or(axis.default, |i| coords.as_ref()[i].1);
 
                 ui.horizontal(|ui| {
-                    if ui.add(Slider::new(&mut value, axis.range.into())).changed() {
+                    if ui.add(Slider::new(&mut value, axis.range)).changed() {
                         match existing {
                             Some(i) => coords.as_mut()[i].1 = value,
                             None => coords.push(axis.tag, value),

--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -125,7 +125,11 @@ impl<'a> Slider<'a> {
     ///
     /// The `value` given will be clamped to the `range`,
     /// unless you change this behavior with [`Self::clamping`].
-    pub fn new<Num: emath::Numeric>(value: &'a mut Num, range: RangeInclusive<Num>) -> Self {
+    pub fn new<Num: emath::Numeric>(
+        value: &'a mut Num,
+        range: impl Into<RangeInclusive<Num>>,
+    ) -> Self {
+        let range = range.into();
         let range_f64 = range.start().to_f64()..=range.end().to_f64();
         let slf = Self::from_get_set(range_f64, move |v: Option<f64>| {
             if let Some(v) = v {


### PR DESCRIPTION
That makes it more ergonomic in some cases, e.g. allows you to use `Rangef`