### PR TITLE
Add ttf-parser and quick-xml advisory ignores to deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,9 @@ version = 2
 ignore = [
   "RUSTSEC-2024-0320", # unmaintained yaml-rust pulled in by syntect
   "RUSTSEC-2025-0141", # https://rustsec.org/advisories/RUSTSEC-2025-0141 - bincode is unmaintained - https://git.sr.ht/~stygianentity/bincode/tree/v3.0/item/README.md
+  "RUSTSEC-2026-0192", # ttf-parser is unmaintained but pulled in by fontdb etc.; skrifa is an alternative
+  "RUSTSEC-2026-0194", # quickxml<0.41.0 (via wayland-scanner): Quadratic run time when checking a start tag for duplicate attribute names
+  "RUSTSEC-2026-0195", # quickxml<0.41.0 (via wayland-scanner): Unbounded namespace-declaration allocation in `NsReader` enables DoS
 ]
 
 [bans]


### PR DESCRIPTION
* [x] I have followed the instructions in the PR template

Deny CI in #8289 is red due to:

* ttf-parser being unmaintained (via fontdb, rustybuzz etc.)
* DoS vulnerabilities in quick-xml (via wayland-scanner, plist, etc.).

These need bumps/replacements in those upstream crates. 