### PR TITLE
Clarify wording of IdTypeMap::remove_by_type documentation

### DIFF
--- a/crates/egui/src/util/id_type_map.rs
+++ b/crates/egui/src/util/id_type_map.rs
@@ -596,7 +596,7 @@ impl IdTypeMap {
         }
     }
 
-    /// Note all state of the given type.
+    /// Remove all state of the given type.
     pub fn remove_by_type<T: 'static>(&mut self) {
         let key = TypeId::of::<T>();
         self.map.retain(|_, e| {


### PR DESCRIPTION
The function to remove all entries of a type from IdTypeMap was confusingly documented as "Note all state of the given type".
As far as I know, (not a native speaker), "noting" shares no meaning with "removing", so I changed the doc to simply state what the function does.
