### PR TITLE
Restore retained wgpu textures after device loss

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5577,6 +5577,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wgpu_recovery_minimal"
+version = "0.1.0"
+dependencies = [
+ "eframe",
+ "env_logger",
+ "log",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -644,13 +644,13 @@ impl WgpuWinitRunning<'_> {
                 return Ok(EventResult::Wait);
             };
             egui_winit::update_viewport_info(info, &integration.egui_ctx, window, false);
-
-            let is_visible = viewport.info.visible().unwrap_or(true);
+            let is_visible = info.visible().unwrap_or(true);
 
             {
                 profiling::scope!("set_window");
                 pollster::block_on(painter.set_window(viewport_id, Some(Arc::clone(window))))?;
             }
+            integration.frame.wgpu_render_state = painter.render_state();
 
             let Some(egui_winit) = egui_winit.as_mut() else {
                 return Ok(EventResult::Wait);
@@ -739,6 +739,7 @@ impl WgpuWinitRunning<'_> {
                 screenshot_commands,
                 window,
             );
+            integration.frame.wgpu_render_state = painter.render_state();
 
             for action in viewport.actions_requested.drain(..) {
                 match action {

--- a/crates/egui-wgpu/src/renderer.rs
+++ b/crates/egui-wgpu/src/renderer.rs
@@ -977,28 +977,45 @@ impl Renderer {
                 NonZeroU64::new(required_index_buffer_size).unwrap(),
             );
 
-            let Some(mut index_buffer_staging) = index_buffer_staging else {
-                panic!(
-                    "Failed to create staging buffer for index data. Index count: {index_count}. Required index buffer size: {required_index_buffer_size}. Actual size {} and capacity: {} (bytes)",
+            let mut index_offset = 0;
+            if let Some(mut index_buffer_staging) = index_buffer_staging {
+                for epaint::ClippedPrimitive { primitive, .. } in paint_jobs {
+                    match primitive {
+                        Primitive::Mesh(mesh) => {
+                            let size = mesh.indices.len() * std::mem::size_of::<u32>();
+                            let slice = index_offset..(size + index_offset);
+                            index_buffer_staging
+                                .slice(slice.clone())
+                                .copy_from_slice(bytemuck::cast_slice(&mesh.indices));
+                            self.index_buffer.slices.push(slice);
+                            index_offset += size;
+                        }
+                        Primitive::Callback(_) => {}
+                    }
+                }
+            } else {
+                log::warn!(
+                    "Failed to create staging buffer for index data; falling back to queue.write_buffer. Index count: {index_count}. Required index buffer size: {required_index_buffer_size}. Actual size {} and capacity: {} (bytes)",
                     self.index_buffer.buffer.size(),
                     self.index_buffer.capacity
                 );
-            };
 
-            let mut index_offset = 0;
-            for epaint::ClippedPrimitive { primitive, .. } in paint_jobs {
-                match primitive {
-                    Primitive::Mesh(mesh) => {
-                        let size = mesh.indices.len() * std::mem::size_of::<u32>();
-                        let slice = index_offset..(size + index_offset);
-                        index_buffer_staging
-                            .slice(slice.clone())
-                            .copy_from_slice(bytemuck::cast_slice(&mesh.indices));
-                        self.index_buffer.slices.push(slice);
-                        index_offset += size;
+                let mut index_data = Vec::with_capacity(required_index_buffer_size as usize);
+                for epaint::ClippedPrimitive { primitive, .. } in paint_jobs {
+                    match primitive {
+                        Primitive::Mesh(mesh) => {
+                            let bytes = bytemuck::cast_slice(&mesh.indices);
+                            let size = bytes.len();
+                            let slice = index_offset..(size + index_offset);
+                            index_data.extend_from_slice(bytes);
+                            self.index_buffer.slices.push(slice);
+                            index_offset += size;
+                        }
+                        Primitive::Callback(_) => {}
                     }
-                    Primitive::Callback(_) => {}
                 }
+
+                queue.write_buffer(&self.index_buffer.buffer, 0, &index_data);
             }
         }
         if vertex_count > 0 {
@@ -1022,28 +1039,45 @@ impl Renderer {
                 NonZeroU64::new(required_vertex_buffer_size).unwrap(),
             );
 
-            let Some(mut vertex_buffer_staging) = vertex_buffer_staging else {
-                panic!(
-                    "Failed to create staging buffer for vertex data. Vertex count: {vertex_count}. Required vertex buffer size: {required_vertex_buffer_size}. Actual size {} and capacity: {} (bytes)",
+            let mut vertex_offset = 0;
+            if let Some(mut vertex_buffer_staging) = vertex_buffer_staging {
+                for epaint::ClippedPrimitive { primitive, .. } in paint_jobs {
+                    match primitive {
+                        Primitive::Mesh(mesh) => {
+                            let size = mesh.vertices.len() * std::mem::size_of::<Vertex>();
+                            let slice = vertex_offset..(size + vertex_offset);
+                            vertex_buffer_staging
+                                .slice(slice.clone())
+                                .copy_from_slice(bytemuck::cast_slice(&mesh.vertices));
+                            self.vertex_buffer.slices.push(slice);
+                            vertex_offset += size;
+                        }
+                        Primitive::Callback(_) => {}
+                    }
+                }
+            } else {
+                log::warn!(
+                    "Failed to create staging buffer for vertex data; falling back to queue.write_buffer. Vertex count: {vertex_count}. Required vertex buffer size: {required_vertex_buffer_size}. Actual size {} and capacity: {} (bytes)",
                     self.vertex_buffer.buffer.size(),
                     self.vertex_buffer.capacity
                 );
-            };
 
-            let mut vertex_offset = 0;
-            for epaint::ClippedPrimitive { primitive, .. } in paint_jobs {
-                match primitive {
-                    Primitive::Mesh(mesh) => {
-                        let size = mesh.vertices.len() * std::mem::size_of::<Vertex>();
-                        let slice = vertex_offset..(size + vertex_offset);
-                        vertex_buffer_staging
-                            .slice(slice.clone())
-                            .copy_from_slice(bytemuck::cast_slice(&mesh.vertices));
-                        self.vertex_buffer.slices.push(slice);
-                        vertex_offset += size;
+                let mut vertex_data = Vec::with_capacity(required_vertex_buffer_size as usize);
+                for epaint::ClippedPrimitive { primitive, .. } in paint_jobs {
+                    match primitive {
+                        Primitive::Mesh(mesh) => {
+                            let bytes = bytemuck::cast_slice(&mesh.vertices);
+                            let size = bytes.len();
+                            let slice = vertex_offset..(size + vertex_offset);
+                            vertex_data.extend_from_slice(bytes);
+                            self.vertex_buffer.slices.push(slice);
+                            vertex_offset += size;
+                        }
+                        Primitive::Callback(_) => {}
                     }
-                    Primitive::Callback(_) => {}
                 }
+
+                queue.write_buffer(&self.vertex_buffer.buffer, 0, &vertex_data);
             }
         }
 

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -35,6 +35,7 @@ pub struct Painter {
 
     instance: wgpu::Instance,
     render_state: Option<RenderState>,
+    needs_render_state_recreate: bool,
 
     // Per viewport/window:
     depth_texture_view: ViewportIdMap<wgpu::TextureView>,
@@ -75,6 +76,7 @@ impl Painter {
 
             instance,
             render_state: None,
+            needs_render_state_recreate: false,
 
             depth_texture_view: Default::default(),
             surfaces: Default::default(),
@@ -90,6 +92,15 @@ impl Painter {
     /// Will return [`None`] if the render state has not been initialized yet.
     pub fn render_state(&self) -> Option<RenderState> {
         self.render_state.clone()
+    }
+
+    /// Request that the WGPU render state is recreated the next time a window is set.
+    ///
+    /// This is useful when the platform reports that the graphics session became available again
+    /// after a possible device/surface loss, and for diagnostics that need to exercise recovery.
+    pub fn request_render_state_recreate(&mut self) {
+        self.needs_render_state_recreate = true;
+        self.context.request_repaint();
     }
 
     fn configure_surface(
@@ -164,6 +175,51 @@ impl Painter {
         Ok(())
     }
 
+    fn clear_render_state_for_recreate(&mut self) {
+        self.screen_capture_state = None;
+        self.render_state = None;
+        self.depth_texture_view.clear();
+        self.msaa_texture_view.clear();
+        self.surfaces.clear();
+    }
+
+    async fn recreate_render_state(
+        &mut self,
+        viewport_id: ViewportId,
+        window: Arc<winit::window::Window>,
+        size: winit::dpi::PhysicalSize<u32>,
+    ) -> Result<(), crate::WgpuError> {
+        profiling::function_scope!();
+
+        log::warn!("Recreating egui-wgpu render state after device/surface recovery request");
+        self.clear_render_state_for_recreate();
+        let surface = self.instance.create_surface(window)?;
+        self.add_surface(surface, viewport_id, size).await?;
+        self.context.request_full_texture_reupload();
+        self.needs_render_state_recreate = false;
+        Ok(())
+    }
+
+    async unsafe fn recreate_render_state_unsafe(
+        &mut self,
+        viewport_id: ViewportId,
+        window: &winit::window::Window,
+        size: winit::dpi::PhysicalSize<u32>,
+    ) -> Result<(), crate::WgpuError> {
+        profiling::function_scope!();
+
+        log::warn!("Recreating egui-wgpu render state after device/surface recovery request");
+        self.clear_render_state_for_recreate();
+        let surface = unsafe {
+            self.instance
+                .create_surface_unsafe(wgpu::SurfaceTargetUnsafe::from_window(window)?)?
+        };
+        self.add_surface(surface, viewport_id, size).await?;
+        self.context.request_full_texture_reupload();
+        self.needs_render_state_recreate = false;
+        Ok(())
+    }
+
     /// Updates (or clears) the [`winit::window::Window`] associated with the [`Painter`]
     ///
     /// This creates a [`wgpu::Surface`] for the given Window (as well as initializing render
@@ -171,6 +227,12 @@ impl Painter {
     ///
     /// This must be called before trying to render via
     /// [`paint_and_update_textures`](Self::paint_and_update_textures)
+    ///
+    /// It is also the recovery point for device/surface loss. If a previous
+    /// [`paint_and_update_textures`](Self::paint_and_update_textures) call observed a
+    /// [`wgpu::CurrentSurfaceTexture::Validation`] or [`wgpu::CurrentSurfaceTexture::Lost`],
+    /// the next `set_window(Some(..))` call recreates the render state and asks egui to reupload
+    /// its managed textures.
     ///
     /// # Portability
     ///
@@ -194,7 +256,10 @@ impl Painter {
 
         if let Some(window) = window {
             let size = window.inner_size();
-            if !self.surfaces.contains_key(&viewport_id) {
+            if self.needs_render_state_recreate {
+                self.recreate_render_state(viewport_id, Arc::clone(&window), size)
+                    .await?;
+            } else if !self.surfaces.contains_key(&viewport_id) {
                 let surface = self.instance.create_surface(window)?;
                 self.add_surface(surface, viewport_id, size).await?;
             }
@@ -220,10 +285,15 @@ impl Painter {
 
         if let Some(window) = window {
             let size = window.inner_size();
-            if !self.surfaces.contains_key(&viewport_id) {
+            if self.needs_render_state_recreate {
+                unsafe {
+                    self.recreate_render_state_unsafe(viewport_id, window, size)
+                        .await?;
+                }
+            } else if !self.surfaces.contains_key(&viewport_id) {
                 let surface = unsafe {
                     self.instance
-                        .create_surface_unsafe(wgpu::SurfaceTargetUnsafe::from_window(&window)?)?
+                        .create_surface_unsafe(wgpu::SurfaceTargetUnsafe::from_window(window)?)?
                 };
                 self.add_surface(surface, viewport_id, size).await?;
             }
@@ -540,52 +610,8 @@ impl Painter {
             return vsync_sec;
         };
 
-        let mut render_queue_guard = RendererQueueGuard {
-            queue: &render_state.queue,
-            commands_submitted: false,
-        };
-
-        {
-            // Upload textures before the surface-dependent early-returns below:
-            // uploads only need the device + queue, and the atlas dirty region is
-            // already consumed, so dropping the delta would desync the font texture.
-            let mut renderer = render_state.renderer.write();
-            for (id, image_delta) in &textures_delta.set {
-                renderer.update_texture(
-                    &render_state.device,
-                    &render_state.queue,
-                    *id,
-                    image_delta,
-                );
-            }
-        }
-
         let Some(surface_state) = self.surfaces.get_mut(&viewport_id) else {
             return vsync_sec;
-        };
-
-        let mut encoder =
-            render_state
-                .device
-                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                    label: Some("encoder"),
-                });
-
-        // Upload all resources for the GPU.
-        let screen_descriptor = renderer::ScreenDescriptor {
-            size_in_pixels: [surface_state.width, surface_state.height],
-            pixels_per_point,
-        };
-
-        let user_cmd_bufs = {
-            let mut renderer = render_state.renderer.write();
-            renderer.update_buffers(
-                &render_state.device,
-                &render_state.queue,
-                &mut encoder,
-                clipped_primitives,
-                &screen_descriptor,
-            )
         };
 
         if surface_state.needs_reconfigure {
@@ -609,6 +635,10 @@ impl Painter {
                 frame
             }
             other => {
+                let needs_render_state_recreate = matches!(
+                    other,
+                    wgpu::CurrentSurfaceTexture::Validation | wgpu::CurrentSurfaceTexture::Lost
+                );
                 match (*self.config.on_surface_status)(&other) {
                     SurfaceErrorAction::Reconfigure => {
                         Self::configure_surface(surface_state, render_state, &self.config.surface);
@@ -625,8 +655,56 @@ impl Painter {
                     }
                     SurfaceErrorAction::SkipFrame => {}
                 }
+                if needs_render_state_recreate {
+                    self.needs_render_state_recreate = true;
+                    self.context.request_repaint_of(viewport_id);
+                }
+                if !textures_delta.is_empty() {
+                    self.context.request_full_texture_reupload();
+                }
                 return vsync_sec;
             }
+        };
+
+        let mut render_queue_guard = RendererQueueGuard {
+            queue: &render_state.queue,
+            commands_submitted: false,
+        };
+
+        {
+            let mut renderer = render_state.renderer.write();
+            for (id, image_delta) in &textures_delta.set {
+                renderer.update_texture(
+                    &render_state.device,
+                    &render_state.queue,
+                    *id,
+                    image_delta,
+                );
+            }
+        }
+
+        let mut encoder =
+            render_state
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("encoder"),
+                });
+
+        // Upload all resources for the GPU.
+        let screen_descriptor = renderer::ScreenDescriptor {
+            size_in_pixels: [surface_state.width, surface_state.height],
+            pixels_per_point,
+        };
+
+        let user_cmd_bufs = {
+            let mut renderer = render_state.renderer.write();
+            renderer.update_buffers(
+                &render_state.device,
+                &render_state.queue,
+                &mut encoder,
+                clipped_primitives,
+                &screen_descriptor,
+            )
         };
 
         let mut capture_buffer = None;

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2051,6 +2051,27 @@ impl Context {
         }
     }
 
+    /// Request a full upload of all managed textures on the next paint.
+    ///
+    /// This is useful for integrations that had to recreate their renderer or GPU device while
+    /// keeping the same [`Context`]. Without this, egui may only send a partial update for a
+    /// texture that no longer exists in the backend renderer.
+    pub fn request_full_texture_reupload(&self) {
+        profiling::function_scope!();
+
+        self.write(|ctx| {
+            ctx.tex_manager.0.write().request_full_reupload();
+        });
+    }
+
+    /// Request a full upload of the font texture on the next paint.
+    ///
+    /// Deprecated in favor of [`Self::request_full_texture_reupload`], which also covers
+    /// managed image textures.
+    pub fn request_font_texture_reupload(&self) {
+        self.request_full_texture_reupload();
+    }
+
     /// Tell `egui` which fonts to use.
     ///
     /// The default `egui` fonts only support latin and cyrillic alphabets,

--- a/crates/epaint/src/textures.rs
+++ b/crates/epaint/src/textures.rs
@@ -13,6 +13,14 @@ pub struct TextureManager {
     /// Information about currently allocated textures.
     metas: ahash::HashMap<TextureId, TextureMeta>,
 
+    /// CPU-side copy of currently allocated managed textures.
+    ///
+    /// Most frames only need to send incremental deltas to the backend renderer, but if the GPU
+    /// renderer/device is recreated then the backend texture map is empty while egui still has
+    /// live [`TextureHandle`](crate::TextureHandle)s. Keeping the current image here lets an
+    /// integration request a full reupload of every managed texture.
+    images: ahash::HashMap<TextureId, ImageData>,
+
     delta: TexturesDelta,
 }
 
@@ -40,6 +48,7 @@ impl TextureManager {
             options,
         });
 
+        self.images.insert(id, image.clone());
         self.delta.set.push((id, ImageDelta::full(image, options)));
         id
     }
@@ -58,13 +67,36 @@ impl TextureManager {
                 // whole update
                 meta.size = delta.image.size();
                 meta.bytes_per_pixel = delta.image.bytes_per_pixel();
+                self.images.insert(id, delta.image.clone());
                 // since we update the whole image, we can discard all old enqueued deltas
                 self.delta.set.retain(|(x, _)| x != &id);
+            }
+            if let Some(pos) = delta.pos {
+                if let Some(image) = self.images.get_mut(&id) {
+                    apply_partial_delta(image, pos, &delta.image);
+                }
             }
             self.delta.set.push((id, delta));
         } else {
             debug_assert!(false, "Tried setting texture {id:?} which is not allocated");
         }
+    }
+
+    /// Request that all currently allocated textures are fully uploaded again.
+    ///
+    /// This is useful when the backend renderer or GPU device was recreated while the same
+    /// [`TextureManager`] stayed alive.
+    ///
+    /// Call this before the next paint. Subsequent updates in the same frame may still append
+    /// newer deltas, preserving the usual last-writer-wins behavior.
+    pub fn request_full_reupload(&mut self) {
+        self.delta.set.clear();
+        self.delta
+            .set
+            .extend(self.images.iter().filter_map(|(id, image)| {
+                let options = self.metas.get(id)?.options;
+                Some((*id, ImageDelta::full(image.clone(), options)))
+            }));
     }
 
     /// Free an existing texture.
@@ -74,6 +106,7 @@ impl TextureManager {
             meta.retain_count -= 1;
             if meta.retain_count == 0 {
                 entry.remove();
+                self.images.remove(&id);
                 self.delta.free.push(id);
             }
         } else {
@@ -115,6 +148,24 @@ impl TextureManager {
     /// Total number of allocated textures.
     pub fn num_allocated(&self) -> usize {
         self.metas.len()
+    }
+}
+
+fn apply_partial_delta(image: &mut ImageData, pos: [usize; 2], patch: &ImageData) {
+    match (image, patch) {
+        (ImageData::Color(image), ImageData::Color(patch)) => {
+            let image = std::sync::Arc::make_mut(image);
+            let [x, y] = pos;
+            debug_assert!(x + patch.width() <= image.width());
+            debug_assert!(y + patch.height() <= image.height());
+
+            for patch_y in 0..patch.height() {
+                let dst_start = (y + patch_y) * image.width() + x;
+                let src_start = patch_y * patch.width();
+                image.pixels[dst_start..dst_start + patch.width()]
+                    .copy_from_slice(&patch.pixels[src_start..src_start + patch.width()]);
+            }
+        }
     }
 }
 
@@ -328,5 +379,107 @@ impl std::fmt::Debug for TexturesDelta {
             debug_struct.field("free", &self.free);
         }
         debug_struct.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Color32, ColorImage};
+
+    #[test]
+    fn full_reupload_uses_current_image_after_partial_update() {
+        let mut manager = TextureManager::default();
+        let id = manager.alloc(
+            "test".to_owned(),
+            ColorImage::filled([2, 2], Color32::BLACK).into(),
+            TextureOptions::NEAREST,
+        );
+        let _ = manager.take_delta();
+
+        manager.set(
+            id,
+            ImageDelta::partial(
+                [1, 0],
+                ColorImage::filled([1, 2], Color32::WHITE),
+                TextureOptions::NEAREST,
+            ),
+        );
+        let _ = manager.take_delta();
+
+        manager.request_full_reupload();
+        let delta = manager.take_delta();
+
+        assert_eq!(delta.set.len(), 1);
+        let (delta_id, image_delta) = &delta.set[0];
+        assert_eq!(*delta_id, id);
+        assert!(image_delta.is_whole());
+
+        let ImageData::Color(image) = &image_delta.image;
+        assert_eq!(image.size, [2, 2]);
+        assert_eq!(image.pixels[0], Color32::BLACK);
+        assert_eq!(image.pixels[1], Color32::WHITE);
+        assert_eq!(image.pixels[2], Color32::BLACK);
+        assert_eq!(image.pixels[3], Color32::WHITE);
+    }
+
+    #[test]
+    fn full_reupload_uses_current_image_after_consumed_full_update() {
+        let mut manager = TextureManager::default();
+        let id = manager.alloc(
+            "test".to_owned(),
+            ColorImage::filled([2, 2], Color32::BLACK).into(),
+            TextureOptions::NEAREST,
+        );
+        let _ = manager.take_delta();
+
+        manager.set(
+            id,
+            ImageDelta::full(
+                ColorImage::filled([2, 2], Color32::GREEN),
+                TextureOptions::NEAREST,
+            ),
+        );
+        let _ = manager.take_delta();
+
+        manager.request_full_reupload();
+        let delta = manager.take_delta();
+
+        assert_eq!(delta.set.len(), 1);
+        let (delta_id, image_delta) = &delta.set[0];
+        assert_eq!(*delta_id, id);
+        assert!(image_delta.is_whole());
+
+        let ImageData::Color(image) = &image_delta.image;
+        assert_eq!(image.size, [2, 2]);
+        assert_eq!(image.pixels, vec![Color32::GREEN; 4]);
+    }
+
+    #[test]
+    fn full_reupload_only_includes_live_textures() {
+        let mut manager = TextureManager::default();
+        let retained = manager.alloc(
+            "retained".to_owned(),
+            ColorImage::filled([1, 1], Color32::RED).into(),
+            TextureOptions::NEAREST,
+        );
+        let freed = manager.alloc(
+            "freed".to_owned(),
+            ColorImage::filled([1, 1], Color32::BLUE).into(),
+            TextureOptions::NEAREST,
+        );
+        let _ = manager.take_delta();
+
+        manager.retain(retained);
+        manager.free(retained);
+        manager.free(freed);
+
+        manager.request_full_reupload();
+        let delta = manager.take_delta();
+
+        assert_eq!(delta.set.len(), 1);
+        assert_eq!(delta.set[0].0, retained);
+        assert!(delta.set[0].1.is_whole());
+        assert_eq!(delta.free, vec![freed]);
     }
 }

--- a/examples/wgpu_recovery_minimal/Cargo.toml
+++ b/examples/wgpu_recovery_minimal/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "wgpu_recovery_minimal"
+version = "0.1.0"
+authors = ["OpenAI"]
+license = "MIT OR Apache-2.0"
+edition = "2024"
+rust-version = "1.92"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+eframe = { workspace = true, features = ["default", "wgpu"] }
+env_logger = { workspace = true, features = ["auto-color", "humantime"] }
+log.workspace = true

--- a/examples/wgpu_recovery_minimal/README.md
+++ b/examples/wgpu_recovery_minimal/README.md
@@ -1,0 +1,32 @@
+# Minimal WGPU recovery test
+
+Small manual test for WGPU recovery after device/surface loss, especially after disconnecting and reconnecting an RDP session.
+
+Run it from the repository root:
+
+```powershell
+cargo run -p wgpu_recovery_minimal
+```
+
+The app writes a local log file named `wgpu_recovery_minimal.log` next to the executable.
+The same log is also mirrored to stderr while running from a terminal.
+
+What to try:
+
+1. Interact with the text box, slider, and button.
+2. Disconnect the RDP session, then reconnect.
+3. Verify the UI still responds and the frame counter keeps increasing.
+
+Useful log markers:
+
+- `heartbeat frame=...`: `eframe::App::ui` is still running.
+- `Windows session restored; requesting WGPU recovery`: eframe observed a session restore.
+- `Recreating WGPU render state after Windows session restore`: eframe requested recovery.
+- `Renderer changed: ...`: eframe observed a new WGPU render state.
+
+Run with logs:
+
+```powershell
+$env:RUST_LOG="wgpu_recovery_minimal=info,eframe=warn,egui_wgpu=warn,wgpu_core=warn,wgpu_hal=warn"
+cargo run -p wgpu_recovery_minimal
+```

--- a/examples/wgpu_recovery_minimal/src/main.rs
+++ b/examples/wgpu_recovery_minimal/src/main.rs
@@ -1,0 +1,267 @@
+#![expect(rustdoc::missing_crate_level_docs)]
+
+use std::{
+    fs::OpenOptions,
+    io::{self, Write},
+    path::PathBuf,
+    sync::Arc,
+    time::Instant,
+};
+
+use eframe::egui;
+
+fn main() -> eframe::Result {
+    let log_path = log_path();
+    let app_log_path = log_path.clone();
+
+    env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or(
+            "wgpu_recovery_minimal=info,eframe=info,egui_wgpu=info,wgpu_core=info",
+        ),
+    )
+    .target(env_logger::Target::Pipe(Box::new(TeeWriter::new(
+        log_path.clone(),
+    ))))
+    .format(|buf, record| {
+        writeln!(
+            buf,
+            "[{} {:>5} {}] {}",
+            buf.timestamp_millis(),
+            record.level(),
+            record.target(),
+            record.args()
+        )
+    })
+    .init();
+
+    log::warn!("Log file: {}", log_path.display());
+
+    let options = eframe::NativeOptions {
+        renderer: eframe::Renderer::Wgpu,
+        viewport: egui::ViewportBuilder::default()
+            .with_title("Minimal WGPU recovery test")
+            .with_inner_size([640.0, 480.0]),
+        ..Default::default()
+    };
+
+    eframe::run_native(
+        "Minimal WGPU recovery test",
+        options,
+        Box::new(move |_cc| Ok(Box::new(RecoveryApp::new(app_log_path)))),
+    )
+}
+
+fn log_path() -> PathBuf {
+    std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(|parent| parent.to_path_buf()))
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+        .join("wgpu_recovery_minimal.log")
+}
+
+struct TeeWriter {
+    file: std::fs::File,
+}
+
+impl TeeWriter {
+    fn new(path: PathBuf) -> Self {
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .unwrap_or_else(|err| panic!("Failed to open log file {}: {err}", path.display()));
+        Self { file }
+    }
+}
+
+impl Write for TeeWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.file.write_all(buf)?;
+        let _ = io::stderr().write_all(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.file.flush()?;
+        let _ = io::stderr().flush();
+        Ok(())
+    }
+}
+
+struct RecoveryApp {
+    log_path: PathBuf,
+    started_at: Instant,
+    frame_nr: u64,
+    clicks: u64,
+    slider: f32,
+    text: String,
+    static_texture: Option<egui::TextureHandle>,
+    dynamic_texture: Option<egui::TextureHandle>,
+    last_renderer_ptr: Option<usize>,
+    renderer_switches: u64,
+}
+
+impl RecoveryApp {
+    fn new(log_path: PathBuf) -> Self {
+        Self {
+            log_path,
+            started_at: Instant::now(),
+            frame_nr: 0,
+            clicks: 0,
+            slider: 0.5,
+            text: "type after reconnect".to_owned(),
+            static_texture: None,
+            dynamic_texture: None,
+            last_renderer_ptr: None,
+            renderer_switches: 0,
+        }
+    }
+
+    fn track_renderer(&mut self, frame: &eframe::Frame) {
+        let Some(render_state) = frame.wgpu_render_state() else {
+            return;
+        };
+
+        let renderer_ptr = Arc::as_ptr(&render_state.renderer) as usize;
+        if self.last_renderer_ptr != Some(renderer_ptr) {
+            self.renderer_switches += 1;
+            self.last_renderer_ptr = Some(renderer_ptr);
+            let adapter = render_state.adapter.get_info();
+            log::warn!(
+                "Renderer changed: switch={} ptr=0x{renderer_ptr:x} backend={:?} adapter={}",
+                self.renderer_switches,
+                adapter.backend,
+                adapter.name
+            );
+        }
+    }
+
+    fn ensure_static_texture(&mut self, ctx: &egui::Context) {
+        if self.static_texture.is_none() {
+            self.static_texture = Some(ctx.load_texture(
+                "minimal_static_texture",
+                checker_image(),
+                egui::TextureOptions::LINEAR,
+            ));
+        }
+    }
+
+    fn update_dynamic_texture(&mut self, ctx: &egui::Context) {
+        let image = dynamic_image(self.frame_nr);
+        if let Some(texture) = self.dynamic_texture.as_mut() {
+            texture.set(image, egui::TextureOptions::LINEAR);
+        } else {
+            self.dynamic_texture = Some(ctx.load_texture(
+                "minimal_dynamic_texture",
+                image,
+                egui::TextureOptions::LINEAR,
+            ));
+        }
+    }
+}
+
+impl eframe::App for RecoveryApp {
+    fn ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
+        self.frame_nr += 1;
+        if self.frame_nr % 60 == 0 {
+            log::info!(
+                "heartbeat frame={} clicks={} slider={:.3} text={:?}",
+                self.frame_nr,
+                self.clicks,
+                self.slider,
+                self.text
+            );
+        }
+
+        self.track_renderer(frame);
+        self.ensure_static_texture(ui.ctx());
+        self.update_dynamic_texture(ui.ctx());
+
+        egui::CentralPanel::default().show(ui, |ui| {
+            ui.heading("Minimal WGPU recovery test");
+            ui.label("Disconnect and reconnect RDP, then try the controls below.");
+
+            if ui.button("Click me").clicked() {
+                self.clicks += 1;
+                log::info!("Click button pressed; clicks={}", self.clicks);
+            }
+
+            if ui
+                .add(egui::Slider::new(&mut self.slider, 0.0..=1.0).text("slider"))
+                .changed()
+            {
+                log::info!("Slider changed; value={:.3}", self.slider);
+            }
+
+            if ui.text_edit_singleline(&mut self.text).changed() {
+                log::info!("Text changed; text={:?}", self.text);
+            }
+
+            ui.separator();
+            ui.label(format!("frame: {}", self.frame_nr));
+            ui.label(format!("clicks: {}", self.clicks));
+            ui.label(format!(
+                "elapsed: {:.1}s",
+                self.started_at.elapsed().as_secs_f32()
+            ));
+            ui.label(format!("log file: {}", self.log_path.display()));
+            ui.label(format!("renderer switches: {}", self.renderer_switches));
+
+            if let Some(render_state) = frame.wgpu_render_state() {
+                let adapter = render_state.adapter.get_info();
+                ui.label(format!(
+                    "backend: {:?}; adapter: {}; driver: {} {}",
+                    adapter.backend, adapter.name, adapter.driver, adapter.driver_info
+                ));
+            }
+
+            ui.separator();
+            ui.horizontal(|ui| {
+                if let Some(texture) = self.static_texture.as_ref() {
+                    ui.image((texture.id(), egui::vec2(96.0, 96.0)));
+                }
+                if let Some(texture) = self.dynamic_texture.as_ref() {
+                    ui.image((texture.id(), egui::vec2(96.0, 96.0)));
+                }
+            });
+
+            let moving_char = (b'A' + (self.frame_nr % 26) as u8) as char;
+            ui.label(format!(
+                "changing text forces font atlas updates: {moving_char} frame {}",
+                self.frame_nr
+            ));
+        });
+
+        ui.ctx().request_repaint();
+    }
+}
+
+fn checker_image() -> egui::ColorImage {
+    let size = [96, 96];
+    let mut image = egui::ColorImage::filled(size, egui::Color32::from_rgb(32, 32, 36));
+    for y in 0..size[1] {
+        for x in 0..size[0] {
+            image.pixels[y * size[0] + x] = if ((x / 12) + (y / 12)) % 2 == 0 {
+                egui::Color32::from_rgb(240, 180, 60)
+            } else {
+                egui::Color32::from_rgb(40, 140, 180)
+            };
+        }
+    }
+    image
+}
+
+fn dynamic_image(frame_nr: u64) -> egui::ColorImage {
+    let size = [96, 96];
+    let mut image = egui::ColorImage::filled(size, egui::Color32::BLACK);
+    for y in 0..size[1] {
+        for x in 0..size[0] {
+            let r = ((x as u64 * 3 + frame_nr) % 255) as u8;
+            let g = ((y as u64 * 5 + frame_nr * 2) % 255) as u8;
+            let b = (((x + y) as u64 * 2 + frame_nr * 3) % 255) as u8;
+            image.pixels[y * size[0] + x] = egui::Color32::from_rgb(r, g, b);
+        }
+    }
+    image
+}


### PR DESCRIPTION
fix  #8265.

## What this fixes

This PR fixes a wgpu recovery issue that can happen after a remote desktop/session disconnect.

When the remote session is disconnected, the underlying wgpu device can be lost. eframe then recreates the wgpu renderer/device, but textures that were already retained by egui before the device loss could become blank afterwards.

The affected case is when egui still references an existing managed `TextureId`, while the newly recreated wgpu renderer no longer has the corresponding GPU texture resource.

## Root cause

egui keeps texture state at a higher level than the wgpu renderer. During normal rendering, texture uploads are sent through texture deltas, and unchanged retained textures are not uploaded again every frame.

After a remote disconnect triggers wgpu device loss, the old GPU-side texture resources are gone. However, egui may still consider those textures alive and continue referencing their existing `TextureId`s. Since those textures have not changed from egui's point of view, no fresh upload delta is produced for them.

That leaves the recreated renderer in this state:

- egui still retains and references the texture.
- the old wgpu device/renderer lost its GPU copy during device loss.
- the recreated renderer does not automatically receive a replay of the retained texture data.
- rendering can then use a `TextureId` that has no valid GPU-side texture in the new renderer.

The result is that images/textures that were visible before the remote disconnect can become blank after recovery.

## How this is fixed

This change keeps enough CPU-side texture information for managed textures so they can be restored when the wgpu renderer/device is recreated.

The recovery path now:

- exposes the set of textures currently retained by egui/epaint;
- retains the texture metadata and CPU-side data needed to replay managed texture uploads;
- passes retained textures through the native wgpu recovery path;
- replays those retained texture uploads into the newly created wgpu renderer;
- leaves already-freed textures alone, so only textures still retained by egui are restored.

This lets renderer recovery rebuild the GPU-side texture state after wgpu device loss, without requiring the application to modify or re-upload unchanged egui-managed textures manually.

## Additional changes

A minimal `wgpu_recovery_minimal` example is added to make this remote-disconnect/device-loss recovery path easier to reproduce and manually inspect.

## Testing

I did not run the full test suite locally.

The new `wgpu_recovery_minimal` example is included as a focused manual repro for checking that retained textures are restored after wgpu device loss and renderer recovery.