### PR TITLE
Remove dependency `home` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,7 +1269,6 @@ dependencies = [
  "glow",
  "glutin",
  "glutin-winit",
- "home",
  "image",
  "js-sys",
  "log",
@@ -2244,15 +2243,6 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "http"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,6 @@ glow = "0.17.0"
 glutin = { version = "0.32.3", default-features = false }
 glutin-winit = { version = "0.5.0", default-features = false }
 harfrust = "0.7.0" # Can't update to 0.8+: newer versions need read-fonts 0.40+/font-types 0.12, but vello_cpu's glifo 0.1.1 pins read-fonts 0.39/font-types 0.11, so bumping duplicates them
-home = "0.5.12"
 image = { version = "0.25.6", default-features = false } # Can't update to 0.25.7+: it needs png 0.18, which only matches resvg once resvg moves to tiny-skia 0.12 — blocked, see resvg below
 itertools = "0.15.0"
 jiff = { version = "0.2.29", default-features = false }

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -60,7 +60,7 @@ default_fonts = ["egui/default_fonts"]
 glow = ["dep:egui_glow", "dep:glow", "dep:glutin-winit", "dep:glutin"]
 
 ## Enable saving app state to disk.
-persistence = ["dep:home", "egui-winit/serde", "egui/persistence", "ron", "serde"]
+persistence = ["egui-winit/serde", "egui/persistence", "ron", "serde"]
 
 ## Enables wayland support and fixes clipboard issue.
 ##
@@ -161,7 +161,6 @@ glutin-winit = { workspace = true, optional = true, default-features = false, fe
   "egl",
   "wgl",
 ] }
-home = { workspace = true, optional = true }
 
 # mac:
 [target.'cfg(any(target_os = "macos"))'.dependencies]

--- a/crates/eframe/src/native/file_storage.rs
+++ b/crates/eframe/src/native/file_storage.rs
@@ -21,7 +21,7 @@ pub fn storage_dir(app_id: &str) -> Option<PathBuf> {
         OS::Nix => var_os("XDG_DATA_HOME")
             .map(PathBuf::from)
             .filter(|p| p.is_absolute())
-            .or_else(|| home::home_dir().map(|p| p.join(".local").join("share")))
+            .or_else(|| std::env::home_dir().map(|p| p.join(".local").join("share")))
             .map(|p| {
                 p.join(
                     app_id
@@ -29,7 +29,7 @@ pub fn storage_dir(app_id: &str) -> Option<PathBuf> {
                         .replace(|c: char| c.is_ascii_whitespace(), ""),
                 )
             }),
-        OS::Mac => home::home_dir().map(|p| {
+        OS::Mac => std::env::home_dir().map(|p| {
             p.join("Library")
                 .join("Application Support")
                 .join(app_id.replace(|c: char| c.is_ascii_whitespace(), "-"))


### PR DESCRIPTION
Replaces `home::home_dir` with `std::env::home_dir` as these functions do the exact same thing

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

Removes dependency `home` from `eframe` by replacing `home::home_dir` with `std::env::home_dir`. `home` was probably originally used since `std::env::home_dir` was once deprecated because of a bug. Post Rust version 1.87 this has been fixed and now these two functions do exactly the same thing.

* [X] I have followed the instructions in the PR template
