### PR TITLE
Stabilize native viewport lifecycle and macOS wgpu fullscreen transitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,9 +2845,8 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "29.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2630921705b9b01dcdd0b6864b9562ca3c1951eecd0f0c4f5f04f61e412647"
+version = "29.0.4"
+source = "git+https://github.com/yay/wgpu.git?rev=79168ef4e432f8593e7f8ae23e9e2470b6f68232#79168ef4e432f8593e7f8ae23e9e2470b6f68232"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -5401,9 +5400,8 @@ checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 
 [[package]]
 name = "wgpu"
-version = "29.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
+version = "29.0.4"
+source = "git+https://github.com/yay/wgpu.git?rev=79168ef4e432f8593e7f8ae23e9e2470b6f68232#79168ef4e432f8593e7f8ae23e9e2470b6f68232"
 dependencies = [
  "arrayvec",
  "bitflags 2.13.0",
@@ -5431,9 +5429,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "29.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e80ac6cf1895df6342f87d975162108f9d98772a0d74bc404ab7304ac29469e"
+version = "29.0.4"
+source = "git+https://github.com/yay/wgpu.git?rev=79168ef4e432f8593e7f8ae23e9e2470b6f68232#79168ef4e432f8593e7f8ae23e9e2470b6f68232"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -5465,45 +5462,40 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "29.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43acd053312501689cd92a01a9638d37f3e41a5fd9534875efa8917ee2d11ac0"
+version = "29.0.4"
+source = "git+https://github.com/yay/wgpu.git?rev=79168ef4e432f8593e7f8ae23e9e2470b6f68232#79168ef4e432f8593e7f8ae23e9e2470b6f68232"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "29.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef043bf135cc68b6f667c55ff4e345ce2b5924d75bad36a47921b0287ca4b24a"
+version = "29.0.4"
+source = "git+https://github.com/yay/wgpu.git?rev=79168ef4e432f8593e7f8ae23e9e2470b6f68232#79168ef4e432f8593e7f8ae23e9e2470b6f68232"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-wasm"
-version = "29.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7b75e72f49035f000dd5262e4126242e92a090a4fd75931ecfe7e60784e6fa"
+version = "29.0.4"
+source = "git+https://github.com/yay/wgpu.git?rev=79168ef4e432f8593e7f8ae23e9e2470b6f68232#79168ef4e432f8593e7f8ae23e9e2470b6f68232"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "29.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725d5c006a8c02967b6d93ef04f6537ec4593313e330cfe86d9d3f946eb90f28"
+version = "29.0.4"
+source = "git+https://github.com/yay/wgpu.git?rev=79168ef4e432f8593e7f8ae23e9e2470b6f68232#79168ef4e432f8593e7f8ae23e9e2470b6f68232"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "29.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a47aef47636562f3937285af4c44b4b5b404b46577471411cc5313a921da7e"
+version = "29.0.4"
+source = "git+https://github.com/yay/wgpu.git?rev=79168ef4e432f8593e7f8ae23e9e2470b6f68232#79168ef4e432f8593e7f8ae23e9e2470b6f68232"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -5550,13 +5542,13 @@ dependencies = [
  "wgpu-types",
  "windows",
  "windows-core",
+ "windows-result",
 ]
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4684f4410da0cf95a4cb63bb5edaac022461dedb6adf0b64d0d9b5f6890d51"
+version = "29.0.4"
+source = "git+https://github.com/yay/wgpu.git?rev=79168ef4e432f8593e7f8ae23e9e2470b6f68232#79168ef4e432f8593e7f8ae23e9e2470b6f68232"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -5564,9 +5556,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2675540fb1a5cfa5ef122d3d5f390e2c75711a0b946410f2d6ac3a0f77d1f6"
+version = "29.0.4"
+source = "git+https://github.com/yay/wgpu.git?rev=79168ef4e432f8593e7f8ae23e9e2470b6f68232#79168ef4e432f8593e7f8ae23e9e2470b6f68232"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ wayland-cursor = { version = "0.31.14", default-features = false }
 web-sys = "0.3.77"
 web-time = "1.1" # Timekeeping for native and web
 webbrowser = "1.2"
-wgpu = { version = "29.0", default-features = false, features = ["std"] }
+wgpu = { version = "29.0", git = "https://github.com/yay/wgpu.git", rev = "79168ef4e432f8593e7f8ae23e9e2470b6f68232", default-features = false, features = ["std"] }
 windows-sys = "0.61.2"
 winit = { version = "0.30.13", default-features = false }
 

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -268,18 +268,20 @@ impl EpiIntegration {
         app: &mut dyn epi::App,
         viewport_ui_cb: Option<&DeferredViewportUiCallback>,
         mut raw_input: egui::RawInput,
-        is_visible: bool,
+        run_ui: bool,
     ) -> egui::FullOutput {
         raw_input.time = Some(self.beginning.elapsed().as_secs_f64());
 
         let close_requested = raw_input.viewport().close_requested();
 
         app.raw_input_hook(&self.egui_ctx, &mut raw_input);
+        // Application hooks cannot override whether eframe will evaluate viewport UI.
+        raw_input.viewport_ui_enabled = run_ui;
 
         let full_output = self.egui_ctx.run_ui(raw_input, |ui| {
             if let Some(viewport_ui_cb) = viewport_ui_cb {
                 // Child viewport
-                if is_visible {
+                if run_ui {
                     profiling::scope!("viewport_callback");
                     viewport_ui_cb(ui);
                 }
@@ -289,7 +291,7 @@ impl EpiIntegration {
                     app.logic(ui.ctx(), &mut self.frame);
                 }
 
-                if is_visible {
+                if run_ui {
                     {
                         profiling::scope!("App::ui");
                         app.ui(ui, &mut self.frame);

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -300,7 +300,7 @@ impl EpiIntegration {
 
         let is_root_viewport = viewport_ui_cb.is_none();
         if is_root_viewport && close_requested {
-            let canceled = full_output.viewport_output[&ViewportId::ROOT]
+            let canceled = full_output.viewport_output.entries[&ViewportId::ROOT]
                 .commands
                 .contains(&egui::ViewportCommand::CancelClose);
             if canceled {

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -667,8 +667,6 @@ impl GlowWinitRunning<'_> {
             viewport_output,
         } = full_output;
 
-        glutin.remove_viewports_not_in(&viewport_output);
-
         let GlutinWindowContext {
             viewports,
             current_gl_context,
@@ -1334,10 +1332,76 @@ impl GlutinWindowContext {
         self.gl_config.display().get_proc_address(addr)
     }
 
-    pub(crate) fn remove_viewports_not_in(
+    /// Moves the GL context away from any viewport that is about to be removed.
+    ///
+    /// Dropping a native window/surface while the GL context is still current to that surface can
+    /// crash on Windows. Before pruning stale child viewports, make the context current on a
+    /// surviving viewport, preferring the root viewport because it should stay alive for the app
+    /// lifetime. If no surviving surface exists, make the context not current.
+    fn make_removed_viewports_not_current(
         &mut self,
         viewport_output: &OrderedViewportIdMap<ViewportOutput>,
     ) {
+        let Self {
+            viewports,
+            current_gl_context,
+            not_current_gl_context,
+            ..
+        } = self;
+
+        let Some(current) = current_gl_context.as_ref() else {
+            return;
+        };
+
+        let removed_current_viewport = viewports.iter().any(|(id, viewport)| {
+            !viewport_output.contains_key(id)
+                && viewport
+                    .gl_surface
+                    .as_ref()
+                    .is_some_and(|gl_surface| gl_surface.is_current(current))
+        });
+
+        if !removed_current_viewport {
+            return;
+        }
+
+        let replacement_surface = viewports
+            .get(&ViewportId::ROOT)
+            .filter(|_| viewport_output.contains_key(&ViewportId::ROOT))
+            .and_then(|viewport| viewport.gl_surface.as_ref())
+            .or_else(|| {
+                viewports.iter().find_map(|(id, viewport)| {
+                    if viewport_output.contains_key(id) {
+                        viewport.gl_surface.as_ref()
+                    } else {
+                        None
+                    }
+                })
+            });
+
+        if let Some(replacement_surface) = replacement_surface {
+            change_gl_context(
+                current_gl_context,
+                not_current_gl_context,
+                replacement_surface,
+            );
+        } else if let Some(current) = current_gl_context.take() {
+            match current.make_not_current() {
+                Ok(not_current) => {
+                    *not_current_gl_context = Some(not_current);
+                }
+                Err(err) => {
+                    log::warn!(
+                        "Failed to make GL context not current before removing viewport: {err}"
+                    );
+                }
+            }
+        }
+    }
+
+    fn remove_viewports_not_in(&mut self, viewport_output: &OrderedViewportIdMap<ViewportOutput>) {
+        self.make_removed_viewports_not_current(viewport_output);
+
         // GC old viewports
         self.viewports
             .retain(|id, _| viewport_output.contains_key(id));
@@ -1351,7 +1415,7 @@ impl GlutinWindowContext {
         &mut self,
         event_loop: &ActiveEventLoop,
         egui_ctx: &egui::Context,
-        viewport_output: &OrderedViewportIdMap<ViewportOutput>,
+        viewport_output: &egui::ViewportOutputReport,
     ) {
         profiling::function_scope!();
 
@@ -1365,7 +1429,7 @@ impl GlutinWindowContext {
                 mut commands,
                 repaint_delay: _, // ignored - we listened to the repaint callback instead
             },
-        ) in viewport_output.clone()
+        ) in viewport_output.entries.clone()
         {
             let ids = ViewportIdPair::from_self_and_parent(viewport_id, parent);
 
@@ -1403,7 +1467,9 @@ impl GlutinWindowContext {
         // Create windows for any new viewports:
         self.initialize_all_windows(event_loop);
 
-        self.remove_viewports_not_in(viewport_output);
+        if viewport_output.is_complete {
+            self.remove_viewports_not_in(&viewport_output.entries);
+        }
     }
 }
 
@@ -1449,7 +1515,11 @@ fn initialize_or_update_viewport(
 
             viewport.ids.parent = ids.parent;
             viewport.class = class;
-            viewport.viewport_ui_cb = viewport_ui_cb;
+            // Child viewport passes can report an existing deferred viewport without its
+            // root-owned callback. Keep the callback so direct repaints still run that viewport.
+            if let Some(viewport_ui_cb) = viewport_ui_cb {
+                viewport.viewport_ui_cb = Some(viewport_ui_cb);
+            }
 
             let (mut delta_commands, recreate) = viewport.builder.patch(builder);
 

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -78,7 +78,80 @@ pub struct SharedState {
     painter: egui_wgpu::winit::Painter,
     viewport_from_window: HashMap<WindowId, ViewportId>,
     focused_viewport: Option<ViewportId>,
-    resized_viewport: Option<ViewportId>,
+
+    /// `Some(NativeResize { state: NativeResizeState::Idle, .. })` must never be stored;
+    /// an idle renderer is represented by `None`.
+    native_resize: Option<NativeResize>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct NativeResize {
+    viewport_id: ViewportId,
+    state: egui_wgpu::winit::NativeResizeState,
+}
+
+impl SharedState {
+    /// Switches the viewport whose Metal surface is configured for `AppKit` native resize.
+    fn set_native_resize(&mut self, next: Option<NativeResize>) {
+        debug_assert!(
+            next.is_none_or(|resize| { resize.state != egui_wgpu::winit::NativeResizeState::Idle }),
+            "idle native resize must be represented by None",
+        );
+
+        if self.native_resize == next {
+            return;
+        }
+
+        if let Some(previous) = self.native_resize
+            && next.map(|resize| resize.viewport_id) != Some(previous.viewport_id)
+        {
+            self.painter.set_native_resize_state(
+                previous.viewport_id,
+                egui_wgpu::winit::NativeResizeState::Idle,
+            );
+        }
+
+        if let Some(next) = next {
+            self.painter
+                .set_native_resize_state(next.viewport_id, next.state);
+        }
+
+        self.native_resize = next;
+    }
+
+    /// Finalizes renderer resize state once `AppKit` reports that native resizing has ended.
+    #[cfg(target_os = "macos")]
+    fn finish_ended_native_resize(&mut self) {
+        let Some(native_resize) = self.native_resize else {
+            return;
+        };
+
+        let native_resize_state = self
+            .viewports
+            .get(&native_resize.viewport_id)
+            .and_then(|viewport| viewport.window.as_deref())
+            .map_or(
+                egui_wgpu::winit::NativeResizeState::Idle,
+                native_resize_state,
+            );
+
+        if native_resize_state == egui_wgpu::winit::NativeResizeState::Idle {
+            self.set_native_resize(None);
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn native_resize_state(window: &Window) -> egui_wgpu::winit::NativeResizeState {
+    use winit::platform::macos::WindowExtMacOS as _;
+
+    if window.is_live_resizing() {
+        egui_wgpu::winit::NativeResizeState::LiveResize
+    } else if window.is_fullscreen_transition() {
+        egui_wgpu::winit::NativeResizeState::FullscreenTransition
+    } else {
+        egui_wgpu::winit::NativeResizeState::Idle
+    }
 }
 
 pub type Viewports = egui::OrderedViewportIdMap<Viewport>;
@@ -337,7 +410,7 @@ impl<'app> WgpuWinitApp<'app> {
             viewports,
             painter,
             focused_viewport: Some(ViewportId::ROOT),
-            resized_viewport: None,
+            native_resize: None,
         }));
 
         {
@@ -605,6 +678,9 @@ impl WgpuWinitRunning<'_> {
             profiling::scope!("Prepare");
             let mut shared_lock = shared.borrow_mut();
 
+            #[cfg(target_os = "macos")]
+            shared_lock.finish_ended_native_resize();
+
             let SharedState {
                 viewports, painter, ..
             } = &mut *shared_lock;
@@ -645,7 +721,7 @@ impl WgpuWinitRunning<'_> {
             };
             egui_winit::update_viewport_info(info, &integration.egui_ctx, window, false);
 
-            let is_visible = viewport.info.visible().unwrap_or(true);
+            let is_visible = info.visible().unwrap_or(true);
 
             {
                 profiling::scope!("set_window");
@@ -698,8 +774,6 @@ impl WgpuWinitRunning<'_> {
             pixels_per_point,
             viewport_output,
         } = full_output;
-
-        remove_viewports_not_in(viewports, painter, viewport_from_window, &viewport_output);
 
         let Some(viewport) = viewports.get_mut(&viewport_id) else {
             return Ok(EventResult::Wait);
@@ -772,8 +846,6 @@ impl WgpuWinitRunning<'_> {
             0.0
         };
 
-        let active_viewports_ids: ViewportIdSet = viewport_output.keys().copied().collect();
-
         handle_viewport_output(
             &integration.egui_ctx,
             &viewport_output,
@@ -781,11 +853,6 @@ impl WgpuWinitRunning<'_> {
             painter,
             viewport_from_window,
         );
-
-        // Prune dead viewports:
-        viewports.retain(|id, _| active_viewports_ids.contains(id));
-        viewport_from_window.retain(|_, id| active_viewports_ids.contains(id));
-        painter.gc_viewports(&active_viewports_ids);
 
         let window = viewport_from_window
             .get(&window_id)
@@ -839,27 +906,20 @@ impl WgpuWinitRunning<'_> {
         // See: https://github.com/emilk/egui/issues/903
         let mut repaint_asap = false;
 
-        // On MacOS the asap repaint is not enough. The drawn frames must be synchronized with
-        // the CoreAnimation transactions driving the window resize process.
-        //
-        // Thus, Painter, responsible for wgpu surfaces and their resize, has to be notified of the
-        // resize lifecycle, yet winit does not provide any events for that. To work around,
-        // the last resized viewport is tracked until a later event outside the live resize stream
-        // is received.
-        //
-        // AppKit can emit `Moved` events during top/left live resize because the window origin
-        // changes along with the content size. Treat those as part of live resize on macOS.
-        //
-        // See: https://github.com/emilk/egui/issues/903
-        let event_keeps_resize_active = matches!(event, winit::event::WindowEvent::Resized(_))
-            || (cfg!(target_os = "macos") && matches!(event, winit::event::WindowEvent::Moved(_)));
+        // On macOS the drawn frames must be synchronized with the CoreAnimation transactions
+        // driving actual AppKit live resize and fullscreen transitions. Initial and programmatic
+        // `Resized` events are not native resize transitions and must not enable transaction
+        // presentation.
+        #[cfg(target_os = "macos")]
+        shared.finish_ended_native_resize();
 
-        if !event_keeps_resize_active
-            && let Some(id) = viewport_id
-            && shared.resized_viewport == viewport_id
+        #[cfg(not(target_os = "macos"))]
+        if !matches!(event, winit::event::WindowEvent::Resized(_))
+            && shared
+                .native_resize
+                .is_some_and(|resize| Some(resize.viewport_id) == viewport_id)
         {
-            shared.painter.on_window_resize_state_change(id, false);
-            shared.resized_viewport = None;
+            shared.set_native_resize(None);
         }
 
         match event {
@@ -890,10 +950,31 @@ impl WgpuWinitRunning<'_> {
                         NonZeroU32::new(physical_size.height),
                     )
                 {
-                    if shared.resized_viewport != viewport_id {
-                        shared.resized_viewport = viewport_id;
-                        shared.painter.on_window_resize_state_change(id, true);
+                    #[cfg(target_os = "macos")]
+                    let native_resize_state = shared
+                        .viewports
+                        .get(&id)
+                        .and_then(|viewport| viewport.window.as_deref())
+                        .map_or(
+                            egui_wgpu::winit::NativeResizeState::Idle,
+                            native_resize_state,
+                        );
+
+                    #[cfg(not(target_os = "macos"))]
+                    let native_resize_state = egui_wgpu::winit::NativeResizeState::LiveResize;
+
+                    if native_resize_state != egui_wgpu::winit::NativeResizeState::Idle {
+                        shared.set_native_resize(Some(NativeResize {
+                            viewport_id: id,
+                            state: native_resize_state,
+                        }));
+                    } else if shared
+                        .native_resize
+                        .is_some_and(|resize| resize.viewport_id == id)
+                    {
+                        shared.set_native_resize(None);
                     }
+
                     shared.painter.on_window_resized(id, width, height);
                     repaint_asap = true;
                 }
@@ -1165,7 +1246,7 @@ fn render_immediate_viewport(
     );
 }
 
-pub(crate) fn remove_viewports_not_in(
+fn remove_viewports_not_in(
     viewports: &mut Viewports,
     painter: &mut egui_wgpu::winit::Painter,
     viewport_from_window: &mut HashMap<WindowId, ViewportId>,
@@ -1174,15 +1255,16 @@ pub(crate) fn remove_viewports_not_in(
     let active_viewports_ids: ViewportIdSet = viewport_output.keys().copied().collect();
 
     // Prune dead viewports:
+    // Drop renderer-owned surfaces before dropping the native windows they reference.
+    painter.gc_viewports(&active_viewports_ids);
     viewports.retain(|id, _| active_viewports_ids.contains(id));
     viewport_from_window.retain(|_, id| active_viewports_ids.contains(id));
-    painter.gc_viewports(&active_viewports_ids);
 }
 
 /// Add new viewports, and update existing ones:
 fn handle_viewport_output(
     egui_ctx: &egui::Context,
-    viewport_output: &OrderedViewportIdMap<ViewportOutput>,
+    viewport_output: &egui::ViewportOutputReport,
     viewports: &mut Viewports,
     painter: &mut egui_wgpu::winit::Painter,
     viewport_from_window: &mut HashMap<WindowId, ViewportId>,
@@ -1197,7 +1279,7 @@ fn handle_viewport_output(
             mut commands,
             repaint_delay: _, // ignored - we listened to the repaint callback instead
         },
-    ) in viewport_output.clone()
+    ) in viewport_output.entries.clone()
     {
         let ids = ViewportIdPair::from_self_and_parent(viewport_id, parent);
 
@@ -1232,7 +1314,14 @@ fn handle_viewport_output(
         }
     }
 
-    remove_viewports_not_in(viewports, painter, viewport_from_window, viewport_output);
+    if viewport_output.is_complete {
+        remove_viewports_not_in(
+            viewports,
+            painter,
+            viewport_from_window,
+            &viewport_output.entries,
+        );
+    }
 }
 
 fn initialize_or_update_viewport<'a>(
@@ -1277,7 +1366,11 @@ fn initialize_or_update_viewport<'a>(
 
             viewport.class = class;
             viewport.ids.parent = ids.parent;
-            viewport.viewport_ui_cb = viewport_ui_cb;
+            // Child viewport passes can report an existing deferred viewport without its
+            // root-owned callback. Keep the callback so direct repaints still run that viewport.
+            if let Some(viewport_ui_cb) = viewport_ui_cb {
+                viewport.viewport_ui_cb = Some(viewport_ui_cb);
+            }
 
             let (mut delta_commands, recreate) = viewport.builder.patch(builder);
 

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -295,10 +295,10 @@ impl AppRunner {
             viewport_output,
         } = full_output;
 
-        if viewport_output.len() > 1 {
+        if viewport_output.entries.len() > 1 {
             log::warn!("Multiple viewports not yet supported on the web");
         }
-        for (_viewport_id, viewport_output) in viewport_output {
+        for (_viewport_id, viewport_output) in viewport_output.entries {
             for command in viewport_output.commands {
                 match command {
                     ViewportCommand::Screenshot(user_data) => {

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -11,14 +11,49 @@ use crate::{
 use egui::{Context, Event, UserData, ViewportId, ViewportIdMap, ViewportIdSet};
 use std::{num::NonZeroU32, sync::Arc};
 
+/// Native window resize state that affects surface presentation.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum NativeResizeState {
+    /// The window is not undergoing a native resize transition.
+    #[default]
+    Idle,
+
+    /// `AppKit` is animating entry into or exit from fullscreen.
+    FullscreenTransition,
+
+    /// `AppKit` is performing an interactive window resize.
+    LiveResize,
+}
+
+#[cfg(all(target_os = "macos", feature = "macos-window-resize-jitter-fix"))]
+impl NativeResizeState {
+    fn presents_with_transaction(self) -> bool {
+        self != Self::Idle
+    }
+
+    fn uses_latency_bump(self) -> bool {
+        self == Self::LiveResize
+    }
+}
+
 struct SurfaceState {
     surface: wgpu::Surface<'static>,
     alpha_mode: wgpu::CompositeAlphaMode,
     width: u32,
     height: u32,
-    resizing: bool,
+    has_presented: bool,
+    native_resize_state: NativeResizeState,
+    #[cfg(all(target_os = "macos", feature = "macos-window-resize-jitter-fix"))]
+    pending_native_resize_state: Option<PendingNativeResizeState>,
     needs_reconfigure: bool,
     needs_recreate: bool,
+}
+
+#[cfg(all(target_os = "macos", feature = "macos-window-resize-jitter-fix"))]
+#[derive(Clone, Copy)]
+struct PendingNativeResizeState {
+    presentation: u64,
+    state: NativeResizeState,
 }
 
 /// Everything you need to paint egui with [`wgpu`] on [`winit`].
@@ -107,7 +142,8 @@ impl Painter {
         // Transaction presentation can hold a drawable during AppKit live resize. Keep the
         // configured low-latency path normally, but use three Metal drawables while resizing.
         #[cfg(all(target_os = "macos", feature = "macos-window-resize-jitter-fix"))]
-        let desired_maximum_frame_latency = if surface_state.resizing {
+        let desired_maximum_frame_latency = if surface_state.native_resize_state.uses_latency_bump()
+        {
             Some(desired_maximum_frame_latency.unwrap_or(2).max(2))
         } else {
             desired_maximum_frame_latency
@@ -159,7 +195,7 @@ impl Painter {
             viewport_id,
             old_state.width,
             old_state.height,
-            old_state.resizing,
+            old_state.native_resize_state,
         );
         Ok(())
     }
@@ -246,7 +282,13 @@ impl Painter {
                     .await?;
             self.render_state = Some(render_state);
         }
-        self.install_surface(surface, viewport_id, size.width, size.height, false);
+        self.install_surface(
+            surface,
+            viewport_id,
+            size.width,
+            size.height,
+            NativeResizeState::Idle,
+        );
         Ok(())
     }
 
@@ -260,7 +302,7 @@ impl Painter {
         viewport_id: ViewportId,
         width: u32,
         height: u32,
-        resizing: bool,
+        native_resize_state: NativeResizeState,
     ) {
         let alpha_mode = {
             // Panic: We use the same failure mode as `resize_and_generate_depth_texture_view_and_msaa_view`
@@ -293,8 +335,11 @@ impl Painter {
                 surface,
                 width,
                 height,
+                has_presented: false,
+                native_resize_state,
+                #[cfg(all(target_os = "macos", feature = "macos-window-resize-jitter-fix"))]
+                pending_native_resize_state: None,
                 alpha_mode,
-                resizing,
                 needs_reconfigure: false,
                 needs_recreate: false,
             },
@@ -392,31 +437,88 @@ impl Painter {
         }
     }
 
-    /// Handles changes of the resizing state.
+    /// Handles changes of the native resize presentation state.
     ///
     /// Should be called prior to the first [`Painter::on_window_resized`] call and after the last in
     /// the chain. Used to apply platform-specific logic, e.g. OSX Metal window resize jitter fix.
-    pub fn on_window_resize_state_change(&mut self, viewport_id: ViewportId, resizing: bool) {
+    pub fn set_native_resize_state(
+        &mut self,
+        viewport_id: ViewportId,
+        native_resize_state: NativeResizeState,
+    ) {
         profiling::function_scope!();
 
         let Some(state) = self.surfaces.get_mut(&viewport_id) else {
             return;
         };
-        if state.resizing == resizing {
-            if resizing {
-                log::debug!(
-                    "Painter::on_window_resize_state_change() redundant call while resizing"
-                );
-            } else {
-                log::debug!(
-                    "Painter::on_window_resize_state_change() redundant call after resizing"
-                );
+        let previous = state.native_resize_state;
+
+        #[cfg(all(target_os = "macos", feature = "macos-window-resize-jitter-fix"))]
+        let presentation = if previous == NativeResizeState::LiveResize
+            && native_resize_state != NativeResizeState::LiveResize
+        {
+            let pending_presentation = state
+                .pending_native_resize_state
+                .filter(|pending| pending.state == native_resize_state)
+                .map(|pending| pending.presentation);
+            unsafe {
+                state
+                    .surface
+                    .as_hal::<wgpu::hal::api::Metal>()
+                    .map(|surface| {
+                        (
+                            pending_presentation
+                                .unwrap_or_else(|| surface.submitted_transaction_presentation()),
+                            surface.completed_transaction_presentation(),
+                        )
+                    })
+            }
+        } else {
+            None
+        };
+
+        #[cfg(all(target_os = "macos", feature = "macos-window-resize-jitter-fix"))]
+        if let Some((submitted, completed)) = presentation
+            && completed < submitted
+        {
+            state.pending_native_resize_state = Some(PendingNativeResizeState {
+                presentation: submitted,
+                state: native_resize_state,
+            });
+            let context = self.context.clone();
+            unsafe {
+                state
+                    .surface
+                    .as_hal::<wgpu::hal::api::Metal>()
+                    .expect("presentation generation came from a Metal surface")
+                    .notify_transaction_presentation(submitted, move || {
+                        context.request_repaint_of(viewport_id)
+                    });
             }
             return;
         }
 
+        #[cfg(all(target_os = "macos", feature = "macos-window-resize-jitter-fix"))]
+        {
+            state.pending_native_resize_state = None;
+        }
+
+        if previous == native_resize_state {
+            if native_resize_state != NativeResizeState::Idle {
+                log::debug!(
+                    "Painter::set_native_resize_state() redundant call during native resize"
+                );
+            } else {
+                log::debug!("Painter::set_native_resize_state() redundant idle call");
+            }
+            return;
+        }
+
+        #[cfg(all(target_os = "macos", feature = "macos-window-resize-jitter-fix"))]
+        let latency_bump_changed =
+            previous.uses_latency_bump() != native_resize_state.uses_latency_bump();
         // Set before reconfiguring so macOS live resize uses the temporary latency bump above.
-        state.resizing = resizing;
+        state.native_resize_state = native_resize_state;
 
         // Resizing is a bit tricky on macOS.
         // It requires enabling ["present_with_transaction"](https://developer.apple.com/documentation/quartzcore/cametallayer/presentswithtransaction)
@@ -436,12 +538,41 @@ impl Painter {
                     hal_surface
                         .render_layer()
                         .lock()
-                        .setPresentsWithTransaction(resizing);
+                        .setPresentsWithTransaction(
+                            native_resize_state.presents_with_transaction(),
+                        );
 
-                    Self::configure_surface(state, render_state, &self.config.surface);
+                    if latency_bump_changed {
+                        Self::configure_surface(state, render_state, &self.config.surface);
+                    }
                 }
             }
         }
+    }
+
+    /// Applies a deferred state once Metal confirms the final transaction drawable was presented.
+    #[cfg(all(target_os = "macos", feature = "macos-window-resize-jitter-fix"))]
+    fn finish_pending_native_resize_state(&mut self, viewport_id: ViewportId) {
+        let Some(pending) = self
+            .surfaces
+            .get(&viewport_id)
+            .and_then(|state| state.pending_native_resize_state)
+        else {
+            return;
+        };
+
+        let completed = unsafe {
+            self.surfaces[&viewport_id]
+                .surface
+                .as_hal::<wgpu::hal::api::Metal>()
+                .map(|surface| surface.completed_transaction_presentation())
+        };
+
+        if completed.is_some_and(|completed| completed < pending.presentation) {
+            return;
+        }
+
+        self.set_native_resize_state(viewport_id, pending.state);
     }
 
     pub fn on_window_resized(
@@ -483,6 +614,9 @@ impl Painter {
         window: &Arc<winit::window::Window>,
     ) -> f32 {
         profiling::function_scope!();
+
+        #[cfg(all(target_os = "macos", feature = "macos-window-resize-jitter-fix"))]
+        self.finish_pending_native_resize_state(viewport_id);
 
         /// Guard to ensure that commands are always submitted to the renderer queue
         /// so that calls to [`write_buffer()`](https://docs.rs/wgpu/latest/wgpu/struct.Queue.html#method.write_buffer)
@@ -624,6 +758,12 @@ impl Painter {
                         self.context.request_repaint_of(viewport_id);
                     }
                     SurfaceErrorAction::SkipFrame => {}
+                }
+                // eframe initially hides native windows until this method returns. If the first
+                // surface acquisition fails, ensure showing that window is followed by another
+                // paint instead of leaving it permanently blank.
+                if !surface_state.has_presented {
+                    self.context.request_repaint_of(viewport_id);
                 }
                 return vsync_sec;
             }
@@ -768,6 +908,7 @@ impl Painter {
             output_frame.present();
             vsync_sec += start.elapsed().as_secs_f32();
         }
+        surface_state.has_presented = true;
 
         vsync_sec
     }

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -1355,11 +1355,12 @@ pub fn update_viewport_info(
     viewport_info.inner_rect = inner_rect;
     viewport_info.outer_rect = outer_rect;
 
+    viewport_info.maximized = Some(window.is_maximized());
+
     if is_init || !cfg!(target_os = "macos") {
-        // Asking for minimized/maximized state at runtime leads to a deadlock on Mac when running
+        // Asking for minimized state at runtime leads to a deadlock on Mac when running
         // `cargo run -p custom_window_frame`.
         // See https://github.com/emilk/egui/issues/3494
-        viewport_info.maximized = Some(window.is_maximized());
         viewport_info.minimized = Some(window.is_minimized().unwrap_or(false));
     }
 

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2643,9 +2643,9 @@ impl ContextImpl {
 
         std::mem::swap(&mut viewport.prev_pass, &mut viewport.this_pass);
 
-        // Integrations may run application logic without running UI for an invisible viewport.
-        // Such a pass cannot authoritatively decide whether its child viewports still exist.
-        let ended_viewport_was_visible = viewport.input.viewport().visible().unwrap_or(true);
+        // Integrations may run application logic without running viewport UI. Such a pass cannot
+        // authoritatively decide whether its child viewports still exist.
+        let ended_viewport_ui_enabled = viewport.input.raw.viewport_ui_enabled;
 
         if repaint_needed {
             self.request_repaint(ended_viewport_id, RepaintCause::new());
@@ -2674,7 +2674,7 @@ impl ContextImpl {
             }
 
             let is_our_child = parent == ended_viewport_id && id != ViewportId::ROOT;
-            if is_our_child && ended_viewport_was_visible {
+            if is_our_child && ended_viewport_ui_enabled {
                 if !viewport.used {
                     log::debug!(
                         "Removing viewport {:?} ({:?}): it was never used this pass",
@@ -2749,7 +2749,7 @@ impl ContextImpl {
             pixels_per_point,
             viewport_output: crate::ViewportOutputReport {
                 entries: viewport_output,
-                is_complete: ended_viewport_id == ViewportId::ROOT && ended_viewport_was_visible,
+                is_complete: ended_viewport_id == ViewportId::ROOT && ended_viewport_ui_enabled,
             },
         }
     }
@@ -4288,7 +4288,7 @@ mod test {
     use crate::{RawInput, ViewportBuilder, ViewportId, ViewportInfo};
 
     #[test]
-    fn invisible_parent_pass_preserves_child_viewports() {
+    fn viewport_ui_enabled_controls_child_retention() {
         let ctx = Context::default();
         ctx.set_embed_viewports(false);
         let child_id = ViewportId::from_hash_of("child");
@@ -4306,10 +4306,14 @@ mod test {
         child_input
             .viewports
             .insert(child_id, ViewportInfo::default());
-        let _ = ctx.run_ui(child_input, |_| {});
+        let output = ctx.run_ui(child_input, |_| {});
+        assert!(!output.viewport_output.is_complete);
         assert_eq!(ctx.cumulative_frame_nr_for(child_id), 1);
 
-        let mut hidden_root_input = RawInput::default();
+        let mut hidden_root_input = RawInput {
+            viewport_ui_enabled: false,
+            ..Default::default()
+        };
         hidden_root_input
             .viewports
             .get_mut(&ViewportId::ROOT)
@@ -4320,7 +4324,13 @@ mod test {
         assert!(!output.viewport_output.is_complete);
         assert_eq!(ctx.cumulative_frame_nr_for(child_id), 1);
 
-        let output = ctx.run_ui(Default::default(), |_| {});
+        let mut hidden_root_input = RawInput::default();
+        hidden_root_input
+            .viewports
+            .get_mut(&ViewportId::ROOT)
+            .unwrap()
+            .occluded = Some(true);
+        let output = ctx.run_ui(hidden_root_input, |_| {});
         assert!(!output.viewport_output.entries.contains_key(&child_id));
         assert!(output.viewport_output.is_complete);
     }

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2643,6 +2643,10 @@ impl ContextImpl {
 
         std::mem::swap(&mut viewport.prev_pass, &mut viewport.this_pass);
 
+        // Integrations may run application logic without running UI for an invisible viewport.
+        // Such a pass cannot authoritatively decide whether its child viewports still exist.
+        let ended_viewport_was_visible = viewport.input.viewport().visible().unwrap_or(true);
+
         if repaint_needed {
             self.request_repaint(ended_viewport_id, RepaintCause::new());
         }
@@ -2670,7 +2674,7 @@ impl ContextImpl {
             }
 
             let is_our_child = parent == ended_viewport_id && id != ViewportId::ROOT;
-            if is_our_child {
+            if is_our_child && ended_viewport_was_visible {
                 if !viewport.used {
                     log::debug!(
                         "Removing viewport {:?} ({:?}): it was never used this pass",
@@ -2743,7 +2747,10 @@ impl ContextImpl {
             textures_delta,
             shapes,
             pixels_per_point,
-            viewport_output,
+            viewport_output: crate::ViewportOutputReport {
+                entries: viewport_output,
+                is_complete: ended_viewport_id == ViewportId::ROOT && ended_viewport_was_visible,
+            },
         }
     }
 }
@@ -4278,6 +4285,45 @@ fn warn_if_rect_changes_id(
 #[cfg(test)]
 mod test {
     use super::Context;
+    use crate::{RawInput, ViewportBuilder, ViewportId, ViewportInfo};
+
+    #[test]
+    fn invisible_parent_pass_preserves_child_viewports() {
+        let ctx = Context::default();
+        ctx.set_embed_viewports(false);
+        let child_id = ViewportId::from_hash_of("child");
+
+        let output = ctx.run_ui(Default::default(), |_ui| {
+            ctx.show_viewport_deferred(child_id, ViewportBuilder::default(), |_, _| {});
+        });
+        assert!(output.viewport_output.entries.contains_key(&child_id));
+        assert!(output.viewport_output.is_complete);
+
+        let mut child_input = RawInput {
+            viewport_id: child_id,
+            ..Default::default()
+        };
+        child_input
+            .viewports
+            .insert(child_id, ViewportInfo::default());
+        let _ = ctx.run_ui(child_input, |_| {});
+        assert_eq!(ctx.cumulative_frame_nr_for(child_id), 1);
+
+        let mut hidden_root_input = RawInput::default();
+        hidden_root_input
+            .viewports
+            .get_mut(&ViewportId::ROOT)
+            .unwrap()
+            .occluded = Some(true);
+        let output = ctx.run_ui(hidden_root_input, |_| {});
+        assert!(output.viewport_output.entries.contains_key(&child_id));
+        assert!(!output.viewport_output.is_complete);
+        assert_eq!(ctx.cumulative_frame_nr_for(child_id), 1);
+
+        let output = ctx.run_ui(Default::default(), |_| {});
+        assert!(!output.viewport_output.entries.contains_key(&child_id));
+        assert!(output.viewport_output.is_complete);
+    }
 
     #[test]
     fn test_single_pass() {

--- a/crates/egui/src/data/input/raw_input.rs
+++ b/crates/egui/src/data/input/raw_input.rs
@@ -22,6 +22,13 @@ pub struct RawInput {
     /// Information about all egui viewports.
     pub viewports: ViewportIdMap<ViewportInfo>,
 
+    /// Whether application UI for the active viewport will be evaluated during this pass.
+    ///
+    /// Integrations that run a pass for non-UI application logic while skipping viewport UI must
+    /// set this to `false`. This prevents egui from treating child viewports omitted by that pass
+    /// as closed. The default is `true`.
+    pub viewport_ui_enabled: bool,
+
     /// The insets used to only render content in a mobile safe area
     ///
     /// `None` will be treated as "same as last frame"
@@ -88,6 +95,7 @@ impl Default for RawInput {
         Self {
             viewport_id: ViewportId::ROOT,
             viewports: std::iter::once((ViewportId::ROOT, Default::default())).collect(),
+            viewport_ui_enabled: true,
             screen_rect: None,
             max_texture_side: None,
             time: None,
@@ -122,6 +130,7 @@ impl RawInput {
                 .iter_mut()
                 .map(|(id, info)| (*id, info.take()))
                 .collect(),
+            viewport_ui_enabled: self.viewport_ui_enabled,
             screen_rect: self.screen_rect.take(),
             safe_area_insets: self.safe_area_insets.take(),
             max_texture_side: self.max_texture_side.take(),
@@ -141,6 +150,7 @@ impl RawInput {
         let Self {
             viewport_id: viewport_ids,
             viewports,
+            viewport_ui_enabled,
             screen_rect,
             max_texture_side,
             time,
@@ -156,6 +166,7 @@ impl RawInput {
 
         self.viewport_id = viewport_ids;
         self.viewports = viewports;
+        self.viewport_ui_enabled = viewport_ui_enabled;
         self.screen_rect = screen_rect.or(self.screen_rect);
         self.max_texture_side = max_texture_side.or(self.max_texture_side);
         self.time = time; // use latest time
@@ -175,6 +186,7 @@ impl RawInput {
         let Self {
             viewport_id,
             viewports,
+            viewport_ui_enabled,
             screen_rect,
             max_texture_side,
             time,
@@ -189,6 +201,7 @@ impl RawInput {
         } = self;
 
         ui.label(format!("Active viewport: {viewport_id:?}"));
+        ui.label(format!("Viewport UI enabled: {viewport_ui_enabled}"));
         let ordered_viewports = viewports
             .iter()
             .map(|(id, value)| (*id, value))
@@ -221,5 +234,23 @@ impl RawInput {
             ui.label(format!("events: {events:#?}"))
                 .on_hover_text("key presses etc");
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RawInput;
+
+    #[test]
+    fn viewport_ui_enabled_survives_take_and_uses_latest_append_value() {
+        let mut input = RawInput {
+            viewport_ui_enabled: false,
+            ..Default::default()
+        };
+
+        assert!(!input.take().viewport_ui_enabled);
+
+        input.append(RawInput::default());
+        assert!(input.viewport_ui_enabled);
     }
 }

--- a/crates/egui/src/data/output.rs
+++ b/crates/egui/src/data/output.rs
@@ -6,6 +6,47 @@ use epaint::text::CharIndex;
 
 use crate::{OrderedViewportIdMap, RepaintCause, ViewportOutput, WidgetType};
 
+/// Viewports reported by an egui pass and whether the report is authoritative.
+#[derive(Clone, Default)]
+pub struct ViewportOutputReport {
+    /// Viewports reported by this pass.
+    pub entries: OrderedViewportIdMap<ViewportOutput>,
+
+    /// Whether missing entries represent closed viewports.
+    ///
+    /// This defaults to `false`, in which case integrations must preserve native viewports absent
+    /// from [`Self::entries`].
+    pub is_complete: bool,
+}
+
+impl ViewportOutputReport {
+    /// Appends a newer report, preserving entries missing from incomplete reports.
+    pub fn append(&mut self, newer: Self) {
+        use std::collections::btree_map::Entry;
+
+        let Self {
+            entries,
+            is_complete,
+        } = newer;
+
+        if is_complete {
+            self.entries.retain(|id, _| entries.contains_key(id));
+        }
+        self.is_complete = is_complete;
+
+        for (id, new_viewport) in entries {
+            match self.entries.entry(id) {
+                Entry::Vacant(entry) => {
+                    entry.insert(new_viewport);
+                }
+                Entry::Occupied(mut entry) => {
+                    entry.get_mut().append(new_viewport);
+                }
+            }
+        }
+    }
+}
+
 /// What egui emits each frame from [`crate::Context::run_ui`].
 ///
 /// The backend should use this.
@@ -32,18 +73,13 @@ pub struct FullOutput {
     /// You can pass this to [`crate::Context::tessellate`] together with [`Self::shapes`].
     pub pixels_per_point: f32,
 
-    /// All the active viewports, including the root.
-    ///
-    /// It is up to the integration to spawn a native window for each viewport,
-    /// and to close any window that no longer has a viewport in this map.
-    pub viewport_output: OrderedViewportIdMap<ViewportOutput>,
+    /// Viewports reported by this pass and whether missing entries represent closed viewports.
+    pub viewport_output: ViewportOutputReport,
 }
 
 impl FullOutput {
     /// Add on new output.
     pub fn append(&mut self, newer: Self) {
-        use std::collections::btree_map::Entry;
-
         let Self {
             platform_output,
             textures_delta,
@@ -56,17 +92,83 @@ impl FullOutput {
         self.textures_delta.append(textures_delta);
         self.shapes = shapes; // Only paint the latest
         self.pixels_per_point = pixels_per_point; // Use latest
+        self.viewport_output.append(viewport_output);
+    }
+}
 
-        for (id, new_viewport) in viewport_output {
-            match self.viewport_output.entry(id) {
-                Entry::Vacant(entry) => {
-                    entry.insert(new_viewport);
-                }
-                Entry::Occupied(mut entry) => {
-                    entry.get_mut().append(new_viewport);
-                }
-            }
+#[cfg(test)]
+mod tests {
+    use super::{FullOutput, ViewportOutputReport};
+    use crate::{ViewportBuilder, ViewportClass, ViewportId, ViewportOutput};
+
+    fn output(is_complete: bool, viewport_ids: impl IntoIterator<Item = ViewportId>) -> FullOutput {
+        let mut viewport_output = ViewportOutputReport {
+            is_complete,
+            ..Default::default()
+        };
+        for viewport_id in viewport_ids {
+            viewport_output.entries.insert(
+                viewport_id,
+                ViewportOutput {
+                    parent: ViewportId::ROOT,
+                    class: ViewportClass::Deferred,
+                    builder: ViewportBuilder::default(),
+                    viewport_ui_cb: None,
+                    commands: vec![],
+                    repaint_delay: std::time::Duration::MAX,
+                },
+            );
         }
+        FullOutput {
+            viewport_output,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn complete_output_removes_stale_entries_when_appended() {
+        let stale = ViewportId::from_hash_of("stale");
+        let active = ViewportId::from_hash_of("active");
+        let mut combined = output(false, [stale, active]);
+
+        combined.append(output(true, [active]));
+
+        assert!(combined.viewport_output.is_complete);
+        assert_eq!(
+            combined
+                .viewport_output
+                .entries
+                .keys()
+                .copied()
+                .collect::<Vec<_>>(),
+            [active]
+        );
+    }
+
+    #[test]
+    fn partial_output_downgrades_complete_output_and_preserves_entries() {
+        let previous = ViewportId::from_hash_of("previous");
+        let newer = ViewportId::from_hash_of("newer");
+        let mut combined = output(true, [previous]);
+
+        combined.append(output(false, [newer]));
+
+        assert!(!combined.viewport_output.is_complete);
+        assert!(combined.viewport_output.entries.contains_key(&previous));
+        assert!(combined.viewport_output.entries.contains_key(&newer));
+    }
+
+    #[test]
+    fn partial_outputs_preserve_their_union_when_appended() {
+        let previous = ViewportId::from_hash_of("previous");
+        let newer = ViewportId::from_hash_of("newer");
+        let mut combined = output(false, [previous]);
+
+        combined.append(output(false, [newer]));
+
+        assert!(!combined.viewport_output.is_complete);
+        assert!(combined.viewport_output.entries.contains_key(&previous));
+        assert!(combined.viewport_output.entries.contains_key(&newer));
     }
 }
 

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -468,7 +468,7 @@ pub use self::{
         input::*,
         output::{
             self, CursorIcon, CustomCursorImage, FullOutput, OpenUrl, OutputCommand,
-            PlatformOutput, UserAttentionType, WidgetInfo,
+            PlatformOutput, UserAttentionType, ViewportOutputReport, WidgetInfo,
         },
     },
     drag_and_drop::DragAndDrop,

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -34,13 +34,13 @@
 //!
 //! ### Embedded viewports
 //! These are not real, independent viewports, but is a fallback mode for when the integration does not support real viewports.
-//! In your callback is called with [`ViewportClass::EmbeddedWindow`] it means the viewport is embedded inside of
+//! If your callback is called with [`ViewportClass::EmbeddedWindow`], it means the viewport is embedded inside of
 //! a regular [`crate::Window`], trapped in the parent viewport.
 //!
 //!
 //! ## Using the viewports
 //! Only one viewport is active at any one time, identified with [`Context::viewport_id`].
-//! You can modify the current (change the title, resize the window, etc) by sending
+//! You can modify the current one (change the title, resize the window, etc) by sending
 //! a [`ViewportCommand`] to it using [`Context::send_viewport_cmd`].
 //! You can interact with other viewports using [`Context::send_viewport_cmd_to`].
 //!
@@ -61,7 +61,7 @@
 //! * There is a [`crate::InputState::viewport`] with information about the current viewport.
 //! * There is a [`crate::RawInput::viewports`] with information about all viewports.
 //! * The repaint callback set by [`Context::set_request_repaint_callback`] points to which viewport should be repainted.
-//! * [`crate::FullOutput::viewport_output`] is a list of viewports which should result in their own independent windows.
+//! * [`crate::FullOutput::viewport_output`] reports viewports which should result in their own independent windows.
 //! * To support immediate viewports you need to call [`Context::set_immediate_viewport_renderer`].
 //! * If you support viewports, you need to call [`Context::set_embed_viewports`] with `false`, or all new viewports will be embedded (the default behavior).
 //!

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -77,10 +77,10 @@ impl EguiGlow {
             viewport_output,
         } = self.egui_ctx.run_ui(raw_input, run_ui);
 
-        if viewport_output.len() > 1 {
+        if viewport_output.entries.len() > 1 {
             log::warn!("Multiple viewports not yet supported by EguiGlow");
         }
-        for (_, ViewportOutput { commands, .. }) in viewport_output {
+        for (_, ViewportOutput { commands, .. }) in viewport_output.entries {
             let mut actions_requested = Default::default();
             egui_winit::process_viewport_commands(
                 &self.egui_ctx,

--- a/crates/egui_kittest/src/lib.rs
+++ b/crates/egui_kittest/src/lib.rs
@@ -685,6 +685,7 @@ impl<'a, State> Harness<'a, State> {
         let requests: Vec<(ViewportId, egui::UserData)> = self
             .output
             .viewport_output
+            .entries
             .iter()
             .flat_map(|(id, viewport)| {
                 viewport.commands.iter().filter_map(move |command| {
@@ -729,6 +730,7 @@ impl<'a, State> Harness<'a, State> {
     fn root_viewport_output(&self) -> &egui::ViewportOutput {
         self.output
             .viewport_output
+            .entries
             .get(&ViewportId::ROOT)
             .expect("Missing root viewport")
     }


### PR DESCRIPTION
What started as an investigation into deferred viewport issues during macOS fullscreen transitions uncovered broader problems in how egui and eframe handle native viewport lifecycle.

This PR builds on https://github.com/emilk/egui/pull/8226 by covering the remaining cases where a pass cannot authoritatively determine the complete viewport set.

## Issues

Extra ghost window sporadically showing up after exiting fullscreen:
<img width="834" height="274" alt="Screenshot 2026-06-30 at 2 21 29 PM" src="https://github.com/user-attachments/assets/aaf99976-90a6-4a93-bc1c-5b30b6e68021" />

Bad viewport scaling during exit fullscreen animation:
<img width="1018" height="734" alt="Screenshot 2026-06-30 at 2 22 05 PM" src="https://github.com/user-attachments/assets/5d7d3bfc-9ccb-4b8c-acd3-ddd38a5d37ae" />

Stretched content during enter full screen animation, with stale content in the bottom left corner:
<img width="920" height="599" alt="Screenshot 2026-06-30 at 2 22 46 PM" src="https://github.com/user-attachments/assets/2ac36c34-cb99-4db8-9a40-63ae54722125" />

In a multi-viewport macOS app using eframe and either wgpu or glow, native fullscreen transitions for secondary viewports could produce several failures:

- fullscreen viewports could become non-interactive after entering native fullscreen
- entering/exiting fullscreen could show stale or stretched content during AppKit’s Space transition
- deferred viewports could be pruned or lose their viewport callback during partial child viewport passes (see below)
- after skipped viewport paints, the first presented frame could use stale surface/viewport state
- if the first wgpu surface acquisition was skipped before any frame presented, the window could remain blank until another repaint was triggered
- after live resize, disabling transaction presentation before the final Metal drawable was shown could leave the window briefly non-interactive and then adjust its size

Video of egui 0.35.0 deferred viewport example behavior on macOS Sequoia 15.7.7: https://youtu.be/4vWCNajjFts
The video shows it can sometimes take a few tries to reproduce certain issues, but they inevitably happen.

One notable issue in the linked video: after a deferred viewport exits fullscreen, macOS can leave behind what looks like an extra native window. That window is not an egui viewport that the app still owns intentionally. It is stale state caused by eframe pruning or updating deferred viewport state from a partial child viewport pass while AppKit is still driving the fullscreen transition.

This PR avoids that by treating only root passes whose viewport UI ran as authoritative for pruning native viewports, and by preserving existing deferred viewport callbacks when incomplete child passes do not report them.

On macOS empirical testing shows that fullscreen windows are sometimes reported as:
* fullscreen=true
* focused=true
* occluded=true
* run_ui=false

## Fixes

This changes egui and its native integrations to:

- represent viewport output as a partial or complete report
- prune missing native viewports only after a complete root report whose viewport UI ran
- preserve deferred viewport callbacks across incomplete passes
- move the current GL context before removing a Glow viewport surface
- drive Metal transaction presentation from AppKit live-resize and fullscreen state
- wait for the final transaction-presented Metal drawable before leaving live-resize presentation state
- retry when the first wgpu surface acquisition is skipped
- refresh native maximize state at runtime on macOS
- distinguish AppKit live resize from fullscreen transitions, enabling transaction presentation for both while retaining [#8229](https://github.com/emilk/egui/pull/8229)’s temporary latency bump only for live resize, so it now works like this:

<html>
<body>

State | presentsWithTransaction | Latency bump
-- | -- | --
LiveResize | yes | yes
FullscreenTransition | yes | no
Idle | no | no

</body>
</html>

## API migration

`FullOutput::viewport_output` is now a `ViewportOutputReport` so integrations cannot
silently ignore whether a viewport report is authoritative.

- Use `output.viewport_output.entries` for the viewport map.
- Check `output.viewport_output.is_complete` before removing missing native viewports.
- Set `raw_input.viewport_ui_enabled = false` when running a pass without evaluating viewport UI.

## Dependency

Depends on rust-windowing/winit#4610 for:

- `WindowExtMacOS::is_live_resizing()`
- `WindowExtMacOS::is_fullscreen_transition()`
- cached version of `WindowDelegate::is_maximized()`

Depends on gfx-rs/wgpu#9828 for:

- submitted and completed Metal transaction-presentation generations
- a one-shot notification after a target generation is presented

Because egui 0.35 uses wgpu 29 while the upstream wgpu PR targets trunk, this branch temporarily pins an equivalent v29 backport in `yay/wgpu`.

This is draft because the required winit and wgpu APIs have not reached versions compatible with egui 0.35. macOS checks may fail until those dependency updates are available.
