### PR TITLE
Prevent accidentally dropping `TexturesDelta`

### DIFF
--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -139,6 +139,13 @@ struct Viewport {
     egui_winit: Option<egui_winit::State>,
 }
 
+impl Drop for Viewport {
+    fn drop(&mut self) {
+        // Avoid debug panic when dropping unapplied deltas on teardown
+        self.pending_delta.clear();
+    }
+}
+
 // ----------------------------------------------------------------------------
 
 impl<'app> GlowWinitApp<'app> {

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -697,8 +697,10 @@ impl GlowWinitRunning<'_> {
             frame_timer.resume();
         }
 
-        for (id, image_delta) in &textures_delta.set {
-            painter.set_texture(*id, image_delta);
+        for (id, image_deltas) in &textures_delta.set {
+            for image_delta in image_deltas {
+                painter.set_texture(*id, image_delta);
+            }
         }
 
         if is_visible {

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -31,15 +31,16 @@ use egui::{
 };
 #[cfg(feature = "accesskit")]
 use egui_winit::accesskit_winit;
-
-use crate::{
-    App, AppCreator, CreationContext, NativeOptions, Result, Storage,
-    native::{epi_integration::EpiIntegration, winit_integration::is_invisible_or_minimized},
-};
+use log::warn;
 
 use super::{
     epi_integration, event_loop_context,
     winit_integration::{EventResult, UserEvent, WinitApp, create_egui_context},
+};
+use crate::epaint::textures::TexturesDelta;
+use crate::{
+    App, AppCreator, CreationContext, NativeOptions, Result, Storage,
+    native::{epi_integration::EpiIntegration, winit_integration::is_invisible_or_minimized},
 };
 
 // ----------------------------------------------------------------------------
@@ -73,6 +74,9 @@ struct GlowWinitRunning<'app> {
 
     // NOTE: one painter shared by all viewports.
     painter: Rc<RefCell<egui_glow::Painter>>,
+
+    /// Any not yet applied deltas for this app.
+    pending_deltas: TexturesDelta,
 }
 
 /// This struct will contain both persistent and temporary glutin state.
@@ -113,6 +117,9 @@ struct Viewport {
     deferred_commands: Vec<egui::viewport::ViewportCommand>,
     info: ViewportInfo,
     actions_requested: Vec<egui_winit::ActionRequested>,
+
+    /// Any not yet applied deltas for this viewport.
+    pending_delta: TexturesDelta,
 
     /// The user-callback that shows the ui.
     /// None for immediate viewports.
@@ -353,6 +360,7 @@ impl<'app> GlowWinitApp<'app> {
             app,
             glutin,
             painter,
+            pending_deltas: Default::default(),
         }))
     }
 }
@@ -653,6 +661,7 @@ impl GlowWinitRunning<'_> {
             app,
             glutin,
             painter,
+            pending_deltas,
             ..
         } = self;
 
@@ -666,6 +675,7 @@ impl GlowWinitRunning<'_> {
             pixels_per_point,
             viewport_output,
         } = full_output;
+        pending_deltas.append(textures_delta);
 
         glutin.remove_viewports_not_in(&viewport_output);
 
@@ -689,7 +699,7 @@ impl GlowWinitRunning<'_> {
 
         // Upload textures even when not visible: the atlas dirty region is already
         // consumed, so dropping the delta would desync the font texture.
-        let has_texture_updates = !textures_delta.set.is_empty() || !textures_delta.free.is_empty();
+        let has_texture_updates = !pending_deltas.set.is_empty() || !pending_deltas.free.is_empty();
         if is_visible || has_texture_updates {
             // We may need to switch contexts again, because of immediate viewports:
             frame_timer.pause();
@@ -697,9 +707,10 @@ impl GlowWinitRunning<'_> {
             frame_timer.resume();
         }
 
-        for (id, image_deltas) in &textures_delta.set {
+        #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
+        for (id, image_deltas) in pending_deltas.set.drain() {
             for image_delta in image_deltas {
-                painter.set_texture(*id, image_delta);
+                painter.set_texture(id, &image_delta);
             }
         }
 
@@ -775,8 +786,9 @@ impl GlowWinitRunning<'_> {
         }
 
         // Free textures *after* painting, since they may still be used in the frame we just drew.
-        for id in &textures_delta.free {
-            painter.free_texture(*id);
+        #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
+        for id in pending_deltas.free.drain() {
+            painter.free_texture(id);
         }
 
         glutin.handle_viewport_output(event_loop, &integration.egui_ctx, &viewport_output);
@@ -1122,6 +1134,7 @@ impl GlutinWindowContext {
                 deferred_commands: vec![],
                 info: viewport_info,
                 actions_requested: Default::default(),
+                pending_delta: Default::default(),
                 viewport_ui_cb: None,
                 gl_surface: None,
                 window: window.map(Arc::new),
@@ -1438,6 +1451,7 @@ fn initialize_or_update_viewport(
                 deferred_commands: vec![],
                 info: Default::default(),
                 actions_requested: Default::default(),
+                pending_delta: Default::default(),
                 viewport_ui_cb,
                 window: None,
                 egui_winit: None,
@@ -1586,8 +1600,10 @@ fn render_immediate_viewport(
     } = &mut *glutin;
 
     let Some(viewport) = viewports.get_mut(&viewport_id) else {
+        warn!("Viewport disappeared unexpectedly!");
         return;
     };
+    viewport.pending_delta.append(textures_delta);
 
     viewport.info.events.clear(); // they should have been processed
 
@@ -1623,7 +1639,7 @@ fn render_immediate_viewport(
         screen_size_in_pixels,
         pixels_per_point,
         &clipped_primitives,
-        &textures_delta,
+        &mut viewport.pending_delta,
     );
 
     {

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -79,6 +79,13 @@ struct GlowWinitRunning<'app> {
     pending_deltas: TexturesDelta,
 }
 
+impl Drop for GlowWinitRunning<'_> {
+    fn drop(&mut self) {
+        // Avoid debug panic when dropping unapplied deltas on teardown
+        self.pending_deltas.clear();
+    }
+}
+
 /// This struct will contain both persistent and temporary glutin state.
 ///
 /// Platform Quirks:
@@ -697,25 +704,15 @@ impl GlowWinitRunning<'_> {
 
         egui_winit.handle_platform_output_with_event_loop(&window, event_loop, platform_output);
 
-        // Upload textures even when not visible: the atlas dirty region is already
-        // consumed, so dropping the delta would desync the font texture.
-        let has_texture_updates = !pending_deltas.set.is_empty() || !pending_deltas.free.is_empty();
-        if is_visible || has_texture_updates {
-            // We may need to switch contexts again, because of immediate viewports:
-            frame_timer.pause();
-            change_gl_context(current_gl_context, not_current_gl_context, gl_surface);
-            frame_timer.resume();
-        }
-
-        #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
-        for (id, image_deltas) in pending_deltas.set.drain() {
-            for image_delta in image_deltas {
-                painter.set_texture(id, &image_delta);
-            }
-        }
-
         if is_visible {
             let clipped_primitives = integration.egui_ctx.tessellate(shapes, pixels_per_point);
+
+            {
+                // We may need to switch contexts again, because of immediate viewports:
+                frame_timer.pause();
+                change_gl_context(current_gl_context, not_current_gl_context, gl_surface);
+                frame_timer.resume();
+            }
 
             let screen_size_in_pixels: [u32; 2] = window.inner_size().into();
 
@@ -723,7 +720,12 @@ impl GlowWinitRunning<'_> {
                 painter.clear(screen_size_in_pixels, clear_color);
             }
 
-            painter.paint_primitives(screen_size_in_pixels, pixels_per_point, &clipped_primitives);
+            painter.paint_and_update_textures(
+                screen_size_in_pixels,
+                pixels_per_point,
+                &clipped_primitives,
+                pending_deltas,
+            );
 
             {
                 for action in viewport.actions_requested.drain(..) {
@@ -783,12 +785,6 @@ impl GlowWinitRunning<'_> {
             {
                 save_screenshot_and_exit(&path, &painter, screen_size_in_pixels);
             }
-        }
-
-        // Free textures *after* painting, since they may still be used in the frame we just drew.
-        #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
-        for id in pending_deltas.free.drain() {
-            painter.free_texture(id);
         }
 
         glutin.handle_viewport_output(event_loop, &integration.egui_ctx, &viewport_output);

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -5,7 +5,7 @@
 //! There is a bunch of improvements we could do,
 //! like removing a bunch of `unwraps`.
 
-use std::{cell::RefCell, num::NonZeroU32, rc::Rc, sync::Arc, time::Instant};
+use std::{cell::RefCell, mem, num::NonZeroU32, rc::Rc, sync::Arc, time::Instant};
 
 use egui_winit::ActionRequested;
 use parking_lot::Mutex;
@@ -16,11 +16,8 @@ use winit::{
 };
 
 use ahash::HashMap;
-use egui::{
-    DeferredViewportUiCallback, FullOutput, ImmediateViewport, OrderedViewportIdMap,
-    ViewportBuilder, ViewportClass, ViewportId, ViewportIdPair, ViewportIdSet, ViewportInfo,
-    ViewportOutput,
-};
+use log::warn;
+use egui::{DeferredViewportUiCallback, FullOutput, ImmediateViewport, OrderedViewportIdMap, TexturesDelta, ViewportBuilder, ViewportClass, ViewportId, ViewportIdPair, ViewportIdSet, ViewportInfo, ViewportOutput};
 #[cfg(feature = "accesskit")]
 use egui_winit::accesskit_winit;
 use winit_integration::UserEvent;
@@ -65,6 +62,15 @@ struct WgpuWinitRunning<'app> {
 
     /// Wrapped in an `Rc<RefCell<…>>` so it can be re-entrantly shared via a weak-pointer.
     shared: Rc<RefCell<SharedState>>,
+
+    pending_deltas: TexturesDelta,
+}
+
+impl Drop for WgpuWinitRunning<'_> {
+    fn drop(&mut self) {
+        // Avoid debug panic when dropping unapplied deltas on teardown
+        self.pending_deltas.clear();
+    }
 }
 
 /// Everything needed by the immediate viewport renderer.\
@@ -90,6 +96,9 @@ pub struct Viewport {
     deferred_commands: Vec<egui::viewport::ViewportCommand>,
     info: ViewportInfo,
     actions_requested: Vec<ActionRequested>,
+
+    /// Any not yet applied deltas for this viewport.
+    pending_deltas: TexturesDelta,
 
     /// `None` for sync viewports.
     viewport_ui_cb: Option<Arc<DeferredViewportUiCallback>>,
@@ -328,6 +337,7 @@ impl<'app> WgpuWinitApp<'app> {
                 viewport_ui_cb: None,
                 window: Some(window),
                 egui_winit: Some(egui_winit),
+                pending_deltas: Default::default(),
             },
         );
 
@@ -358,6 +368,7 @@ impl<'app> WgpuWinitApp<'app> {
             integration,
             app,
             shared,
+            pending_deltas: Default::default(),
         }))
     }
 }
@@ -596,6 +607,7 @@ impl WgpuWinitRunning<'_> {
             app,
             integration,
             shared,
+            pending_deltas,
         } = self;
 
         let mut frame_timer = crate::stopwatch::Stopwatch::new();
@@ -699,6 +711,8 @@ impl WgpuWinitRunning<'_> {
             viewport_output,
         } = full_output;
 
+        pending_deltas.append(textures_delta);
+
         remove_viewports_not_in(viewports, painter, viewport_from_window, &viewport_output);
 
         let Some(viewport) = viewports.get_mut(&viewport_id) else {
@@ -735,7 +749,7 @@ impl WgpuWinitRunning<'_> {
                 pixels_per_point,
                 app.clear_color(&egui_ctx.global_style().visuals),
                 &clipped_primitives,
-                &textures_delta,
+                pending_deltas,
                 screenshot_commands,
                 window,
             );
@@ -1125,8 +1139,11 @@ fn render_immediate_viewport(
     } = &mut *shared_mut;
 
     let Some(viewport) = viewports.get_mut(&ids.this) else {
+        warn!("Viewport disappeared unexpectedly!");
         return;
     };
+    viewport.pending_deltas.append(textures_delta);
+
     viewport.info.events.clear(); // they should have been processed
     let (Some(egui_winit), Some(window)) = (&mut viewport.egui_winit, &viewport.window) else {
         return;
@@ -1149,7 +1166,7 @@ fn render_immediate_viewport(
         pixels_per_point,
         [0.0, 0.0, 0.0, 0.0],
         &clipped_primitives,
-        &textures_delta,
+        &mut viewport.pending_deltas,
         vec![],
         window,
     );
@@ -1268,6 +1285,7 @@ fn initialize_or_update_viewport<'a>(
                 viewport_ui_cb,
                 window: None,
                 egui_winit: None,
+                pending_deltas: Default::default(),
             })
         }
 

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -115,6 +115,13 @@ pub struct Viewport {
     egui_winit: Option<egui_winit::State>,
 }
 
+impl Drop for Viewport {
+    fn drop(&mut self) {
+        // Avoid debug panic when dropping unapplied deltas on teardown
+        self.pending_delta.clear();
+    }
+}
+
 // ----------------------------------------------------------------------------
 
 impl<'app> WgpuWinitApp<'app> {

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -5,7 +5,7 @@
 //! There is a bunch of improvements we could do,
 //! like removing a bunch of `unwraps`.
 
-use std::{cell::RefCell, mem, num::NonZeroU32, rc::Rc, sync::Arc, time::Instant};
+use std::{cell::RefCell, num::NonZeroU32, rc::Rc, sync::Arc, time::Instant};
 
 use egui_winit::ActionRequested;
 use parking_lot::Mutex;
@@ -16,10 +16,14 @@ use winit::{
 };
 
 use ahash::HashMap;
-use log::warn;
-use egui::{DeferredViewportUiCallback, FullOutput, ImmediateViewport, OrderedViewportIdMap, TexturesDelta, ViewportBuilder, ViewportClass, ViewportId, ViewportIdPair, ViewportIdSet, ViewportInfo, ViewportOutput};
+use egui::{
+    DeferredViewportUiCallback, FullOutput, ImmediateViewport, OrderedViewportIdMap, TexturesDelta,
+    ViewportBuilder, ViewportClass, ViewportId, ViewportIdPair, ViewportIdSet, ViewportInfo,
+    ViewportOutput,
+};
 #[cfg(feature = "accesskit")]
 use egui_winit::accesskit_winit;
+use log::warn;
 use winit_integration::UserEvent;
 
 use crate::{
@@ -98,7 +102,7 @@ pub struct Viewport {
     actions_requested: Vec<ActionRequested>,
 
     /// Any not yet applied deltas for this viewport.
-    pending_deltas: TexturesDelta,
+    pending_delta: TexturesDelta,
 
     /// `None` for sync viewports.
     viewport_ui_cb: Option<Arc<DeferredViewportUiCallback>>,
@@ -337,7 +341,7 @@ impl<'app> WgpuWinitApp<'app> {
                 viewport_ui_cb: None,
                 window: Some(window),
                 egui_winit: Some(egui_winit),
-                pending_deltas: Default::default(),
+                pending_delta: Default::default(),
             },
         );
 
@@ -1142,7 +1146,7 @@ fn render_immediate_viewport(
         warn!("Viewport disappeared unexpectedly!");
         return;
     };
-    viewport.pending_deltas.append(textures_delta);
+    viewport.pending_delta.append(textures_delta);
 
     viewport.info.events.clear(); // they should have been processed
     let (Some(egui_winit), Some(window)) = (&mut viewport.egui_winit, &viewport.window) else {
@@ -1166,7 +1170,7 @@ fn render_immediate_viewport(
         pixels_per_point,
         [0.0, 0.0, 0.0, 0.0],
         &clipped_primitives,
-        &mut viewport.pending_deltas,
+        &mut viewport.pending_delta,
         vec![],
         window,
     );
@@ -1285,7 +1289,7 @@ fn initialize_or_update_viewport<'a>(
                 viewport_ui_cb,
                 window: None,
                 egui_winit: None,
-                pending_deltas: Default::default(),
+                pending_delta: Default::default(),
             })
         }
 

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -324,7 +324,6 @@ impl AppRunner {
 
     /// Paint the results of the last call to [`Self::logic`].
     pub fn paint(&mut self) {
-        let textures_delta = std::mem::take(&mut self.textures_delta);
         let clipped_primitives = std::mem::take(&mut self.clipped_primitives);
 
         if let Some(clipped_primitives) = clipped_primitives {
@@ -347,7 +346,7 @@ impl AppRunner {
                 self.app.clear_color(&self.egui_ctx.global_style().visuals),
                 &clipped_primitives,
                 self.egui_ctx.pixels_per_point(),
-                &textures_delta,
+                &mut self.textures_delta,
                 screenshot_commands,
             ) {
                 log::error!("Failed to paint: {}", super::string_from_js_value(&err));

--- a/crates/eframe/src/web/web_painter.rs
+++ b/crates/eframe/src/web/web_painter.rs
@@ -24,7 +24,7 @@ pub(crate) trait WebPainter {
         clear_color: [f32; 4],
         clipped_primitives: &[egui::ClippedPrimitive],
         pixels_per_point: f32,
-        textures_delta: &egui::TexturesDelta,
+        textures_delta: &mut egui::TexturesDelta,
         capture: Vec<UserData>,
     ) -> Result<(), JsValue>;
 

--- a/crates/eframe/src/web/web_painter_glow.rs
+++ b/crates/eframe/src/web/web_painter_glow.rs
@@ -66,6 +66,7 @@ impl WebPainter for WebPainterGlow {
     ) -> Result<(), JsValue> {
         let canvas_dimension = [self.canvas.width(), self.canvas.height()];
 
+        #[allow(clippy::iter_over_hash_type)] // Order doesn't matter here
         for (id, image_deltas) in textures_delta.set.drain() {
             for image_delta in image_deltas {
                 self.painter.set_texture(*id, image_delta);
@@ -81,6 +82,7 @@ impl WebPainter for WebPainterGlow {
             self.screenshots.push((image, capture));
         }
 
+        #[allow(clippy::iter_over_hash_type)] // Order doesn't matter here
         for id in textures_delta.free.drain() {
             self.painter.free_texture(id);
         }

--- a/crates/eframe/src/web/web_painter_glow.rs
+++ b/crates/eframe/src/web/web_painter_glow.rs
@@ -66,7 +66,7 @@ impl WebPainter for WebPainterGlow {
     ) -> Result<(), JsValue> {
         let canvas_dimension = [self.canvas.width(), self.canvas.height()];
 
-        #[allow(clippy::iter_over_hash_type)] // Order doesn't matter here
+        #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
         for (id, image_deltas) in textures_delta.set.drain() {
             for image_delta in image_deltas {
                 self.painter.set_texture(id, &image_delta);
@@ -82,7 +82,7 @@ impl WebPainter for WebPainterGlow {
             self.screenshots.push((image, capture));
         }
 
-        #[allow(clippy::iter_over_hash_type)] // Order doesn't matter here
+        #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
         for id in textures_delta.free.drain() {
             self.painter.free_texture(id);
         }

--- a/crates/eframe/src/web/web_painter_glow.rs
+++ b/crates/eframe/src/web/web_painter_glow.rs
@@ -69,7 +69,7 @@ impl WebPainter for WebPainterGlow {
         #[allow(clippy::iter_over_hash_type)] // Order doesn't matter here
         for (id, image_deltas) in textures_delta.set.drain() {
             for image_delta in image_deltas {
-                self.painter.set_texture(*id, image_delta);
+                self.painter.set_texture(id, &image_delta);
             }
         }
 

--- a/crates/eframe/src/web/web_painter_glow.rs
+++ b/crates/eframe/src/web/web_painter_glow.rs
@@ -61,13 +61,15 @@ impl WebPainter for WebPainterGlow {
         clear_color: [f32; 4],
         clipped_primitives: &[egui::ClippedPrimitive],
         pixels_per_point: f32,
-        textures_delta: &egui::TexturesDelta,
+        textures_delta: &mut egui::TexturesDelta,
         capture: Vec<UserData>,
     ) -> Result<(), JsValue> {
         let canvas_dimension = [self.canvas.width(), self.canvas.height()];
 
-        for (id, image_delta) in &textures_delta.set {
-            self.painter.set_texture(*id, image_delta);
+        for (id, image_deltas) in textures_delta.set.drain() {
+            for image_delta in image_deltas {
+                self.painter.set_texture(*id, image_delta);
+            }
         }
 
         egui_glow::painter::clear(self.painter.gl(), canvas_dimension, clear_color);
@@ -79,7 +81,7 @@ impl WebPainter for WebPainterGlow {
             self.screenshots.push((image, capture));
         }
 
-        for &id in &textures_delta.free {
+        for id in textures_delta.free.drain() {
             self.painter.free_texture(id);
         }
 

--- a/crates/eframe/src/web/web_painter_wgpu.rs
+++ b/crates/eframe/src/web/web_painter_wgpu.rs
@@ -164,7 +164,7 @@ impl WebPainter for WebPainterWgpu {
         clear_color: [f32; 4],
         clipped_primitives: &[egui::ClippedPrimitive],
         pixels_per_point: f32,
-        textures_delta: &egui::TexturesDelta,
+        textures_delta: &mut egui::TexturesDelta,
         capture_data: Vec<UserData>,
     ) -> Result<(), JsValue> {
         let capture = !capture_data.is_empty();
@@ -210,13 +210,15 @@ impl WebPainter for WebPainterWgpu {
 
         let user_cmd_bufs = {
             let mut renderer = render_state.renderer.write();
-            for (id, image_delta) in &textures_delta.set {
-                renderer.update_texture(
-                    &render_state.device,
-                    &render_state.queue,
-                    *id,
-                    image_delta,
-                );
+            for (id, image_deltas) in textures_delta.set.drain() {
+                for image_delta in image_deltas {
+                    renderer.update_texture(
+                        &render_state.device,
+                        &render_state.queue,
+                        id,
+                        &image_delta,
+                    );
+                }
             }
 
             renderer.update_buffers(
@@ -388,8 +390,8 @@ impl WebPainter for WebPainterWgpu {
         // However, once we called `wgpu::Queue::submit`, it is up for wgpu to determine how long the underlying gpu resource has to live.
         {
             let mut renderer = render_state.renderer.write();
-            for id in &textures_delta.free {
-                renderer.free_texture(id);
+            for id in textures_delta.free.drain() {
+                renderer.free_texture(&id);
             }
         }
 

--- a/crates/eframe/src/web/web_painter_wgpu.rs
+++ b/crates/eframe/src/web/web_painter_wgpu.rs
@@ -210,7 +210,7 @@ impl WebPainter for WebPainterWgpu {
 
         let user_cmd_bufs = {
             let mut renderer = render_state.renderer.write();
-            #[allow(clippy::iter_over_hash_type)] // Order doesn't matter here
+            #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
             for (id, image_deltas) in textures_delta.set.drain() {
                 for image_delta in image_deltas {
                     renderer.update_texture(
@@ -391,7 +391,7 @@ impl WebPainter for WebPainterWgpu {
         // However, once we called `wgpu::Queue::submit`, it is up for wgpu to determine how long the underlying gpu resource has to live.
         {
             let mut renderer = render_state.renderer.write();
-            #[allow(clippy::iter_over_hash_type)] // Order doesn't matter here
+            #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
             for id in textures_delta.free.drain() {
                 renderer.free_texture(&id);
             }

--- a/crates/eframe/src/web/web_painter_wgpu.rs
+++ b/crates/eframe/src/web/web_painter_wgpu.rs
@@ -210,6 +210,7 @@ impl WebPainter for WebPainterWgpu {
 
         let user_cmd_bufs = {
             let mut renderer = render_state.renderer.write();
+            #[allow(clippy::iter_over_hash_type)] // Order doesn't matter here
             for (id, image_deltas) in textures_delta.set.drain() {
                 for image_delta in image_deltas {
                     renderer.update_texture(
@@ -390,6 +391,7 @@ impl WebPainter for WebPainterWgpu {
         // However, once we called `wgpu::Queue::submit`, it is up for wgpu to determine how long the underlying gpu resource has to live.
         {
             let mut renderer = render_state.renderer.write();
+            #[allow(clippy::iter_over_hash_type)] // Order doesn't matter here
             for id in textures_delta.free.drain() {
                 renderer.free_texture(&id);
             }

--- a/crates/egui-wgpu/src/renderer.rs
+++ b/crates/egui-wgpu/src/renderer.rs
@@ -729,6 +729,16 @@ impl Renderer {
         });
 
         queue_write_data_to_texture(&texture, origin);
+
+        // A full update must (re)create the texture at exactly the delta's size,
+        // or glyph UVs (normalized by the CPU atlas size) will sample the wrong rows.
+        debug_assert!(
+            image_delta.pos.is_some() || [texture.width(), texture.height()] == [width, height],
+            "egui texture {id:?}: GPU texture is {}x{} but full delta is {width}x{height}",
+            texture.width(),
+            texture.height(),
+        );
+
         self.textures.insert(
             id,
             Texture {

--- a/crates/egui-wgpu/src/renderer.rs
+++ b/crates/egui-wgpu/src/renderer.rs
@@ -729,16 +729,6 @@ impl Renderer {
         });
 
         queue_write_data_to_texture(&texture, origin);
-
-        // A full update must (re)create the texture at exactly the delta's size,
-        // or glyph UVs (normalized by the CPU atlas size) will sample the wrong rows.
-        debug_assert!(
-            image_delta.pos.is_some() || [texture.width(), texture.height()] == [width, height],
-            "egui texture {id:?}: GPU texture is {}x{} but full delta is {width}x{height}",
-            texture.width(),
-            texture.height(),
-        );
-
         self.textures.insert(
             id,
             Texture {

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -478,7 +478,7 @@ impl Painter {
         pixels_per_point: f32,
         clear_color: [f32; 4],
         clipped_primitives: &[epaint::ClippedPrimitive],
-        textures_delta: &epaint::textures::TexturesDelta,
+        textures_delta: &mut epaint::textures::TexturesDelta,
         capture_data: Vec<UserData>,
         window: &Arc<winit::window::Window>,
     ) -> f32 {
@@ -550,13 +550,15 @@ impl Painter {
             // uploads only need the device + queue, and the atlas dirty region is
             // already consumed, so dropping the delta would desync the font texture.
             let mut renderer = render_state.renderer.write();
-            for (id, image_delta) in &textures_delta.set {
-                renderer.update_texture(
-                    &render_state.device,
-                    &render_state.queue,
-                    *id,
-                    image_delta,
-                );
+            for (id, image_deltas) in textures_delta.set.drain() {
+                for image_delta in image_deltas {
+                    renderer.update_texture(
+                        &render_state.device,
+                        &render_state.queue,
+                        id,
+                        &image_delta,
+                    );
+                }
             }
         }
 

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -740,8 +740,8 @@ impl Painter {
         {
             let mut renderer = render_state.renderer.write();
             #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
-            for id in &textures_delta.free {
-                renderer.free_texture(id);
+            for id in textures_delta.free.drain() {
+                renderer.free_texture(&id);
             }
         }
 

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -550,6 +550,7 @@ impl Painter {
             // uploads only need the device + queue, and the atlas dirty region is
             // already consumed, so dropping the delta would desync the font texture.
             let mut renderer = render_state.renderer.write();
+            #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
             for (id, image_deltas) in textures_delta.set.drain() {
                 for image_delta in image_deltas {
                     renderer.update_texture(
@@ -744,6 +745,7 @@ impl Painter {
         // However, once we called `wgpu::Queue::submit`, it is up for wgpu to determine how long the underlying gpu resource has to live.
         {
             let mut renderer = render_state.renderer.write();
+            #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
             for id in &textures_delta.free {
                 renderer.free_texture(id);
             }

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -545,24 +545,6 @@ impl Painter {
             commands_submitted: false,
         };
 
-        {
-            // Upload textures before the surface-dependent early-returns below:
-            // uploads only need the device + queue, and the atlas dirty region is
-            // already consumed, so dropping the delta would desync the font texture.
-            let mut renderer = render_state.renderer.write();
-            #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
-            for (id, image_deltas) in textures_delta.set.drain() {
-                for image_delta in image_deltas {
-                    renderer.update_texture(
-                        &render_state.device,
-                        &render_state.queue,
-                        id,
-                        &image_delta,
-                    );
-                }
-            }
-        }
-
         let Some(surface_state) = self.surfaces.get_mut(&viewport_id) else {
             return vsync_sec;
         };
@@ -582,6 +564,18 @@ impl Painter {
 
         let user_cmd_bufs = {
             let mut renderer = render_state.renderer.write();
+            #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
+            for (id, image_deltas) in textures_delta.set.drain() {
+                for image_delta in image_deltas {
+                    renderer.update_texture(
+                        &render_state.device,
+                        &render_state.queue,
+                        id,
+                        &image_delta,
+                    );
+                }
+            }
+
             renderer.update_buffers(
                 &render_state.device,
                 &render_state.queue,

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -4296,6 +4296,7 @@ mod test {
             assert_eq!(num_calls, 1);
             assert_eq!(output.platform_output.num_completed_passes, 1);
             assert!(!output.platform_output.requested_discard());
+            output.drop_without_applying_deltas();
         }
 
         // A single call, with a denied request to discard:
@@ -4321,6 +4322,7 @@ mod test {
                     .reason,
                 "test"
             );
+            output.drop_without_applying_deltas();
         }
     }
 
@@ -4341,6 +4343,7 @@ mod test {
             assert_eq!(num_calls, 1);
             assert_eq!(output.platform_output.num_completed_passes, 1);
             assert!(!output.platform_output.requested_discard());
+            output.drop_without_applying_deltas();
         }
 
         // Request discard once:
@@ -4363,6 +4366,7 @@ mod test {
                 !output.platform_output.requested_discard(),
                 "The request should have been cleared when fulfilled"
             );
+            output.drop_without_applying_deltas();
         }
 
         // Request discard twice:
@@ -4387,6 +4391,7 @@ mod test {
                 output.platform_output.requested_discard(),
                 "The unfulfilled request should be reported"
             );
+            output.drop_without_applying_deltas();
         }
     }
 
@@ -4415,6 +4420,7 @@ mod test {
                 !output.platform_output.requested_discard(),
                 "The request should have been cleared when fulfilled"
             );
+            output.drop_without_applying_deltas();
         }
     }
 }

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -775,6 +775,7 @@ impl Context {
     ///     ui.label("Hello egui!");
     /// });
     /// // handle full_output
+    /// # full_output.drop_without_applying_deltas();
     /// ```
     #[must_use]
     pub fn run_ui(&self, new_input: RawInput, mut run_ui: impl FnMut(&mut Ui)) -> FullOutput {
@@ -892,6 +893,7 @@ impl Context {
     ///
     /// let full_output = ctx.end_pass();
     /// // handle full_output
+    /// # full_output.drop_without_applying_deltas();
     /// ```
     pub fn begin_pass(&self, mut new_input: RawInput) {
         profiling::function_scope!();

--- a/crates/egui/src/data/output.rs
+++ b/crates/egui/src/data/output.rs
@@ -16,7 +16,7 @@ pub struct FullOutput {
 
     /// Texture changes since last frame (including the font texture).
     ///
-    /// The backend needs to apply [`crate::TexturesDelta::set`] _before_ painting,
+    /// The backend needs to apply [`crate::TexturesDelta::push`] _before_ painting,
     /// and free any texture in [`crate::TexturesDelta::free`] _after_ painting.
     ///
     /// It is assumed that all egui viewports share the same painter and texture namespace.

--- a/crates/egui/src/data/output.rs
+++ b/crates/egui/src/data/output.rs
@@ -68,6 +68,12 @@ impl FullOutput {
             }
         }
     }
+
+    /// [`epaint::textures::TexturesDelta`] will panic when dropped with still unapplied deltas,
+    /// this is a helper to clear the deltas.
+    pub fn drop_without_applying_deltas(mut self) {
+        self.textures_delta.clear();
+    }
 }
 
 /// Information about text being edited.

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -673,18 +673,20 @@ pub enum WidgetType {
 pub fn __run_test_ctx(mut run_ui: impl FnMut(&Context)) {
     let ctx = Context::default();
     ctx.set_fonts(FontDefinitions::empty()); // prevent fonts from being loaded (save CPU time)
-    let _ = ctx.run_ui(Default::default(), |ui| {
+    let output = ctx.run_ui(Default::default(), |ui| {
         run_ui(ui.ctx());
     });
+    output.drop_without_applying_deltas();
 }
 
 /// For use in tests; especially doctests.
 pub fn __run_test_ui(mut add_contents: impl FnMut(&mut Ui)) {
     let ctx = Context::default();
     ctx.set_fonts(FontDefinitions::empty()); // prevent fonts from being loaded (save CPU time)
-    let _ = ctx.run_ui(Default::default(), |ui| {
+    let output = ctx.run_ui(Default::default(), |ui| {
         add_contents(ui);
     });
+    output.drop_without_applying_deltas();
 }
 
 pub fn accesskit_root_id() -> Id {

--- a/crates/egui/src/text_selection/label_text_selection.rs
+++ b/crates/egui/src/text_selection/label_text_selection.rs
@@ -773,7 +773,7 @@ mod tests {
             .or_default()
             .selection = Some(test_selection());
 
-        let _ = ctx.run_ui(RawInput::default(), |_| {});
+        let output = ctx.run_ui(RawInput::default(), |_| {});
         assert!(
             plugin
                 .lock()
@@ -782,11 +782,13 @@ mod tests {
                 .is_some_and(ViewportLabelSelectionState::has_selection),
             "a pass in another viewport must not clear the child viewport selection"
         );
+        output.drop_without_applying_deltas();
 
-        let _ = ctx.run_ui(child_viewport_input(child_viewport_id), |_| {});
+        let output = ctx.run_ui(child_viewport_input(child_viewport_id), |_| {});
         assert!(
             !plugin.lock().has_selection(),
             "the selection must be cleared when its labels disappear from the same viewport"
         );
+        output.drop_without_applying_deltas();
     }
 }

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -72,7 +72,7 @@
 use std::sync::Arc;
 
 use epaint::{Pos2, Vec2};
-
+use epaint::textures::TexturesDelta;
 use crate::{AsId, Context, Id, Ui};
 
 // ----------------------------------------------------------------------------

--- a/crates/egui/src/viewport.rs
+++ b/crates/egui/src/viewport.rs
@@ -71,9 +71,8 @@
 
 use std::sync::Arc;
 
-use epaint::{Pos2, Vec2};
-use epaint::textures::TexturesDelta;
 use crate::{AsId, Context, Id, Ui};
+use epaint::{Pos2, Vec2};
 
 // ----------------------------------------------------------------------------
 

--- a/crates/egui_demo_lib/benches/benchmark.rs
+++ b/crates/egui_demo_lib/benches/benchmark.rs
@@ -28,18 +28,21 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         // The most end-to-end benchmark.
         c.bench_function("demo_with_tessellate__realistic", |b| {
             b.iter(|| {
-                let full_output = ctx.run_ui(RawInput::default(), |ui| {
+                let mut full_output = ctx.run_ui(RawInput::default(), |ui| {
                     demo_windows.ui(ui);
                 });
-                ctx.tessellate(full_output.shapes, full_output.pixels_per_point)
+                ctx.tessellate(full_output.shapes, full_output.pixels_per_point);
+
+                full_output.textures_delta.clear(); // Don't panic on drop with unapplied deltas
             });
         });
 
         c.bench_function("demo_no_tessellate", |b| {
             b.iter(|| {
-                ctx.run_ui(RawInput::default(), |ui| {
+                let output = ctx.run_ui(RawInput::default(), |ui| {
                     demo_windows.ui(ui);
-                })
+                });
+                output.drop_without_applying_deltas();
             });
         });
 
@@ -49,6 +52,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         c.bench_function("demo_only_tessellate", |b| {
             b.iter(|| ctx.tessellate(full_output.shapes.clone(), full_output.pixels_per_point));
         });
+        full_output.drop_without_applying_deltas();
     }
 
     if false {
@@ -66,7 +70,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     {
         let ctx = egui::Context::default();
-        let _ = ctx.run_ui(RawInput::default(), |ui| {
+        let output = ctx.run_ui(RawInput::default(), |ui| {
             c.bench_function("label &str", |b| {
                 b.iter_batched_ref(
                     || create_benchmark_ui(ui),
@@ -86,11 +90,12 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 );
             });
         });
+        output.drop_without_applying_deltas();
     }
 
     {
         let ctx = egui::Context::default();
-        let _ = ctx.run_ui(RawInput::default(), |ui| {
+        let output = ctx.run_ui(RawInput::default(), |ui| {
             let mut group = c.benchmark_group("button");
 
             // To ensure we have a valid image, let's use the font texture. The size
@@ -134,6 +139,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 );
             });
         });
+
+        output.drop_without_applying_deltas();
     }
 
     {

--- a/crates/egui_demo_lib/src/lib.rs
+++ b/crates/egui_demo_lib/src/lib.rs
@@ -72,11 +72,12 @@ fn test_egui_e2e() {
 
     const NUM_FRAMES: usize = 5;
     for _ in 0..NUM_FRAMES {
-        let full_output = ctx.run_ui(raw_input.clone(), |ui| {
+        let mut full_output = ctx.run_ui(raw_input.clone(), |ui| {
             demo_windows.ui(ui);
         });
         let clipped_primitives = ctx.tessellate(full_output.shapes, full_output.pixels_per_point);
         assert!(!clipped_primitives.is_empty());
+        full_output.textures_delta.clear(); // Don't panic on drop with unapplied deltas
     }
 }
 
@@ -91,7 +92,7 @@ fn test_egui_zero_window_size() {
 
     const NUM_FRAMES: usize = 5;
     for _ in 0..NUM_FRAMES {
-        let full_output = ctx.run_ui(raw_input.clone(), |ui| {
+        let mut full_output = ctx.run_ui(raw_input.clone(), |ui| {
             demo_windows.ui(ui);
         });
         let clipped_primitives = ctx.tessellate(full_output.shapes, full_output.pixels_per_point);
@@ -100,6 +101,7 @@ fn test_egui_zero_window_size() {
             "There should be nothing to show, has at least one primitive with clip_rect: {:?}",
             clipped_primitives[0].clip_rect
         );
+        full_output.textures_delta.clear(); // Don't panic on drop with unapplied deltas
     }
 }
 

--- a/crates/egui_glow/src/painter.rs
+++ b/crates/egui_glow/src/painter.rs
@@ -362,8 +362,10 @@ impl Painter {
     ) {
         profiling::function_scope!();
 
-        for (id, image_delta) in &textures_delta.set {
-            self.set_texture(*id, image_delta);
+        for (id, image_deltas) in &textures_delta.set {
+            for image_delta in image_deltas {
+                self.set_texture(*id, image_delta);
+            }
         }
 
         self.paint_primitives(screen_size_px, pixels_per_point, clipped_primitives);

--- a/crates/egui_glow/src/painter.rs
+++ b/crates/egui_glow/src/painter.rs
@@ -358,19 +358,21 @@ impl Painter {
         screen_size_px: [u32; 2],
         pixels_per_point: f32,
         clipped_primitives: &[egui::ClippedPrimitive],
-        textures_delta: &egui::TexturesDelta,
+        textures_delta: &mut egui::TexturesDelta,
     ) {
         profiling::function_scope!();
 
-        for (id, image_deltas) in &textures_delta.set {
+        #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
+        for (id, image_deltas) in textures_delta.set.drain() {
             for image_delta in image_deltas {
-                self.set_texture(*id, image_delta);
+                self.set_texture(id, &image_delta);
             }
         }
 
         self.paint_primitives(screen_size_px, pixels_per_point, clipped_primitives);
 
-        for &id in &textures_delta.free {
+        #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
+        for id in textures_delta.free.drain() {
             self.free_texture(id);
         }
     }

--- a/crates/egui_glow/src/winit.rs
+++ b/crates/egui_glow/src/winit.rs
@@ -107,8 +107,11 @@ impl EguiGlow {
         let shapes = std::mem::take(&mut self.shapes);
         let mut textures_delta = std::mem::take(&mut self.textures_delta);
 
-        for (id, image_delta) in textures_delta.set {
-            self.painter.set_texture(id, &image_delta);
+        #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
+        for (id, image_deltas) in textures_delta.set.drain() {
+            for image_delta in image_deltas {
+                self.painter.set_texture(id, &image_delta);
+            }
         }
 
         let pixels_per_point = self.pixels_per_point;
@@ -117,7 +120,8 @@ impl EguiGlow {
         self.painter
             .paint_primitives(dimensions, pixels_per_point, &clipped_primitives);
 
-        for id in textures_delta.free.drain(..) {
+        #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
+        for id in textures_delta.free.drain() {
             self.painter.free_texture(id);
         }
     }

--- a/crates/egui_kittest/src/lib.rs
+++ b/crates/egui_kittest/src/lib.rs
@@ -147,7 +147,7 @@ impl<'a, State> Harness<'a, State> {
             response = app.run(ui, &mut state, false);
         });
 
-        renderer.handle_delta(&output.textures_delta);
+        renderer.handle_delta(&mut output.textures_delta);
 
         let mut harness = Self {
             app,
@@ -269,7 +269,7 @@ impl<'a, State> Harness<'a, State> {
                 .take()
                 .expect("AccessKit was disabled"),
         );
-        self.renderer.handle_delta(&output.textures_delta);
+        self.renderer.handle_delta(&mut output.textures_delta);
         self.output = output;
 
         self.handle_viewport_commands();

--- a/crates/egui_kittest/src/renderer.rs
+++ b/crates/egui_kittest/src/renderer.rs
@@ -1,4 +1,5 @@
 use egui::TexturesDelta;
+use std::mem;
 
 pub trait TestRenderer {
     /// We use this to pass the glow / wgpu render state to [`eframe::Frame`].
@@ -6,7 +7,7 @@ pub trait TestRenderer {
     fn setup_eframe(&self, _cc: &mut eframe::CreationContext<'_>, _frame: &mut eframe::Frame) {}
 
     /// Handle a [`TexturesDelta`] by updating the renderer's textures.
-    fn handle_delta(&mut self, delta: &TexturesDelta);
+    fn handle_delta(&mut self, delta: &mut TexturesDelta);
 
     /// Render the [`crate::Harness`] and return the resulting image.
     ///
@@ -25,7 +26,7 @@ pub trait TestRenderer {
 /// By default, this will create a wgpu renderer if the wgpu feature is enabled.
 pub enum LazyRenderer {
     Uninitialized {
-        texture_ops: Vec<egui::TexturesDelta>,
+        textures_delta: TexturesDelta,
         builder: Option<Box<dyn FnOnce() -> Box<dyn TestRenderer>>>,
     },
     Initialized {
@@ -39,7 +40,7 @@ impl Default for LazyRenderer {
         return Self::new(crate::wgpu::WgpuTestRenderer::new);
         #[cfg(not(feature = "wgpu"))]
         return Self::Uninitialized {
-            texture_ops: Vec::new(),
+            textures_delta: Vec::new(),
             builder: None,
         };
     }
@@ -48,16 +49,19 @@ impl Default for LazyRenderer {
 impl LazyRenderer {
     pub fn new<T: TestRenderer + 'static>(create_renderer: impl FnOnce() -> T + 'static) -> Self {
         Self::Uninitialized {
-            texture_ops: Vec::new(),
+            textures_delta: Default::default(),
             builder: Some(Box::new(move || Box::new(create_renderer()))),
         }
     }
 }
 
 impl TestRenderer for LazyRenderer {
-    fn handle_delta(&mut self, delta: &TexturesDelta) {
+    fn handle_delta(&mut self, delta: &mut TexturesDelta) {
         match self {
-            Self::Uninitialized { texture_ops, .. } => texture_ops.push(delta.clone()),
+            Self::Uninitialized {
+                textures_delta: texture_ops,
+                ..
+            } => texture_ops.append(mem::take(delta)),
             Self::Initialized { renderer } => renderer.handle_delta(delta),
         }
     }
@@ -70,21 +74,32 @@ impl TestRenderer for LazyRenderer {
     ) -> Result<image::RgbaImage, String> {
         match self {
             Self::Uninitialized {
-                texture_ops,
+                textures_delta,
                 builder: build,
             } => {
                 let mut renderer = build.take().ok_or({
                     "No default renderer available. \
                     Enable the wgpu feature or set one via HarnessBuilder::renderer"
                 })?();
-                for delta in texture_ops.drain(..) {
-                    renderer.handle_delta(&delta);
+                if !textures_delta.is_empty() {
+                    renderer.handle_delta(textures_delta);
                 }
                 let image = renderer.render(ctx, output)?;
                 *self = Self::Initialized { renderer };
                 Ok(image)
             }
             Self::Initialized { renderer } => renderer.render(ctx, output),
+        }
+    }
+}
+
+impl Drop for LazyRenderer {
+    fn drop(&mut self) {
+        match self {
+            Self::Uninitialized { textures_delta, .. } => {
+                textures_delta.clear(); // Don't panic when dropping unapplied deltas
+            }
+            Self::Initialized { .. } => {}
         }
     }
 }

--- a/crates/egui_kittest/src/wgpu.rs
+++ b/crates/egui_kittest/src/wgpu.rs
@@ -137,15 +137,23 @@ impl crate::TestRenderer for WgpuTestRenderer {
         frame.wgpu_render_state = Some(self.render_state.clone());
     }
 
-    fn handle_delta(&mut self, delta: &TexturesDelta) {
+    fn handle_delta(&mut self, delta: &mut TexturesDelta) {
         let mut renderer = self.render_state.renderer.write();
-        for (id, image) in &delta.set {
-            renderer.update_texture(
-                &self.render_state.device,
-                &self.render_state.queue,
-                *id,
-                image,
-            );
+        #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
+        for (id, images) in delta.set.drain() {
+            for image in images {
+                renderer.update_texture(
+                    &self.render_state.device,
+                    &self.render_state.queue,
+                    id,
+                    &image,
+                );
+            }
+        }
+
+        #[expect(clippy::iter_over_hash_type)] // Order doesn't matter here
+        for id in delta.free.drain() {
+            renderer.free_texture(&id);
         }
     }
 

--- a/crates/egui_kittest/tests/accesskit.rs
+++ b/crates/egui_kittest/tests/accesskit.rs
@@ -144,7 +144,8 @@ fn accesskit_output_single_egui_frame(run_ui: impl FnMut(&mut Ui)) -> TreeUpdate
     ctx.global_style_mut(|style| style.animation_time = 0.0);
     ctx.enable_accesskit();
 
-    let output = ctx.run_ui(RawInput::default(), run_ui);
+    let mut output = ctx.run_ui(RawInput::default(), run_ui);
+    output.textures_delta.clear(); // Don't panic on drop with unapplied deltas
 
     output
         .platform_output

--- a/crates/epaint/src/textures.rs
+++ b/crates/epaint/src/textures.rs
@@ -1,7 +1,7 @@
-use std::mem;
 use crate::{ImageData, ImageDelta, TextureId};
 use ahash::{HashMap, HashSet};
 use smallvec::{SmallVec, smallvec};
+use std::mem;
 
 // ----------------------------------------------------------------------------
 
@@ -299,7 +299,6 @@ impl TexturesDelta {
     /// If this [`TexturesDelta`] already contains this [`TextureId`], and this is a `whole` delta,
     /// the previous deltas for this id are discarded.
     pub fn set(&mut self, id: TextureId, delta: ImageDelta) {
-        dbg!(&id, &delta.is_whole());
         if delta.is_whole() {
             // It replaces the whole texture, fine to overwrite any previous deltas
             self.set.insert(id, smallvec![delta]);
@@ -309,12 +308,13 @@ impl TexturesDelta {
     }
 
     pub fn free(&mut self, id: TextureId) {
-        dbg!(&id);
         self.free.insert(id);
     }
 
+    #[expect(clippy::iter_over_hash_type)]
     pub fn append(&mut self, mut newer: Self) {
-        dbg!(&self, &newer);
+        // Only clear previous entries on append, not on set, since within a frame a texture might
+        // be created and immediately removed again.
         for id in &newer.free {
             self.set.remove(id);
         }
@@ -334,13 +334,12 @@ impl TexturesDelta {
 
 impl Drop for TexturesDelta {
     fn drop(&mut self) {
-        if cfg!(debug_assertions) && !self.is_empty() {
-            panic!(
-                "Dropped TexturesDelta with {} unapplied deltas. Deltas need to be handled. \
-                If you want to drop this intentionally call `clear` before dropping.",
-                self.free.len() + self.set.len()
-            );
-        }
+        debug_assert!(
+            self.is_empty(),
+            "Dropped TexturesDelta with {} unapplied deltas. Deltas need to be handled. \
+            If you want to drop this intentionally call `clear` before dropping.",
+            self.free.len() + self.set.len()
+        );
     }
 }
 
@@ -351,6 +350,7 @@ impl std::fmt::Debug for TexturesDelta {
         let mut debug_struct = f.debug_struct("TexturesDelta");
         if !self.set.is_empty() {
             let mut string = String::new();
+            #[expect(clippy::iter_over_hash_type)]
             for (tex_id, deltas) in &self.set {
                 for delta in deltas {
                     let size = delta.image.size();

--- a/crates/epaint/src/textures.rs
+++ b/crates/epaint/src/textures.rs
@@ -1,4 +1,7 @@
+use std::mem;
 use crate::{ImageData, ImageDelta, TextureId};
+use ahash::{HashMap, HashSet};
+use smallvec::{SmallVec, smallvec};
 
 // ----------------------------------------------------------------------------
 
@@ -40,7 +43,7 @@ impl TextureManager {
             options,
         });
 
-        self.delta.set.push((id, ImageDelta::full(image, options)));
+        self.delta.set(id, ImageDelta::full(image, options));
         id
     }
 
@@ -58,10 +61,8 @@ impl TextureManager {
                 // whole update
                 meta.size = delta.image.size();
                 meta.bytes_per_pixel = delta.image.bytes_per_pixel();
-                // since we update the whole image, we can discard all old enqueued deltas
-                self.delta.set.retain(|(x, _)| x != &id);
             }
-            self.delta.set.push((id, delta));
+            self.delta.set(id, delta);
         } else {
             debug_assert!(false, "Tried setting texture {id:?} which is not allocated");
         }
@@ -74,7 +75,7 @@ impl TextureManager {
             meta.retain_count -= 1;
             if meta.retain_count == 0 {
                 entry.remove();
-                self.delta.free.push(id);
+                self.delta.free(id);
             }
         } else {
             debug_assert!(false, "Tried freeing texture {id:?} which is not allocated");
@@ -115,6 +116,12 @@ impl TextureManager {
     /// Total number of allocated textures.
     pub fn num_allocated(&self) -> usize {
         self.metas.len()
+    }
+}
+
+impl Drop for TextureManager {
+    fn drop(&mut self) {
+        self.delta.clear(); // Prevent a debug panic on application shutdown
     }
 }
 
@@ -276,10 +283,10 @@ pub enum TextureWrapMode {
 #[must_use = "The painter must take care of this"]
 pub struct TexturesDelta {
     /// New or changed textures. Apply before painting.
-    pub set: Vec<(TextureId, ImageDelta)>,
+    pub set: HashMap<TextureId, SmallVec<[ImageDelta; 1]>>,
 
     /// Textures to free after painting.
-    pub free: Vec<TextureId>,
+    pub free: HashSet<TextureId>,
 }
 
 impl TexturesDelta {
@@ -287,14 +294,53 @@ impl TexturesDelta {
         self.set.is_empty() && self.free.is_empty()
     }
 
+    /// Inserts a [`ImageDelta`].
+    ///
+    /// If this [`TexturesDelta`] already contains this [`TextureId`], and this is a `whole` delta,
+    /// the previous deltas for this id are discarded.
+    pub fn set(&mut self, id: TextureId, delta: ImageDelta) {
+        dbg!(&id, &delta.is_whole());
+        if delta.is_whole() {
+            // It replaces the whole texture, fine to overwrite any previous deltas
+            self.set.insert(id, smallvec![delta]);
+        } else {
+            self.set.entry(id).or_default().push(delta);
+        }
+    }
+
+    pub fn free(&mut self, id: TextureId) {
+        dbg!(&id);
+        self.free.insert(id);
+    }
+
     pub fn append(&mut self, mut newer: Self) {
-        self.set.extend(newer.set);
-        self.free.append(&mut newer.free);
+        dbg!(&self, &newer);
+        for id in &newer.free {
+            self.set.remove(id);
+        }
+        for (id, deltas) in newer.set.drain() {
+            for delta in deltas {
+                self.set(id, delta);
+            }
+        }
+        self.free.extend(mem::take(&mut newer.free));
     }
 
     pub fn clear(&mut self) {
         self.set.clear();
         self.free.clear();
+    }
+}
+
+impl Drop for TexturesDelta {
+    fn drop(&mut self) {
+        if cfg!(debug_assertions) && !self.is_empty() {
+            panic!(
+                "Dropped TexturesDelta with {} unapplied deltas. Deltas need to be handled. \
+                If you want to drop this intentionally call `clear` before dropping.",
+                self.free.len() + self.set.len()
+            );
+        }
     }
 }
 
@@ -305,21 +351,23 @@ impl std::fmt::Debug for TexturesDelta {
         let mut debug_struct = f.debug_struct("TexturesDelta");
         if !self.set.is_empty() {
             let mut string = String::new();
-            for (tex_id, delta) in &self.set {
-                let size = delta.image.size();
-                if let Some(pos) = delta.pos {
-                    write!(
-                        string,
-                        "{:?} partial ([{} {}] - [{} {}]), ",
-                        tex_id,
-                        pos[0],
-                        pos[1],
-                        pos[0] + size[0],
-                        pos[1] + size[1]
-                    )
-                    .ok();
-                } else {
-                    write!(string, "{:?} full {}x{}, ", tex_id, size[0], size[1]).ok();
+            for (tex_id, deltas) in &self.set {
+                for delta in deltas {
+                    let size = delta.image.size();
+                    if let Some(pos) = delta.pos {
+                        write!(
+                            string,
+                            "{:?} partial ([{} {}] - [{} {}]), ",
+                            tex_id,
+                            pos[0],
+                            pos[1],
+                            pos[0] + size[0],
+                            pos[1] + size[1]
+                        )
+                        .ok();
+                    } else {
+                        write!(string, "{:?} full {}x{}, ", tex_id, size[0], size[1]).ok();
+                    }
                 }
             }
             debug_struct.field("set", &string);

--- a/crates/epaint/src/textures.rs
+++ b/crates/epaint/src/textures.rs
@@ -43,7 +43,7 @@ impl TextureManager {
             options,
         });
 
-        self.delta.set(id, ImageDelta::full(image, options));
+        self.delta.push(id, ImageDelta::full(image, options));
         id
     }
 
@@ -62,7 +62,7 @@ impl TextureManager {
                 meta.size = delta.image.size();
                 meta.bytes_per_pixel = delta.image.bytes_per_pixel();
             }
-            self.delta.set(id, delta);
+            self.delta.push(id, delta);
         } else {
             debug_assert!(false, "Tried setting texture {id:?} which is not allocated");
         }
@@ -298,7 +298,7 @@ impl TexturesDelta {
     ///
     /// If this [`TexturesDelta`] already contains this [`TextureId`], and this is a `whole` delta,
     /// the previous deltas for this id are discarded.
-    pub fn set(&mut self, id: TextureId, delta: ImageDelta) {
+    pub fn push(&mut self, id: TextureId, delta: ImageDelta) {
         if delta.is_whole() {
             // It replaces the whole texture, fine to overwrite any previous deltas
             self.set.insert(id, smallvec![delta]);
@@ -320,7 +320,7 @@ impl TexturesDelta {
         }
         for (id, deltas) in newer.set.drain() {
             for delta in deltas {
-                self.set(id, delta);
+                self.push(id, delta);
             }
         }
         self.free.extend(mem::take(&mut newer.free));


### PR DESCRIPTION
We had a ton of issues around `TexturesDelta` that weren't properly applied because we early-out of some function:
* https://github.com/emilk/egui/pull/8313
* https://github.com/emilk/egui/pull/8250
* https://github.com/emilk/egui/pull/8279

This PR changes texture updates, so that we always store them after taking them out of `FullOutput` and keep the delta around until it's actually applied (by passing &mut refs and draining instead of iterating). So even if we add a new early return somewhere, that can't break texture updates.

It also optimizes `TexturesDelta::append` by dropping any previous deltas if there's a new `whole` delta or a `free`.

It also adds a debug assert that any `TexturesDelta` is empty when dropped, as an additional safeguard in case the bug sneaks back in.