### PR TITLE
Ignore RUSTSEC-2026-0206 (rustybuzz unmaintained) in cargo-deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -36,7 +36,7 @@ ignore = [
   "RUSTSEC-2026-0192", # ttf-parser is unmaintained. Only brought in via winit/sctk-adwaita (wayland window frame rendering)
   "RUSTSEC-2026-0194", # quick-xml DoS - fix is in >=0.41, but held back transitively by zbus_xml (accesskit) and wayland-scanner (winit)
   "RUSTSEC-2026-0195", # quick-xml DoS - same as above
-  "RUSTSEC-2026-0206", # rustybuzz is unmaintained. Brought in via resvg/usvg (egui_extras SVG support). resvg can't be bumped yet (tiny-skia version conflict, see Cargo.toml). Recommended replacement is harfrust, not yet adopted by resvg.
+  "RUSTSEC-2026-0206", # rustybuzz is unmaintained. Brought in via resvg. TODO(linebender/resvg#922): Remove once the PR lands and is released
 ]
 
 [bans]

--- a/deny.toml
+++ b/deny.toml
@@ -36,6 +36,7 @@ ignore = [
   "RUSTSEC-2026-0192", # ttf-parser is unmaintained. Only brought in via winit/sctk-adwaita (wayland window frame rendering)
   "RUSTSEC-2026-0194", # quick-xml DoS - fix is in >=0.41, but held back transitively by zbus_xml (accesskit) and wayland-scanner (winit)
   "RUSTSEC-2026-0195", # quick-xml DoS - same as above
+  "RUSTSEC-2026-0206", # rustybuzz is unmaintained. Brought in via resvg/usvg (egui_extras SVG support). resvg can't be bumped yet (tiny-skia version conflict, see Cargo.toml). Recommended replacement is harfrust, not yet adopted by resvg.
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

- [x] I have followed the instructions in the PR template

Fixes the 12 failing `cargo-deny` CI checks on `main` (introduced by #8289).

### Root cause

`rustybuzz` was flagged as unmaintained by [RUSTSEC-2026-0206](https://rustsec.org/advisories/RUSTSEC-2026-0206), reported on 2026-07-12 — after the previous cargo-deny fix (#8300) was merged on 2026-07-07. The advisory fires on all 12 cargo-deny target triples.

`rustybuzz` is pulled in transitively via `resvg` → `usvg`, which `egui_extras` uses for SVG support.

### Why ignore (not fix)?

- `resvg` is pinned at `0.45.1` and cannot be bumped: `0.47` needs `tiny-skia 0.12`, but `winit 0.30`'s `sctk-adwaita` is stuck on `tiny-skia 0.11` (see comment in `Cargo.toml` line 128).
- The advisory's recommended replacement is [`harfrust`](https://github.com/harfbuzz/harfrust), which `resvg` has not adopted yet.
- This is the same pattern used for the other transitively-unmaintained advisories already in the ignore list (`ttf-parser` via winit, `quick-xml` via accesskit/wayland, `bincode`, `yaml-rust`).

### Change

Added `RUSTSEC-2026-0206` to the `[advisories] ignore` list in `deny.toml` with an explanatory comment.

## Test plan

- [x] `cargo deny check advisories` — passes (`advisories ok`)
- [x] `cargo deny check` — all sections pass (`advisories ok, bans ok, licenses ok, sources ok`)
