### PR TITLE
eframe: use the activation token from the environment on window creation

### DIFF
--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -2135,6 +2135,37 @@ pub fn create_winit_window_attributes(
         window_attributes = window_attributes.with_name(app_id, "");
     }
 
+    // Consume the activation token our launcher handed us, so the first
+    // window actually gets the focus.
+    //
+    // A desktop entry with `StartupNotify=true` passes a token through
+    // `XDG_ACTIVATION_TOKEN` (Wayland) or `DESKTOP_STARTUP_ID` (X11), and
+    // winit can only apply it at window creation. eframe never read it, so
+    // under a compositor that enforces focus-stealing prevention the window
+    // opened unfocused and stayed that way: `ViewportCommand::Focus` is
+    // exactly the request such a compositor refuses, so nothing could
+    // recover it and the user had to click the window themselves.
+    //
+    // The variables are cleared once read, per the startup-notification
+    // spec: a token is single-use, and leaving it in the environment would
+    // have every later window — and every child process — replay it.
+    #[cfg(all(target_os = "linux", any(feature = "wayland", feature = "x11")))]
+    {
+        use winit::platform::startup_notify::{
+            WindowAttributesExtStartupNotify as _, reset_activation_token_env,
+        };
+        let token = std::env::var("XDG_ACTIVATION_TOKEN")
+            .or_else(|_| std::env::var("DESKTOP_STARTUP_ID"))
+            .ok()
+            .filter(|t| !t.is_empty());
+        if let Some(token) = token {
+            log::debug!("using the activation token from the environment to focus the window");
+            reset_activation_token_env();
+            window_attributes = window_attributes
+                .with_activation_token(winit::window::ActivationToken::from_raw(token));
+        }
+    }
+
     #[cfg(all(feature = "x11", target_os = "linux"))]
     {
         use winit::platform::x11::WindowAttributesExtX11 as _;


### PR DESCRIPTION
- related #8282 
- part of https://github.com/emilk/egui/issues/8142

A desktop entry with `StartupNotify=true` hands the launched process an activation token through `XDG_ACTIVATION_TOKEN` (Wayland) or `DESKTOP_STARTUP_ID` (X11). winit can apply one, but only at window creation, via `WindowAttributesExtStartupNotify::with_activation_token`. eframe never reads it, so the token our launcher went to the trouble of issuing is thrown away.

winit's own docs are blunt about the consequence:

> The `ActivationToken` is essential to ensure that your newly created window will obtain the focus, otherwise the user could be required to click on the window.

That is what I ran into: under Mutter the window opens unfocused and cannot recover, since `ViewportCommand::Focus` is precisely the request focus-stealing prevention blocks. On a kiosk-style setup the cost goes past a missing title-bar highlight — a compositor only grants a pointer constraint to a focused surface, so `CursorGrab` silently does nothing too.

This reads the variable when building the window attributes and passes it to winit. The environment is cleared afterwards through winit's `reset_activation_token_env()`, per the startup-notification spec: a token is single-use, and leaving it around would have every later viewport, and every child process, replay it.

Linux only, behind the existing `wayland`/`x11` features; a no-op when the variables are absent.