### PR TITLE
Fix comment style: add space after //

### DIFF
--- a/crates/eframe/src/web/web_painter_wgpu.rs
+++ b/crates/eframe/src/web/web_painter_wgpu.rs
@@ -90,7 +90,7 @@ impl WebPainterWgpu {
             && create_new.display_handle.is_none()
         {
             // Force WebGL, useful for quick & dirty testing:
-            //create_new.instance_descriptor.backends = wgpu::Backends::GL;
+            // create_new.instance_descriptor.backends = wgpu::Backends::GL;
             create_new.display_handle = Some(Box::new(WebDisplay));
         }
 

--- a/crates/egui/src/animation_manager.rs
+++ b/crates/egui/src/animation_manager.rs
@@ -95,7 +95,7 @@ impl AnimationManager {
                     anim.from_value..=anim.to_value,
                 );
                 if anim.to_value != value {
-                    anim.from_value = current_value; //start new animation from current position of playing animation
+                    anim.from_value = current_value; // start new animation from current position of playing animation
                     anim.to_value = value;
                     anim.toggle_time = input.time;
                 }

--- a/crates/epaint/src/shapes/bezier_shape.rs
+++ b/crates/epaint/src/shapes/bezier_shape.rs
@@ -86,7 +86,7 @@ impl CubicBezierShape {
 
     /// Logical bounding rectangle (ignoring stroke width)
     pub fn logical_bounding_rect(&self) -> Rect {
-        //temporary solution
+        // temporary solution
         let (mut min_x, mut max_x) = if self.points[0].x < self.points[3].x {
             (self.points[0].x, self.points[3].x)
         } else {
@@ -793,7 +793,7 @@ mod tests {
         assert!((bbox.max.x - 180.0).abs() < 0.01);
         assert!((bbox.max.y - 170.0).abs() < 0.01);
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.1, &mut |pos, _t| {
             result.push(pos);
         });
@@ -817,7 +817,7 @@ mod tests {
         assert!((bbox.max.x - 130.42).abs() < 0.01);
         assert!((bbox.max.y - 170.0).abs() < 0.01);
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.1, &mut |pos, _t| {
             result.push(pos);
         });
@@ -837,28 +837,28 @@ mod tests {
             fill: Default::default(),
             stroke: Default::default(),
         };
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(1.0, &mut |pos, _t| {
             result.push(pos);
         });
 
         assert_eq!(result.len(), 9);
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.1, &mut |pos, _t| {
             result.push(pos);
         });
 
         assert_eq!(result.len(), 25);
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.01, &mut |pos, _t| {
             result.push(pos);
         });
 
         assert_eq!(result.len(), 77);
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.001, &mut |pos, _t| {
             result.push(pos);
         });
@@ -938,35 +938,35 @@ mod tests {
             stroke: Default::default(),
         };
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(1.0, &mut |pos, _t| {
             result.push(pos);
         });
 
         assert_eq!(result.len(), 10);
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.5, &mut |pos, _t| {
             result.push(pos);
         });
 
         assert_eq!(result.len(), 13);
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.1, &mut |pos, _t| {
             result.push(pos);
         });
 
         assert_eq!(result.len(), 28);
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.01, &mut |pos, _t| {
             result.push(pos);
         });
 
         assert_eq!(result.len(), 83);
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.001, &mut |pos, _t| {
             result.push(pos);
         });
@@ -988,7 +988,7 @@ mod tests {
             stroke: Default::default(),
         };
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.01, &mut |pos, _t| {
             result.push(pos);
         });
@@ -1007,7 +1007,7 @@ mod tests {
             stroke: Default::default(),
         };
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.01, &mut |pos, _t| {
             result.push(pos);
         });
@@ -1026,7 +1026,7 @@ mod tests {
             stroke: Default::default(),
         };
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.01, &mut |pos, _t| {
             result.push(pos);
         });
@@ -1045,7 +1045,7 @@ mod tests {
             stroke: Default::default(),
         };
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.01, &mut |pos, _t| {
             result.push(pos);
         });
@@ -1064,7 +1064,7 @@ mod tests {
             stroke: Default::default(),
         };
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.01, &mut |pos, _t| {
             result.push(pos);
         });
@@ -1083,7 +1083,7 @@ mod tests {
             stroke: Default::default(),
         };
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.01, &mut |pos, _t| {
             result.push(pos);
         });
@@ -1100,34 +1100,34 @@ mod tests {
             stroke: Default::default(),
         };
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(1.0, &mut |pos, _t| {
             result.push(pos);
         });
 
         assert_eq!(result.len(), 9);
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.5, &mut |pos, _t| {
             result.push(pos);
         });
 
         assert_eq!(result.len(), 11);
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.1, &mut |pos, _t| {
             result.push(pos);
         });
 
         assert_eq!(result.len(), 24);
 
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.01, &mut |pos, _t| {
             result.push(pos);
         });
 
         assert_eq!(result.len(), 72);
-        let mut result = vec![curve.points[0]]; //add the start point
+        let mut result = vec![curve.points[0]]; // add the start point
         curve.for_each_flattened_with_t(0.001, &mut |pos, _t| {
             result.push(pos);
         });


### PR DESCRIPTION
## Summary

- [x] I have followed the instructions in the PR template

Fixes comment-style violations of the `CONTRIBUTING.md` code style rule:

> `// Comment like this.` and not `//like this`

### Files changed

- `crates/epaint/src/shapes/bezier_shape.rs`: `//temporary solution` → `// temporary solution`, and 22× `//add the start point` → `// add the start point`
- `crates/egui/src/animation_manager.rs`: `//start new animation…` → `// start new animation…`
- `crates/eframe/src/web/web_painter_wgpu.rs`: `//create_new.instance_descriptor…` → `// create_new.instance_descriptor…`

No code logic changes — only adding the missing space after `//` in inline and standalone comments.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p epaint -p egui`
- [x] `cargo test -p epaint --lib`
