### PR TITLE
Optimize CubicBezierShape::find_cross_t

### DIFF
--- a/crates/epaint/src/shapes/bezier_shape.rs
+++ b/crates/epaint/src/shapes/bezier_shape.rs
@@ -205,7 +205,7 @@ impl CubicBezierShape {
     /// B.x * (P3.y - P0.y) - B.y * (P3.x - P0.x) + P0.x * (P0.y - P3.y) + P0.y * (P3.x - P0.x) = 0
     /// B.x = (P3.x - 3 * P2.x + 3 * P1.x - P0.x) * t^3 + (3 * P2.x - 6 * P1.x + 3 * P0.x) * t^2 + (3 * P1.x - 3 * P0.x) * t + P0.x
     /// B.y = (P3.y - 3 * P2.y + 3 * P1.y - P0.y) * t^3 + (3 * P2.y - 6 * P1.y + 3 * P0.y) * t^2 + (3 * P1.y - 3 * P0.y) * t + P0.y
-    /// Combine the above three equations and iliminate B.x and B.y, we get:
+    /// Combine the above three equations and eliminate B.x and B.y, we get:
     /// ```text
     /// t^3 * ( (P3.x - 3*P2.x + 3*P1.x - P0.x) * (P3.y - P0.y) - (P3.y - 3*P2.y + 3*P1.y - P0.y) * (P3.x - P0.x))
     /// + t^2 * ( (3 * P2.x - 6 * P1.x + 3 * P0.x) * (P3.y - P0.y) - (3 * P2.y - 6 * P1.y + 3 * P0.y) * (P3.x - P0.x))
@@ -213,13 +213,13 @@ impl CubicBezierShape {
     /// + (P0.x * (P3.y - P0.y) - P0.y * (P3.x - P0.x)) + P0.x * (P0.y - P3.y) + P0.y * (P3.x - P0.x)
     /// = 0
     /// ```
-    /// or `a * t^3 + b * t^2 + c * t + d = 0`
+    /// or `a * t^3 + b * t^2 + c * t + d = 0` where `d = 0`
     ///
     /// let x = t - b / (3 * a), then we have:
     /// ```text
     /// x^3 + p * x + q = 0, where:
     /// p = (3.0 * a * c - b^2) / (3.0 * a^2)
-    /// q = (2.0 * b^3 - 9.0 * a * b * c + 27.0 * a^2 * d) / (27.0 * a^3)
+    /// q = (2.0 * b^3 - 9.0 * a * b * c) / (27.0 * a^3)
     /// ```
     ///
     /// when p > 0, there will be one real root, two complex roots
@@ -237,27 +237,24 @@ impl CubicBezierShape {
 
         let a = (p3.x - 3.0 * p2.x + 3.0 * p1.x - p0.x) * (p3.y - p0.y)
             - (p3.y - 3.0 * p2.y + 3.0 * p1.y - p0.y) * (p3.x - p0.x);
-        let b = (3.0 * p2.x - 6.0 * p1.x + 3.0 * p0.x) * (p3.y - p0.y)
-            - (3.0 * p2.y - 6.0 * p1.y + 3.0 * p0.y) * (p3.x - p0.x);
-        let c =
-            (3.0 * p1.x - 3.0 * p0.x) * (p3.y - p0.y) - (3.0 * p1.y - 3.0 * p0.y) * (p3.x - p0.x);
-        let d = p0.x * (p3.y - p0.y) - p0.y * (p3.x - p0.x)
-            + p0.x * (p0.y - p3.y)
-            + p0.y * (p3.x - p0.x);
+        let b =
+            (p2.x - 2.0 * p1.x + p0.x) * (p3.y - p0.y) - (p2.y - 2.0 * p1.y + p0.y) * (p3.x - p0.x); // Common factor of 3 removed from b
+        let c = (p1.x - p0.x) * (p3.y - p0.y) - (p1.y - p0.y) * (p3.x - p0.x); // Common factor of 3 removed from c
 
-        let h = -b / (3.0 * a);
-        let p = (3.0 * a * c - b * b) / (3.0 * a * a);
-        let q = (2.0 * b * b * b - 9.0 * a * b * c + 27.0 * a * a * d) / (27.0 * a * a * a);
+        let h = -b / a; // Factor of 3 reintroduced for b
+        let p = (a * c - b * b) / (a * a); // Factor of 3 reintroduced for b and c and common factor 3 removed from p
+        let q = (2.0 * b * b * b - 3.0 * a * b * c) / (a * a * a); // Factor of 3 reintroduced for b and c
 
         if p > 0.0 {
             return None;
         }
-        let r = (-(p / 3.0).powi(3)).sqrt();
+        let p = -p;
+        let r = (p.powi(3)).sqrt(); // Factor of 3 introduced for p
         let theta = (-q / (2.0 * r)).acos() / 3.0;
 
-        let t1 = 2.0 * r.cbrt() * theta.cos() + h;
-        let t2 = 2.0 * r.cbrt() * (theta + 120.0 * core::f32::consts::PI / 180.0).cos() + h;
-        let t3 = 2.0 * r.cbrt() * (theta + 240.0 * core::f32::consts::PI / 180.0).cos() + h;
+        let t1 = 2.0 * p.sqrt() * theta.cos() + h;
+        let t2 = 2.0 * p.sqrt() * (theta + 120.0 * core::f32::consts::PI / 180.0).cos() + h;
+        let t3 = 2.0 * p.sqrt() * (theta + 240.0 * core::f32::consts::PI / 180.0).cos() + h;
 
         if t1 > epsilon && t1 < 1.0 - epsilon {
             return Some(t1);


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [x] I have followed the instructions in the PR template

Factor out common constants to reduce the number of multiplications. During checking the results (comparing my hand-optimized code with the previous version using AI), the AI pointed out that d is always 0, so I removed that as well.

It is possible to rewrite the equations a bit further, like: 
`let p = (a / c - h * h);`
but not sure that it will be beneficial (on superscalar machines) due to introduced data dependencies.

I also have a doubt what will happen when p = 0. I think it may have to be special cased as p = 0 => r = 0 => division by zero (before taking acos).