### PR TITLE
Fix cargo deny failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,9 +1029,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,9 @@ version = 2
 ignore = [
   "RUSTSEC-2024-0320", # unmaintained yaml-rust pulled in by syntect
   "RUSTSEC-2025-0141", # https://rustsec.org/advisories/RUSTSEC-2025-0141 - bincode is unmaintained - https://git.sr.ht/~stygianentity/bincode/tree/v3.0/item/README.md
+  "RUSTSEC-2026-0192", # ttf-parser is unmaintained - pulled in by ab_glyph via sctk-adwaita (Linux) - no replacement available
+  "RUSTSEC-2026-0194", # quick-xml quadratic run time on duplicate attribute check - transitive via zbus_xml and wayland-scanner (Linux only), which are both still on quick-xml < 0.41
+  "RUSTSEC-2026-0195", # quick-xml NsReader memory exhaustion - transitive via zbus_xml and wayland-scanner (Linux only), which are both still on quick-xml < 0.41
 ]
 
 [bans]


### PR DESCRIPTION
CI's `cargo deny` check started failing on new RustSec advisories. This PR fixes it:

* Update `crossbeam-epoch` 0.9.18 → 0.9.20, fixing [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) (invalid pointer dereference in `fmt::Pointer`)
* Ignore three advisories that have no upstream fix available:
  * [RUSTSEC-2026-0192](https://rustsec.org/advisories/RUSTSEC-2026-0192): `ttf-parser` is unmaintained (pulled in by `ab_glyph` via `sctk-adwaita` on Linux)
  * [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) / [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195): `quick-xml` quadratic runtime and memory-exhaustion issues. The fix requires quick-xml ≥ 0.41, but both dependents (`zbus_xml` and `wayland-scanner`, Linux-only) are still on < 0.41. The ignores can be dropped once the zbus/wayland ecosystems update.

Note: I tried bumping `zbus_xml` to 5.1.1, but it pulls in `zvariant` 5.12 which duplicates `winnow` and trips the bans check, with no advisory benefit — so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)