### PR TITLE
Clean up clippy lint config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,11 @@ all = "warn"
 
 # See also clippy.toml
 [workspace.lints.clippy]
+# `all` = `correctness` + `suspicious` + `style` + `complexity` + `perf`.
+# The remaining groups are `nursery` and `restriction`,
+# which are not meant to be enabled wholesale - we cherry-pick from them below.
 all = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
 allow_attributes = "warn"
@@ -216,7 +220,6 @@ missing_assert_message = "warn"
 mutex_integer = "warn"
 needless_pass_by_ref_mut = "warn"
 needless_type_cast = "warn"
-negative_feature_names = "warn"
 non_zero_suggestions = "warn"
 nonstandard_macro_braces = "warn"
 or_fun_call = "warn"
@@ -258,7 +261,6 @@ unwrap_used = "warn"
 use_self = "warn"
 useless_let_if_seq = "warn"
 verbose_file_reads = "warn"
-wildcard_dependencies = "warn"
 
 
 # Pedantic lints we opt out of, with the number of hits at the time we enabled `pedantic`:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,10 +288,11 @@ trivially_copy_pass_by_ref = "allow" # 119 hits
 unreadable_literal = "allow" # 513 hits
 used_underscore_binding = "allow" # 25 hits
 
-# These are meh:
+# Other:
 assigning_clones = "allow" # No please
 manual_range_contains = "allow" # this one is just worse imho
 map_unwrap_or = "allow" # so is this one
+multiple_crate_versions = "allow" # we handle this with `cargo deny`
 wildcard_imports = "allow" # `use crate::*` is useful to avoid merge conflicts when adding/removing imports
 
 # NOTE: these are in `restriction`/`nursery`, so the `allow` is a no-op today.

--- a/examples/popups/Cargo.toml
+++ b/examples/popups/Cargo.toml
@@ -2,6 +2,7 @@
 name = "popups"
 edition.workspace = true
 license.workspace = true
+publish = false
 rust-version.workspace = true
 version.workspace = true
 

--- a/tests/egui_tests/Cargo.toml
+++ b/tests/egui_tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "egui_tests"
 edition.workspace = true
 license.workspace = true
+publish = false
 rust-version.workspace = true
 version.workspace = true
 


### PR DESCRIPTION
* [x] I have followed the instructions in the PR template

Remove clippy lint groups already covered by `all` (`complexity`, `perf`, `suspicious`, and the misspelled `correctnesss`), and two individual lints covered by the `cargo` group (`negative_feature_names`, `wildcard_dependencies`).

Add `publish = false` to the two internal crates that were missing it (`popups`, `egui_tests`), which silences the `clippy::cargo_common_metadata` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)