### PR TITLE
Give every viewport an AccessKit adapter, not just the root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.36.1 - 2026-08-07
+* Fix `Sense::drag` detecting drags when clicking widget above it [#8396](https://github.com/emilk/egui/pull/8396) by [@lucasmerlin](https://github.com/lucasmerlin)
+
+
 ## 0.36.0 - 2026-08-05
 
 ### Highlights ✨

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,7 +1243,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "ecolor"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "bytemuck",
  "cint",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "egui_demo_app"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "egui_demo_lib"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "criterion",
  "document-features",
@@ -1403,7 +1403,7 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "ahash",
  "document-features",
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "egui_inspection"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "document-features",
  "egui",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "egui_kittest"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "dify",
  "document-features",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "egui_tests"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "egui",
  "egui_extras",
@@ -1503,7 +1503,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "emath"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.36.0"
+version = "0.36.1"
 
 [[package]]
 name = "equivalent"
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "popups"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "eframe",
  "env_logger",
@@ -5903,7 +5903,7 @@ checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "xtask"
-version = "0.36.0"
+version = "0.36.1"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.95"
-version = "0.36.0"
+version = "0.36.1"
 
 
 [profile.release]
@@ -56,19 +56,19 @@ opt-level = 2
 
 
 [workspace.dependencies]
-emath = { version = "0.36.0", path = "crates/emath", default-features = false }
-ecolor = { version = "0.36.0", path = "crates/ecolor", default-features = false }
-epaint = { version = "0.36.0", path = "crates/epaint", default-features = false }
-epaint_default_fonts = { version = "0.36.0", path = "crates/epaint_default_fonts" }
-egui = { version = "0.36.0", path = "crates/egui", default-features = false }
-egui-winit = { version = "0.36.0", path = "crates/egui-winit", default-features = false }
-egui_extras = { version = "0.36.0", path = "crates/egui_extras", default-features = false }
-egui-wgpu = { version = "0.36.0", path = "crates/egui-wgpu", default-features = false }
-egui_demo_lib = { version = "0.36.0", path = "crates/egui_demo_lib", default-features = false }
-egui_glow = { version = "0.36.0", path = "crates/egui_glow", default-features = false }
-egui_inspection = { version = "0.36.0", path = "crates/egui_inspection", default-features = false }
-egui_kittest = { version = "0.36.0", path = "crates/egui_kittest", default-features = false }
-eframe = { version = "0.36.0", path = "crates/eframe", default-features = false }
+emath = { version = "0.36.1", path = "crates/emath", default-features = false }
+ecolor = { version = "0.36.1", path = "crates/ecolor", default-features = false }
+epaint = { version = "0.36.1", path = "crates/epaint", default-features = false }
+epaint_default_fonts = { version = "0.36.1", path = "crates/epaint_default_fonts" }
+egui = { version = "0.36.1", path = "crates/egui", default-features = false }
+egui-winit = { version = "0.36.1", path = "crates/egui-winit", default-features = false }
+egui_extras = { version = "0.36.1", path = "crates/egui_extras", default-features = false }
+egui-wgpu = { version = "0.36.1", path = "crates/egui-wgpu", default-features = false }
+egui_demo_lib = { version = "0.36.1", path = "crates/egui_demo_lib", default-features = false }
+egui_glow = { version = "0.36.1", path = "crates/egui_glow", default-features = false }
+egui_inspection = { version = "0.36.1", path = "crates/egui_inspection", default-features = false }
+egui_kittest = { version = "0.36.1", path = "crates/egui_kittest", default-features = false }
+eframe = { version = "0.36.1", path = "crates/eframe", default-features = false }
 
 accesskit = "0.24.1"
 accesskit_consumer = "0.35.0" # Can't update to 0.36+: kittest 0.4 pins accesskit_consumer 0.35, so bumping splits it into two versions

--- a/crates/ecolor/CHANGELOG.md
+++ b/crates/ecolor/CHANGELOG.md
@@ -6,6 +6,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.36.1 - 2026-08-07
+Nothing new
+
+
 ## 0.36.0 - 2026-08-05
 Nothing new
 

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -7,6 +7,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.36.1 - 2026-08-07
+Nothing new
+
+
 ## 0.36.0 - 2026-08-05
 ### 🔧 Changed
 * Improve robustness of text input handling for `eframe/web` [#8045](https://github.com/emilk/egui/pull/8045) by [@umajho](https://github.com/umajho)

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -115,6 +115,13 @@ struct GlutinWindowContext {
     window_from_viewport: OrderedViewportIdMap<WindowId>,
 
     focused_viewport: Option<ViewportId>,
+
+    /// Handed to the AccessKit adapter of every viewport that gets a window,
+    /// so assistive technology reaches the child windows too and not only the
+    /// root. Filled in after construction: the root's window is created
+    /// inside `new`, before the caller can hand us anything.
+    #[cfg(feature = "accesskit")]
+    accesskit_proxy: Option<EventLoopProxy<UserEvent>>,
 }
 
 struct Viewport {
@@ -316,6 +323,10 @@ impl<'app> GlowWinitApp<'app> {
 
         #[cfg(feature = "accesskit")]
         {
+            // The root's window already exists, so its adapter is created
+            // here; every viewport created from now on picks the proxy up in
+            // `initialize_window`.
+            glutin.accesskit_proxy = Some(self.repaint_proxy.lock().clone());
             let event_loop_proxy = self.repaint_proxy.lock().clone();
             let viewport = glutin.viewports.get_mut(&ViewportId::ROOT).unwrap(); // we always have a root
             if let Viewport {
@@ -323,6 +334,7 @@ impl<'app> GlowWinitApp<'app> {
                 egui_winit: Some(egui_winit),
                 ..
             } = viewport
+                && egui_winit.accesskit.is_none()
             {
                 egui_winit.init_accesskit(event_loop, window, event_loop_proxy);
             }
@@ -1221,6 +1233,8 @@ impl GlutinWindowContext {
             max_texture_side: None,
             window_from_viewport,
             focused_viewport: Some(ViewportId::ROOT),
+            #[cfg(feature = "accesskit")]
+            accesskit_proxy: None,
         };
 
         slf.initialize_window(ViewportId::ROOT, event_loop)?;
@@ -1252,19 +1266,37 @@ impl GlutinWindowContext {
     ) -> Result {
         profiling::function_scope!();
 
+        // Cloned before the viewport is borrowed: the adapter is created
+        // below, while `self` is tied up by that borrow.
+        #[cfg(feature = "accesskit")]
+        let accesskit_proxy = self.accesskit_proxy.clone();
+
         let viewport = self
             .viewports
             .get_mut(&viewport_id)
             .expect("viewport doesn't exist");
 
+        // AccessKit's winit adapter refuses to attach to a window that has
+        // already been shown, and the root is the only one we hold back (it
+        // starts hidden to avoid the white flash of #2279). Hold the others
+        // back too, just until the adapter is in place.
+        #[cfg(feature = "accesskit")]
+        let mut reveal_after_accesskit = false;
+
         let window = if let Some(window) = &mut viewport.window {
             window
         } else {
             log::debug!("Creating a window for viewport {viewport_id:?}");
-            let window_attributes = egui_winit::create_winit_window_attributes(
+            #[cfg_attr(not(feature = "accesskit"), expect(unused_mut))]
+            let mut window_attributes = egui_winit::create_winit_window_attributes(
                 &self.egui_ctx,
                 viewport.builder.clone(),
             );
+            #[cfg(feature = "accesskit")]
+            if accesskit_proxy.is_some() && window_attributes.visible {
+                reveal_after_accesskit = true;
+                window_attributes = window_attributes.with_visible(false);
+            }
             if window_attributes.transparent()
                 && self.gl_config.supports_transparency() == Some(false)
             {
@@ -1293,6 +1325,20 @@ impl GlutinWindowContext {
                 self.max_texture_side,
             )
         });
+
+        // Every viewport with a window gets an adapter, not just the root: a
+        // deferred child viewport is a real window, and assistive technology
+        // sees nothing inside one without it.
+        #[cfg(feature = "accesskit")]
+        if let Some(proxy) = accesskit_proxy
+            && let Some(egui_winit) = viewport.egui_winit.as_mut()
+            && egui_winit.accesskit.is_none()
+        {
+            egui_winit.init_accesskit(event_loop, window, proxy);
+            if reveal_after_accesskit {
+                window.set_visible(true);
+            }
+        }
 
         if viewport.gl_surface.is_none() {
             log::debug!("Creating a gl_surface for viewport {viewport_id:?}");

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -89,6 +89,12 @@ pub struct SharedState {
     viewport_from_window: HashMap<WindowId, ViewportId>,
     focused_viewport: Option<ViewportId>,
     resized_viewport: Option<ViewportId>,
+
+    /// Handed to the AccessKit adapter of every viewport that gets a window,
+    /// so assistive technology reaches the child windows too and not only the
+    /// root.
+    #[cfg(feature = "accesskit")]
+    accesskit_proxy: Option<EventLoopProxy<UserEvent>>,
 }
 
 pub type Viewports = egui::OrderedViewportIdMap<Viewport>;
@@ -156,6 +162,9 @@ impl<'app> WgpuWinitApp<'app> {
             return;
         };
         let mut shared = running.shared.borrow_mut();
+        // Cloned before the destructure below borrows the rest of the state.
+        #[cfg(feature = "accesskit")]
+        let accesskit_proxy = shared.accesskit_proxy.clone();
         let SharedState {
             viewports,
             painter,
@@ -169,19 +178,24 @@ impl<'app> WgpuWinitApp<'app> {
                 &running.integration.egui_ctx,
                 viewport_from_window,
                 painter,
+                #[cfg(feature = "accesskit")]
+                accesskit_proxy.as_ref(),
             );
         }
     }
 
     #[cfg(target_os = "android")]
     fn recreate_window(&self, event_loop: &ActiveEventLoop, running: &WgpuWinitRunning<'app>) {
+        let mut shared = running.shared.borrow_mut();
+        #[cfg(feature = "accesskit")]
+        let accesskit_proxy = shared.accesskit_proxy.clone();
         let SharedState {
             egui_ctx,
             viewports,
             viewport_from_window,
             painter,
             ..
-        } = &mut *running.shared.borrow_mut();
+        } = &mut *shared;
 
         initialize_or_update_viewport(
             viewports,
@@ -191,7 +205,14 @@ impl<'app> WgpuWinitApp<'app> {
             None,
             painter,
         )
-        .initialize_window(event_loop, egui_ctx, viewport_from_window, painter);
+        .initialize_window(
+            event_loop,
+            egui_ctx,
+            viewport_from_window,
+            painter,
+            #[cfg(feature = "accesskit")]
+            accesskit_proxy.as_ref(),
+        );
     }
 
     #[cfg(target_os = "android")]
@@ -359,6 +380,11 @@ impl<'app> WgpuWinitApp<'app> {
             painter,
             focused_viewport: Some(ViewportId::ROOT),
             resized_viewport: None,
+            // The root's adapter was created above, where its window is;
+            // every viewport created from now on picks this up in
+            // `initialize_window`.
+            #[cfg(feature = "accesskit")]
+            accesskit_proxy: Some(self.repaint_proxy.lock().clone()),
         }));
 
         {
@@ -1054,6 +1080,7 @@ impl Viewport {
         egui_ctx: &egui::Context,
         windows_id: &mut HashMap<WindowId, ViewportId>,
         painter: &mut egui_wgpu::winit::Painter,
+        #[cfg(feature = "accesskit")] accesskit_proxy: Option<&EventLoopProxy<UserEvent>>,
     ) {
         if self.window.is_some() {
             return; // we already have one
@@ -1063,7 +1090,20 @@ impl Viewport {
 
         let viewport_id = self.ids.this;
 
-        match egui_winit::create_window(egui_ctx, event_loop, &self.builder) {
+        // AccessKit's winit adapter refuses to attach to a window that has
+        // already been shown, and the root is the only one eframe already
+        // holds back (it starts hidden to avoid the white flash of #2279).
+        // Hold the others back too, just until the adapter is in place.
+        #[cfg_attr(not(feature = "accesskit"), expect(unused_mut))]
+        let mut builder = self.builder.clone();
+        #[cfg(feature = "accesskit")]
+        let reveal_after_accesskit =
+            accesskit_proxy.is_some() && builder.visible.unwrap_or(true) && {
+                builder = builder.with_visible(false);
+                true
+            };
+
+        match egui_winit::create_window(egui_ctx, event_loop, &builder) {
             Ok(window) => {
                 windows_id.insert(window.id(), viewport_id);
 
@@ -1075,14 +1115,28 @@ impl Viewport {
                     log::error!("on set_window: viewport_id {viewport_id:?} {err}");
                 }
 
-                self.egui_winit = Some(egui_winit::State::new(
+                #[cfg_attr(not(feature = "accesskit"), expect(unused_mut))]
+                let mut egui_winit = egui_winit::State::new(
                     egui_ctx.clone(),
                     viewport_id,
                     event_loop,
                     Some(window.scale_factor() as f32),
                     event_loop.system_theme(),
                     painter.max_texture_side(),
-                ));
+                );
+
+                // Every viewport with a window gets an adapter, not just the
+                // root: a deferred child viewport is a real window, and
+                // assistive technology sees nothing inside one without it.
+                #[cfg(feature = "accesskit")]
+                if let Some(proxy) = accesskit_proxy {
+                    egui_winit.init_accesskit(event_loop, &window, proxy.clone());
+                    if reveal_after_accesskit {
+                        window.set_visible(true);
+                    }
+                }
+
+                self.egui_winit = Some(egui_winit);
 
                 egui_winit::update_viewport_info(&mut self.info, egui_ctx, &window, true);
                 self.window = Some(window);
@@ -1149,13 +1203,16 @@ fn render_immediate_viewport(
     } = immediate_viewport;
 
     let input = {
+        let mut shared = shared.borrow_mut();
+        #[cfg(feature = "accesskit")]
+        let accesskit_proxy = shared.accesskit_proxy.clone();
         let SharedState {
             egui_ctx,
             viewports,
             painter,
             viewport_from_window,
             ..
-        } = &mut *shared.borrow_mut();
+        } = &mut *shared;
 
         let viewport = initialize_or_update_viewport(
             viewports,
@@ -1167,7 +1224,14 @@ fn render_immediate_viewport(
         );
         if viewport.window.is_none() {
             event_loop_context::with_current_event_loop(|event_loop| {
-                viewport.initialize_window(event_loop, egui_ctx, viewport_from_window, painter);
+                viewport.initialize_window(
+                    event_loop,
+                    egui_ctx,
+                    viewport_from_window,
+                    painter,
+                    #[cfg(feature = "accesskit")]
+                    accesskit_proxy.as_ref(),
+                );
             });
         }
 

--- a/crates/egui-wgpu/CHANGELOG.md
+++ b/crates/egui-wgpu/CHANGELOG.md
@@ -6,6 +6,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.36.1 - 2026-08-07
+Nothing new
+
+
 ## 0.36.0 - 2026-08-05
 * Upgrade wgpu to v30 [#8289](https://github.com/emilk/egui/pull/8289) by [@akx](https://github.com/akx)
 * Fix: ensure mapped range is dropped before unmapping buffer in capture [#8337](https://github.com/emilk/egui/pull/8337) by [@MagicCrazyMan](https://github.com/MagicCrazyMan)

--- a/crates/egui-winit/CHANGELOG.md
+++ b/crates/egui-winit/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.36.1 - 2026-08-07
+Nothing new
+
+
 ## 0.36.0 - 2026-08-05
 Nothing new
 

--- a/crates/egui/src/interaction.rs
+++ b/crates/egui/src/interaction.rs
@@ -198,17 +198,22 @@ pub(crate) fn interact(
                 // When the mouse first is pressed, it could be either,
                 // so we postpone the decision until we know.
                 //
-                // …unless a click is no longer possible at all: a click has to be
-                // released on the widget, and `hits.click` tells us whether the
-                // pointer is still somewhere a release would land on this widget.
-                // Note that this is not the same as being inside `interact_rect`:
-                // the hit-test also picks up widgets within `interact_radius`, and
-                // lets a widget on top take the hit.
+                // …unless the pointer has left the widget: a click has to be
+                // released on the widget, so once the pointer is outside there is
+                // nothing left to wait for.
                 //
                 // Deciding here means a thin drag handle (narrower than
                 // `max_click_dist`) doesn't spend the decision window as neither
                 // hovered nor dragged, which would make its highlight blink out.
-                let could_still_be_clicked = hits.click.is_some_and(|hit| hit.id == widget.id);
+                // The hit-test picks up widgets within `interact_radius`, so
+                // `hits.click` can name such a handle even when the pointer is a
+                // few points outside it.
+                //
+                // A widget on top might "steal" the click hit, but then the pointer is still inside
+                // us, and pressing that button must not start a drag. So we check both.
+                let pointer_is_inside = hits.contains_pointer.iter().any(|w| w.id == widget.id);
+                let could_still_be_clicked =
+                    pointer_is_inside || hits.click.is_some_and(|hit| hit.id == widget.id);
                 input.pointer.is_decidedly_dragging() || !could_still_be_clicked
             } else {
                 // This widget is just sensitive to drags, so we can mark it as dragged right away:

--- a/crates/egui_extras/CHANGELOG.md
+++ b/crates/egui_extras/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.36.1 - 2026-08-07
+Nothing new
+
+
 ## 0.36.0 - 2026-08-05
 Nothing new
 

--- a/crates/egui_glow/CHANGELOG.md
+++ b/crates/egui_glow/CHANGELOG.md
@@ -6,6 +6,10 @@ Changes since the last release can be found at <https://github.com/emilk/egui/co
 
 
 
+## 0.36.1 - 2026-08-07
+Nothing new
+
+
 ## 0.36.0 - 2026-08-05
 Nothing new
 

--- a/crates/egui_inspection/CHANGELOG.md
+++ b/crates/egui_inspection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the `egui_inspection` crate will be noted in this file.
 This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
+## 0.36.1 - 2026-08-07
+Nothing new
+
+
 ## 0.36.0 - 2026-08-05
 * Add `egui_inspection::Request::Settle` [#8344](https://github.com/emilk/egui/pull/8344) by [@lucasmerlin](https://github.com/lucasmerlin)
 

--- a/crates/egui_kittest/CHANGELOG.md
+++ b/crates/egui_kittest/CHANGELOG.md
@@ -6,6 +6,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.36.1 - 2026-08-07
+Nothing new
+
+
 ## 0.36.0 - 2026-08-05
 * Handle `ViewportCommand::InnerSize` in `egui_kittest` [#8350](https://github.com/emilk/egui/pull/8350) by [@lucasmerlin](https://github.com/lucasmerlin)
 * Report failing pixels by threshold when a kittest snapshot fails [#8360](https://github.com/emilk/egui/pull/8360) by [@emilk](https://github.com/emilk)

--- a/crates/emath/CHANGELOG.md
+++ b/crates/emath/CHANGELOG.md
@@ -6,6 +6,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.36.1 - 2026-08-07
+Nothing new
+
+
 ## 0.36.0 - 2026-08-05
 Nothing new
 

--- a/crates/epaint/CHANGELOG.md
+++ b/crates/epaint/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.36.1 - 2026-08-07
+Nothing new
+
+
 ## 0.36.0 - 2026-08-05
 * Add `LayoutJob::clear` [#8376](https://github.com/emilk/egui/pull/8376) by [@emilk](https://github.com/emilk)
 * Add `extra_text_line_spacing` to control vertical spacing between text lines [#8040](https://github.com/emilk/egui/pull/8040) by [@rustbasic](https://github.com/rustbasic)

--- a/crates/epaint_default_fonts/CHANGELOG.md
+++ b/crates/epaint_default_fonts/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.36.1 - 2026-08-07
+Nothing new
+
+
 ## 0.36.0 - 2026-08-05
 Nothing new
 

--- a/tests/egui_tests/tests/test_click_or_drag.rs
+++ b/tests/egui_tests/tests/test_click_or_drag.rs
@@ -185,3 +185,50 @@ fn click_inside_a_widget_still_clicks() {
         "press and release without moving should be a click"
     );
 }
+
+/// A button inside a draggable row takes the click hit, because it is on top.
+/// The pointer is still inside the row though, so the press must stay undecided —
+/// otherwise the row starts dragging the moment the user touches the button.
+#[test]
+fn press_on_a_button_inside_a_draggable_row_stays_undecided() {
+    let button_id = Id::new("button");
+    let button_size = Vec2::new(50.0, 20.0);
+
+    let mut harness = Harness::builder()
+        .with_step_dt(1.0 / 60.0)
+        .with_size(Vec2::new(300.0, 200.0))
+        .build_ui(move |ui| {
+            let row_rect = ui.max_rect();
+            ui.interact(row_rect, widget_id(), Sense::click_and_drag());
+
+            // Allocated after the row, so it ends up _on top_ of it.
+            let button_rect = Rect::from_min_size(row_rect.min, button_size);
+            ui.interact(button_rect, button_id, Sense::click());
+        });
+    harness.step();
+
+    let grab = Rect::from_min_size(widget_rect(&harness).min, button_size).center();
+    press_at(&mut harness, grab);
+
+    let (_hovered, dragged) = widget_state(&harness);
+    assert!(
+        !dragged,
+        "pressing a button inside the row must not start dragging the row"
+    );
+
+    harness.event(egui::Event::PointerButton {
+        pos: grab,
+        button: egui::PointerButton::Primary,
+        pressed: false,
+        modifiers: egui::Modifiers::NONE,
+    });
+    harness.step();
+
+    assert!(
+        harness
+            .ctx
+            .read_response(button_id)
+            .is_some_and(|r| r.clicked()),
+        "the button should have been clicked"
+    );
+}


### PR DESCRIPTION
`init_accesskit` is only ever called for `ViewportId::ROOT`. An application whose real windows are deferred child viewports therefore exposes nothing to assistive technology inside them: a screen reader or a UI automation client sees a window with no contents.

I hit this in a Windows tray application, where the root viewport is a 1×1 invisible window and every real window is a deferred child viewport.

| measured with a UI Automation client (Windows, glow) | descendants in the UIA tree |
|---|---|
| widgets in a deferred child viewport, before | **0** |
| the same widgets in a root viewport | 9 |

## What the change does

`initialize_window` now creates an adapter for any viewport that gets a window.

Two details that are not obvious from the diff:

- **The context has to hold an `EventLoopProxy`.** `ActiveEventLoop` cannot make one and the adapter needs it, so it is stored and filled in after construction — the root's window is created inside `new`, before a caller can hand one over.
- **Windows other than the root are held back until the adapter is attached.** `accesskit_winit` panics if the adapter is created after the window has been shown, and the root is the only window eframe already creates hidden (the white-flash fix of #2279). They are revealed as soon as the adapter is in place.

## The wgpu half is not verified at runtime

The measurement above is glow. I have no wgpu application with deferred child viewports to point a UI automation client at, so **the second commit is compile-checked only**: `--features wgpu,accesskit`, `--features wgpu` alone, and `clippy --all-features`. It is the same shape as the glow change, with one difference — the wgpu path creates its window through `egui_winit::create_window`, which also resolves the target monitor, so the "start hidden" flag is set on the `ViewportBuilder` rather than on the `WindowAttributes` it produces.

I would rather send it unverified than keep it out of tree. This has been carried as a patch for two releases of my own project, and the alternative to sending it is carrying it for two more.

**If you would prefer the glow commit only, it stands alone** — the two commits are independent, and dropping the second one leaves a working PR.

## Checks

`cargo fmt --all --check`, `cargo clippy -p eframe --all-targets --all-features -- -D warnings`, `cargo doc -p eframe --lib --all-features` (all with `-D warnings`), and `cargo check -p eframe --no-default-features` for `glow`, `wgpu` and `glow,wgpu`, each with and without `accesskit`.

I could not run `./scripts/check.sh` in full on Windows — the wasm targets, the macOS-rendered snapshots and `typos` are not available here — which is why this is a draft.
