### PR TITLE
Fix documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ui.image(egui::include_image!("ferris.png"));
 
 ## Quick start
 
-There are simple examples in [the `examples/` folder](https://github.com/emilk/egui/blob/main/examples/). If you want to write a web app, then go to <https://github.com/emilk/eframe_template/> and follow the instructions. The official docs are at <https://docs.rs/egui>. For inspiration and more examples, check out the [the egui web demo](https://www.egui.rs/#demo) and follow the links in it to its source code.
+There are simple examples in [the `examples/` folder](https://github.com/emilk/egui/blob/main/examples/). If you want to write a web app, then go to <https://github.com/emilk/eframe_template/> and follow the instructions. The official docs are at <https://docs.rs/egui>. For inspiration and more examples, check out [the egui web demo](https://www.egui.rs/#demo) and follow the links in it to its source code.
 
 If you want to integrate egui into an existing engine, go to the [Integrations](#integrations) section.
 

--- a/crates/egui_extras/README.md
+++ b/crates/egui_extras/README.md
@@ -6,7 +6,7 @@
 ![MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Apache](https://img.shields.io/badge/license-Apache-blue.svg)
 
-This is a crate that adds some features on top top of [`egui`](https://github.com/emilk/egui). This crate is for experimental features, and features that require big dependencies that do not belong in `egui`.
+This is a crate that adds some features on top of [`egui`](https://github.com/emilk/egui). This crate is for experimental features, and features that require big dependencies that do not belong in `egui`.
 
 ## Images
 One thing `egui_extras` is commonly used for is to install image loaders for `egui`:


### PR DESCRIPTION
Two small documentation typos noticed while reading the docs:

- `crates/egui_extras/README.md`: "adds some features on top top of" -> "adds some features on top of"
- `README.md`: "check out the [the egui web demo]" -> "check out [the egui web demo]" (removes the duplicated "the"; link text and target unchanged)

Documentation only; no code changes.
