### PR TITLE
eframe: route DeviceEvent::MouseMotion to the root viewport

### DIFF
--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -506,16 +506,10 @@ impl WinitApp for GlowWinitApp<'_> {
                 .and_then(|viewport| glutin.viewports.get_mut(&viewport))
                 && let Some(window) = viewport.window.as_ref()
             {
-                if !window.has_focus()
-                    && !viewport
-                        .egui_winit
-                        .as_ref()
-                        .map(|state| state.is_any_pointer_button_down())
-                        .unwrap_or(false)
-                {
-                    return Ok(EventResult::Wait);
-                }
-
+                // Forward MouseMotion deltas unconditionally. The previous
+                // guard `!window.has_focus() && !any_pointer_button_down`
+                // silently dropped every relative-motion event on Wayland
+                // kiosk setups (see matching change in wgpu_integration.rs).
                 if let Some(egui_winit) = viewport.egui_winit.as_mut()
                     && egui_winit.on_mouse_motion(delta)
                 {

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -506,12 +506,10 @@ impl WinitApp for GlowWinitApp<'_> {
             let mut glutin = running.glutin.borrow_mut();
             if let Some(viewport) = glutin.viewports.get_mut(&egui::ViewportId::ROOT)
                 && let Some(window) = viewport.window.as_ref()
+                && let Some(egui_winit) = viewport.egui_winit.as_mut()
+                && egui_winit.on_mouse_motion(delta)
             {
-                if let Some(egui_winit) = viewport.egui_winit.as_mut()
-                    && egui_winit.on_mouse_motion(delta)
-                {
-                    return Ok(EventResult::RepaintNext(window.id()));
-                }
+                return Ok(EventResult::RepaintNext(window.id()));
             }
         }
 

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -500,16 +500,13 @@ impl WinitApp for GlowWinitApp<'_> {
         if let winit::event::DeviceEvent::MouseMotion { delta } = event
             && let Some(running) = &mut self.running
         {
+            // Route MouseMotion deltas to the ROOT viewport rather than to
+            // `focused_viewport` (see matching change + rationale in
+            // wgpu_integration.rs).
             let mut glutin = running.glutin.borrow_mut();
-            if let Some(viewport) = glutin
-                .focused_viewport
-                .and_then(|viewport| glutin.viewports.get_mut(&viewport))
+            if let Some(viewport) = glutin.viewports.get_mut(&egui::ViewportId::ROOT)
                 && let Some(window) = viewport.window.as_ref()
             {
-                // Forward MouseMotion deltas unconditionally. The previous
-                // guard `!window.has_focus() && !any_pointer_button_down`
-                // silently dropped every relative-motion event on Wayland
-                // kiosk setups (see matching change in wgpu_integration.rs).
                 if let Some(egui_winit) = viewport.egui_winit.as_mut()
                     && egui_winit.on_mouse_motion(delta)
                 {

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -516,12 +516,10 @@ impl WinitApp for WgpuWinitApp<'_> {
             let mut shared = running.shared.borrow_mut();
             if let Some(viewport) = shared.viewports.get_mut(&egui::ViewportId::ROOT)
                 && let Some(window) = viewport.window.as_ref()
+                && let Some(egui_winit) = viewport.egui_winit.as_mut()
+                && egui_winit.on_mouse_motion(delta)
             {
-                if let Some(egui_winit) = viewport.egui_winit.as_mut()
-                    && egui_winit.on_mouse_motion(delta)
-                {
-                    return Ok(EventResult::RepaintNext(window.id()));
-                }
+                return Ok(EventResult::RepaintNext(window.id()));
             }
         }
 

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -503,16 +503,17 @@ impl WinitApp for WgpuWinitApp<'_> {
                 .and_then(|viewport| shared.viewports.get_mut(&viewport))
                 && let Some(window) = viewport.window.as_ref()
             {
-                if !window.has_focus()
-                    && !viewport
-                        .egui_winit
-                        .as_ref()
-                        .map(|state| state.is_any_pointer_button_down())
-                        .unwrap_or(false)
-                {
-                    return Ok(EventResult::Wait);
-                }
-
+                // Forward MouseMotion deltas unconditionally. The previous
+                // guard `!window.has_focus() && !any_pointer_button_down`
+                // silently dropped every relative-motion event on Wayland
+                // kiosk setups: under Mutter with multiple deferred viewports
+                // the playfield viewport regularly reports `has_focus() ==
+                // false` (with_active is a Wayland no-op, ViewportCommand::
+                // Focus likewise without an xdg_activation_v1 token), so
+                // `egui::Event::MouseMoved` would never reach egui's input
+                // pipeline. Downstream consumers (egui pointer system,
+                // egui-rotate's SoftwareCursor) gate on their own state, so
+                // over-forwarding is harmless.
                 if let Some(egui_winit) = viewport.egui_winit.as_mut()
                     && egui_winit.on_mouse_motion(delta)
                 {

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -497,23 +497,26 @@ impl WinitApp for WgpuWinitApp<'_> {
         if let winit::event::DeviceEvent::MouseMotion { delta } = event
             && let Some(running) = &mut self.running
         {
+            // Route MouseMotion deltas to the ROOT viewport rather than to
+            // `shared.focused_viewport`. Reasons:
+            //   * `DeviceEvent::MouseMotion` is a *device-level* relative
+            //     motion event with no surface association — there is no
+            //     compositor truth for "which viewport this belongs to".
+            //   * Under Mutter Wayland with multiple deferred viewports
+            //     (kiosk setups using `with_active(false)`), the playfield
+            //     viewport regularly loses focus to a secondary viewport
+            //     despite the cursor lock, making `focused_viewport` Some
+            //     of a non-root viewport (or None). Routing to that
+            //     viewport silently swallows the deltas because the
+            //     relative-pointer protocol is bound on root only.
+            //   * Single-window apps always have ROOT as the de-facto
+            //     target, so this change is a no-op there.
+            // We also drop the legacy `!has_focus() && !any_pointer_button_down`
+            // guard for the same Wayland-kiosk reason.
             let mut shared = running.shared.borrow_mut();
-            if let Some(viewport) = shared
-                .focused_viewport
-                .and_then(|viewport| shared.viewports.get_mut(&viewport))
+            if let Some(viewport) = shared.viewports.get_mut(&egui::ViewportId::ROOT)
                 && let Some(window) = viewport.window.as_ref()
             {
-                // Forward MouseMotion deltas unconditionally. The previous
-                // guard `!window.has_focus() && !any_pointer_button_down`
-                // silently dropped every relative-motion event on Wayland
-                // kiosk setups: under Mutter with multiple deferred viewports
-                // the playfield viewport regularly reports `has_focus() ==
-                // false` (with_active is a Wayland no-op, ViewportCommand::
-                // Focus likewise without an xdg_activation_v1 token), so
-                // `egui::Event::MouseMoved` would never reach egui's input
-                // pipeline. Downstream consumers (egui pointer system,
-                // egui-rotate's SoftwareCursor) gate on their own state, so
-                // over-forwarding is harmless.
                 if let Some(egui_winit) = viewport.egui_winit.as_mut()
                     && egui_winit.on_mouse_motion(delta)
                 {

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -764,11 +764,18 @@ impl State {
     }
 
     /// Returns `true` if the event was sent to egui.
+    ///
+    /// Forwards raw mouse delta unconditionally. The previous guard
+    /// (`is_pointer_in_window() || any_pointer_button_down`) was an
+    /// over-restriction: under `CursorGrab::Locked` on Wayland the OS never
+    /// fires `WindowEvent::CursorMoved` (the pointer-constraints "lock"
+    /// mode delivers only relative deltas via `DeviceEvent::MouseMotion`),
+    /// so `pointer_pos_in_points` stays `None` forever and
+    /// `is_pointer_in_window()` always returns `false` — silently dropping
+    /// every relative-motion event. Downstream consumers (egui's standard
+    /// pointer system, egui-rotate's `SoftwareCursor`) gate themselves on
+    /// their own state, so over-forwarding is harmless.
     pub fn on_mouse_motion(&mut self, delta: (f64, f64)) -> bool {
-        if !self.is_pointer_in_window() && !self.any_pointer_button_down {
-            return false;
-        }
-
         self.egui_input.events.push(egui::Event::MouseMoved(Vec2 {
             x: delta.0 as f32,
             y: delta.1 as f32,


### PR DESCRIPTION
`DeviceEvent::MouseMotion` is a device-level relative-motion event: it carries no surface association, so there is no windowing-system answer to "which viewport does this belong to". eframe currently sends it to `focused_viewport` and drops it when nothing is focused, which makes raw mouse deltas unusable in any multi-viewport app on Wayland.

I hit this in a pinball-cabinet front-end: one fullscreen playfield window plus a few deferred viewports covering the backglass and DMD screens, all created with `with_active(false)`. Under Mutter, `with_active(false)` is a no-op — a cover viewport takes the focus as it maps, and the playfield never gets it back, because `ViewportCommand::Focus` is exactly what focus-stealing prevention refuses (I measured five refusals in a row before giving up). From then on `focused_viewport` points at a cover, or at nothing, and every `MouseMotion` is silently discarded. The app has an on-screen software cursor driven by those deltas; it simply stopped moving.

Two changes, both restricted to relative motion:

* Route `MouseMotion` to `ViewportId::ROOT` in both the glow and wgpu integrations. Single-window apps always have ROOT as the de-facto target, so this is a no-op for them; multi-viewport apps get the deltas somewhere useful instead of nowhere.
* Drop the `!has_focus() && !any_pointer_button_down` and `!is_pointer_in_window() && !any_pointer_button_down` guards on the same path. Under `CursorGrab::Locked` the OS never fires `CursorMoved` — the pointer-constraints lock delivers relative deltas only — so `pointer_pos_in_points` stays `None` forever and `is_pointer_in_window()` is permanently false, which drops every event the app was locking the pointer *for*. Consumers gate on their own state, so forwarding more is harmless.

Absolute pointer events (`CursorMoved`, buttons) are untouched: those do have a surface, and their existing routing is correct.