### PR TITLE
Fix `Frame::set_wgpu_surface_config` having no effect

### DIFF
--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -691,6 +691,14 @@ impl WgpuWinitRunning<'_> {
             ..
         } = &mut *shared_mut;
 
+        // Propagate any surface config the app set this frame via
+        // `Frame::set_wgpu_surface_config`. The frame carries its own clone of the
+        // `RenderState`, so copy the config into the painter's own copy — the one read in
+        // `paint_and_update_textures` — otherwise the change would never take effect.
+        if let Some(surface_config) = integration.frame.wgpu_surface_config() {
+            painter.set_surface_config(surface_config);
+        }
+
         let FullOutput {
             platform_output,
             textures_delta,

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -92,6 +92,19 @@ impl Painter {
         self.render_state.clone()
     }
 
+    /// Overwrite the runtime-mutable [`RenderState::surface_config`] held by this painter.
+    ///
+    /// The [`RenderState`] returned by [`Self::render_state`] is a clone, so mutating
+    /// `surface_config` on that clone (for example the copy `eframe` keeps in its `Frame`)
+    /// never reaches the copy consulted in [`Self::paint_and_update_textures`]. `eframe`
+    /// calls this once per frame to push the app-requested config into the painter's own
+    /// copy; the change is applied on the next paint.
+    pub fn set_surface_config(&mut self, surface_config: SurfaceConfig) {
+        if let Some(render_state) = self.render_state.as_mut() {
+            render_state.surface_config = surface_config;
+        }
+    }
+
     fn configure_surface(
         surface_state: &SurfaceState,
         render_state: &RenderState,


### PR DESCRIPTION
`Frame::set_wgpu_surface_config` writes into the `RenderState` clone stored in the frame, but the painter consults its *own* separate clone when applying runtime surface changes in `Painter::paint_and_update_textures`. Unlike the Arc-backed `device`, `queue` and `renderer`, `RenderState::surface_config` is a plain value, so the two clones diverge and the app-requested config was never picked up — the surface was never reconfigured.

Add `Painter::set_surface_config` and call it once per frame from the wgpu integration to push the frame's config into the painter's copy before painting.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [ ] I have followed the instructions in the PR template
