### PR TITLE
Add `MenuConfig::submenu_gap` to override the hardcoded gap between a menu and its submenus

### DIFF
--- a/crates/egui/src/containers/menu.rs
+++ b/crates/egui/src/containers/menu.rs
@@ -509,10 +509,9 @@ impl SubMenu {
             });
         }
 
-        let gap = menu_config
+        let gap = frame.total_margin().sum().x / 2.0 + menu_config
             .submenu_gap
-            .unwrap_or_else(|| frame.total_margin().sum().x / 2.0 + 2.0);
-
+            .unwrap_or(2.0);
         let mut response = button_response.clone();
         // Expand the button rect so that the button and the first item in the submenu are aligned
         let expand = Vec2::new(0.0, frame.total_margin().sum().y / 2.0);

--- a/crates/egui/src/containers/menu.rs
+++ b/crates/egui/src/containers/menu.rs
@@ -73,6 +73,13 @@ pub struct MenuConfig {
     ///
     /// Default is [`menu_style`].
     pub style: StyleModifier,
+
+    /// Override the gap between a menu and each submenu it opens.
+    ///
+    /// When `None` (the default) the gap is derived from the menu frame's margin
+    /// (`margin.x / 2.0 + 2.0`). Set it to place submenus flush against their
+    /// parent menu (`Some(0.0)`) or further away.
+    pub submenu_gap: Option<f32>,
 }
 
 impl Default for MenuConfig {
@@ -81,6 +88,7 @@ impl Default for MenuConfig {
             close_behavior: PopupCloseBehavior::default(),
             bar: false,
             style: menu_style.into(),
+            submenu_gap: None,
         }
     }
 }
@@ -106,6 +114,15 @@ impl MenuConfig {
     #[inline]
     pub fn style(mut self, style: impl Into<StyleModifier>) -> Self {
         self.style = style.into();
+        self
+    }
+
+    /// Override the gap between a menu and each submenu it opens (see the
+    /// [`submenu_gap`](Self::submenu_gap) field). `0.0` places submenus flush
+    /// against their parent menu.
+    #[inline]
+    pub fn submenu_gap(mut self, gap: f32) -> Self {
+        self.submenu_gap = Some(gap);
         self
     }
 
@@ -492,7 +509,9 @@ impl SubMenu {
             });
         }
 
-        let gap = frame.total_margin().sum().x / 2.0 + 2.0;
+        let gap = menu_config
+            .submenu_gap
+            .unwrap_or_else(|| frame.total_margin().sum().x / 2.0 + 2.0);
 
         let mut response = button_response.clone();
         // Expand the button rect so that the button and the first item in the submenu are aligned


### PR DESCRIPTION
The gap between a menu and the submenu it opens is hardcoded in `SubMenu::show`
(`frame.total_margin().sum().x / 2.0 + 2.0`), so a submenu can't be placed flush
against its parent — even with a zero menu margin a ~2px gap remains.

This adds an optional `submenu_gap: Option<f32>` to `MenuConfig` (plus a
`MenuConfig::submenu_gap(f32)` builder). When set it overrides the offset; when
`None` it falls back to the existing computed value, so existing menus are
unaffected. Because a menu's `MenuConfig` propagates to its submenus, setting it
once on the root menu applies to the whole tree.

```rust
egui::MenuButton::new("Add")
    .config(egui::MenuConfig::new().submenu_gap(0.0)) // flush submenus
    .ui(ui, |ui| { /* … */ });
```

* [x] I have followed the instructions in the PR template
