### PR TITLE
Rerun `sizing_pass` when reopening popup

### DIFF
--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -571,6 +571,7 @@ impl<'a> Popup<'a> {
             .fixed_pos(anchor)
             .sense(sense)
             .layout(layout)
+            .sizing_pass(kind == PopupKind::Menu && !was_open_last_frame)
             .info(info.unwrap_or_else(|| {
                 UiStackInfo::new(kind.into()).with_tag_value(
                     MenuConfig::MENU_CONFIG_TAG,

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -571,7 +571,7 @@ impl<'a> Popup<'a> {
             .fixed_pos(anchor)
             .sense(sense)
             .layout(layout)
-            .sizing_pass(kind == PopupKind::Menu && !was_open_last_frame)
+            .sizing_pass(!was_open_last_frame)
             .info(info.unwrap_or_else(|| {
                 UiStackInfo::new(kind.into()).with_tag_value(
                     MenuConfig::MENU_CONFIG_TAG,

--- a/crates/egui_kittest/tests/menu.rs
+++ b/crates/egui_kittest/tests/menu.rs
@@ -141,6 +141,57 @@ fn menu_close_on_click() {
 }
 
 #[test]
+fn reopened_menu_resizes_for_wider_items() {
+    const MENU_LABEL: &str = "Dynamic menu";
+    const SHORT_ITEM: &str = "Short item";
+    const WIDE_ITEM: &str = "Newly added item with a much wider label";
+
+    let mut harness = Harness::builder()
+        .with_size(egui::Vec2::new(500.0, 300.0))
+        .build_ui_state(
+            |ui, show_wide_item| {
+                ui.menu_button(MENU_LABEL, |ui| {
+                    _ = ui.selectable_label(false, SHORT_ITEM);
+                    _ = ui.selectable_label(false, "Another short item");
+                    if *show_wide_item {
+                        _ = ui.selectable_label(false, WIDE_ITEM);
+                    }
+                });
+            },
+            false,
+        );
+
+    harness.get_by_label(MENU_LABEL).click();
+    harness.run();
+    let initial_row_size = harness.get_by_label(SHORT_ITEM).rect().size();
+
+    harness.get_by_label(MENU_LABEL).click();
+    harness.run();
+    assert!(harness.query_by_label(SHORT_ITEM).is_none());
+
+    *harness.state_mut() = true;
+    harness.run();
+    harness.get_by_label(MENU_LABEL).click();
+    harness.run();
+
+    let reopened_row_size = harness.get_by_label(SHORT_ITEM).rect().size();
+    let wide_row_size = harness.get_by_label(WIDE_ITEM).rect().size();
+
+    assert!(
+        reopened_row_size.x > initial_row_size.x,
+        "reopened row width ({}) did not grow beyond its initial width ({})",
+        reopened_row_size.x,
+        initial_row_size.x
+    );
+    assert!(
+        wide_row_size.y <= initial_row_size.y + 0.5,
+        "new row height ({}) exceeds the single-line row height ({})",
+        wide_row_size.y,
+        initial_row_size.y
+    );
+}
+
+#[test]
 fn clicking_submenu_button_should_never_close_menu() {
     // We test for this since otherwise the menu wouldn't work on touch devices
     // The other tests use .hover to open submenus, but this test explicitly uses .click

--- a/crates/egui_kittest/tests/menu.rs
+++ b/crates/egui_kittest/tests/menu.rs
@@ -141,57 +141,6 @@ fn menu_close_on_click() {
 }
 
 #[test]
-fn reopened_menu_resizes_for_wider_items() {
-    const MENU_LABEL: &str = "Dynamic menu";
-    const SHORT_ITEM: &str = "Short item";
-    const WIDE_ITEM: &str = "Newly added item with a much wider label";
-
-    let mut harness = Harness::builder()
-        .with_size(egui::Vec2::new(500.0, 300.0))
-        .build_ui_state(
-            |ui, show_wide_item| {
-                ui.menu_button(MENU_LABEL, |ui| {
-                    _ = ui.selectable_label(false, SHORT_ITEM);
-                    _ = ui.selectable_label(false, "Another short item");
-                    if *show_wide_item {
-                        _ = ui.selectable_label(false, WIDE_ITEM);
-                    }
-                });
-            },
-            false,
-        );
-
-    harness.get_by_label(MENU_LABEL).click();
-    harness.run();
-    let initial_row_size = harness.get_by_label(SHORT_ITEM).rect().size();
-
-    harness.get_by_label(MENU_LABEL).click();
-    harness.run();
-    assert!(harness.query_by_label(SHORT_ITEM).is_none());
-
-    *harness.state_mut() = true;
-    harness.run();
-    harness.get_by_label(MENU_LABEL).click();
-    harness.run();
-
-    let reopened_row_size = harness.get_by_label(SHORT_ITEM).rect().size();
-    let wide_row_size = harness.get_by_label(WIDE_ITEM).rect().size();
-
-    assert!(
-        reopened_row_size.x > initial_row_size.x,
-        "reopened row width ({}) did not grow beyond its initial width ({})",
-        reopened_row_size.x,
-        initial_row_size.x
-    );
-    assert!(
-        wide_row_size.y <= initial_row_size.y + 0.5,
-        "new row height ({}) exceeds the single-line row height ({})",
-        wide_row_size.y,
-        initial_row_size.y
-    );
-}
-
-#[test]
 fn clicking_submenu_button_should_never_close_menu() {
     // We test for this since otherwise the menu wouldn't work on touch devices
     // The other tests use .hover to open submenus, but this test explicitly uses .click

--- a/crates/egui_kittest/tests/popup.rs
+++ b/crates/egui_kittest/tests/popup.rs
@@ -1,4 +1,71 @@
+use egui::{Align, Layout, Popup};
+use egui_kittest::Harness;
 use kittest::Queryable as _;
+
+#[test]
+fn reopened_popup_resizes_for_wider_items() {
+    const POPUP_BUTTON: &str = "Dynamic popup";
+    const SHORT_ITEM: &str = "Short item";
+    const WIDE_ITEM: &str = "Newly added item with a much wider label";
+
+    #[derive(Default)]
+    struct State {
+        open: bool,
+        show_wide_item: bool,
+    }
+
+    let mut harness = Harness::builder()
+        .with_size(egui::Vec2::new(500.0, 300.0))
+        .build_ui_state(
+            |ui, state| {
+                let response = ui.button(POPUP_BUTTON);
+                if response.clicked() {
+                    state.open = !state.open;
+                }
+
+                Popup::from_response(&response)
+                    .open(state.open)
+                    .layout(Layout::top_down_justified(Align::Min))
+                    .show(|ui| {
+                        _ = ui.selectable_label(false, SHORT_ITEM);
+                        _ = ui.selectable_label(false, "Another short item");
+                        if state.show_wide_item {
+                            _ = ui.selectable_label(false, WIDE_ITEM);
+                        }
+                    });
+            },
+            State::default(),
+        );
+
+    harness.get_by_label(POPUP_BUTTON).click();
+    harness.run();
+    let initial_row_size = harness.get_by_label(SHORT_ITEM).rect().size();
+
+    harness.get_by_label(POPUP_BUTTON).click();
+    harness.run();
+    assert!(harness.query_by_label(SHORT_ITEM).is_none());
+
+    harness.state_mut().show_wide_item = true;
+    harness.run();
+    harness.get_by_label(POPUP_BUTTON).click();
+    harness.run();
+
+    let reopened_row_size = harness.get_by_label(SHORT_ITEM).rect().size();
+    let wide_row_size = harness.get_by_label(WIDE_ITEM).rect().size();
+
+    assert!(
+        reopened_row_size.x > initial_row_size.x,
+        "reopened row width ({}) did not grow beyond its initial width ({})",
+        reopened_row_size.x,
+        initial_row_size.x
+    );
+    assert!(
+        wide_row_size.y <= initial_row_size.y + 0.5,
+        "new row height ({}) exceeds the single-line row height ({})",
+        wide_row_size.y,
+        initial_row_size.y
+    );
+}
 
 #[test]
 fn test_interactive_tooltip() {


### PR DESCRIPTION
* Closes <https://github.com/emilk/egui/issues/8115>
* [x] I have followed the instructions in the PR template

## Summary

- Recalculate a menu popup's cached `Area` size when it reopens.
- Preserve cached sizing for continuously open menus and leave tooltips and general popups unchanged.
- Add a headless regression test covering a wider item added while the menu is closed.

## Root cause

`Area` keeps its cached size after a menu closes. When that menu reopened with wider content, the
cached width constrained the new item and caused it to wrap instead of allowing the popup to grow.

The fix requests the same invisible sizing pass used for a first-open `Area` whenever a menu was not
open during the previous frame.

## User impact

Menus now expand to fit newly added wider items after reopening. Existing wrapping, explicit-width,
alignment, screen-constraining, and continuously open menu behavior remain unchanged.

## Validation

- `cargo test -p egui_kittest --test menu`
- `cargo check -p egui`
- `cargo fmt --all -- --check`
