### PR TITLE
Fix window with a `Grid` being widenable but not shrinkable again

### DIFF
--- a/crates/egui/src/grid.rs
+++ b/crates/egui/src/grid.rs
@@ -94,11 +94,14 @@ pub(crate) struct GridLayout {
 
 impl GridLayout {
     pub(crate) fn new(ui: &Ui, id: Id, prev_state: Option<State>) -> Self {
-        // An enclosing sizing pass (e.g. `Resize` measuring our minimum width) wants to
-        // know how small we can get.
-        let in_outer_sizing_pass = ui.is_sizing_pass() && prev_state.is_some();
-
         let is_first_frame = prev_state.is_none();
+
+        // An enclosing sizing pass (e.g. `Resize` measuring our minimum width) wants to know
+        // how small we can get. Note that on our first frame we run a sizing pass of our own
+        // (see `show_dyn`), which is a different situation: there we have no remembered sizes
+        // to protect, and must in fact produce some.
+        let in_outer_sizing_pass = !is_first_frame && ui.is_sizing_pass();
+
         let prev_state = prev_state.unwrap_or_default();
 
         // TODO(emilk): respect current layout

--- a/crates/egui/src/grid.rs
+++ b/crates/egui/src/grid.rs
@@ -75,6 +75,11 @@ pub(crate) struct GridLayout {
     curr_state: State,
     initial_available: Rect,
 
+    /// Are we inside an enclosing sizing pass (e.g. [`crate::Resize`] measuring
+    /// the minimum content width)? If so we must not remember the (narrow) sizes
+    /// we measure during it.
+    in_outer_sizing_pass: bool,
+
     // Options:
     num_columns: Option<usize>,
     spacing: Vec2,
@@ -89,6 +94,10 @@ pub(crate) struct GridLayout {
 
 impl GridLayout {
     pub(crate) fn new(ui: &Ui, id: Id, prev_state: Option<State>) -> Self {
+        // An enclosing sizing pass (e.g. `Resize` measuring our minimum width) wants to
+        // know how small we can get.
+        let in_outer_sizing_pass = ui.is_sizing_pass() && prev_state.is_some();
+
         let is_first_frame = prev_state.is_none();
         let prev_state = prev_state.unwrap_or_default();
 
@@ -110,6 +119,7 @@ impl GridLayout {
             prev_state,
             curr_state: State::default(),
             initial_available,
+            in_outer_sizing_pass,
 
             num_columns: None,
             spacing: ui.spacing().item_spacing,
@@ -179,8 +189,20 @@ impl GridLayout {
         Rect::from_min_size(available.min, vec2(width, height))
     }
 
+    /// The last column is given all the available width, so width-filling widgets
+    /// (`Separator`, `TextEdit`, …) in it make us remember a column width that is really
+    /// just "however wide we happened to be". During a sizing pass that remembered width
+    /// would be reported as our minimum width, so ignore it there.
+    fn is_stretchy_last_column(&self) -> bool {
+        self.in_outer_sizing_pass && Some(self.col + 1) == self.num_columns
+    }
+
     pub(crate) fn next_cell(&self, cursor: Rect, child_size: Vec2) -> Rect {
-        let width = self.prev_state.col_width(self.col).unwrap_or(0.0);
+        let width = if self.is_stretchy_last_column() {
+            0.0
+        } else {
+            self.prev_state.col_width(self.col).unwrap_or(0.0)
+        };
         let height = self.prev_row_height(self.row);
         let size = child_size.max(vec2(width, height));
         Rect::from_min_size(cursor.min, size).round_ui()
@@ -273,6 +295,12 @@ impl GridLayout {
     }
 
     pub(crate) fn save(&self) {
+        if self.in_outer_sizing_pass {
+            // The sizes we measured are minimums, not what we will actually be
+            // rendered at, so don't remember them.
+            return;
+        }
+
         // We need to always save state on the first frame, otherwise request_discard
         // would be called repeatedly (see #5132)
         if self.curr_state != self.prev_state || self.is_first_frame {

--- a/crates/egui/src/grid.rs
+++ b/crates/egui/src/grid.rs
@@ -78,7 +78,7 @@ pub(crate) struct GridLayout {
     /// Are we inside an enclosing sizing pass (e.g. [`crate::Resize`] measuring
     /// the minimum content width)? If so we must not remember the (narrow) sizes
     /// we measure during it.
-    in_outer_sizing_pass: bool,
+    sizing_pass: bool,
 
     // Options:
     num_columns: Option<usize>,
@@ -96,11 +96,8 @@ impl GridLayout {
     pub(crate) fn new(ui: &Ui, id: Id, prev_state: Option<State>) -> Self {
         let is_first_frame = prev_state.is_none();
 
-        // An enclosing sizing pass (e.g. `Resize` measuring our minimum width) wants to know
-        // how small we can get. Note that on our first frame we run a sizing pass of our own
-        // (see `show_dyn`), which is a different situation: there we have no remembered sizes
-        // to protect, and must in fact produce some.
-        let in_outer_sizing_pass = !is_first_frame && ui.is_sizing_pass();
+        // An outer sizing pass, we should render as small as possible.
+        let sizing_pass = ui.is_sizing_pass();
 
         let prev_state = prev_state.unwrap_or_default();
 
@@ -122,7 +119,7 @@ impl GridLayout {
             prev_state,
             curr_state: State::default(),
             initial_available,
-            in_outer_sizing_pass,
+            sizing_pass,
 
             num_columns: None,
             spacing: ui.spacing().item_spacing,
@@ -192,16 +189,8 @@ impl GridLayout {
         Rect::from_min_size(available.min, vec2(width, height))
     }
 
-    /// The last column is given all the available width, so width-filling widgets
-    /// (`Separator`, `TextEdit`, …) in it make us remember a column width that is really
-    /// just "however wide we happened to be". During a sizing pass that remembered width
-    /// would be reported as our minimum width, so ignore it there.
-    fn is_stretchy_last_column(&self) -> bool {
-        self.in_outer_sizing_pass && Some(self.col + 1) == self.num_columns
-    }
-
     pub(crate) fn next_cell(&self, cursor: Rect, child_size: Vec2) -> Rect {
-        let width = if self.is_stretchy_last_column() {
+        let width = if self.sizing_pass {
             0.0
         } else {
             self.prev_state.col_width(self.col).unwrap_or(0.0)
@@ -298,12 +287,6 @@ impl GridLayout {
     }
 
     pub(crate) fn save(&self) {
-        if self.in_outer_sizing_pass {
-            // The sizes we measured are minimums, not what we will actually be
-            // rendered at, so don't remember them.
-            return;
-        }
-
         // We need to always save state on the first frame, otherwise request_discard
         // would be called repeatedly (see #5132)
         if self.curr_state != self.prev_state || self.is_first_frame {

--- a/crates/egui_kittest/tests/regression_tests.rs
+++ b/crates/egui_kittest/tests/regression_tests.rs
@@ -513,6 +513,61 @@ fn window_resize_wraps_to_content_min_width() {
     );
 }
 
+/// A `Grid` gives its last column all the available width, so a width-filling widget in it
+/// (here a `Separator`) makes the grid remember a column width that is really just
+/// "however wide the window happened to be".
+///
+/// When `Resize` then measures the minimum content width in a sizing pass, that remembered
+/// width must not be reported as the minimum — otherwise the window can be widened but
+/// never shrunk again.
+#[test]
+fn window_with_grid_can_shrink_after_being_widened() {
+    let window_title = "grid_shrink_regression";
+    let mut harness = Harness::builder()
+        .with_size(Vec2::new(800.0, 600.0))
+        .build_ui(move |ui| {
+            Window::new(window_title)
+                .default_pos([20.0, 20.0])
+                .default_width(280.0)
+                .show(ui.ctx(), |ui| {
+                    egui::Grid::new("grid").num_columns(2).show(ui, |ui| {
+                        ui.label("Separator");
+                        ui.separator(); // Fills the available width
+                        ui.end_row();
+                    });
+                });
+        });
+    harness.run();
+
+    let drag_right_edge = |harness: &mut Harness<'_>, dx: f32| {
+        let rect = harness
+            .get_by_role_and_label(Role::Window, window_title)
+            .rect();
+        let grab = Pos2::new(rect.right(), rect.center().y);
+        harness.hover_at(grab);
+        harness.run();
+        harness.drag_at(grab);
+        harness.run();
+        harness.hover_at(grab + Vec2::new(dx, 0.0));
+        harness.run();
+        harness.drop_at(grab + Vec2::new(dx, 0.0));
+        harness.run();
+        harness
+            .get_by_role_and_label(Role::Window, window_title)
+            .rect()
+            .width()
+    };
+
+    let widened = drag_right_edge(&mut harness, 300.0);
+    let shrunk = drag_right_edge(&mut harness, -300.0);
+
+    assert!(
+        shrunk < widened - 200.0,
+        "window could not be shrunk again after being widened: \
+         widened to {widened}, then only shrunk to {shrunk}"
+    );
+}
+
 /// Ensure that the size passed to window is actually treated as outer size (including
 /// margins and borders).
 #[test]


### PR DESCRIPTION
## Related

* Fixes a regression from #8152
* Part of #2921

Reported symptom: you can widen the Widget Gallery window, but it won't shrink again.

I'm not sure this fix is the best one, but it does work.

# Claude says
## Cause

A `Grid` gives its **last** column all the available width, so a width-filling widget in it (`Separator`, `TextEdit`, `ProgressBar`, …) makes the `Grid` remember a `col_width` that is really just "however wide we happened to be".

At the start of a resize drag, `Resize` runs a one-frame sizing pass (#8152) to measure the minimum content width and clamps the drag against it. But `GridLayout::next_cell` inflated every cell to `prev_state.col_width`, so the `Grid` reported its previous width as its minimum — even though it was only offered `min_size.x`. The clamp is a lower bound, so widening kept working while shrinking was blocked at the widened width.

## Fix

During an enclosing sizing pass, don't inflate the stretchy last column to its remembered width, and don't store the measured (narrow) widths.

Minimal repro (fails before, passes after — added as a regression test):

```rust
Window::new("x").default_width(280.0).show(ctx, |ui| {
    egui::Grid::new("grid").num_columns(2).show(ui, |ui| {
        ui.label("Separator");
        ui.separator(); // fills the last column
        ui.end_row();
    });
});
```

`Panel` is unaffected — it clamps only against the user's `min_size`, with no content-min sizing pass.

* [x] I have followed the instructions in the PR template

🤖 Generated with [Claude Code](https://claude.com/claude-code)
