### PR TITLE
feat: add more documentation on `Image::texture_options`

### DIFF
--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -114,7 +114,9 @@ impl<'a> Image<'a> {
         })
     }
 
-    /// Texture options used when creating the texture.
+    /// Texture options used when creating the texture. If the texture is already loaded. This
+    /// function will not work. You will need to use this options while loading the texture, for
+    /// example in [`Context::load_texture`].
     #[inline]
     pub fn texture_options(mut self, texture_options: TextureOptions) -> Self {
         self.texture_options = texture_options;


### PR DESCRIPTION
* [x] I have followed the instructions in the PR template


<img width="1012" height="108" alt="image" src="https://github.com/user-attachments/assets/abbabcff-55a3-4563-a2f2-9a39f811c696" />
