### PR TITLE
Keep app logic running when a redraw is never delivered

### DIFF
--- a/crates/eframe/src/native/frame_watchdog.rs
+++ b/crates/eframe/src/native/frame_watchdog.rs
@@ -1,0 +1,172 @@
+use core::time::Duration;
+use std::time::Instant;
+
+use ahash::HashMap;
+use winit::window::WindowId;
+
+/// Detects redraws that were requested but never delivered.
+///
+/// On Wayland a compositor may withhold `wl_surface.frame` for a hidden
+/// surface. winit then suppresses `RedrawRequested` until the callback
+/// arrives, and the gate does not re-arm on its own, so `App::update` stops
+/// forever. See <https://github.com/emilk/egui/issues/5136>.
+pub struct FrameWatchdog {
+    deadline: Duration,
+    /// When each window's outstanding redraw was requested.
+    pending: HashMap<WindowId, Instant>,
+}
+
+impl FrameWatchdog {
+    pub fn new(deadline: Duration) -> Self {
+        Self {
+            deadline,
+            pending: HashMap::default(),
+        }
+    }
+
+    pub fn note_redraw_requested(&mut self, window_id: WindowId, now: Instant) {
+        self.pending.entry(window_id).or_insert(now);
+    }
+
+    pub fn note_redraw_delivered(&mut self, window_id: WindowId) {
+        self.forget(window_id);
+    }
+
+    pub fn forget(&mut self, window_id: WindowId) {
+        self.pending.remove(&window_id);
+    }
+
+    /// Returns the windows whose redraw is overdue, re-arming each one so a
+    /// lasting stall is reported again after every deadline.
+    pub fn overdue(&mut self, now: Instant) -> Vec<WindowId> {
+        let overdue: Vec<WindowId> = self
+            .pending
+            .iter()
+            .filter(|(_, requested)| now.duration_since(**requested) >= self.deadline)
+            .map(|(window_id, _)| *window_id)
+            .collect();
+        for window_id in &overdue {
+            self.pending.insert(*window_id, now);
+        }
+        overdue
+    }
+
+    pub fn next_check(&self) -> Option<Instant> {
+        self.pending
+            .values()
+            .min()
+            .map(|requested| *requested + self.deadline)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Fixture {
+        watchdog: FrameWatchdog,
+        start: Instant,
+    }
+
+    impl Fixture {
+        const DEADLINE: Duration = Duration::from_millis(500);
+
+        fn new() -> Self {
+            Self {
+                watchdog: FrameWatchdog::new(Self::DEADLINE),
+                start: Instant::now(),
+            }
+        }
+
+        fn at(&self, millis: u64) -> Instant {
+            self.start + Duration::from_millis(millis)
+        }
+
+        fn window() -> WindowId {
+            WindowId::dummy()
+        }
+
+        fn overdue_at(&mut self, millis: u64) -> Vec<WindowId> {
+            let now = self.at(millis);
+            self.watchdog.overdue(now)
+        }
+    }
+
+    #[test]
+    fn reports_nothing_when_no_redraw_was_requested() {
+        let mut fixture = Fixture::new();
+        assert!(fixture.overdue_at(10_000).is_empty());
+        assert_eq!(fixture.watchdog.next_check(), None);
+    }
+
+    #[test]
+    fn reports_nothing_before_the_deadline() {
+        let mut fixture = Fixture::new();
+        fixture
+            .watchdog
+            .note_redraw_requested(Fixture::window(), fixture.at(0));
+        assert!(fixture.overdue_at(499).is_empty());
+    }
+
+    #[test]
+    fn reports_the_window_once_the_deadline_passes() {
+        let mut fixture = Fixture::new();
+        fixture
+            .watchdog
+            .note_redraw_requested(Fixture::window(), fixture.at(0));
+        assert_eq!(fixture.overdue_at(500), vec![Fixture::window()]);
+    }
+
+    #[test]
+    fn a_delivered_redraw_clears_the_pending_request() {
+        let mut fixture = Fixture::new();
+        fixture
+            .watchdog
+            .note_redraw_requested(Fixture::window(), fixture.at(0));
+        fixture.watchdog.note_redraw_delivered(Fixture::window());
+        assert!(fixture.overdue_at(10_000).is_empty());
+    }
+
+    #[test]
+    fn keeps_the_original_request_time_while_still_pending() {
+        let mut fixture = Fixture::new();
+        fixture
+            .watchdog
+            .note_redraw_requested(Fixture::window(), fixture.at(0));
+        fixture
+            .watchdog
+            .note_redraw_requested(Fixture::window(), fixture.at(400));
+        assert_eq!(fixture.overdue_at(500), vec![Fixture::window()]);
+    }
+
+    #[test]
+    fn rearms_after_reporting_so_a_stall_repeats_at_the_deadline() {
+        let mut fixture = Fixture::new();
+        fixture
+            .watchdog
+            .note_redraw_requested(Fixture::window(), fixture.at(0));
+
+        assert_eq!(fixture.overdue_at(500), vec![Fixture::window()]);
+        assert!(fixture.overdue_at(600).is_empty());
+        assert_eq!(fixture.overdue_at(1000), vec![Fixture::window()]);
+    }
+
+    #[test]
+    fn forget_drops_the_window() {
+        let mut fixture = Fixture::new();
+        fixture
+            .watchdog
+            .note_redraw_requested(Fixture::window(), fixture.at(0));
+        fixture.watchdog.forget(Fixture::window());
+        assert!(fixture.overdue_at(10_000).is_empty());
+    }
+
+    #[test]
+    fn next_check_is_the_earliest_deadline() {
+        let mut fixture = Fixture::new();
+        fixture
+            .watchdog
+            .note_redraw_requested(Fixture::window(), fixture.at(200));
+        assert_eq!(fixture.watchdog.next_check(), Some(fixture.at(700)));
+    }
+}

--- a/crates/eframe/src/native/frame_watchdog.rs
+++ b/crates/eframe/src/native/frame_watchdog.rs
@@ -12,6 +12,7 @@ use winit::window::WindowId;
 /// forever. See <https://github.com/emilk/egui/issues/5136>.
 pub struct FrameWatchdog {
     deadline: Duration,
+
     /// When each window's outstanding redraw was requested.
     pending: HashMap<WindowId, Instant>,
 }

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -36,7 +36,7 @@ use log::warn;
 
 use super::{
     epi_integration, event_loop_context,
-    winit_integration::{EventResult, UserEvent, WinitApp, create_egui_context},
+    winit_integration::{EventResult, PaintPolicy, UserEvent, WinitApp, create_egui_context},
 };
 use crate::epaint::textures::TexturesDelta;
 use crate::{
@@ -458,9 +458,10 @@ impl WinitApp for GlowWinitApp<'_> {
         &mut self,
         event_loop: &ActiveEventLoop,
         window_id: WindowId,
+        paint: PaintPolicy,
     ) -> Result<EventResult> {
         if let Some(running) = &mut self.running {
-            running.run_ui_and_paint(event_loop, window_id)
+            running.run_ui_and_paint(event_loop, window_id, paint)
         } else {
             Ok(EventResult::Wait)
         }
@@ -567,6 +568,7 @@ impl GlowWinitRunning<'_> {
         &mut self,
         event_loop: &ActiveEventLoop,
         window_id: WindowId,
+        paint: PaintPolicy,
     ) -> Result<EventResult> {
         profiling::function_scope!();
 
@@ -620,8 +622,9 @@ impl GlowWinitRunning<'_> {
             let mut raw_input = egui_winit.take_egui_input(window);
             let viewport_ui_cb = viewport.viewport_ui_cb.clone();
 
-            let show_ui =
-                is_visible || is_viewport_or_descendant_visible(&glutin.viewports, viewport_id);
+            let show_ui = paint.may_paint()
+                && (is_visible
+                    || is_viewport_or_descendant_visible(&glutin.viewports, viewport_id));
 
             self.integration.pre_update();
 

--- a/crates/eframe/src/native/mod.rs
+++ b/crates/eframe/src/native/mod.rs
@@ -1,6 +1,7 @@
 mod app_icon;
 mod epi_integration;
 mod event_loop_context;
+mod frame_watchdog;
 pub mod run;
 
 #[cfg(target_os = "macos")]

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -14,7 +14,8 @@ use crate::{
     Result, epi,
     native::{
         event_loop_context,
-        winit_integration::{EventResult, is_invisible_or_minimized},
+        frame_watchdog::FrameWatchdog,
+        winit_integration::{EventResult, PaintPolicy, is_invisible_or_minimized},
     },
 };
 
@@ -25,6 +26,13 @@ use crate::{
 /// processing viewport commands like `Visible(true)`.
 /// See <https://github.com/emilk/egui/issues/7776>.
 const INVISIBLE_WINDOW_REPAINT_INTERVAL: Duration = Duration::from_millis(100);
+
+/// How long to wait for a `RedrawRequested` before assuming it will never come.
+///
+/// A compositor may withhold the frame callback for a surface it considers
+/// hidden, which suppresses `RedrawRequested` indefinitely.
+/// See <https://github.com/emilk/egui/issues/5136>.
+const MISSED_FRAME_DEADLINE: Duration = Duration::from_millis(500);
 
 // ----------------------------------------------------------------------------
 fn create_event_loop(native_options: &mut epi::NativeOptions) -> Result<EventLoop<UserEvent>> {
@@ -79,6 +87,7 @@ fn with_event_loop<R>(
 /// some events, but otherwise forwards events to the [`WinitApp`].
 struct WinitAppWrapper<T: WinitApp> {
     windows_next_repaint_times: HashMap<WindowId, Instant>,
+    frame_watchdog: FrameWatchdog,
     winit_app: T,
     return_result: Result<(), crate::Error>,
     run_and_return: bool,
@@ -88,6 +97,7 @@ impl<T: WinitApp> WinitAppWrapper<T> {
     fn new(winit_app: T, run_and_return: bool) -> Self {
         Self {
             windows_next_repaint_times: HashMap::default(),
+            frame_watchdog: FrameWatchdog::new(MISSED_FRAME_DEADLINE),
             winit_app,
             return_result: Ok(()),
             run_and_return,
@@ -114,7 +124,9 @@ impl<T: WinitApp> WinitAppWrapper<T> {
                 .insert(window_id, Instant::now());
 
             // Fix flickering on Windows, see https://github.com/emilk/egui/pull/2280
-            event_result = self.winit_app.run_ui_and_paint(event_loop, window_id);
+            event_result =
+                self.winit_app
+                    .run_ui_and_paint(event_loop, window_id, PaintPolicy::IfVisible);
         }
 
         let combined_result = event_result.map(|event_result| match event_result {
@@ -190,6 +202,7 @@ impl<T: WinitApp> WinitAppWrapper<T> {
         let now = Instant::now();
 
         let mut invisible_window_ids = Vec::new();
+        let watchdog = &mut self.frame_watchdog;
 
         self.windows_next_repaint_times
             .retain(|window_id, repaint_time| {
@@ -214,6 +227,7 @@ impl<T: WinitApp> WinitAppWrapper<T> {
                         // busy-loops a whole CPU core.
                         // See https://github.com/emilk/egui/issues/8326.
                         window.request_redraw();
+                        watchdog.note_redraw_requested(*window_id, now);
                     }
                 } else {
                     log::trace!("No window found for {window_id:?}");
@@ -225,7 +239,9 @@ impl<T: WinitApp> WinitAppWrapper<T> {
         // RedrawRequested events on Windows. This ensures that viewport
         // commands like Visible(true) are still processed.
         for window_id in &invisible_window_ids {
-            let event_result = self.winit_app.run_ui_and_paint(event_loop, *window_id);
+            let event_result =
+                self.winit_app
+                    .run_ui_and_paint(event_loop, *window_id, PaintPolicy::IfVisible);
             self.handle_event_result(event_loop, event_result);
         }
 
@@ -247,9 +263,26 @@ impl<T: WinitApp> WinitAppWrapper<T> {
         // `ControlFlow::Poll` set earlier was never undone once the last timed
         // repaint had been consumed, leaving the loop spinning.
         // See https://github.com/emilk/egui/issues/8326.
+        // A redraw we asked for may never be delivered: a compositor can withhold
+        // the frame callback for a surface it considers hidden, and winit then
+        // suppresses `RedrawRequested` indefinitely. Keep the app's logic ticking
+        // so it can still react (e.g. ask to be shown again).
+        // See https://github.com/emilk/egui/issues/5136.
+        for window_id in self.frame_watchdog.overdue(Instant::now()) {
+            log::debug!("No RedrawRequested for {window_id:?} within the deadline");
+            let event_result =
+                self.winit_app
+                    .run_ui_and_paint(event_loop, window_id, PaintPolicy::Never);
+            self.handle_event_result(event_loop, event_result);
+        }
+
         let next_repaint_time = self.windows_next_repaint_times.values().min().copied();
-        event_loop.set_control_flow(match next_repaint_time {
-            Some(next_repaint_time) => ControlFlow::WaitUntil(next_repaint_time),
+        let next_wakeup = match (next_repaint_time, self.frame_watchdog.next_check()) {
+            (Some(repaint), Some(check)) => Some(repaint.min(check)),
+            (repaint, check) => repaint.or(check),
+        };
+        event_loop.set_control_flow(match next_wakeup {
+            Some(next_wakeup) => ControlFlow::WaitUntil(next_wakeup),
             None => ControlFlow::Wait,
         });
     }
@@ -372,7 +405,13 @@ impl<T: WinitApp> ApplicationHandler<UserEvent> for WinitAppWrapper<T> {
         event_loop_context::with_event_loop_context(event_loop, move || {
             let event_result = match event {
                 winit::event::WindowEvent::RedrawRequested => {
-                    self.winit_app.run_ui_and_paint(event_loop, window_id)
+                    self.frame_watchdog.note_redraw_delivered(window_id);
+                    self.winit_app
+                        .run_ui_and_paint(event_loop, window_id, PaintPolicy::IfVisible)
+                }
+                winit::event::WindowEvent::Destroyed => {
+                    self.frame_watchdog.forget(window_id);
+                    self.winit_app.window_event(event_loop, window_id, event)
                 }
                 _ => self.winit_app.window_event(event_loop, window_id, event),
             };

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -31,7 +31,7 @@ use crate::{
     App, AppCreator, CreationContext, NativeOptions, Result, Storage,
     native::{
         epi_integration::EpiIntegration,
-        winit_integration::{EventResult, sleep_if_invisible_or_minimized},
+        winit_integration::{EventResult, PaintPolicy, sleep_if_invisible_or_minimized},
     },
 };
 
@@ -432,11 +432,12 @@ impl WinitApp for WgpuWinitApp<'_> {
         &mut self,
         event_loop: &ActiveEventLoop,
         window_id: WindowId,
+        paint: PaintPolicy,
     ) -> Result<EventResult> {
         self.initialized_all_windows(event_loop);
 
         if let Some(running) = &mut self.running {
-            running.run_ui_and_paint(window_id, event_loop)
+            running.run_ui_and_paint(window_id, event_loop, paint)
         } else {
             Ok(EventResult::Wait)
         }
@@ -600,6 +601,7 @@ impl WgpuWinitRunning<'_> {
         &mut self,
         window_id: WindowId,
         event_loop: &ActiveEventLoop,
+        paint: PaintPolicy,
     ) -> Result<EventResult> {
         profiling::function_scope!();
 
@@ -681,7 +683,8 @@ impl WgpuWinitRunning<'_> {
             };
             let mut raw_input = egui_winit.take_egui_input(window);
 
-            let show_ui = is_visible || is_viewport_or_descendant_visible(viewports, viewport_id);
+            let show_ui = paint.may_paint()
+                && (is_visible || is_viewport_or_descendant_visible(viewports, viewport_id));
 
             integration.pre_update();
 

--- a/crates/eframe/src/native/winit_integration.rs
+++ b/crates/eframe/src/native/winit_integration.rs
@@ -29,6 +29,29 @@ pub fn sleep_if_invisible_or_minimized(window: Option<&Window>) {
     }
 }
 
+/// Whether an egui pass is allowed to paint.
+///
+/// A pass that may not paint still runs the app's logic, so the app keeps
+/// ticking and can react (e.g. ask to be shown again).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PaintPolicy {
+    /// Paint if the viewport is visible. This is the normal case.
+    IfVisible,
+
+    /// Never paint, no matter what the viewport reports.
+    ///
+    /// Used when a requested redraw was never delivered, so painting would be
+    /// pointless: see <https://github.com/emilk/egui/issues/5136>.
+    Never,
+}
+
+impl PaintPolicy {
+    /// May a pass under this policy paint?
+    pub fn may_paint(self) -> bool {
+        self == Self::IfVisible
+    }
+}
+
 /// Create an egui context, restoring it from storage if possible.
 pub fn create_egui_context(storage: Option<&dyn crate::Storage>) -> egui::Context {
     profiling::function_scope!();
@@ -97,10 +120,12 @@ pub trait WinitApp {
 
     fn save_and_destroy(&mut self);
 
+    /// Run an egui pass, painting the result unless `paint` forbids it.
     fn run_ui_and_paint(
         &mut self,
         event_loop: &ActiveEventLoop,
         window_id: WindowId,
+        paint: PaintPolicy,
     ) -> crate::Result<EventResult>;
 
     fn suspended(&mut self, event_loop: &ActiveEventLoop) -> crate::Result<EventResult>;


### PR DESCRIPTION
On Wayland a compositor may withhold `wl_surface.frame` for a surface it considers hidden. winit then suppresses `RedrawRequested` until the callback arrives, and the gate never re-arms on its own, so `App::update` and `App::logic` stop forever - even after the window is shown again.

eframe cannot detect this on Wayland: `Window::is_visible`, `Window::is_minimized`, `ViewportInfo::occluded` and `ViewportInfo::minimized` all return `None` there, so `is_invisible_or_minimized` is `false` and the existing invisible-window path never runs.

Add a `FrameWatchdog` that records each `request_redraw` and reports the windows whose `RedrawRequested` never arrived within 500ms. Those windows run a logic-only egui pass, so the app keeps ticking and can still react (e.g. ask to be shown again), without painting a frame the compositor would not display.


* Closes #5136 
* [X] I have followed the instructions in the PR template
