### PR TITLE
Eframe: make webbrowser dependency optional

### DIFF
--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -122,6 +122,9 @@ __screenshot = []
 ## and capture screenshots. Off unless the env var is set; no-op on wasm.
 inspection = ["dep:egui_inspection", "accesskit"]
 
+## Enables the `links` feature on `egui-winit`, allowing for links to open in browser.
+links = ["egui-winit/links"]
+
 [dependencies]
 egui = { workspace = true, default-features = false, features = ["bytemuck"] }
 
@@ -145,7 +148,7 @@ serde = { workspace = true, optional = true }
 # -------------------------------------------
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-egui-winit = { workspace = true, default-features = false, features = ["clipboard", "links"] }
+egui-winit = { workspace = true, default-features = false, features = ["clipboard"] }
 image = { workspace = true, features = ["png"] } # Needed for app icon
 winit = { workspace = true, default-features = false, features = ["rwh_06"] }
 

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -28,12 +28,12 @@ workspace = true
 default = [
   "accesskit",
   "default_fonts",
+  "links",
   "wayland", # Required for Linux support (including CI!)
   "web_screen_reader",
   "wgpu",
   "winit/default",
   "x11",
-  "links"
 ]
 
 ## Enable platform accessibility API implementations through [AccessKit](https://accesskit.dev/).

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -33,6 +33,7 @@ default = [
   "wgpu",
   "winit/default",
   "x11",
+  "links"
 ]
 
 ## Enable platform accessibility API implementations through [AccessKit](https://accesskit.dev/).


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes #8371
* [x] I have followed the instructions in the PR template

Adds a `link` feature to eframe to allow disabling links on egui-winit. The feature is enabled by default so nothing changes for existing users of eframe.
