### PR TITLE
Fallback `window_title_frame` to `window_frame` when unspecified

### DIFF
--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -627,8 +627,8 @@ impl Window<'_> {
         let style = ctx.global_style();
 
         // We get or create the Frame for the title and content
-        let window_title_frame = title_frame.unwrap_or_else(|| Frame::window(&style));
         let window_frame = frame.unwrap_or_else(|| Frame::window(&style));
+        let window_title_frame = title_frame.unwrap_or_else(|| window_frame);
 
         // We apply the window margin by using the `ScrollArea::content_margin`.
         let window_content_margin = window_frame.inner_margin;

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -628,7 +628,7 @@ impl Window<'_> {
 
         // We get or create the Frame for the title and content
         let window_frame = frame.unwrap_or_else(|| Frame::window(&style));
-        let window_title_frame = title_frame.unwrap_or_else(|| window_frame);
+        let window_title_frame = title_frame.unwrap_or(window_frame);
 
         // We apply the window margin by using the `ScrollArea::content_margin`.
         let window_content_margin = window_frame.inner_margin;


### PR DESCRIPTION
### Summary
When `title_frame` is not explicitly set, fall back to `window_frame` instead of `Frame::window(&style)`.

### Motivation
If a custom `frame` is provided for a window, `window_title_frame` should maintain visual consistency with it by default unless a separate `title_frame` is specified.

* Related #8154 
* Related #8353 
