### PR TITLE
Add `LayoutJob::clear`

### DIFF
--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -114,6 +114,13 @@ impl Default for LayoutJob {
 }
 
 impl LayoutJob {
+    /// Clear the text and sections while preserving the layout settings.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.text.clear();
+        self.sections.clear();
+    }
+
     /// Break on `\n` and at the given wrap width.
     #[inline]
     pub fn simple(text: String, font_id: FontId, color: Color32, wrap_width: f32) -> Self {


### PR DESCRIPTION
## Summary

- Add `LayoutJob::clear` to reuse layout settings while rebuilding text.
- Cover preservation of every layout setting.

## Test

- `cargo clippy -p epaint --all-features --all-targets`
- `cargo test -p epaint --all-features`

* [x] I have followed the instructions in the PR template