### PR TITLE
Remove `Modifiers` from `RawInput` and make it a `egui::Event`

### DIFF
--- a/crates/eframe/src/web/backend.rs
+++ b/crates/eframe/src/web/backend.rs
@@ -20,6 +20,12 @@ pub(crate) struct WebInput {
     /// Helps to track the delta rotation from gesture events
     pub accumulated_rotation: f32,
 
+    /// The last modifier state we sent to egui.
+    ///
+    /// The web has no dedicated modifier event, so we derive the state from each DOM event and
+    /// emit [`egui::Event::ModifiersChanged`] when it changes (see [`Self::set_modifiers`]).
+    pub modifiers: egui::Modifiers,
+
     /// The raw input to `egui`.
     pub raw: egui::RawInput,
 }
@@ -53,10 +59,22 @@ impl WebInput {
         }
 
         // log::debug!("on_web_page_focus_change: {focused}");
-        self.raw.modifiers = egui::Modifiers::default(); // Avoid sticky modifier keys on alt-tab:
+        self.modifiers = egui::Modifiers::default(); // Avoid sticky modifier keys on alt-tab:
         self.raw.focused = focused;
         self.raw.events.push(egui::Event::WindowFocused(focused));
         self.primary_touch = None;
+    }
+
+    /// Update the modifier state, emitting [`egui::Event::ModifiersChanged`] if it changed.
+    ///
+    /// Call before pushing the DOM event itself so egui sees the new modifier state first.
+    pub fn set_modifiers(&mut self, modifiers: egui::Modifiers) {
+        if self.modifiers != modifiers {
+            self.modifiers = modifiers;
+            self.raw
+                .events
+                .push(egui::Event::ModifiersChanged(modifiers));
+        }
     }
 }
 

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -196,7 +196,7 @@ pub(crate) fn on_keydown(event: web_sys::KeyboardEvent, runner: &mut AppRunner) 
     }
 
     let modifiers = modifiers_from_kb_event(&event);
-    runner.input.raw.modifiers = modifiers;
+    runner.input.set_modifiers(modifiers);
 
     let key = event.key();
     let egui_key = translate_key(&key);
@@ -287,7 +287,7 @@ fn install_keyup(runner_ref: &WebRunner, target: &EventTarget) -> Result<(), JsV
 #[expect(clippy::needless_pass_by_value)] // So that we can pass it directly to `add_event_listener`
 pub(crate) fn on_keyup(event: web_sys::KeyboardEvent, runner: &mut AppRunner) {
     let modifiers = modifiers_from_kb_event(&event);
-    runner.input.raw.modifiers = modifiers;
+    runner.input.set_modifiers(modifiers);
 
     let mut should_stop_propagation = true;
 
@@ -535,11 +535,11 @@ fn install_pointerdown(runner_ref: &WebRunner, target: &EventTarget) -> Result<(
         "pointerdown",
         |event: web_sys::PointerEvent, runner: &mut AppRunner| {
             let modifiers = modifiers_from_mouse_event(&event);
-            runner.input.raw.modifiers = modifiers;
+            runner.input.set_modifiers(modifiers);
             let mut should_stop_propagation = true;
             if let Some(button) = button_from_mouse_event(&event) {
                 let pos = pos_from_mouse_event(runner.canvas(), &event, runner.egui_ctx());
-                let modifiers = runner.input.raw.modifiers;
+                let modifiers = runner.input.modifiers;
                 let egui_event = egui::Event::PointerButton {
                     pos,
                     button,
@@ -572,7 +572,7 @@ fn install_pointerup(runner_ref: &WebRunner, target: &EventTarget) -> Result<(),
         "pointerup",
         |event: web_sys::PointerEvent, runner| {
             let modifiers = modifiers_from_mouse_event(&event);
-            runner.input.raw.modifiers = modifiers;
+            runner.input.set_modifiers(modifiers);
 
             let pos = pos_from_mouse_event(runner.canvas(), &event, runner.egui_ctx());
 
@@ -581,7 +581,7 @@ fn install_pointerup(runner_ref: &WebRunner, target: &EventTarget) -> Result<(),
                 egui::pos2(event.client_x() as f32, event.client_y() as f32),
             ) && let Some(button) = button_from_mouse_event(&event)
             {
-                let modifiers = runner.input.raw.modifiers;
+                let modifiers = runner.input.modifiers;
                 let egui_event = egui::Event::PointerButton {
                     pos,
                     button,
@@ -647,7 +647,7 @@ fn is_interested_in_pointer_event(runner: &AppRunner, pos: egui::Pos2) -> bool {
 fn install_mousemove(runner_ref: &WebRunner, target: &EventTarget) -> Result<(), JsValue> {
     runner_ref.add_event_listener(target, "mousemove", |event: web_sys::MouseEvent, runner| {
         let modifiers = modifiers_from_mouse_event(&event);
-        runner.input.raw.modifiers = modifiers;
+        runner.input.set_modifiers(modifiers);
 
         let pos = pos_from_mouse_event(runner.canvas(), &event, runner.egui_ctx());
 
@@ -705,7 +705,7 @@ fn install_touchstart(runner_ref: &WebRunner, target: &EventTarget) -> Result<()
                     pos,
                     button: egui::PointerButton::Primary,
                     pressed: true,
-                    modifiers: runner.input.raw.modifiers,
+                    modifiers: runner.input.modifiers,
                 };
                 should_stop_propagation = (runner.web_options.should_stop_propagation)(&egui_event);
                 should_prevent_default = (runner.web_options.should_prevent_default)(&egui_event);
@@ -770,7 +770,7 @@ fn install_touchend(runner_ref: &WebRunner, target: &EventTarget) -> Result<(), 
                 pos,
                 button: egui::PointerButton::Primary,
                 pressed: false,
-                modifiers: runner.input.raw.modifiers,
+                modifiers: runner.input.modifiers,
             };
             should_stop_propagation &= (runner.web_options.should_stop_propagation)(&egui_event);
             should_prevent_default &= (runner.web_options.should_prevent_default)(&egui_event);
@@ -832,7 +832,7 @@ fn install_wheel(runner_ref: &WebRunner, target: &EventTarget) -> Result<(), JsV
 
         let modifiers = modifiers_from_wheel_event(&event);
 
-        let egui_event = if modifiers.ctrl && !runner.input.raw.modifiers.ctrl {
+        let egui_event = if modifiers.ctrl && !runner.input.modifiers.ctrl {
             // The browser is saying the ctrl key is down, but it isn't _really_.
             // This happens on pinch-to-zoom on multitouch trackpads
             // egui will treat ctrl+scroll as zoom, so it all works.

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -84,6 +84,13 @@ pub struct State {
     viewport_id: ViewportId,
     start_time: web_time::Instant,
     egui_input: egui::RawInput,
+
+    /// The current modifier state.
+    ///
+    /// egui no longer stores this on [`egui::RawInput`]; we keep our own copy so we can stamp
+    /// it onto per-event `modifiers` fields and emit [`egui::Event::ModifiersChanged`].
+    modifiers: egui::Modifiers,
+
     pointer_pos_in_points: Option<egui::Pos2>,
     any_pointer_button_down: bool,
     current_cursor_icon: Option<egui::CursorIcon>,
@@ -146,6 +153,7 @@ impl State {
                 .unwrap_or_else(web_time::Instant::now),
             egui_ctx,
             egui_input,
+            modifiers: egui::Modifiers::default(),
             pointer_pos_in_points: None,
             any_pointer_button_down: false,
             current_cursor_icon: None,
@@ -422,6 +430,10 @@ impl State {
                 };
 
                 self.egui_input.focused = focused;
+                if !focused {
+                    // Avoid sticky modifiers when focus is lost (egui clears its own copy too).
+                    self.modifiers = egui::Modifiers::default();
+                }
                 self.egui_input
                     .events
                     .push(egui::Event::WindowFocused(focused));
@@ -473,15 +485,19 @@ impl State {
                 let shift = state.shift_key();
                 let super_ = state.super_key();
 
-                self.egui_input.modifiers.alt = alt;
-                self.egui_input.modifiers.ctrl = ctrl;
-                self.egui_input.modifiers.shift = shift;
-                self.egui_input.modifiers.mac_cmd = cfg!(target_os = "macos") && super_;
-                self.egui_input.modifiers.command = if cfg!(target_os = "macos") {
+                self.modifiers.alt = alt;
+                self.modifiers.ctrl = ctrl;
+                self.modifiers.shift = shift;
+                self.modifiers.mac_cmd = cfg!(target_os = "macos") && super_;
+                self.modifiers.command = if cfg!(target_os = "macos") {
                     super_
                 } else {
                     ctrl
                 };
+
+                self.egui_input
+                    .events
+                    .push(egui::Event::ModifiersChanged(self.modifiers));
 
                 EventResponse {
                     repaint: true,
@@ -541,7 +557,7 @@ impl State {
                     unit: egui::MouseWheelUnit::Point,
                     delta: Vec2::new(delta.x, delta.y) / pixels_per_point,
                     phase: to_egui_touch_phase(*phase),
-                    modifiers: self.egui_input.modifiers,
+                    modifiers: self.modifiers,
                 });
                 EventResponse {
                     repaint: true,
@@ -790,7 +806,7 @@ impl State {
                 pos,
                 button,
                 pressed,
-                modifiers: self.egui_input.modifiers,
+                modifiers: self.modifiers,
             });
 
             if self.simulate_touch_screen {
@@ -937,7 +953,7 @@ impl State {
                 ),
             };
             let phase = to_egui_touch_phase(phase);
-            let modifiers = self.egui_input.modifiers;
+            let modifiers = self.modifiers;
             self.egui_input.events.push(egui::Event::MouseWheel {
                 unit,
                 delta,
@@ -998,13 +1014,13 @@ impl State {
         // See also: https://github.com/emilk/egui/issues/3653
         if let Some(active_key) = logical_key.or(physical_key) {
             if pressed {
-                if is_cut_command(self.egui_input.modifiers, active_key) {
+                if is_cut_command(self.modifiers, active_key) {
                     self.egui_input.events.push(egui::Event::Cut);
                     return;
-                } else if is_copy_command(self.egui_input.modifiers, active_key) {
+                } else if is_copy_command(self.modifiers, active_key) {
                     self.egui_input.events.push(egui::Event::Copy);
                     return;
-                } else if is_paste_command(self.egui_input.modifiers, active_key) {
+                } else if is_paste_command(self.modifiers, active_key) {
                     if let Some(contents) = self.clipboard.get() {
                         let contents = contents.replace("\r\n", "\n");
                         if !contents.is_empty() {
@@ -1020,7 +1036,7 @@ impl State {
                 physical_key,
                 pressed,
                 repeat: false, // egui will fill this in for us!
-                modifiers: self.egui_input.modifiers,
+                modifiers: self.modifiers,
             });
         }
 
@@ -1036,9 +1052,8 @@ impl State {
                 // We need to ignore these characters that are side-effects of commands.
                 // Also make sure the key is pressed (not released). On Linux, text might
                 // contain some data even when the key is released.
-                let is_cmd = self.egui_input.modifiers.ctrl
-                    || self.egui_input.modifiers.command
-                    || self.egui_input.modifiers.mac_cmd;
+                let is_cmd =
+                    self.modifiers.ctrl || self.modifiers.command || self.modifiers.mac_cmd;
                 if pressed && !is_cmd {
                     self.egui_input
                         .events

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -87,7 +87,7 @@ pub struct State {
 
     /// The current modifier state.
     ///
-    /// egui no longer stores this on [`egui::RawInput`]; we keep our own copy so we can stamp
+    /// We keep a copy so we can stamp
     /// it onto per-event `modifiers` fields and emit [`egui::Event::ModifiersChanged`].
     modifiers: egui::Modifiers,
 

--- a/crates/egui/src/data/input/event.rs
+++ b/crates/egui/src/data/input/event.rs
@@ -69,6 +69,9 @@ pub enum Event {
         modifiers: Modifiers,
     },
 
+    /// The set of held modifier keys changed.
+    ModifiersChanged(Modifiers),
+
     /// The mouse or touch moved to a new place.
     PointerMoved(Pos2),
 

--- a/crates/egui/src/data/input/raw_input.rs
+++ b/crates/egui/src/data/input/raw_input.rs
@@ -1,6 +1,6 @@
 use crate::{OrderedViewportIdMap, Theme, ViewportId, ViewportIdMap, emath::Rect};
 
-use super::{DroppedFile, Event, HoveredFile, Modifiers, SafeAreaInsets, ViewportInfo};
+use super::{DroppedFile, Event, HoveredFile, SafeAreaInsets, ViewportInfo};
 
 /// What the integrations provides to egui at the start of each frame.
 ///
@@ -53,9 +53,6 @@ pub struct RawInput {
     /// Can safely be left at its default value.
     pub predicted_dt: f32,
 
-    /// Which modifier keys are down at the start of the frame?
-    pub modifiers: Modifiers,
-
     /// In-order events received this frame.
     ///
     /// There is currently no way to know if egui handles a particular event,
@@ -92,7 +89,6 @@ impl Default for RawInput {
             max_texture_side: None,
             time: None,
             predicted_dt: 1.0 / 60.0,
-            modifiers: Modifiers::default(),
             events: vec![],
             hovered_files: Default::default(),
             dropped_files: Default::default(),
@@ -127,7 +123,6 @@ impl RawInput {
             max_texture_side: self.max_texture_side.take(),
             time: self.time,
             predicted_dt: self.predicted_dt,
-            modifiers: self.modifiers,
             events: std::mem::take(&mut self.events),
             hovered_files: self.hovered_files.clone(),
             dropped_files: std::mem::take(&mut self.dropped_files),
@@ -145,7 +140,6 @@ impl RawInput {
             max_texture_side,
             time,
             predicted_dt,
-            modifiers,
             mut events,
             mut hovered_files,
             mut dropped_files,
@@ -160,7 +154,6 @@ impl RawInput {
         self.max_texture_side = max_texture_side.or(self.max_texture_side);
         self.time = time; // use latest time
         self.predicted_dt = predicted_dt; // use latest dt
-        self.modifiers = modifiers; // use latest
         self.events.append(&mut events);
         self.hovered_files.append(&mut hovered_files);
         self.dropped_files.append(&mut dropped_files);
@@ -179,7 +172,6 @@ impl RawInput {
             max_texture_side,
             time,
             predicted_dt,
-            modifiers,
             events,
             hovered_files,
             dropped_files,
@@ -210,7 +202,6 @@ impl RawInput {
             ui.label("time: None");
         }
         ui.label(format!("predicted_dt: {:.1} ms", 1e3 * predicted_dt));
-        ui.label(format!("modifiers: {modifiers:#?}"));
         ui.label(format!("hovered_files: {}", hovered_files.len()));
         ui.label(format!("dropped_files: {}", dropped_files.len()));
         ui.label(format!("focused: {focused}"));

--- a/crates/egui/src/input_state/mod.rs
+++ b/crates/egui/src/input_state/mod.rs
@@ -393,7 +393,6 @@ impl InputState {
         let pointer = self.pointer.begin_pass(time, &new, options);
 
         let mut keys_down = self.keys_down;
-        // Carry the modifier state over: integrations only send `ModifiersChanged` on change.
         let mut modifiers = self.modifiers;
         let mut zoom_factor_delta = 1.0; // TODO(emilk): smoothing for zoom factor
         let mut rotation_radians = 0.0;

--- a/crates/egui/src/input_state/mod.rs
+++ b/crates/egui/src/input_state/mod.rs
@@ -393,6 +393,8 @@ impl InputState {
         let pointer = self.pointer.begin_pass(time, &new, options);
 
         let mut keys_down = self.keys_down;
+        // Carry the modifier state over: integrations only send `ModifiersChanged` on change.
+        let mut modifiers = self.modifiers;
         let mut zoom_factor_delta = 1.0; // TODO(emilk): smoothing for zoom factor
         let mut rotation_radians = 0.0;
 
@@ -429,6 +431,9 @@ impl InputState {
                         *modifiers,
                     );
                 }
+                Event::ModifiersChanged(new_modifiers) => {
+                    modifiers = *new_modifiers;
+                }
                 Event::Zoom(factor) => {
                     zoom_factor_delta *= *factor;
                 }
@@ -442,6 +447,7 @@ impl InputState {
                     // So we take the safe route and just clear all the keys and modifiers when
                     // the app loses focus.
                     keys_down.clear();
+                    modifiers = Modifiers::default();
                 }
                 _ => {}
             }
@@ -482,7 +488,7 @@ impl InputState {
             predicted_dt: new.predicted_dt,
             stable_dt,
             focused: new.focused,
-            modifiers: new.modifiers,
+            modifiers,
             keys_down,
             events: new.events.clone(), // TODO(emilk): remove clone() and use raw.events
             raw: new,

--- a/crates/egui_kittest/src/lib.rs
+++ b/crates/egui_kittest/src/lib.rs
@@ -735,7 +735,7 @@ impl<'a, State> Harness<'a, State> {
 
     /// The root node of the test harness.
     pub fn root(&self) -> Node<'_> {
-        Node::new(self.kittest.root(), &self.queued_events)
+        Node::new(self.kittest.root(), &self.queued_events, self.ctx.pixels_per_point())
     }
 
     /// Spawn a real native eframe window running this harness's app, reusing its [`egui::Context`].

--- a/crates/egui_kittest/src/lib.rs
+++ b/crates/egui_kittest/src/lib.rs
@@ -735,10 +735,7 @@ impl<'a, State> Harness<'a, State> {
 
     /// The root node of the test harness.
     pub fn root(&self) -> Node<'_> {
-        Node {
-            accesskit_node: self.kittest.root(),
-            queue: &self.queued_events,
-        }
+        Node::new(self.kittest.root(), &self.queued_events)
     }
 
     /// Spawn a real native eframe window running this harness's app, reusing its [`egui::Context`].

--- a/crates/egui_kittest/src/lib.rs
+++ b/crates/egui_kittest/src/lib.rs
@@ -251,14 +251,7 @@ impl<'a, State> Harness<'a, State> {
             self._step(false);
         }
         for event in events {
-            match event {
-                EventType::Event(event) => {
-                    self.input.events.push(event);
-                }
-                EventType::Modifiers(modifiers) => {
-                    self.input.modifiers = modifiers;
-                }
-            }
+            self.input.events.push(event);
             self._step(false);
         }
     }
@@ -471,7 +464,7 @@ impl<'a, State> Harness<'a, State> {
 
     /// Queue an event to be processed in the next frame.
     pub fn event(&self, event: egui::Event) {
-        self.queued_events.lock().push(EventType::Event(event));
+        self.queued_events.lock().push(event);
     }
 
     /// Queue an event with modifiers.
@@ -479,15 +472,15 @@ impl<'a, State> Harness<'a, State> {
     /// Queues the modifiers to be pressed, then the event, then the modifiers to be released.
     pub fn event_modifiers(&self, event: egui::Event, modifiers: Modifiers) {
         let mut queue = self.queued_events.lock();
-        queue.push(EventType::Modifiers(modifiers));
-        queue.push(EventType::Event(event));
-        queue.push(EventType::Modifiers(Modifiers::default()));
+        queue.push(egui::Event::ModifiersChanged(modifiers));
+        queue.push(event);
+        queue.push(egui::Event::ModifiersChanged(Modifiers::default()));
     }
 
     fn modifiers(&self, modifiers: Modifiers) {
         self.queued_events
             .lock()
-            .push(EventType::Modifiers(modifiers));
+            .push(egui::Event::ModifiersChanged(modifiers));
     }
 
     pub fn key_down(&self, key: egui::Key) {
@@ -735,7 +728,11 @@ impl<'a, State> Harness<'a, State> {
 
     /// The root node of the test harness.
     pub fn root(&self) -> Node<'_> {
-        Node::new(self.kittest.root(), &self.queued_events, self.ctx.pixels_per_point())
+        Node::new(
+            self.kittest.root(),
+            &self.queued_events,
+            self.ctx.pixels_per_point(),
+        )
     }
 
     /// Spawn a real native eframe window running this harness's app, reusing its [`egui::Context`].

--- a/crates/egui_kittest/src/node.rs
+++ b/crates/egui_kittest/src/node.rs
@@ -19,6 +19,7 @@ pub type EventQueue = Mutex<Vec<EventType>>;
 pub struct Node<'tree> {
     pub(crate) accesskit_node: AccessKitNode<'tree>,
     pub(crate) queue: &'tree EventQueue,
+    pub(crate) pixels_per_point: f32,
 }
 
 impl Debug for Node<'_> {
@@ -33,16 +34,17 @@ impl<'tree> NodeT<'tree> for Node<'tree> {
     }
 
     fn new_related(&self, child_node: AccessKitNode<'tree>) -> Self {
-        Self::new(child_node, self.queue)
+        Self::new(child_node, self.queue, self.pixels_per_point)
     }
 }
 
 impl<'tree> Node<'tree> {
     /// Construct a new accesskit node
-    pub fn new(accesskit_node: AccessKitNode<'tree>, queue: &'tree EventQueue) -> Self {
+    pub fn new(accesskit_node: AccessKitNode<'tree>, queue: &'tree EventQueue, pixels_per_point: f32) -> Self {
         Self {
             queue,
             accesskit_node,
+            pixels_per_point,
         }
     }
 
@@ -113,14 +115,17 @@ impl<'tree> Node<'tree> {
         ));
     }
 
+    /// This returns the rect in logical ui coordinates while the underlying [`accesskit::Node`] has it
+    /// in physical screen coordinates.
     pub fn rect(&self) -> egui::Rect {
         let rect = self
             .accesskit_node
             .bounding_box()
             .expect("Every egui node should have a rect");
+        let ppp = self.pixels_per_point;
         egui::Rect {
-            min: Pos2::new(rect.x0 as f32, rect.y0 as f32),
-            max: Pos2::new(rect.x1 as f32, rect.y1 as f32),
+            min: Pos2::new(rect.x0 as f32 / ppp, rect.y0 as f32 / ppp),
+            max: Pos2::new(rect.x1 as f32 / ppp, rect.y1 as f32 / ppp),
         }
     }
 

--- a/crates/egui_kittest/src/node.rs
+++ b/crates/egui_kittest/src/node.rs
@@ -37,9 +37,9 @@ impl<'tree> NodeT<'tree> for Node<'tree> {
     }
 }
 
-impl Node<'_> {
+impl<'tree> Node<'tree> {
     /// Construct a new accesskit node
-    pub fn new(accesskit_node: AccessKitNode<'_>, queue: &EventQueue) -> Self {
+    pub fn new(accesskit_node: AccessKitNode<'tree>, queue: &'tree EventQueue) -> Self {
         Self {
             queue,
             accesskit_node,

--- a/crates/egui_kittest/src/node.rs
+++ b/crates/egui_kittest/src/node.rs
@@ -4,12 +4,16 @@ use egui::{Modifiers, PointerButton, Pos2, accesskit};
 use kittest::{AccessKitNode, NodeT, debug_fmt_node};
 use std::fmt::{Debug, Formatter};
 
-pub(crate) enum EventType {
+/// Modifiers aren't part of [`egui::Event`] and must be handled by the integration, so we need
+/// an enum to handle these.
+///
+/// The most recent [`Self::Modifiers`] should always be passed to [`egui::RawInput`].
+pub enum EventType {
     Event(egui::Event),
     Modifiers(Modifiers),
 }
 
-pub(crate) type EventQueue = Mutex<Vec<EventType>>;
+pub type EventQueue = Mutex<Vec<EventType>>;
 
 #[derive(Clone, Copy)]
 pub struct Node<'tree> {
@@ -29,14 +33,19 @@ impl<'tree> NodeT<'tree> for Node<'tree> {
     }
 
     fn new_related(&self, child_node: AccessKitNode<'tree>) -> Self {
-        Self {
-            queue: self.queue,
-            accesskit_node: child_node,
-        }
+        Self::new(child_node, self.queue)
     }
 }
 
 impl Node<'_> {
+    /// Construct a new accesskit node
+    pub fn new(accesskit_node: AccessKitNode<'_>, queue: &EventQueue) -> Self {
+        Self {
+            queue,
+            accesskit_node,
+        }
+    }
+
     fn event(&self, event: egui::Event) {
         self.queue.lock().push(EventType::Event(event));
     }

--- a/crates/egui_kittest/src/node.rs
+++ b/crates/egui_kittest/src/node.rs
@@ -4,16 +4,7 @@ use egui::{Modifiers, PointerButton, Pos2, accesskit};
 use kittest::{AccessKitNode, NodeT, debug_fmt_node};
 use std::fmt::{Debug, Formatter};
 
-/// Modifiers aren't part of [`egui::Event`] and must be handled by the integration, so we need
-/// an enum to handle these.
-///
-/// The most recent [`Self::Modifiers`] should always be passed to [`egui::RawInput`].
-pub enum EventType {
-    Event(egui::Event),
-    Modifiers(Modifiers),
-}
-
-pub type EventQueue = Mutex<Vec<EventType>>;
+pub type EventQueue = Mutex<Vec<egui::Event>>;
 
 #[derive(Clone, Copy)]
 pub struct Node<'tree> {
@@ -40,20 +31,26 @@ impl<'tree> NodeT<'tree> for Node<'tree> {
 
 impl<'tree> Node<'tree> {
     /// Construct a new accesskit node
-    pub fn new(accesskit_node: AccessKitNode<'tree>, queue: &'tree EventQueue, pixels_per_point: f32) -> Self {
+    pub fn new(
+        accesskit_node: AccessKitNode<'tree>,
+        queue: &'tree EventQueue,
+        pixels_per_point: f32,
+    ) -> Self {
         Self {
-            queue,
             accesskit_node,
+            queue,
             pixels_per_point,
         }
     }
 
     fn event(&self, event: egui::Event) {
-        self.queue.lock().push(EventType::Event(event));
+        self.queue.lock().push(event);
     }
 
     fn modifiers(&self, modifiers: Modifiers) {
-        self.queue.lock().push(EventType::Modifiers(modifiers));
+        self.queue
+            .lock()
+            .push(egui::Event::ModifiersChanged(modifiers));
     }
 
     pub fn hover(&self) {


### PR DESCRIPTION
- needs #8335 

Previously it was impossible to correctly set modifiers via egui inspection, since that only passes egui::Event and egui::Event had no way to generally express modifiers. 
Now modifiers are passed to egui as a Event and not as a field of `RawInput`.


