### PR TITLE
Fully support text suggestions for `eframe/web`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,7 @@ dependencies = [
  "ron",
  "serde",
  "smallvec",
+ "unicode-general-category",
  "unicode-segmentation",
 ]
 

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -394,7 +394,7 @@ impl AppRunner {
 
         if self.has_focus() {
             // The eframe app has focus.
-            if let Some(ime) = ime {
+            if let Some(ime) = &ime {
                 if ime.should_interrupt_composition {
                     self.text_agent.interrupt_ime_composition();
                 }

--- a/crates/eframe/src/web/text_agent.rs
+++ b/crates/eframe/src/web/text_agent.rs
@@ -285,10 +285,14 @@ impl InputState {
             .as_ref()
             .and_then(|ime| ime.preceding_text.as_deref())
             .unwrap_or("");
-        self.input.set_value(text);
-        let len = text.encode_utf16().count() as u32;
-        self.input.set_selection_start(Some(len)).ok();
-        self.last_text = text.to_owned();
+        if text != self.input.value() {
+            self.input.set_value(text);
+            let len = text.encode_utf16().count() as u32;
+            self.input.set_selection_start(Some(len)).ok();
+        }
+        if text != self.last_text {
+            self.last_text = text.to_owned();
+        }
     }
 
     fn handle_input_event(&mut self, event: &web_sys::InputEvent, runner: &mut AppRunner) {

--- a/crates/eframe/src/web/text_agent.rs
+++ b/crates/eframe/src/web/text_agent.rs
@@ -236,7 +236,9 @@ impl InputState {
         }
         self.ime_output = ime;
 
-        let Some(ime) = ime else { return Ok(()) };
+        let Some(ime) = &self.ime_output else {
+            return Ok(());
+        };
 
         // NOTE: we don't set the input's `type` to `password` based on
         // `ime.purpose`, because that would confuse some password managers.
@@ -272,12 +274,21 @@ impl InputState {
             &format!("{}px", canvas.offset_top() as f32 + clamped_y),
         )?;
 
+        self.clear();
+
         Ok(())
     }
 
     fn clear(&mut self) {
-        self.input.set_value("");
-        self.last_text.clear();
+        let text = self
+            .ime_output
+            .as_ref()
+            .and_then(|ime| ime.preceding_text.as_deref())
+            .unwrap_or("");
+        self.input.set_value(text);
+        let len = text.encode_utf16().count() as u32;
+        self.input.set_selection_start(Some(len)).ok();
+        self.last_text = text.to_owned();
     }
 
     fn handle_input_event(&mut self, event: &web_sys::InputEvent, runner: &mut AppRunner) {
@@ -318,19 +329,21 @@ impl InputState {
         }
 
         let preedit_text: String = text.chars().skip(prefix_len).collect();
-        let out_event = if event.is_composing() {
-            // We handle the composition update here instead of in a
-            // `compositionupdate` event because the selection range
-            // has not yet been updated when `compositionupdate` fires.
-            let active_range_chars = self.active_range_chars(&text, prefix_len);
-            egui::Event::Ime(egui::ImeEvent::Preedit {
-                text: preedit_text,
-                active_range_chars,
-            })
-        } else {
-            egui::Event::Text(preedit_text)
-        };
-        runner.input.raw.events.push(out_event);
+        if !preedit_text.is_empty() {
+            let out_event = if event.is_composing() {
+                // We handle the composition update here instead of in a
+                // `compositionupdate` event because the selection range
+                // has not yet been updated when `compositionupdate` fires.
+                let active_range_chars = self.active_range_chars(&text, prefix_len);
+                egui::Event::Ime(egui::ImeEvent::Preedit {
+                    text: preedit_text,
+                    active_range_chars,
+                })
+            } else {
+                egui::Event::Text(preedit_text)
+            };
+            runner.input.raw.events.push(out_event);
+        }
 
         if event.is_composing() {
             self.last_text = text.chars().take(prefix_len).collect();

--- a/crates/egui/Cargo.toml
+++ b/crates/egui/Cargo.toml
@@ -79,6 +79,7 @@ log.workspace = true
 nohash-hasher.workspace = true
 profiling.workspace = true
 smallvec.workspace = true
+unicode-general-category.workspace = true
 unicode-segmentation.workspace = true
 
 #! ### Optional dependencies

--- a/crates/egui/src/data/output.rs
+++ b/crates/egui/src/data/output.rs
@@ -79,7 +79,7 @@ impl FullOutput {
 /// Information about text being edited.
 ///
 /// Useful for IME.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct IMEOutput {
     /// IME's purpose.
@@ -95,6 +95,25 @@ pub struct IMEOutput {
 
     /// Whether any ongoing IME composition should be interrupted.
     pub should_interrupt_composition: bool,
+
+    /// Text immediately preceding the composition, provided as context for
+    /// suggestions.
+    ///
+    /// Long preceding text can hurt performance, so consider truncating it to a
+    /// reasonable length.
+    ///
+    /// One approach is to scan backward through the text and stop when any of
+    /// the following conditions is met. This approach is not sophisticated, but
+    /// it works in practice:
+    /// - Limit the text to 256 bytes.
+    /// - If a line break is encountered, truncate the text immediately after
+    ///   it.
+    /// - If punctuation is encountered, truncate the text at (including) that
+    ///   punctuation character.
+    /// - Once the limit has been reached, if whitespace has been encountered
+    ///   and the first space-separated word is incomplete, truncate the text
+    ///   at the last complete word.
+    pub preceding_text: Option<String>,
 }
 
 /// Commands that the egui integration should execute at the end of a frame.
@@ -214,7 +233,9 @@ impl PlatformOutput {
         self.cursor_image = cursor_image;
         self.events.append(&mut events);
         self.mutable_text_under_cursor = mutable_text_under_cursor;
-        self.ime = ime.or(self.ime);
+        if let Some(ime) = ime {
+            self.ime = Some(ime);
+        }
         self.num_completed_passes += num_completed_passes;
         self.request_discard_reasons
             .append(&mut request_discard_reasons);

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -919,10 +919,18 @@ impl TextEdit<'_> {
                     }
                     if ui.memory(|mem| mem.owns_ime_events(id)) {
                         // Set IME output (in screen coords) when text is editable and visible
+
                         let to_global = ui
                             .ctx()
                             .layer_transform_to_global(ui.layer_id())
                             .unwrap_or_default();
+
+                        let preceding_text_end = cursor_range.as_sorted_char_range().start;
+                        let preceding_text_start =
+                            truncate_preceding_text(text.as_str(), preceding_text_end);
+                        let preceding_text =
+                            text.char_range(preceding_text_start..preceding_text_end);
+
                         ui.output_mut(|o| {
                             o.ime = Some(crate::output::IMEOutput {
                                 purpose: if password {
@@ -933,6 +941,11 @@ impl TextEdit<'_> {
                                 rect: to_global * inner_rect,
                                 cursor_rect: to_global * primary_cursor_rect,
                                 should_interrupt_composition: false,
+                                preceding_text: if password {
+                                    None
+                                } else {
+                                    Some(preceding_text.to_owned())
+                                },
                             });
                         });
                     }
@@ -1012,6 +1025,65 @@ fn mask_if_password(is_password: bool, text: &str) -> String {
     } else {
         text.to_owned()
     }
+}
+
+/// Find the start of the preceding text following the strategy described in the
+/// documentation of [`crate::output::IMEOutput::preceding_text`]. Returns the
+/// index of the first character to include in the preceding text.
+fn truncate_preceding_text(
+    text: &str,
+    preceding_text_end: epaint::text::CharIndex,
+) -> epaint::text::CharIndex {
+    use unicode_general_category::GeneralCategory;
+
+    const MAX_BYTES: usize = 256;
+
+    if preceding_text_end == epaint::text::CharIndex::ZERO {
+        return epaint::text::CharIndex::ZERO;
+    }
+
+    let preceding_text = text.char_range(epaint::text::CharIndex::ZERO..preceding_text_end);
+
+    let mut used_bytes = 0;
+    let mut last_whitespace_index: Option<epaint::text::CharIndex> = None;
+    let mut i = preceding_text_end - 1;
+    for c in preceding_text.chars().rev() {
+        let char_bytes = c.len_utf8();
+        if used_bytes + char_bytes > MAX_BYTES {
+            if c == ' ' {
+                return i + 1;
+            }
+            if let Some(last_whitespace_index) = last_whitespace_index {
+                return last_whitespace_index + 1;
+            } else {
+                return i + 1;
+            };
+        }
+        if matches!(c, '\r' | '\n') {
+            return i + 1;
+        }
+        match unicode_general_category::get_general_category(c) {
+            GeneralCategory::LineSeparator | GeneralCategory::ParagraphSeparator => {
+                return i + 1;
+            }
+            GeneralCategory::SpaceSeparator => {
+                last_whitespace_index = Some(i);
+            }
+            GeneralCategory::ClosePunctuation
+            | GeneralCategory::ConnectorPunctuation
+            | GeneralCategory::DashPunctuation
+            | GeneralCategory::FinalPunctuation
+            | GeneralCategory::InitialPunctuation
+            | GeneralCategory::OpenPunctuation
+            | GeneralCategory::OtherPunctuation => {
+                return i;
+            }
+            _ => {}
+        }
+        used_bytes += char_bytes;
+        i = i.saturating_sub(1);
+    }
+    epaint::text::CharIndex::ZERO
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Follow-up to #8045
* Supersedes #8068
* [x] I have followed the instructions in the PR template

TODO:
- [x] Update suggestions when the cursor is moved on Android.
- [ ] Update suggestions when the cursor is moved on iOS/iPadOS. (#8068 demonstrated that this should be possible.)
- [ ] `preceding_text` -> `InputContext::preceding_text`.
- [ ] Include `succeeding_text` in the input context. (`struct InputContext { preceding_text: String, succeeding_text: String, }`)
- [ ] Performance: Move `InputContext` from `IMEOutput` to `Context`, and add `IMEOutput::input_context_changed`, so the input context can be updated only when necessary and is not copied for every frame.
- [ ] Prevent unintended changes to the text agent `<input>`'s selection range (e.g., from iOS' spacebar trackpad feature).