### PR TITLE
Remove dependency on `memoffset`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,7 +1439,6 @@ dependencies = [
  "glutin",
  "glutin-winit",
  "log",
- "memoffset",
  "profiling",
  "winit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,6 @@ jiff = { version = "0.2.29", default-features = false }
 js-sys = "0.3.77"
 kittest = { version = "0.4.0" }
 log = { version = "0.4.33", features = ["std"] }
-memoffset = "0.9.1"
 mimalloc = "0.1.52"
 mime_guess2 = { version = "2.3", default-features = false }
 mint = "0.5.9"

--- a/crates/egui_glow/Cargo.toml
+++ b/crates/egui_glow/Cargo.toml
@@ -56,7 +56,6 @@ egui-winit = { workspace = true, optional = true, default-features = false }
 bytemuck.workspace = true
 glow.workspace = true
 log.workspace = true
-memoffset.workspace = true
 profiling.workspace = true
 
 #! ### Optional dependencies

--- a/crates/egui_glow/src/painter.rs
+++ b/crates/egui_glow/src/painter.rs
@@ -1,6 +1,7 @@
 #![expect(clippy::unwrap_used)]
 #![expect(unsafe_code)]
 
+use core::mem::offset_of;
 use std::{collections::HashMap, sync::Arc};
 
 use egui::{
@@ -8,7 +9,6 @@ use egui::{
     epaint::{Mesh, PaintCallbackInfo, Primitive, Vertex},
 };
 use glow::HasContext as _;
-use memoffset::offset_of;
 
 use crate::check_for_gl_error;
 use crate::misc_util::{compile_shader, link_program};


### PR DESCRIPTION
Hi, I may or may not have used your crate but I'd like to say a quick thank you for it anyway!
I'm going down the list of reverse dependencies on `memoffset`.

This PR aims to remove the `memoffset` crate from your dependencies.
[`core::mem::offset_of`](https://doc.rust-lang.org/core/mem/macro.offset_of.html) was stabilised in rustc 1.77 which I believe is at or below your MSRV.

The `memoffset` crate 0.9.1 says that

> If you're using a rustc version greater or equal to 1.77,
> this crate's offset_of!() macro simply forwards to core::mem::offset_of!().

I consider it very unlikely (see [here](https://github.com/rust-lang/rust/issues/111839)) for any usage of the `offset_of!` macro to break but please check anyway.
I hope we can all enjoy the benefits of one less dependency :)

---
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [x] I have followed the instructions in the PR template *except for `./scripts/check.sh` which doesn't run in my environment* (I'm unwilling to chase it down because I'm firing off a whole bunch of these PRs to various repositories, sorry.)

`cargo clippy` gives 1 unrelated warning.