### PR TITLE
Add option to open and close context menus on press instead of click

### DIFF
--- a/crates/egui/src/containers/menu.rs
+++ b/crates/egui/src/containers/menu.rs
@@ -66,7 +66,8 @@ pub struct MenuConfig {
     /// Is this a menu bar?
     bar: bool,
 
-    /// If the user clicks, should we close the menu?
+    /// When should pointer presses/clicks close the menu?
+    /// See [`PopupCloseBehavior`].
     pub close_behavior: PopupCloseBehavior,
 
     /// Override the menu style.
@@ -93,7 +94,8 @@ impl MenuConfig {
         Self::default()
     }
 
-    /// If the user clicks, should we close the menu?
+    /// When should pointer presses/clicks close the menu?
+    /// See [`PopupCloseBehavior`].
     #[inline]
     pub fn close_behavior(mut self, close_behavior: PopupCloseBehavior) -> Self {
         self.close_behavior = close_behavior;
@@ -545,13 +547,27 @@ impl SubMenu {
                 && response.ctx.input(|i| i.pointer.any_click())
                 && hover_pos.is_some_and(|pos| popup_response.response.interact_rect.contains(pos));
 
-            let click_close = match menu_config.close_behavior {
+            let pressed_outside = is_deepest_submenu
+                && popup_response.response.pressed_elsewhere()
+                && menu_root_response.pressed_elsewhere();
+
+            // Only *primary* clicks close from the inside, so that the release of the
+            // secondary press that opened a context menu can never close it.
+            let primary_clicked_inside = is_deepest_submenu
+                && !submenu_button_clicked
+                && response.ctx.input(|i| i.pointer.primary_clicked())
+                && hover_pos.is_some_and(|pos| popup_response.response.interact_rect.contains(pos));
+
+            let pointer_close = match menu_config.close_behavior {
                 PopupCloseBehavior::CloseOnClick => clicked_outside || clicked_inside,
                 PopupCloseBehavior::CloseOnClickOutside => clicked_outside,
+                PopupCloseBehavior::CloseOnPressOutside => {
+                    pressed_outside || primary_clicked_inside
+                }
                 PopupCloseBehavior::IgnoreClicks => false,
             };
 
-            if click_close {
+            if pointer_close {
                 set_open = Some(false);
                 ui.close();
             }

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -92,6 +92,11 @@ pub enum PopupCloseBehavior {
     /// so that e.g. clicking a menu item still closes the menu.
     ///
     /// It is used in [`Popup::context_menu`].
+    ///
+    /// Note: this behavior is designed for popups that open on press.
+    /// For popups toggled by a button click (e.g. [`Popup::menu`]),
+    /// pressing the button would close the popup,
+    /// only for the click completing on release to toggle it open again.
     CloseOnPressOutside,
 
     /// Clicks will be ignored. Popup might be closed manually by calling [`Popup::close_all`]

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -91,7 +91,8 @@ pub enum PopupCloseBehavior {
     /// It will also close when the popup is *clicked* with the primary button,
     /// so that e.g. clicking a menu item still closes the menu.
     ///
-    /// It is used in [`Popup::context_menu`].
+    /// It is used in [`Popup::context_menu`] when
+    /// [`crate::style::Interaction::context_menu_opens_on_press`] is enabled.
     ///
     /// Note: this behavior is designed for popups that open on press.
     /// For popups toggled by a button click (e.g. [`Popup::menu`]),
@@ -254,31 +255,46 @@ impl<'a> Popup<'a> {
             .gap(0.0)
     }
 
-    /// Show a context menu when the widget was pressed with the secondary mouse button
+    /// Show a context menu when the widget was secondary clicked
     /// (or pressed-and-held on a touch screen).
     /// Sets the layout to `Layout::top_down_justified(Align::Min)`.
     /// In contrast to [`Self::menu`], this will open at the pointer position.
     ///
-    /// The menu opens on press, and closes when a pointer button is pressed outside it
+    /// If [`crate::style::Interaction::context_menu_opens_on_press`] is enabled,
+    /// the menu instead opens already on secondary button *press*,
+    /// and closes when a pointer button is pressed outside it
     /// or when an item inside it is clicked
     /// (see [`PopupCloseBehavior::CloseOnPressOutside`]).
     pub fn context_menu(response: &Response) -> Self {
-        Self::menu(response)
+        let opens_on_press = response
+            .ctx
+            .global_style()
+            .interaction
+            .context_menu_opens_on_press;
+        let should_open = if opens_on_press {
             // Checking `secondary_clicked` in addition to `secondary_pressed` ensures the
             // menu also opens when the press and release arrive in the same frame.
-            .open_memory(
-                if response.secondary_pressed() || response.secondary_clicked() {
-                    Some(SetOpenCommand::Bool(true))
-                } else if response.clicked() {
-                    // Explicitly close the menu on keyboard/accessibility activation of the widget.
-                    // Pointer presses on the widget already close it via `CloseOnPressOutside`.
-                    Some(SetOpenCommand::Bool(false))
-                } else {
-                    None
-                },
-            )
+            response.secondary_pressed() || response.secondary_clicked()
+        } else {
+            response.secondary_clicked()
+        };
+        let close_behavior = if opens_on_press {
+            PopupCloseBehavior::CloseOnPressOutside
+        } else {
+            PopupCloseBehavior::CloseOnClick
+        };
+        Self::menu(response)
+            .open_memory(if should_open {
+                Some(SetOpenCommand::Bool(true))
+            } else if response.clicked() {
+                // Explicitly close the menu if the widget was clicked
+                // Without this, the context menu would stay open if the user clicks the widget
+                Some(SetOpenCommand::Bool(false))
+            } else {
+                None
+            })
             .at_pointer_fixed()
-            .close_behavior(PopupCloseBehavior::CloseOnPressOutside)
+            .close_behavior(close_behavior)
     }
 
     /// Set the kind of the popup. Used for [`Area::kind`] and [`Area::order`].
@@ -345,7 +361,8 @@ impl<'a> Popup<'a> {
     ///
     /// Defaults to [`PopupCloseBehavior::CloseOnClick`],
     /// except for [`Popup::context_menu`], which uses
-    /// [`PopupCloseBehavior::CloseOnPressOutside`].
+    /// [`PopupCloseBehavior::CloseOnPressOutside`] when
+    /// [`crate::style::Interaction::context_menu_opens_on_press`] is enabled.
     ///
     /// This will do nothing if [`Popup::open`] was called.
     #[inline]

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -85,6 +85,15 @@ pub enum PopupCloseBehavior {
     /// but in the popup's body
     CloseOnClickOutside,
 
+    /// Popup will be closed as soon as a pointer button is *pressed* outside its body,
+    /// without waiting for a release (in contrast to [`Self::CloseOnClickOutside`]).
+    ///
+    /// It will also close when the popup is *clicked* with the primary button,
+    /// so that e.g. clicking a menu item still closes the menu.
+    ///
+    /// It is used in [`Popup::context_menu`].
+    CloseOnPressOutside,
+
     /// Clicks will be ignored. Popup might be closed manually by calling [`Popup::close_all`]
     /// or by pressing the escape button
     IgnoreClicks,
@@ -240,21 +249,31 @@ impl<'a> Popup<'a> {
             .gap(0.0)
     }
 
-    /// Show a context menu when the widget was secondary clicked.
+    /// Show a context menu when the widget was pressed with the secondary mouse button
+    /// (or pressed-and-held on a touch screen).
     /// Sets the layout to `Layout::top_down_justified(Align::Min)`.
     /// In contrast to [`Self::menu`], this will open at the pointer position.
+    ///
+    /// The menu opens on press, and closes when a pointer button is pressed outside it
+    /// or when an item inside it is clicked
+    /// (see [`PopupCloseBehavior::CloseOnPressOutside`]).
     pub fn context_menu(response: &Response) -> Self {
         Self::menu(response)
-            .open_memory(if response.secondary_clicked() {
-                Some(SetOpenCommand::Bool(true))
-            } else if response.clicked() {
-                // Explicitly close the menu if the widget was clicked
-                // Without this, the context menu would stay open if the user clicks the widget
-                Some(SetOpenCommand::Bool(false))
-            } else {
-                None
-            })
+            // Checking `secondary_clicked` in addition to `secondary_pressed` ensures the
+            // menu also opens when the press and release arrive in the same frame.
+            .open_memory(
+                if response.secondary_pressed() || response.secondary_clicked() {
+                    Some(SetOpenCommand::Bool(true))
+                } else if response.clicked() {
+                    // Explicitly close the menu on keyboard/accessibility activation of the widget.
+                    // Pointer presses on the widget already close it via `CloseOnPressOutside`.
+                    Some(SetOpenCommand::Bool(false))
+                } else {
+                    None
+                },
+            )
             .at_pointer_fixed()
+            .close_behavior(PopupCloseBehavior::CloseOnPressOutside)
     }
 
     /// Set the kind of the popup. Used for [`Area::kind`] and [`Area::order`].
@@ -318,6 +337,10 @@ impl<'a> Popup<'a> {
     }
 
     /// Set the close behavior of the popup.
+    ///
+    /// Defaults to [`PopupCloseBehavior::CloseOnClick`],
+    /// except for [`Popup::context_menu`], which uses
+    /// [`PopupCloseBehavior::CloseOnPressOutside`].
     ///
     /// This will do nothing if [`Popup::open`] was called.
     #[inline]
@@ -590,16 +613,22 @@ impl<'a> Popup<'a> {
             frame.show(ui, content).inner
         });
 
-        // If the popup was just opened with a click, we don't want to immediately close it again.
-        let close_click = was_open_last_frame && ctx.input(|i| i.pointer.any_click());
-
-        let closed_by_click = match close_behavior {
-            PopupCloseBehavior::CloseOnClick => close_click,
-            PopupCloseBehavior::CloseOnClickOutside => {
-                close_click && response.response.clicked_elsewhere()
-            }
-            PopupCloseBehavior::IgnoreClicks => false,
-        };
+        // If the popup was just opened with a press or click, we don't want to immediately
+        // close it again, hence the `was_open_last_frame` check.
+        let closed_by_pointer = was_open_last_frame
+            && match close_behavior {
+                PopupCloseBehavior::CloseOnClick => ctx.input(|i| i.pointer.any_click()),
+                PopupCloseBehavior::CloseOnClickOutside => response.response.clicked_elsewhere(),
+                PopupCloseBehavior::CloseOnPressOutside => {
+                    // Only *primary* clicks close from the inside:
+                    // the release of the secondary press that opened the popup may land
+                    // within its body (the popup opens at the pointer) and must not close it.
+                    response.response.pressed_elsewhere()
+                        || (ctx.input(|i| i.pointer.primary_clicked())
+                            && !response.response.clicked_elsewhere())
+                }
+                PopupCloseBehavior::IgnoreClicks => false,
+            };
 
         // Mark the menu as shown, so the sub menu open state is not reset
         MenuState::mark_shown(&ctx, id);
@@ -607,7 +636,7 @@ impl<'a> Popup<'a> {
         // If a submenu is open, the CloseBehavior is handled there
         let is_any_submenu_open = !MenuState::is_deepest_open_sub_menu(&response.response.ctx, id);
 
-        let should_close = (!is_any_submenu_open && closed_by_click)
+        let should_close = (!is_any_submenu_open && closed_by_pointer)
             || ctx.input(|i| i.key_pressed(Key::Escape))
             || response.response.should_close();
 

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -219,6 +219,35 @@ impl Response {
         self.flags.contains(Flags::LONG_TOUCHED)
     }
 
+    /// Returns true if a press of the given pointer button began on this widget this frame.
+    ///
+    /// In contrast to [`Self::clicked_by`], this fires already on press,
+    /// without waiting for the button to be released.
+    ///
+    /// Note that the widget must be sensing clicks or drags with [`Sense::click`] or [`Sense::drag`].
+    ///
+    /// If another pointer button is already held down on this widget,
+    /// a press of `button` elsewhere in the same frame may also return true.
+    /// If the button is pressed and released within the same frame,
+    /// this returns false, but [`Self::clicked_by`] returns true.
+    #[inline]
+    pub fn pressed_by(&self, button: PointerButton) -> bool {
+        self.flags.contains(Flags::IS_POINTER_BUTTON_DOWN_ON)
+            && self.ctx.input(|i| i.pointer.button_pressed(button))
+    }
+
+    /// Returns true if a press of the secondary pointer button (e.g. the right mouse button)
+    /// began on this widget this frame.
+    ///
+    /// In contrast to [`Self::secondary_clicked`], this fires already on press,
+    /// without waiting for the button to be released.
+    ///
+    /// This also returns true if the widget was pressed-and-held on a touch screen.
+    #[inline]
+    pub fn secondary_pressed(&self) -> bool {
+        self.flags.contains(Flags::LONG_TOUCHED) || self.pressed_by(PointerButton::Secondary)
+    }
+
     /// Returns true if this widget was clicked this frame by the middle mouse button.
     ///
     /// A click is registered when the mouse or touch is released within
@@ -291,6 +320,41 @@ impl Response {
                 }
             } else {
                 false // clicked without a pointer, weird
+            }
+        } else {
+            false
+        }
+    }
+
+    /// `true` if a pointer button was pressed *outside* the rect of this widget this frame.
+    ///
+    /// This is like [`Self::clicked_elsewhere`], but responds already on press,
+    /// without waiting for a click (press + release).
+    ///
+    /// Presses on widgets contained in this one count as presses inside this widget,
+    /// so that pressing a button in an area will not be considered as pressing "elsewhere" from the area.
+    ///
+    /// Presses on other layers above this widget *will* be considered as pressing elsewhere.
+    pub fn pressed_elsewhere(&self) -> bool {
+        let (pointer_interact_pos, any_pressed) = self
+            .ctx
+            .input(|i| (i.pointer.interact_pos(), i.pointer.any_pressed()));
+
+        // We do not use self.pressed_by(), because we want to catch all presses within our frame,
+        // even if we aren't clickable (or even enabled).
+        // This is important for popups and such that should close when the user presses elsewhere.
+        if any_pressed {
+            if self.contains_pointer() || self.hovered() {
+                false
+            } else if let Some(pos) = pointer_interact_pos {
+                let layer_under_pointer = self.ctx.layer_id_at(pos);
+                if layer_under_pointer == Some(self.layer_id) {
+                    !self.interact_rect.contains(pos)
+                } else {
+                    true
+                }
+            } else {
+                false // pressed without a pointer, weird
             }
         } else {
             false
@@ -988,7 +1052,11 @@ impl Response {
         self
     }
 
-    /// Response to secondary clicks (right-clicks) by showing the given menu.
+    /// Show the given menu when the widget is pressed with the secondary mouse button
+    /// (or pressed-and-held on a touch screen).
+    ///
+    /// The menu opens on press, and closes when a pointer button is pressed outside it
+    /// or when an item inside it is clicked.
     ///
     /// Make sure the widget senses clicks (e.g. [`crate::Button`] does, [`crate::Label`] does not).
     ///

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -1052,10 +1052,11 @@ impl Response {
         self
     }
 
-    /// Show the given menu when the widget is pressed with the secondary mouse button
-    /// (or pressed-and-held on a touch screen).
+    /// Response to secondary clicks (right-clicks) by showing the given menu.
     ///
-    /// The menu opens on press, and closes when a pointer button is pressed outside it
+    /// If [`crate::style::Interaction::context_menu_opens_on_press`] is enabled,
+    /// the menu instead opens already on secondary button press,
+    /// and closes when a pointer button is pressed outside it
     /// or when an item inside it is clicked.
     ///
     /// Make sure the widget senses clicks (e.g. [`crate::Button`] does, [`crate::Label`] does not).

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -938,6 +938,15 @@ pub struct Interaction {
     /// The default is `true`, but text selection can be slightly glitchy,
     /// so you may want to disable it.
     pub multi_widget_text_select: bool,
+
+    /// Should context menus open on secondary button *press*, instead of on click
+    /// (press + release), like native context menus?
+    ///
+    /// If `true`, context menus also close as soon as a pointer button is pressed
+    /// outside them (see [`crate::PopupCloseBehavior::CloseOnPressOutside`]).
+    ///
+    /// The default is `false` (open and close on click).
+    pub context_menu_opens_on_press: bool,
 }
 
 /// Look and feel of the text cursor.
@@ -1481,6 +1490,7 @@ impl Default for Interaction {
             tooltip_grace_time: 0.2,
             selectable_labels: true,
             multi_widget_text_select: true,
+            context_menu_opens_on_press: false,
         }
     }
 }
@@ -2074,6 +2084,7 @@ impl Interaction {
             tooltip_grace_time,
             selectable_labels,
             multi_widget_text_select,
+            context_menu_opens_on_press,
         } = self;
 
         ui.spacing_mut().item_spacing = vec2(12.0, 8.0);
@@ -2121,6 +2132,11 @@ impl Interaction {
         ui.checkbox(
             show_tooltips_only_when_still,
             "Only show tooltips if mouse is still",
+        );
+
+        ui.checkbox(
+            context_menu_opens_on_press,
+            "Open context menus on press (instead of click)",
         );
 
         ui.horizontal(|ui| {

--- a/crates/egui_demo_lib/src/demo/popups.rs
+++ b/crates/egui_demo_lib/src/demo/popups.rs
@@ -155,14 +155,21 @@ impl crate::View for PopupsDemo {
         self.apply_options(Popup::menu(&response).id(Id::new("menu")))
             .show(|ui| self.nested_menus(ui));
 
-        // We don't apply `self.close_behavior` here: context menus open on press,
-        // so the click-based close behaviors would close them as soon as the
-        // pressed button is released.
-        Popup::context_menu(&response)
-            .id(Id::new("context_menu"))
-            .align(self.align4)
-            .gap(self.gap)
-            .show(|ui| self.nested_menus(ui));
+        let context_menu = Popup::context_menu(&response).id(Id::new("context_menu"));
+        let context_menu = if ui
+            .ctx()
+            .global_style()
+            .interaction
+            .context_menu_opens_on_press
+        {
+            // The click-based close behaviors would close a press-opened context menu
+            // as soon as the pressed button is released, so we don't apply
+            // `self.close_behavior` here.
+            context_menu.align(self.align4).gap(self.gap)
+        } else {
+            self.apply_options(context_menu)
+        };
+        context_menu.show(|ui| self.nested_menus(ui));
 
         if self.popup_open {
             self.apply_options(Popup::from_response(&response).id(Id::new("popup")))
@@ -315,6 +322,28 @@ impl crate::View for PopupsDemo {
             ui.horizontal(|ui| {
                 rust_view_ui(ui, "let popup_open = ");
                 ui.checkbox(&mut self.popup_open, "");
+                rust_view_ui(ui, ";");
+            });
+
+            ui.horizontal(|ui| {
+                rust_view_ui(ui, "style.interaction.context_menu_opens_on_press = ");
+                let mut opens_on_press = ui
+                    .ctx()
+                    .global_style()
+                    .interaction
+                    .context_menu_opens_on_press;
+                if ui
+                    .checkbox(&mut opens_on_press, "")
+                    .on_hover_text(
+                        "Open the context menu on right-button press instead of click. \
+                         It will then also close as soon as you press outside it.",
+                    )
+                    .changed()
+                {
+                    ui.ctx().all_styles_mut(|style| {
+                        style.interaction.context_menu_opens_on_press = opens_on_press;
+                    });
+                }
                 rust_view_ui(ui, ";");
             });
             ui.monospace("");

--- a/crates/egui_demo_lib/src/demo/popups.rs
+++ b/crates/egui_demo_lib/src/demo/popups.rs
@@ -155,7 +155,13 @@ impl crate::View for PopupsDemo {
         self.apply_options(Popup::menu(&response).id(Id::new("menu")))
             .show(|ui| self.nested_menus(ui));
 
-        self.apply_options(Popup::context_menu(&response).id(Id::new("context_menu")))
+        // We don't apply `self.close_behavior` here: context menus open on press,
+        // so the click-based close behaviors would close them as soon as the
+        // pressed button is released.
+        Popup::context_menu(&response)
+            .id(Id::new("context_menu"))
+            .align(self.align4)
+            .gap(self.gap)
             .show(|ui| self.nested_menus(ui));
 
         if self.popup_open {

--- a/crates/egui_demo_lib/src/demo/popups.rs
+++ b/crates/egui_demo_lib/src/demo/popups.rs
@@ -277,6 +277,12 @@ impl crate::View for PopupsDemo {
                         "Closes when the user clicks outside the popup",
                     ),
                     (
+                        PopupCloseBehavior::CloseOnPressOutside,
+                        "CloseOnPressOutside",
+                        "Closes as soon as the user presses outside the popup, \
+                         or clicks inside it with the primary button",
+                    ),
+                    (
                         PopupCloseBehavior::IgnoreClicks,
                         "IgnoreClicks",
                         "Close only when the button is clicked again",

--- a/crates/egui_kittest/tests/context_menu.rs
+++ b/crates/egui_kittest/tests/context_menu.rs
@@ -27,6 +27,16 @@ impl ContextMenuTest {
             .with_size(egui::Vec2::new(500.0, 300.0))
             .build_ui_state(|ui, state| state.ui(ui), self)
     }
+
+    /// Like [`Self::into_harness`], but with
+    /// [`egui::style::Interaction::context_menu_opens_on_press`] enabled.
+    fn into_press_harness(self) -> Harness<'static, Self> {
+        let harness = self.into_harness();
+        harness
+            .ctx
+            .all_styles_mut(|style| style.interaction.context_menu_opens_on_press = true);
+        harness
+    }
 }
 
 fn press_at(harness: &Harness<'_, ContextMenuTest>, pos: Pos2, button: PointerButton) {
@@ -58,8 +68,34 @@ fn open_with_press(harness: &mut Harness<'_, ContextMenuTest>) -> Pos2 {
 }
 
 #[test]
-fn context_menu_opens_on_secondary_press() {
+fn context_menu_default_opens_on_click_not_press() {
     let mut harness = ContextMenuTest::default().into_harness();
+
+    // With the default style, the menu must NOT open on press...
+    let pos = harness.get_by_label("Right-click me").rect().center();
+    press_at(&harness, pos, PointerButton::Secondary);
+    harness.run();
+    assert!(harness.query_by_label("Item").is_none());
+
+    // ...but when the click completes on release.
+    release_at(&harness, pos, PointerButton::Secondary);
+    harness.run();
+    assert!(harness.query_by_label("Item").is_some());
+
+    // And it must NOT close on press outside...
+    press_at(&harness, OUTSIDE_POS, PointerButton::Primary);
+    harness.run();
+    assert!(harness.query_by_label("Item").is_some());
+
+    // ...but when the click outside completes on release.
+    release_at(&harness, OUTSIDE_POS, PointerButton::Primary);
+    harness.run();
+    assert!(harness.query_by_label("Item").is_none());
+}
+
+#[test]
+fn context_menu_opens_on_secondary_press() {
+    let mut harness = ContextMenuTest::default().into_press_harness();
 
     // The menu should open on press, before the button is released.
     open_with_press(&mut harness);
@@ -68,7 +104,7 @@ fn context_menu_opens_on_secondary_press() {
 
 #[test]
 fn context_menu_stays_open_after_release() {
-    let mut harness = ContextMenuTest::default().into_harness();
+    let mut harness = ContextMenuTest::default().into_press_harness();
 
     let pos = open_with_press(&mut harness);
     release_at(&harness, pos, PointerButton::Secondary);
@@ -79,7 +115,7 @@ fn context_menu_stays_open_after_release() {
 
 #[test]
 fn context_menu_quick_right_click_keeps_menu_open() {
-    let mut harness = ContextMenuTest::default().into_harness();
+    let mut harness = ContextMenuTest::default().into_press_harness();
 
     // Press and release arrive in the same frame here. The release lands at the
     // menu's corner (the menu opens at the pointer), and must not close it.
@@ -91,7 +127,7 @@ fn context_menu_quick_right_click_keeps_menu_open() {
 
 #[test]
 fn context_menu_closes_on_primary_press_outside() {
-    let mut harness = ContextMenuTest::default().into_harness();
+    let mut harness = ContextMenuTest::default().into_press_harness();
 
     open_with_press(&mut harness);
 
@@ -108,7 +144,7 @@ fn context_menu_closes_on_primary_press_outside() {
 
 #[test]
 fn context_menu_closes_on_secondary_press_outside() {
-    let mut harness = ContextMenuTest::default().into_harness();
+    let mut harness = ContextMenuTest::default().into_press_harness();
 
     open_with_press(&mut harness);
 
@@ -125,7 +161,7 @@ fn context_menu_closes_on_secondary_press_outside() {
 
 #[test]
 fn context_menu_item_click_fires_and_closes() {
-    let mut harness = ContextMenuTest::default().into_harness();
+    let mut harness = ContextMenuTest::default().into_press_harness();
 
     open_with_press(&mut harness);
 
@@ -137,7 +173,7 @@ fn context_menu_item_click_fires_and_closes() {
 
 #[test]
 fn context_menu_press_inside_does_not_close() {
-    let mut harness = ContextMenuTest::default().into_harness();
+    let mut harness = ContextMenuTest::default().into_press_harness();
 
     open_with_press(&mut harness);
 
@@ -156,7 +192,7 @@ fn context_menu_press_inside_does_not_close() {
 
 #[test]
 fn context_menu_submenu_closes_on_press_outside() {
-    let mut harness = ContextMenuTest::default().into_harness();
+    let mut harness = ContextMenuTest::default().into_press_harness();
 
     open_with_press(&mut harness);
 

--- a/crates/egui_kittest/tests/context_menu.rs
+++ b/crates/egui_kittest/tests/context_menu.rs
@@ -1,0 +1,172 @@
+use egui::{Modifiers, PointerButton, Popup, Pos2, Ui};
+use egui_kittest::Harness;
+use kittest::Queryable as _;
+
+const OUTSIDE_POS: Pos2 = Pos2::new(450.0, 280.0);
+
+#[derive(Default)]
+struct ContextMenuTest {
+    item_clicked: bool,
+}
+
+impl ContextMenuTest {
+    fn ui(&mut self, ui: &mut Ui) {
+        let response = ui.button("Right-click me");
+        Popup::context_menu(&response).show(|ui| {
+            if ui.button("Item").clicked() {
+                self.item_clicked = true;
+            }
+            ui.menu_button("Submenu", |ui| {
+                _ = ui.button("Sub item");
+            });
+        });
+    }
+
+    fn into_harness(self) -> Harness<'static, Self> {
+        Harness::builder()
+            .with_size(egui::Vec2::new(500.0, 300.0))
+            .build_ui_state(|ui, state| state.ui(ui), self)
+    }
+}
+
+fn press_at(harness: &Harness<'_, ContextMenuTest>, pos: Pos2, button: PointerButton) {
+    harness.event(egui::Event::PointerMoved(pos));
+    harness.event(egui::Event::PointerButton {
+        pos,
+        button,
+        pressed: true,
+        modifiers: Modifiers::default(),
+    });
+}
+
+fn release_at(harness: &Harness<'_, ContextMenuTest>, pos: Pos2, button: PointerButton) {
+    harness.event(egui::Event::PointerButton {
+        pos,
+        button,
+        pressed: false,
+        modifiers: Modifiers::default(),
+    });
+}
+
+/// Secondary-press the anchor button and run, so the menu is open
+/// while the button is still held down.
+fn open_with_press(harness: &mut Harness<'_, ContextMenuTest>) -> Pos2 {
+    let pos = harness.get_by_label("Right-click me").rect().center();
+    press_at(harness, pos, PointerButton::Secondary);
+    harness.run();
+    pos
+}
+
+#[test]
+fn context_menu_opens_on_secondary_press() {
+    let mut harness = ContextMenuTest::default().into_harness();
+
+    // The menu should open on press, before the button is released.
+    open_with_press(&mut harness);
+    assert!(harness.query_by_label("Item").is_some());
+}
+
+#[test]
+fn context_menu_stays_open_after_release() {
+    let mut harness = ContextMenuTest::default().into_harness();
+
+    let pos = open_with_press(&mut harness);
+    release_at(&harness, pos, PointerButton::Secondary);
+    harness.run();
+    harness.run();
+    assert!(harness.query_by_label("Item").is_some());
+}
+
+#[test]
+fn context_menu_quick_right_click_keeps_menu_open() {
+    let mut harness = ContextMenuTest::default().into_harness();
+
+    // Press and release arrive in the same frame here. The release lands at the
+    // menu's corner (the menu opens at the pointer), and must not close it.
+    harness.get_by_label("Right-click me").click_secondary();
+    harness.run();
+    harness.run();
+    assert!(harness.query_by_label("Item").is_some());
+}
+
+#[test]
+fn context_menu_closes_on_primary_press_outside() {
+    let mut harness = ContextMenuTest::default().into_harness();
+
+    open_with_press(&mut harness);
+
+    // The menu should close on press, before the button is released.
+    press_at(&harness, OUTSIDE_POS, PointerButton::Primary);
+    harness.run();
+    assert!(harness.query_by_label("Item").is_none());
+    assert!(!harness.state().item_clicked);
+
+    release_at(&harness, OUTSIDE_POS, PointerButton::Primary);
+    harness.run();
+    assert!(harness.query_by_label("Item").is_none());
+}
+
+#[test]
+fn context_menu_closes_on_secondary_press_outside() {
+    let mut harness = ContextMenuTest::default().into_harness();
+
+    open_with_press(&mut harness);
+
+    press_at(&harness, OUTSIDE_POS, PointerButton::Secondary);
+    harness.run();
+    assert!(harness.query_by_label("Item").is_none());
+
+    // A secondary release over empty space should not reopen the menu.
+    release_at(&harness, OUTSIDE_POS, PointerButton::Secondary);
+    harness.run();
+    harness.run();
+    assert!(harness.query_by_label("Item").is_none());
+}
+
+#[test]
+fn context_menu_item_click_fires_and_closes() {
+    let mut harness = ContextMenuTest::default().into_harness();
+
+    open_with_press(&mut harness);
+
+    harness.get_by_label("Item").click();
+    harness.run();
+    assert!(harness.state().item_clicked);
+    assert!(harness.query_by_label("Item").is_none());
+}
+
+#[test]
+fn context_menu_press_inside_does_not_close() {
+    let mut harness = ContextMenuTest::default().into_harness();
+
+    open_with_press(&mut harness);
+
+    let item_pos = harness.get_by_label("Item").rect().center();
+    press_at(&harness, item_pos, PointerButton::Primary);
+    harness.run();
+    assert!(harness.query_by_label("Item").is_some());
+    assert!(!harness.state().item_clicked);
+
+    // The item fires on release, closing the menu.
+    release_at(&harness, item_pos, PointerButton::Primary);
+    harness.run();
+    assert!(harness.state().item_clicked);
+    assert!(harness.query_by_label("Item").is_none());
+}
+
+#[test]
+fn context_menu_submenu_closes_on_press_outside() {
+    let mut harness = ContextMenuTest::default().into_harness();
+
+    open_with_press(&mut harness);
+
+    harness.get_by_label_contains("Submenu").hover();
+    harness.run();
+    harness.run();
+    assert!(harness.query_by_label("Sub item").is_some());
+
+    press_at(&harness, OUTSIDE_POS, PointerButton::Primary);
+    harness.run();
+    assert!(harness.query_by_label("Sub item").is_none());
+    assert!(harness.query_by_label("Item").is_none());
+}


### PR DESCRIPTION
## Motivation

* Motivated by <https://github.com/nannou-org/gantz/issues/193>

Context menus in egui require a full click (press + release) to open and to close. Native context menus on most platforms respond already on press: right-press opens the menu, and pressing anywhere outside dismisses it. This PR adds that behavior as an **opt-in** - default behavior is unchanged.

## Usage

```rust
ctx.all_styles_mut(|style| style.interaction.context_menu_opens_on_press = true);
```

With the flag enabled, `Popup::context_menu` / `Response::context_menu`:

- open on secondary button *press* (long-touch on touch screens still works),
- close as soon as a pointer button is pressed outside the menu,
- still fire menu items on click (release) as before, which also still closes the menu.

## What's added

- `Style::interaction.context_menu_opens_on_press: bool` (default `false`), also exposed in the style settings UI.
- `PopupCloseBehavior::CloseOnPressOutside`: closes on any press outside the popup, or a *primary* click inside it. Used by context menus when the flag is enabled. Can also be set on any `Popup` via `close_behavior`.
- `Response::pressed_by`, `Response::secondary_pressed` and `Response::pressed_elsewhere` - press-based counterparts of the existing `clicked_by` / `secondary_clicked` / `clicked_elsewhere`.

## Testing

- In the demo app, open the **Popups** demo and tick `style.interaction.context_menu_opens_on_press` (also togglable under Settings -> Style -> Interaction), then right-press the demo button. Compare with the flag off.
- New kittest suite `crates/egui_kittest/tests/context_menu.rs`: 9 tests covering open-on-press, close-on-press-outside, item activation, submenus, and one locking in the default (click-based) behavior with the flag off.

## Design notes

- Inside the popup, only *primary* clicks close it. The popup opens exactly at the press position (`PointerFixed` anchor), so the release of the opening right-press lands on the popup's corner. An any-click rule would close the menu again on every quick right-click.
- The open check is `secondary_pressed() || secondary_clicked()`: the fallback keeps menus opening when press and release arrive batched in the same frame (fast clicks at low frame rates, `egui_kittest` clicks). A side effect is that right-clicking the anchor again while the menu is open now moves the menu to the new position (with the flag off, it closes, as before).
- `pressed_elsewhere` mirrors `clicked_elsewhere` and uses `interact_pos()` rather than `press_origin()`, since the latter is cleared when press and release arrive in the same frame.
- `CloseOnPressOutside` is documented as unsuitable for popups toggled by a button click (e.g. `Popup::menu`): the press would close the popup and the completing click would toggle it open again.

## Breaking changes

No behavioral changes with the flag off (default). Compile-level:

- New variant on `PopupCloseBehavior` breaks exhaustive matches.
- New field on `style::Interaction` breaks struct literals that don't use `..Default::default()`.
