### PR TITLE
Fix SelectableLabel text shift with inactive strokes

### DIFF
--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -364,7 +364,12 @@ impl<'a> Button<'a> {
         layout = if has_frame_margin && (state != WidgetState::Inactive || frame_when_inactive) {
             layout.frame(frame)
         } else {
-            layout.frame(Frame::new().inner_margin(frame.inner_margin))
+            let inner_margin = if has_frame_margin {
+                frame.inner_margin + Margin::from(frame.stroke.width)
+            } else {
+                frame.inner_margin
+            };
+            layout.frame(Frame::new().inner_margin(inner_margin))
         };
 
         let mut prepared = layout.min_size(min_size).allocate(ui);

--- a/crates/egui/src/widgets/button.rs
+++ b/crates/egui/src/widgets/button.rs
@@ -364,12 +364,7 @@ impl<'a> Button<'a> {
         layout = if has_frame_margin && (state != WidgetState::Inactive || frame_when_inactive) {
             layout.frame(frame)
         } else {
-            let inner_margin = if has_frame_margin {
-                frame.inner_margin + Margin::from(frame.stroke.width)
-            } else {
-                frame.inner_margin
-            };
-            layout.frame(Frame::new().inner_margin(inner_margin))
+            layout.frame(Frame::new().inner_margin(frame.inner_margin))
         };
 
         let mut prepared = layout.min_size(min_size).allocate(ui);

--- a/crates/egui_kittest/tests/regression_tests.rs
+++ b/crates/egui_kittest/tests/regression_tests.rs
@@ -191,6 +191,24 @@ pub fn override_text_color_affects_interactive_widgets() {
     results.add(harness.try_snapshot("override_text_color_interactive"));
 }
 
+/// <https://github.com/emilk/egui/issues/8125>
+#[test]
+pub fn selectable_label_text_should_not_shift_when_inactive_stroke_is_unpainted() {
+    let mut harness = Harness::new_ui(|ui| {
+        ui.visuals_mut().widgets.inactive.bg_stroke = Stroke::new(1.0, egui::Color32::GRAY);
+        let _ = ui.selectable_label(false, "item");
+    });
+
+    harness.run();
+    let inactive_text_pos = text_shape_pos(harness.output(), "item");
+
+    harness.get_by_label("item").hover();
+    harness.run();
+    let hovered_text_pos = text_shape_pos(harness.output(), "item");
+
+    assert_eq!(inactive_text_pos, hovered_text_pos);
+}
+
 /// <https://github.com/rerun-io/rerun/issues/11301>
 #[test]
 pub fn menus_should_close_even_if_submenu_disappears() {
@@ -263,6 +281,24 @@ pub fn menus_should_close_even_if_submenu_disappears() {
             harness.query_by_label_contains(SUB_MENU_BUTTON).is_none(),
             "Menu failed to close. frame_delay = {frame_delay}"
         );
+    }
+}
+
+fn text_shape_pos(output: &egui::FullOutput, text: &str) -> Pos2 {
+    output
+        .shapes
+        .iter()
+        .find_map(|clipped_shape| text_shape_pos_in_shape(&clipped_shape.shape, text))
+        .unwrap_or_else(|| panic!("could not find text shape for {text:?}"))
+}
+
+fn text_shape_pos_in_shape(shape: &egui::Shape, text: &str) -> Option<Pos2> {
+    match shape {
+        egui::Shape::Text(text_shape) if text_shape.galley.text() == text => Some(text_shape.pos),
+        egui::Shape::Vec(shapes) => shapes
+            .iter()
+            .find_map(|shape| text_shape_pos_in_shape(shape, text)),
+        _ => None,
     }
 }
 

--- a/crates/egui_kittest/tests/regression_tests.rs
+++ b/crates/egui_kittest/tests/regression_tests.rs
@@ -200,12 +200,15 @@ pub fn selectable_label_text_should_not_shift_when_inactive_stroke_is_unpainted(
     });
 
     harness.run();
+    let inactive_rect = harness.get_by_label("item").rect();
     let inactive_text_pos = text_shape_pos(harness.output(), "item");
 
     harness.get_by_label("item").hover();
     harness.run();
+    let hovered_rect = harness.get_by_label("item").rect();
     let hovered_text_pos = text_shape_pos(harness.output(), "item");
 
+    assert_eq!(inactive_rect.size(), hovered_rect.size());
     assert_eq!(inactive_text_pos, hovered_text_pos);
 }
 


### PR DESCRIPTION
* Closes <https://github.com/emilk/egui/issues/8125>
* [ ] I have followed the instructions in the PR template

## Summary

`Button::atom_ui` used the stroke-compensated frame margin even when an inactive frameless selectable button did not paint that stroke. With a non-zero inactive bg stroke, the text jumped when hovering and the hover frame was painted.

This restores the unpainted stroke padding for the inactive/no-frame path only, and adds a kittest regression that compares the text shape position before and after hover.

## Testing

- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p egui_kittest selectable_label_text_should_not_shift_when_inactive_stroke_is_unpainted -- --nocapture` (failed before the fix with `[11.0 9.5]` vs `[12.0 9.5]`, passes after)
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p egui_kittest --test regression_tests` (passes; two pre-existing warnings in `override_text_color_affects_interactive_widgets`)
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p egui`
- `PATH="$HOME/.cargo/bin:$PATH" cargo clippy -p egui -- -D warnings`
- `PATH="$HOME/.cargo/bin:$PATH" cargo clippy -p egui -p egui_kittest --test regression_tests -- -D warnings` (fails on existing `clippy::unnecessary_wraps` in `crates/egui_kittest/src/app_kind.rs:26`)
- `git diff --check`

I opened this as draft because I did not run `./scripts/check.sh`.

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.