### PR TITLE
Improve backtrace trimming for cranelift

### DIFF
--- a/crates/egui/src/callstack.rs
+++ b/crates/egui/src/callstack.rs
@@ -89,7 +89,18 @@ pub fn capture() -> String {
         }
 
         // Remove frames that are part of egui itself, since they are not useful to the user.
-        let skip_crates = ["egui", "eframe", "egui_plot", "egui_extras"];
+        let skip_crates = [
+            "alloc",
+            "backtrace",
+            "core",
+            "eframe",
+            "egui_extras",
+            "egui_plot",
+            "egui",
+            "epaint",
+            "std",
+            "winit",
+        ];
         for crate_name in skip_crates {
             let name = frame.name.trim_start_matches('<');
             if name.starts_with(crate_name)

--- a/crates/egui/src/callstack.rs
+++ b/crates/egui/src/callstack.rs
@@ -88,16 +88,25 @@ pub fn capture() -> String {
             return false;
         }
 
-        // Remove stuff that isn't user calls:
+        // Remove frames that are part of egui itself, since they are not useful to the user.
+        let skip_crates = ["egui", "eframe", "egui_plot", "egui_extras"];
+        for crate_name in skip_crates {
+            let name = frame.name.trim_start_matches('<');
+            if name.starts_with(crate_name)
+                && name
+                    .as_bytes()
+                    .get(crate_name.len())
+                    .copied()
+                    .is_none_or(|b| b.is_ascii_punctuation() && b != b'_')
+            {
+                return false;
+            }
+        }
+
         let skip_prefixes = [
             // "backtrace::", // not needed, since we cut at egui::callstack::capture
-            "egui::",
-            "<egui::",
             "<F as egui::widgets::Widget>",
-            "egui_plot::",
-            "egui_extras::",
             "core::ptr::drop_in_place<egui::ui::Ui>",
-            "eframe::",
             "core::ops::function::FnOnce::call_once",
             "<alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once",
         ];


### PR DESCRIPTION
When using the cranelift backend we would get stack traces that would contain a lot of egui callstacks. This should solve it.