### PR TITLE
Avoid cloning owned font data when constructing font faces

### DIFF
--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -394,11 +394,9 @@ impl Default for SmoothHinting {
 
 pub type Blob = Arc<dyn AsRef<[u8]> + Send + Sync>;
 
-fn blob_from_font_data(data: &FontData) -> Blob {
-    match data.clone().font {
-        Cow::Borrowed(bytes) => Arc::new(bytes) as Blob,
-        Cow::Owned(bytes) => Arc::new(bytes) as Blob,
-    }
+fn blob_from_font_data(data: &Arc<FontData>) -> Blob {
+    let data: Arc<FontData> = Arc::clone(data);
+    data
 }
 
 /// Describes the font data and the sizes to use.


### PR DESCRIPTION
* Closes N/A
* [x] I have followed the instructions in the PR template

## Summary

Reuse the `Arc<FontData>` already stored in `FontDefinitions` as the owning `Blob` for each font face.

Previously, `blob_from_font_data` cloned `FontData`. When the font uses `Cow::Owned`, this also cloned the entire underlying font byte buffer.

`FontData` already implements `AsRef<[u8]>`, so its existing `Arc` can be used directly as the stable owner required by `FontCell` and Skrifa.

## Reproduction

A black-box eframe reproduction is available here:

https://github.com/undermoonn/egui-font-data-clone-repro

The repository contains two branches:

- `main`: crates.io `eframe/epaint 0.35.0`
- `patched`: the same application with only `epaint` and `emath` patched to this change

The application code and font are identical between the branches. It loads a
7.95 MiB Noto Sans SC font from disk using `FontData::from_owned` and renders
through glow/OpenGL.

Three Windows runs were measured for each branch:

| Branch | Private bytes mean | Working set mean |
| --- | ---: | ---: |
| `main` | 99.46 MiB | 85.61 MiB |
| `patched` | 91.63 MiB | 77.61 MiB |
| Reduction | **7.83 MiB** | **8.00 MiB** |

The process-level reduction closely matches the 7.95 MiB font file.

## Safety

`FontCell` retains its own strong `Arc` reference, so the font bytes remain alive
at a stable address for as long as Skrifa references them.

The shared data cannot be mutated in place. Any use of `Arc::make_mut` creates a
separate copy instead of modifying bytes referenced by an existing font face.

## Testing

- `cargo test --locked -p epaint --lib` — 45 passed
- `cargo clippy --locked -p epaint --all-targets --all-features -- -D warnings`
- `cargo check --locked -p epaint --no-default-features`
- `cargo fmt -p epaint -- --check`
- Black-box eframe comparison linked above