### PR TITLE
Give every viewport an AccessKit adapter, not just the root

### DIFF
--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -116,6 +116,13 @@ struct GlutinWindowContext {
     window_from_viewport: OrderedViewportIdMap<WindowId>,
 
     focused_viewport: Option<ViewportId>,
+
+    /// Handed to the AccessKit adapter of every viewport that gets a window,
+    /// so assistive technology reaches the child windows too and not only the
+    /// root. Filled in after construction: the root's window is created
+    /// inside `new`, before the caller can hand us anything.
+    #[cfg(feature = "accesskit")]
+    accesskit_proxy: Option<EventLoopProxy<UserEvent>>,
 }
 
 struct Viewport {
@@ -317,6 +324,10 @@ impl<'app> GlowWinitApp<'app> {
 
         #[cfg(feature = "accesskit")]
         {
+            // The root's window already exists, so its adapter is created
+            // here; every viewport created from now on picks the proxy up in
+            // `initialize_window`.
+            glutin.accesskit_proxy = Some(self.repaint_proxy.lock().clone());
             let event_loop_proxy = self.repaint_proxy.lock().clone();
             let viewport = glutin.viewports.get_mut(&ViewportId::ROOT).unwrap(); // we always have a root
             if let Viewport {
@@ -324,6 +335,7 @@ impl<'app> GlowWinitApp<'app> {
                 egui_winit: Some(egui_winit),
                 ..
             } = viewport
+                && egui_winit.accesskit.is_none()
             {
                 egui_winit.init_accesskit(event_loop, window, event_loop_proxy);
             }
@@ -1222,6 +1234,8 @@ impl GlutinWindowContext {
             max_texture_side: None,
             window_from_viewport,
             focused_viewport: Some(ViewportId::ROOT),
+            #[cfg(feature = "accesskit")]
+            accesskit_proxy: None,
         };
 
         slf.initialize_window(ViewportId::ROOT, event_loop)?;
@@ -1253,19 +1267,37 @@ impl GlutinWindowContext {
     ) -> Result {
         profiling::function_scope!();
 
+        // Cloned before the viewport is borrowed: the adapter is created
+        // below, while `self` is tied up by that borrow.
+        #[cfg(feature = "accesskit")]
+        let accesskit_proxy = self.accesskit_proxy.clone();
+
         let viewport = self
             .viewports
             .get_mut(&viewport_id)
             .expect("viewport doesn't exist");
 
+        // AccessKit's winit adapter refuses to attach to a window that has
+        // already been shown, and the root is the only one we hold back (it
+        // starts hidden to avoid the white flash of #2279). Hold the others
+        // back too, just until the adapter is in place.
+        #[cfg(feature = "accesskit")]
+        let mut reveal_after_accesskit = false;
+
         let window = if let Some(window) = &mut viewport.window {
             window
         } else {
             log::debug!("Creating a window for viewport {viewport_id:?}");
-            let window_attributes = egui_winit::create_winit_window_attributes(
+            #[cfg_attr(not(feature = "accesskit"), expect(unused_mut))]
+            let mut window_attributes = egui_winit::create_winit_window_attributes(
                 &self.egui_ctx,
                 viewport.builder.clone(),
             );
+            #[cfg(feature = "accesskit")]
+            if accesskit_proxy.is_some() && window_attributes.visible {
+                reveal_after_accesskit = true;
+                window_attributes = window_attributes.with_visible(false);
+            }
             if window_attributes.transparent()
                 && self.gl_config.supports_transparency() == Some(false)
             {
@@ -1294,6 +1326,20 @@ impl GlutinWindowContext {
                 self.max_texture_side,
             )
         });
+
+        // Every viewport with a window gets an adapter, not just the root: a
+        // deferred child viewport is a real window, and assistive technology
+        // sees nothing inside one without it.
+        #[cfg(feature = "accesskit")]
+        if let Some(proxy) = accesskit_proxy
+            && let Some(egui_winit) = viewport.egui_winit.as_mut()
+            && egui_winit.accesskit.is_none()
+        {
+            egui_winit.init_accesskit(event_loop, window, proxy);
+            if reveal_after_accesskit {
+                window.set_visible(true);
+            }
+        }
 
         if viewport.gl_surface.is_none() {
             log::debug!("Creating a gl_surface for viewport {viewport_id:?}");

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -90,6 +90,12 @@ pub struct SharedState {
     viewport_from_window: HashMap<WindowId, ViewportId>,
     focused_viewport: Option<ViewportId>,
     resized_viewport: Option<ViewportId>,
+
+    /// Handed to the AccessKit adapter of every viewport that gets a window,
+    /// so assistive technology reaches the child windows too and not only the
+    /// root.
+    #[cfg(feature = "accesskit")]
+    accesskit_proxy: Option<EventLoopProxy<UserEvent>>,
 }
 
 pub type Viewports = egui::OrderedViewportIdMap<Viewport>;
@@ -157,6 +163,9 @@ impl<'app> WgpuWinitApp<'app> {
             return;
         };
         let mut shared = running.shared.borrow_mut();
+        // Cloned before the destructure below borrows the rest of the state.
+        #[cfg(feature = "accesskit")]
+        let accesskit_proxy = shared.accesskit_proxy.clone();
         let SharedState {
             viewports,
             painter,
@@ -170,19 +179,24 @@ impl<'app> WgpuWinitApp<'app> {
                 &running.integration.egui_ctx,
                 viewport_from_window,
                 painter,
+                #[cfg(feature = "accesskit")]
+                accesskit_proxy.as_ref(),
             );
         }
     }
 
     #[cfg(target_os = "android")]
     fn recreate_window(&self, event_loop: &ActiveEventLoop, running: &WgpuWinitRunning<'app>) {
+        let mut shared = running.shared.borrow_mut();
+        #[cfg(feature = "accesskit")]
+        let accesskit_proxy = shared.accesskit_proxy.clone();
         let SharedState {
             egui_ctx,
             viewports,
             viewport_from_window,
             painter,
             ..
-        } = &mut *running.shared.borrow_mut();
+        } = &mut *shared;
 
         initialize_or_update_viewport(
             viewports,
@@ -192,7 +206,14 @@ impl<'app> WgpuWinitApp<'app> {
             None,
             painter,
         )
-        .initialize_window(event_loop, egui_ctx, viewport_from_window, painter);
+        .initialize_window(
+            event_loop,
+            egui_ctx,
+            viewport_from_window,
+            painter,
+            #[cfg(feature = "accesskit")]
+            accesskit_proxy.as_ref(),
+        );
     }
 
     #[cfg(target_os = "android")]
@@ -360,6 +381,11 @@ impl<'app> WgpuWinitApp<'app> {
             painter,
             focused_viewport: Some(ViewportId::ROOT),
             resized_viewport: None,
+            // The root's adapter was created above, where its window is;
+            // every viewport created from now on picks this up in
+            // `initialize_window`.
+            #[cfg(feature = "accesskit")]
+            accesskit_proxy: Some(self.repaint_proxy.lock().clone()),
         }));
 
         {
@@ -1055,6 +1081,7 @@ impl Viewport {
         egui_ctx: &egui::Context,
         windows_id: &mut HashMap<WindowId, ViewportId>,
         painter: &mut egui_wgpu::winit::Painter,
+        #[cfg(feature = "accesskit")] accesskit_proxy: Option<&EventLoopProxy<UserEvent>>,
     ) {
         if self.window.is_some() {
             return; // we already have one
@@ -1064,7 +1091,20 @@ impl Viewport {
 
         let viewport_id = self.ids.this;
 
-        match egui_winit::create_window(egui_ctx, event_loop, &self.builder) {
+        // AccessKit's winit adapter refuses to attach to a window that has
+        // already been shown, and the root is the only one eframe already
+        // holds back (it starts hidden to avoid the white flash of #2279).
+        // Hold the others back too, just until the adapter is in place.
+        #[cfg_attr(not(feature = "accesskit"), expect(unused_mut))]
+        let mut builder = self.builder.clone();
+        #[cfg(feature = "accesskit")]
+        let reveal_after_accesskit =
+            accesskit_proxy.is_some() && builder.visible.unwrap_or(true) && {
+                builder = builder.with_visible(false);
+                true
+            };
+
+        match egui_winit::create_window(egui_ctx, event_loop, &builder) {
             Ok(window) => {
                 windows_id.insert(window.id(), viewport_id);
 
@@ -1076,14 +1116,28 @@ impl Viewport {
                     log::error!("on set_window: viewport_id {viewport_id:?} {err}");
                 }
 
-                self.egui_winit = Some(egui_winit::State::new(
+                #[cfg_attr(not(feature = "accesskit"), expect(unused_mut))]
+                let mut egui_winit = egui_winit::State::new(
                     egui_ctx.clone(),
                     viewport_id,
                     event_loop,
                     Some(window.scale_factor() as f32),
                     event_loop.system_theme(),
                     painter.max_texture_side(),
-                ));
+                );
+
+                // Every viewport with a window gets an adapter, not just the
+                // root: a deferred child viewport is a real window, and
+                // assistive technology sees nothing inside one without it.
+                #[cfg(feature = "accesskit")]
+                if let Some(proxy) = accesskit_proxy {
+                    egui_winit.init_accesskit(event_loop, &window, proxy.clone());
+                    if reveal_after_accesskit {
+                        window.set_visible(true);
+                    }
+                }
+
+                self.egui_winit = Some(egui_winit);
 
                 egui_winit::update_viewport_info(&mut self.info, egui_ctx, &window, true);
                 self.window = Some(window);
@@ -1150,13 +1204,16 @@ fn render_immediate_viewport(
     } = immediate_viewport;
 
     let input = {
+        let mut shared = shared.borrow_mut();
+        #[cfg(feature = "accesskit")]
+        let accesskit_proxy = shared.accesskit_proxy.clone();
         let SharedState {
             egui_ctx,
             viewports,
             painter,
             viewport_from_window,
             ..
-        } = &mut *shared.borrow_mut();
+        } = &mut *shared;
 
         let viewport = initialize_or_update_viewport(
             viewports,
@@ -1168,7 +1225,14 @@ fn render_immediate_viewport(
         );
         if viewport.window.is_none() {
             event_loop_context::with_current_event_loop(|event_loop| {
-                viewport.initialize_window(event_loop, egui_ctx, viewport_from_window, painter);
+                viewport.initialize_window(
+                    event_loop,
+                    egui_ctx,
+                    viewport_from_window,
+                    painter,
+                    #[cfg(feature = "accesskit")]
+                    accesskit_proxy.as_ref(),
+                );
             });
         }
 


### PR DESCRIPTION
`init_accesskit` is only ever called for `ViewportId::ROOT`. An application whose real windows are deferred child viewports therefore exposes nothing to assistive technology inside them: a screen reader or a UI automation client sees a window with no contents.

I hit this in a Windows tray application, where the root viewport is a 1×1 invisible window and every real window is a deferred child viewport.

| measured with a UI Automation client (Windows, glow) | descendants in the UIA tree |
|---|---|
| widgets in a deferred child viewport, before | **0** |
| the same widgets in a root viewport | 9 |

## What the change does

`initialize_window` now creates an adapter for any viewport that gets a window.

Two details that are not obvious from the diff:

- **The context has to hold an `EventLoopProxy`.** `ActiveEventLoop` cannot make one and the adapter needs it, so it is stored and filled in after construction — the root's window is created inside `new`, before a caller can hand one over.
- **Windows other than the root are held back until the adapter is attached.** `accesskit_winit` panics if the adapter is created after the window has been shown, and the root is the only window eframe already creates hidden (the white-flash fix of #2279). They are revealed as soon as the adapter is in place.

## The wgpu half is not verified at runtime

The measurement above is glow. I have no wgpu application with deferred child viewports to point a UI automation client at, so **the second commit is compile-checked only**: `--features wgpu,accesskit`, `--features wgpu` alone, and `clippy --all-features`. It is the same shape as the glow change, with one difference — the wgpu path creates its window through `egui_winit::create_window`, which also resolves the target monitor, so the "start hidden" flag is set on the `ViewportBuilder` rather than on the `WindowAttributes` it produces.

I would rather send it unverified than keep it out of tree. This has been carried as a patch for two releases of my own project, and the alternative to sending it is carrying it for two more.

**If you would prefer the glow commit only, it stands alone** — the two commits are independent, and dropping the second one leaves a working PR.

## Checks

`cargo fmt --all --check`, `cargo clippy -p eframe --all-targets --all-features -- -D warnings`, `cargo doc -p eframe --lib --all-features` (all with `-D warnings`), and `cargo check -p eframe --no-default-features` for `glow`, `wgpu` and `glow,wgpu`, each with and without `accesskit`.

I could not run `./scripts/check.sh` in full on Windows — the wasm targets, the macOS-rendered snapshots and `typos` are not available here — which is why this is a draft.
