### PR TITLE
Store `web_sys::File` inside of `DroppedFile`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,6 +1312,7 @@ dependencies = [
  "serde",
  "smallvec",
  "unicode-segmentation",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,7 +1285,6 @@ dependencies = [
  "serde",
  "static_assertions",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
  "web-time",
  "wgpu",

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -206,7 +206,6 @@ image = { workspace = true, features = ["png"] } # For copying images
 js-sys.workspace = true
 percent-encoding.workspace = true
 wasm-bindgen.workspace = true
-wasm-bindgen-futures.workspace = true
 web-sys = { workspace = true, features = [
   "AddEventListenerOptions",
   "BinaryType",

--- a/crates/eframe/src/lib.rs
+++ b/crates/eframe/src/lib.rs
@@ -155,10 +155,6 @@ compile_error!("`accesskit` feature is only available with `android-game-activit
 // Re-export all useful libraries:
 pub use {egui, egui::emath, egui::epaint};
 
-#[cfg(target_arch = "wasm32")]
-#[path = "web/dropped_file.rs"]
-mod dropped_file;
-
 #[cfg(feature = "glow")]
 pub use {egui_glow, glow};
 

--- a/crates/eframe/src/lib.rs
+++ b/crates/eframe/src/lib.rs
@@ -155,6 +155,10 @@ compile_error!("`accesskit` feature is only available with `android-game-activit
 // Re-export all useful libraries:
 pub use {egui, egui::emath, egui::epaint};
 
+#[cfg(target_arch = "wasm32")]
+#[path = "web/dropped_file.rs"]
+mod dropped_file;
+
 #[cfg(feature = "glow")]
 pub use {egui_glow, glow};
 

--- a/crates/eframe/src/web/dropped_file.rs
+++ b/crates/eframe/src/web/dropped_file.rs
@@ -15,7 +15,8 @@ impl egui::DroppedFile for WebDroppedFile {
     fn bytes_async(&self) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, String>> + '_>> {
         let file = self.file.clone();
         Box::pin(async move {
-            let array_buffer = wasm_bindgen_futures::JsFuture::from(file.array_buffer())
+            let array_buffer = file
+                .array_buffer()
                 .await
                 .map_err(|err| crate::web::string_from_js_value(&err))?;
             Ok(js_sys::Uint8Array::new(&array_buffer).to_vec())

--- a/crates/eframe/src/web/dropped_file.rs
+++ b/crates/eframe/src/web/dropped_file.rs
@@ -1,0 +1,28 @@
+use std::{future::Future, pin::Pin};
+
+#[derive(Debug)]
+pub(crate) struct WebDroppedFile {
+    file: web_sys::File,
+}
+
+impl WebDroppedFile {
+    pub(crate) fn from_web_file(file: web_sys::File) -> egui::DroppedFileHandle {
+        std::sync::Arc::new(Self { file })
+    }
+}
+
+impl egui::DroppedFile for WebDroppedFile {
+    fn bytes_async(&self) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, String>> + '_>> {
+        let file = self.file.clone();
+        Box::pin(async move {
+            let array_buffer = wasm_bindgen_futures::JsFuture::from(file.array_buffer())
+                .await
+                .map_err(|err| crate::web::string_from_js_value(&err))?;
+            Ok(js_sys::Uint8Array::new(&array_buffer).to_vec())
+        })
+    }
+
+    fn web_file(&self) -> Option<&web_sys::File> {
+        Some(&self.file)
+    }
+}

--- a/crates/eframe/src/web/dropped_file.rs
+++ b/crates/eframe/src/web/dropped_file.rs
@@ -12,10 +12,10 @@ pub(crate) struct WebFile {
     path: PathBuf,
 }
 
-impl WebFile {
-    pub(crate) fn from_web_file(file: web_sys::File) -> egui::DroppedFileHandle {
+impl From<web_sys::File> for WebFile {
+    fn from(file: web_sys::File) -> Self {
         let path = file.name().into();
-        std::sync::Arc::new(Self { file, path })
+        Self { file, path }
     }
 }
 

--- a/crates/eframe/src/web/dropped_file.rs
+++ b/crates/eframe/src/web/dropped_file.rs
@@ -1,17 +1,29 @@
-use std::{future::Future, pin::Pin};
+use std::{
+    future::Future,
+    path::{Path, PathBuf},
+    pin::Pin,
+};
 
 #[derive(Debug)]
 pub(crate) struct WebFile {
     file: web_sys::File,
+    // We store a `PathBuf` here so that we can hand out `Path`s
+    // without allocating each time.
+    path: PathBuf,
 }
 
 impl WebFile {
     pub(crate) fn from_web_file(file: web_sys::File) -> egui::DroppedFileHandle {
-        std::sync::Arc::new(Self { file })
+        let path = file.name().into();
+        std::sync::Arc::new(Self { file, path })
     }
 }
 
 impl egui::DroppedFile for WebFile {
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
     fn bytes_async(&self) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, String>> + '_>> {
         let file = self.file.clone();
         Box::pin(async move {

--- a/crates/eframe/src/web/dropped_file.rs
+++ b/crates/eframe/src/web/dropped_file.rs
@@ -1,17 +1,17 @@
 use std::{future::Future, pin::Pin};
 
 #[derive(Debug)]
-pub(crate) struct WebDroppedFile {
+pub(crate) struct WebFile {
     file: web_sys::File,
 }
 
-impl WebDroppedFile {
+impl WebFile {
     pub(crate) fn from_web_file(file: web_sys::File) -> egui::DroppedFileHandle {
         std::sync::Arc::new(Self { file })
     }
 }
 
-impl egui::DroppedFile for WebDroppedFile {
+impl egui::DroppedFile for WebFile {
     fn bytes_async(&self) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, String>> + '_>> {
         let file = self.file.clone();
         Box::pin(async move {

--- a/crates/eframe/src/web/dropped_file.rs
+++ b/crates/eframe/src/web/dropped_file.rs
@@ -15,6 +15,13 @@ impl egui::DroppedFile for WebFile {
     fn bytes_async(&self) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, String>> + '_>> {
         let file = self.file.clone();
         Box::pin(async move {
+            if file.size() > f64::from(u32::MAX) {
+                return Err(format!(
+                    "File is too large: browser file reads are limited to {} bytes",
+                    u32::MAX
+                ));
+            }
+
             let array_buffer = file
                 .array_buffer()
                 .await

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -993,7 +993,7 @@ fn install_drag_and_drop(runner_ref: &WebRunner, target: &EventTarget) -> Result
                             .input
                             .raw
                             .dropped_files
-                            .push(crate::dropped_file::WebDroppedFile::from_web_file(file));
+                            .push(crate::dropped_file::WebFile::from_web_file(file));
                     }
                 }
             }

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -989,11 +989,9 @@ fn install_drag_and_drop(runner_ref: &WebRunner, target: &EventTarget) -> Result
                     if let Some(file) = files.get(i) {
                         log::debug!("Dropped {:?} ({} bytes)", file.name(), file.size());
 
-                        runner
-                            .input
-                            .raw
-                            .dropped_files
-                            .push(super::dropped_file::WebFile::from_web_file(file));
+                        runner.input.raw.dropped_files.push(std::sync::Arc::new(
+                            super::dropped_file::WebFile::from(file),
+                        ));
                     }
                 }
             }

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -989,12 +989,11 @@ fn install_drag_and_drop(runner_ref: &WebRunner, target: &EventTarget) -> Result
                     if let Some(file) = files.get(i) {
                         log::debug!("Dropped {:?} ({} bytes)", file.name(), file.size());
 
-                        // We hand the app the handle and let it decide what, and when, to read.
                         runner
                             .input
                             .raw
                             .dropped_files
-                            .push(egui::DroppedFile { file });
+                            .push(crate::dropped_file::WebDroppedFile::from_web_file(file));
                     }
                 }
             }

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -993,7 +993,7 @@ fn install_drag_and_drop(runner_ref: &WebRunner, target: &EventTarget) -> Result
                             .input
                             .raw
                             .dropped_files
-                            .push(crate::dropped_file::WebFile::from_web_file(file));
+                            .push(super::dropped_file::WebFile::from_web_file(file));
                     }
                 }
             }

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -978,62 +978,28 @@ fn install_drag_and_drop(runner_ref: &WebRunner, target: &EventTarget) -> Result
         event.prevent_default();
     })?;
 
-    runner_ref.add_event_listener(target, "drop", {
-        let runner_ref = runner_ref.clone();
+    runner_ref.add_event_listener(target, "drop", |event: web_sys::DragEvent, runner| {
+        if let Some(data_transfer) = event.data_transfer() {
+            // TODO(https://github.com/emilk/egui/issues/3702): support dropping folders
+            runner.input.raw.hovered_files.clear();
+            runner.needs_repaint.repaint_asap();
 
-        move |event: web_sys::DragEvent, runner| {
-            if let Some(data_transfer) = event.data_transfer() {
-                // TODO(https://github.com/emilk/egui/issues/3702): support dropping folders
-                runner.input.raw.hovered_files.clear();
-                runner.needs_repaint.repaint_asap();
+            if let Some(files) = data_transfer.files() {
+                for i in 0..files.length() {
+                    if let Some(file) = files.get(i) {
+                        log::debug!("Dropped {:?} ({} bytes)", file.name(), file.size());
 
-                if let Some(files) = data_transfer.files() {
-                    for i in 0..files.length() {
-                        if let Some(file) = files.get(i) {
-                            let name = file.name();
-                            let mime = file.type_();
-                            let last_modified = std::time::UNIX_EPOCH
-                                + std::time::Duration::from_millis(file.last_modified() as u64);
-
-                            log::debug!("Loading {:?} ({} bytes)…", name, file.size());
-
-                            let future = wasm_bindgen_futures::JsFuture::from(file.array_buffer());
-
-                            let runner_ref = runner_ref.clone();
-                            let future = async move {
-                                match future.await {
-                                    Ok(array_buffer) => {
-                                        let bytes = js_sys::Uint8Array::new(&array_buffer).to_vec();
-                                        log::debug!("Loaded {:?} ({} bytes).", name, bytes.len());
-
-                                        if let Some(mut runner_lock) = runner_ref.try_lock() {
-                                            runner_lock.input.raw.dropped_files.push(
-                                                egui::DroppedFile {
-                                                    name,
-                                                    mime,
-                                                    last_modified: Some(last_modified),
-                                                    bytes: Some(bytes.into()),
-                                                    ..Default::default()
-                                                },
-                                            );
-                                            runner_lock.needs_repaint.repaint_asap();
-                                        }
-                                    }
-                                    Err(err) => {
-                                        log::error!(
-                                            "Failed to read file: {}",
-                                            string_from_js_value(&err)
-                                        );
-                                    }
-                                }
-                            };
-                            wasm_bindgen_futures::spawn_local(future);
-                        }
+                        // We hand the app the handle and let it decide what, and when, to read.
+                        runner
+                            .input
+                            .raw
+                            .dropped_files
+                            .push(egui::DroppedFile { file });
                     }
                 }
-                event.stop_propagation();
-                event.prevent_default();
             }
+            event.stop_propagation();
+            event.prevent_default();
         }
     })?;
 

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -5,6 +5,7 @@
 
 mod app_runner;
 mod backend;
+mod dropped_file;
 mod events;
 mod input;
 mod panic_handler;

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -207,13 +207,12 @@ fn set_clipboard_text(s: &str) {
             return;
         }
         let promise = window.navigator().clipboard().write_text(s);
-        let future = wasm_bindgen_futures::JsFuture::from(promise);
         let future = async move {
-            if let Err(err) = future.await {
+            if let Err(err) = promise.await {
                 log::error!("Copy/cut action failed: {}", string_from_js_value(&err));
             }
         };
-        wasm_bindgen_futures::spawn_local(future);
+        js_sys::futures::spawn_local(future);
     }
 }
 
@@ -248,16 +247,15 @@ fn set_clipboard_image(image: &egui::ColorImage) {
         };
         let items = js_sys::Array::of1(&item);
         let promise = window.navigator().clipboard().write(&items);
-        let future = wasm_bindgen_futures::JsFuture::from(promise);
         let future = async move {
-            if let Err(err) = future.await {
+            if let Err(err) = promise.await {
                 log::error!(
                     "Copy/cut image action failed: {}",
                     string_from_js_value(&err)
                 );
             }
         };
-        wasm_bindgen_futures::spawn_local(future);
+        js_sys::futures::spawn_local(future);
     }
 }
 

--- a/crates/egui-winit/src/dropped_file.rs
+++ b/crates/egui-winit/src/dropped_file.rs
@@ -1,24 +1,19 @@
-use std::{future::Future, path::Path, pin::Pin};
+use std::path::Path;
 
 #[derive(Debug)]
-pub(crate) struct NativeDroppedFile {
+pub(crate) struct NativeFile {
     path: std::path::PathBuf,
 }
 
-impl NativeDroppedFile {
+impl NativeFile {
     pub(crate) fn from_path(path: std::path::PathBuf) -> egui::DroppedFileHandle {
         std::sync::Arc::new(Self { path })
     }
 }
 
-impl egui::DroppedFile for NativeDroppedFile {
+impl egui::DroppedFile for NativeFile {
     fn path(&self) -> &Path {
         &self.path
-    }
-
-    fn bytes_async(&self) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, String>> + '_>> {
-        let path = self.path.clone();
-        Box::pin(async move { std::fs::read(path).map_err(|err| err.to_string()) })
     }
 
     fn bytes(&self) -> Result<Vec<u8>, String> {

--- a/crates/egui-winit/src/dropped_file.rs
+++ b/crates/egui-winit/src/dropped_file.rs
@@ -1,0 +1,27 @@
+use std::{future::Future, path::Path, pin::Pin};
+
+#[derive(Debug)]
+pub(crate) struct NativeDroppedFile {
+    path: std::path::PathBuf,
+}
+
+impl NativeDroppedFile {
+    pub(crate) fn from_path(path: std::path::PathBuf) -> egui::DroppedFileHandle {
+        std::sync::Arc::new(Self { path })
+    }
+}
+
+impl egui::DroppedFile for NativeDroppedFile {
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn bytes_async(&self) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, String>> + '_>> {
+        let path = self.path.clone();
+        Box::pin(async move { std::fs::read(path).map_err(|err| err.to_string()) })
+    }
+
+    fn bytes(&self) -> Result<Vec<u8>, String> {
+        std::fs::read(&self.path).map_err(|err| err.to_string())
+    }
+}

--- a/crates/egui-winit/src/dropped_file.rs
+++ b/crates/egui-winit/src/dropped_file.rs
@@ -1,13 +1,13 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub(crate) struct NativeFile {
-    path: std::path::PathBuf,
+    path: PathBuf,
 }
 
-impl NativeFile {
-    pub(crate) fn from_path(path: std::path::PathBuf) -> egui::DroppedFileHandle {
-        std::sync::Arc::new(Self { path })
+impl From<PathBuf> for NativeFile {
+    fn from(path: PathBuf) -> Self {
+        Self { path }
     }
 }
 

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -21,12 +21,15 @@ use egui::{Pos2, Rect, Theme, Vec2, ViewportBuilder, ViewportCommand, ViewportId
 pub use winit;
 
 pub mod clipboard;
+mod dropped_file;
 mod safe_area;
 mod window_settings;
 
 pub use window_settings::WindowSettings;
 
 use raw_window_handle::HasDisplayHandle;
+
+use dropped_file::NativeDroppedFile;
 
 use winit::{
     dpi::{PhysicalPosition, PhysicalSize},
@@ -470,7 +473,7 @@ impl State {
                 self.egui_input.hovered_files.clear();
                 self.egui_input
                     .dropped_files
-                    .push(egui::DroppedFile { path: path.clone() });
+                    .push(NativeDroppedFile::from_path(path.clone()));
                 EventResponse {
                     repaint: true,
                     consumed: false,

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -468,10 +468,9 @@ impl State {
             }
             WindowEvent::DroppedFile(path) => {
                 self.egui_input.hovered_files.clear();
-                self.egui_input.dropped_files.push(egui::DroppedFile {
-                    path: Some(path.clone()),
-                    ..Default::default()
-                });
+                self.egui_input
+                    .dropped_files
+                    .push(egui::DroppedFile { path: path.clone() });
                 EventResponse {
                     repaint: true,
                     consumed: false,

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -29,7 +29,7 @@ pub use window_settings::WindowSettings;
 
 use raw_window_handle::HasDisplayHandle;
 
-use dropped_file::NativeDroppedFile;
+use dropped_file::NativeFile;
 
 use winit::{
     dpi::{PhysicalPosition, PhysicalSize},
@@ -473,7 +473,7 @@ impl State {
                 self.egui_input.hovered_files.clear();
                 self.egui_input
                     .dropped_files
-                    .push(NativeDroppedFile::from_path(path.clone()));
+                    .push(NativeFile::from_path(path.clone()));
                 EventResponse {
                     repaint: true,
                     consumed: false,

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -473,7 +473,7 @@ impl State {
                 self.egui_input.hovered_files.clear();
                 self.egui_input
                     .dropped_files
-                    .push(NativeFile::from_path(path.clone()));
+                    .push(std::sync::Arc::new(NativeFile::from(path.clone())));
                 EventResponse {
                     repaint: true,
                     consumed: false,

--- a/crates/egui/Cargo.toml
+++ b/crates/egui/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--generate-link-to-definition"]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [lib]
 
@@ -90,3 +91,9 @@ document-features = { workspace = true, optional = true }
 
 ron = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive", "rc"] }
+
+
+# web:
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# For `DroppedFile`, which hands web apps a file handle instead of its contents.
+web-sys = { workspace = true, features = ["File"] }

--- a/crates/egui/src/data/input/dropped_file.rs
+++ b/crates/egui/src/data/input/dropped_file.rs
@@ -1,18 +1,17 @@
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 #[cfg(target_arch = "wasm32")]
 use std::{future::Future, pin::Pin};
-
-#[cfg(not(target_arch = "wasm32"))]
-use std::path::Path;
 
 /// A file dropped into egui.
 ///
 /// The integration owns the concrete file handle, letting egui remain independent of windowing
 /// backends and file APIs.
 pub trait DroppedFile: std::fmt::Debug {
-    /// The path of a file dropped on a native platform.
-    #[cfg(not(target_arch = "wasm32"))]
+    /// The path of the dropped file.
+    ///
+    /// This is an absolute path on native platforms. On the web, it is a relative path containing
+    /// only the file name because browsers do not expose the file's local path.
     fn path(&self) -> &Path;
 
     /// Read the file contents.

--- a/crates/egui/src/data/input/dropped_file.rs
+++ b/crates/egui/src/data/input/dropped_file.rs
@@ -1,4 +1,7 @@
-use std::{future::Future, pin::Pin, sync::Arc};
+use std::sync::Arc;
+
+#[cfg(target_arch = "wasm32")]
+use std::{future::Future, pin::Pin};
 
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::Path;
@@ -15,9 +18,18 @@ pub trait DroppedFile: std::fmt::Debug {
     /// Read the file contents.
     ///
     /// This is asynchronous because browsers can only read files asynchronously.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the browser cannot read the file.
+    #[cfg(target_arch = "wasm32")]
     fn bytes_async(&self) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, String>> + '_>>;
 
     /// Read the file contents.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be read.
     #[cfg(not(target_arch = "wasm32"))]
     fn bytes(&self) -> Result<Vec<u8>, String>;
 

--- a/crates/egui/src/data/input/dropped_file.rs
+++ b/crates/egui/src/data/input/dropped_file.rs
@@ -1,26 +1,40 @@
+use std::{future::Future, pin::Pin, sync::Arc};
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::Path;
+
 /// A file dropped into egui.
 ///
-/// egui never reads the contents. The representation depends on the target because native and web
-/// integrations cannot produce each other's handle type.
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    all(feature = "serde", not(target_arch = "wasm32")),
-    derive(serde::Deserialize, serde::Serialize)
-)]
-pub struct DroppedFile {
-    /// A path on the local file system.
+/// The integration owns the concrete file handle, letting egui remain independent of windowing
+/// backends and file APIs.
+pub trait DroppedFile: std::fmt::Debug {
+    /// The path of a file dropped on a native platform.
     #[cfg(not(target_arch = "wasm32"))]
-    pub path: std::path::PathBuf,
+    fn path(&self) -> &Path;
 
-    /// A handle to a file picked by the user in the browser.
+    /// Read the file contents.
     ///
-    /// Nothing is read until you ask for it, e.g. with `Blob::array_buffer` or
-    /// `Blob::stream`. Both are asynchronous, so a typical app spawns the read with
-    /// `wasm_bindgen_futures::spawn_local` and stores the result in its own state.
-    ///
-    /// A `web_sys::File` is a JavaScript handle, so it is `Send + Sync` only in wasm builds
-    /// without `target_feature = "atomics"`. With atomics enabled, [`crate::Context`]
-    /// therefore stops being `Send + Sync`.
+    /// This is asynchronous because browsers can only read files asynchronously.
+    fn bytes_async(&self) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, String>> + '_>>;
+
+    /// Read the file contents.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn bytes(&self) -> Result<Vec<u8>, String>;
+
+    /// The browser file handle, if this file was dropped on the web.
     #[cfg(target_arch = "wasm32")]
-    pub file: web_sys::File,
+    fn web_file(&self) -> Option<&web_sys::File> {
+        None
+    }
 }
+
+/// A shared reference to a dropped file.
+#[cfg(not(all(target_arch = "wasm32", target_feature = "atomics")))]
+pub type DroppedFileHandle = Arc<dyn DroppedFile + Send + Sync>;
+
+/// A shared reference to a dropped file.
+///
+/// This is not necessarily `Send + Sync` when wasm threads are enabled, because
+/// [`web_sys::File`] is not thread-safe in that configuration.
+#[cfg(all(target_arch = "wasm32", target_feature = "atomics"))]
+pub type DroppedFileHandle = Arc<dyn DroppedFile>;

--- a/crates/egui/src/data/input/dropped_file.rs
+++ b/crates/egui/src/data/input/dropped_file.rs
@@ -1,19 +1,26 @@
 /// A file dropped into egui.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+///
+/// egui never reads the contents. The representation depends on the target because native and web
+/// integrations cannot produce each other's handle type.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    all(feature = "serde", not(target_arch = "wasm32")),
+    derive(serde::Deserialize, serde::Serialize)
+)]
 pub struct DroppedFile {
-    /// Set by the `egui-winit` backend.
-    pub path: Option<std::path::PathBuf>,
+    /// A path on the local file system.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub path: std::path::PathBuf,
 
-    /// Name of the file. Set by the `eframe` web backend.
-    pub name: String,
-
-    /// With the `eframe` web backend, this is set to the mime-type of the file (if available).
-    pub mime: String,
-
-    /// Set by the `eframe` web backend.
-    pub last_modified: Option<std::time::SystemTime>,
-
-    /// Set by the `eframe` web backend.
-    pub bytes: Option<std::sync::Arc<[u8]>>,
+    /// A handle to a file picked by the user in the browser.
+    ///
+    /// Nothing is read until you ask for it, e.g. with `Blob::array_buffer` or
+    /// `Blob::stream`. Both are asynchronous, so a typical app spawns the read with
+    /// `wasm_bindgen_futures::spawn_local` and stores the result in its own state.
+    ///
+    /// A `web_sys::File` is a JavaScript handle, so it is `Send + Sync` only in wasm builds
+    /// without `target_feature = "atomics"`. With atomics enabled, [`crate::Context`]
+    /// therefore stops being `Send + Sync`.
+    #[cfg(target_arch = "wasm32")]
+    pub file: web_sys::File,
 }

--- a/crates/egui/src/data/input/mod.rs
+++ b/crates/egui/src/data/input/mod.rs
@@ -16,7 +16,7 @@ mod touch;
 mod viewport_info;
 
 pub use self::{
-    dropped_file::DroppedFile,
+    dropped_file::{DroppedFile, DroppedFileHandle},
     event::Event,
     event_filter::EventFilter,
     hovered_file::HoveredFile,

--- a/crates/egui/src/data/input/raw_input.rs
+++ b/crates/egui/src/data/input/raw_input.rs
@@ -65,8 +65,12 @@ pub struct RawInput {
 
     /// Dragged files dropped into egui.
     ///
+    /// egui never reads the file contents. It is up to you to read whatever you need, when you
+    /// need it.
+    ///
     /// Note: when using `eframe` on Windows, this will always be empty if drag-and-drop support has
     /// been disabled in [`crate::viewport::ViewportBuilder`].
+    #[cfg_attr(all(feature = "serde", target_arch = "wasm32"), serde(skip))]
     pub dropped_files: Vec<DroppedFile>,
 
     /// The native window has the keyboard focus (i.e. is receiving key presses).

--- a/crates/egui/src/data/input/raw_input.rs
+++ b/crates/egui/src/data/input/raw_input.rs
@@ -1,6 +1,6 @@
 use crate::{OrderedViewportIdMap, Theme, ViewportId, ViewportIdMap, emath::Rect};
 
-use super::{DroppedFile, Event, HoveredFile, SafeAreaInsets, ViewportInfo};
+use super::{DroppedFileHandle, Event, HoveredFile, SafeAreaInsets, ViewportInfo};
 
 /// What the integrations provides to egui at the start of each frame.
 ///
@@ -13,7 +13,7 @@ use super::{DroppedFile, Event, HoveredFile, SafeAreaInsets, ViewportInfo};
 ///
 /// Ii "points" can be calculated from native physical pixels
 /// using `pixels_per_point` = [`crate::Context::zoom_factor`] * `native_pixels_per_point`;
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct RawInput {
     /// The id of the active viewport.
@@ -65,13 +65,13 @@ pub struct RawInput {
 
     /// Dragged files dropped into egui.
     ///
-    /// egui never reads the file contents. It is up to you to read whatever you need, when you
-    /// need it.
+    /// egui never reads the file contents. Call [`DroppedFile::bytes_async`] to read a dropped
+    /// file.
     ///
     /// Note: when using `eframe` on Windows, this will always be empty if drag-and-drop support has
     /// been disabled in [`crate::viewport::ViewportBuilder`].
-    #[cfg_attr(all(feature = "serde", target_arch = "wasm32"), serde(skip))]
-    pub dropped_files: Vec<DroppedFile>,
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub dropped_files: Vec<DroppedFileHandle>,
 
     /// The native window has the keyboard focus (i.e. is receiving key presses).
     ///

--- a/crates/egui/src/data/input/raw_input.rs
+++ b/crates/egui/src/data/input/raw_input.rs
@@ -65,8 +65,15 @@ pub struct RawInput {
 
     /// Dragged files dropped into egui.
     ///
-    /// egui never reads the file contents. Call [`DroppedFile::bytes_async`] to read a dropped
-    /// file.
+    /// egui never reads the file contents.
+    #[cfg_attr(
+        not(target_arch = "wasm32"),
+        doc = "Call [`crate::DroppedFile::bytes`] to read a dropped file."
+    )]
+    #[cfg_attr(
+        target_arch = "wasm32",
+        doc = "Call [`crate::DroppedFile::bytes_async`] to read a dropped file."
+    )]
     ///
     /// Note: when using `eframe` on Windows, this will always be empty if drag-and-drop support has
     /// been disabled in [`crate::viewport::ViewportBuilder`].

--- a/crates/egui_demo_app/src/wrap_app.rs
+++ b/crates/egui_demo_app/src/wrap_app.rs
@@ -519,25 +519,20 @@ impl WrapApp {
                 .open(&mut open)
                 .show(ctx, |ui| {
                     for file in &self.dropped_files {
-                        let mut info = if let Some(path) = &file.path {
-                            path.display().to_string()
-                        } else if file.name.is_empty() {
-                            "???".to_owned()
-                        } else {
-                            file.name.clone()
-                        };
+                        #[cfg(not(target_arch = "wasm32"))]
+                        let info = file.path.display().to_string();
 
-                        let mut additional_info = vec![];
-                        if !file.mime.is_empty() {
-                            additional_info.push(format!("type: {}", file.mime));
-                        }
-                        if let Some(bytes) = &file.bytes {
-                            additional_info.push(format!("{} bytes", bytes.len()));
-                        }
-                        if !additional_info.is_empty() {
-                            use std::fmt::Write as _;
-                            write!(info, " ({})", additional_info.join(", ")).ok();
-                        }
+                        // The size and mime-type are free to read; the contents are not,
+                        // so we never touch them here.
+                        #[cfg(target_arch = "wasm32")]
+                        let info = {
+                            let (name, mime) = (file.file.name(), file.file.type_());
+                            if mime.is_empty() {
+                                format!("{name} ({} bytes)", file.file.size())
+                            } else {
+                                format!("{name} ({} bytes, type: {mime})", file.file.size())
+                            }
+                        };
 
                         ui.label(info);
                     }

--- a/crates/egui_demo_app/src/wrap_app.rs
+++ b/crates/egui_demo_app/src/wrap_app.rs
@@ -183,7 +183,7 @@ pub struct WrapApp {
     #[cfg(any(feature = "glow", feature = "wgpu"))]
     custom3d: Option<crate::apps::Custom3d>,
 
-    dropped_files: Vec<egui::DroppedFile>,
+    dropped_files: Vec<egui::DroppedFileHandle>,
 }
 
 impl WrapApp {
@@ -520,17 +520,20 @@ impl WrapApp {
                 .show(ctx, |ui| {
                     for file in &self.dropped_files {
                         #[cfg(not(target_arch = "wasm32"))]
-                        let info = file.path.display().to_string();
+                        let info = file.path().display().to_string();
 
                         // The size and mime-type are free to read; the contents are not,
                         // so we never touch them here.
                         #[cfg(target_arch = "wasm32")]
                         let info = {
-                            let (name, mime) = (file.file.name(), file.file.type_());
+                            let Some(web_file) = file.web_file() else {
+                                continue;
+                            };
+                            let (name, mime) = (web_file.name(), web_file.type_());
                             if mime.is_empty() {
-                                format!("{name} ({} bytes)", file.file.size())
+                                format!("{name} ({} bytes)", web_file.size())
                             } else {
-                                format!("{name} ({} bytes, type: {mime})", file.file.size())
+                                format!("{name} ({} bytes, type: {mime})", web_file.size())
                             }
                         };
 

--- a/examples/file_dialog/src/main.rs
+++ b/examples/file_dialog/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> eframe::Result {
 
 #[derive(Default)]
 struct MyApp {
-    dropped_files: Vec<egui::DroppedFile>,
+    dropped_files: Vec<egui::DroppedFileHandle>,
     picked_path: Option<String>,
 }
 
@@ -49,11 +49,13 @@ impl eframe::App for MyApp {
 
                     for file in &self.dropped_files {
                         #[cfg(not(target_arch = "wasm32"))]
-                        ui.label(file.path.display().to_string());
+                        ui.label(file.path().display().to_string());
 
                         #[cfg(target_arch = "wasm32")]
                         {
-                            let web_file = &file.file;
+                            let Some(web_file) = file.web_file() else {
+                                continue;
+                            };
                             let name = web_file.name();
                             let mime = web_file.type_();
                             let size = web_file.size();

--- a/examples/file_dialog/src/main.rs
+++ b/examples/file_dialog/src/main.rs
@@ -48,27 +48,21 @@ impl eframe::App for MyApp {
                     ui.label("Dropped files:");
 
                     for file in &self.dropped_files {
-                        let mut info = if let Some(path) = &file.path {
-                            path.display().to_string()
-                        } else if file.name.is_empty() {
-                            "???".to_owned()
-                        } else {
-                            file.name.clone()
-                        };
+                        #[cfg(not(target_arch = "wasm32"))]
+                        ui.label(file.path.display().to_string());
 
-                        let mut additional_info = vec![];
-                        if !file.mime.is_empty() {
-                            additional_info.push(format!("type: {}", file.mime));
+                        #[cfg(target_arch = "wasm32")]
+                        {
+                            let web_file = &file.file;
+                            let name = web_file.name();
+                            let mime = web_file.type_();
+                            let size = web_file.size();
+                            if mime.is_empty() {
+                                ui.label(format!("{name} ({size} bytes)"));
+                            } else {
+                                ui.label(format!("{name} (type: {mime}, {size} bytes)"));
+                            }
                         }
-                        if let Some(bytes) = &file.bytes {
-                            additional_info.push(format!("{} bytes", bytes.len()));
-                        }
-                        if !additional_info.is_empty() {
-                            use std::fmt::Write as _;
-                            write!(info, " ({})", additional_info.join(", ")).ok();
-                        }
-
-                        ui.label(info);
                     }
                 });
             }


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes #4654
* Related #4667
* [x] I have followed the instructions in the PR template

This PR avoids materializing the contents of a file that was dragged into an egui application on the web. It does so by storing the `web_sys::File` handle directly on WASM.

This breaks the existing API of `DroppedFile` on the web, because there is no way to retrieve the bytes synchronously form a `DroppedFile` anymore, forcing handling call sites to become asynchronous.

The native API remains the same.