### PR TITLE
fix: ensure mapped range is dropped before unmapping buffer in capture

### DIFF
--- a/crates/egui-wgpu/src/capture.rs
+++ b/crates/egui-wgpu/src/capture.rs
@@ -230,6 +230,7 @@ impl CaptureState {
                     ));
                 }
             }
+            drop(mapped_range);
             buffer.unmap();
 
             tx.send((


### PR DESCRIPTION
After upgrading to wgpu v30, it requires to drop the `BufferView` return by `get_mapped_range` before unmap the buffer. Fix it in this pr, making screenshot event crash no more