### PR TITLE
Add `epaint::RoundedRect` primitive

### DIFF
--- a/crates/epaint/src/lib.rs
+++ b/crates/epaint/src/lib.rs
@@ -33,6 +33,7 @@ mod margin;
 mod margin_f32;
 mod mesh;
 pub mod mutex;
+mod rounded_rect;
 mod shadow;
 pub mod shape_transform;
 mod shapes;
@@ -56,6 +57,7 @@ pub use self::{
     margin::Margin,
     margin_f32::*,
     mesh::{Mesh, Mesh16, Vertex},
+    rounded_rect::RoundedRect,
     shadow::Shadow,
     shapes::{
         CircleShape, CubicBezierShape, EllipseShape, PaintCallback, PaintCallbackInfo, PathShape,

--- a/crates/epaint/src/rounded_rect.rs
+++ b/crates/epaint/src/rounded_rect.rs
@@ -8,17 +8,40 @@ use crate::CornerRadius;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct RoundedRect {
-    pub rect: Rect,
-    pub corner_radius: CornerRadius,
+    rect: Rect,
+    corner_radius: CornerRadius,
 }
 
 impl RoundedRect {
+    /// The corner radius is clamped to half the size of the rectangle,
+    /// like in the tessellator, so that we agree with the rendered shape.
     #[inline]
     pub fn new(rect: Rect, corner_radius: impl Into<CornerRadius>) -> Self {
+        let max_radius = (0.5 * rect.size().min_elem()).clamp(0.0, 255.0) as u8;
         Self {
             rect,
-            corner_radius: corner_radius.into(),
+            corner_radius: corner_radius.into().at_most(max_radius),
         }
+    }
+
+    #[inline]
+    pub fn rect(&self) -> Rect {
+        self.rect
+    }
+
+    #[inline]
+    pub fn corner_radius(&self) -> CornerRadius {
+        self.corner_radius
+    }
+
+    /// Expand the rectangle and the corner radii by the given amount.
+    #[inline]
+    #[must_use]
+    pub fn expand(self, amount: u8) -> Self {
+        Self::new(
+            self.rect.expand(f32::from(amount)),
+            self.corner_radius + amount,
+        )
     }
 
     /// Clamp the given position to lie within this rounded rectangle.
@@ -30,7 +53,6 @@ impl RoundedRect {
             corner_radius,
         } = *self;
         let pos = rect.clamp(pos);
-        let max_radius = 0.5 * rect.size().min_elem();
         let corners = [
             (f32::from(corner_radius.nw), vec2(-1.0, -1.0)),
             (f32::from(corner_radius.ne), vec2(1.0, -1.0)),
@@ -38,8 +60,6 @@ impl RoundedRect {
             (f32::from(corner_radius.se), vec2(1.0, 1.0)),
         ];
         for (radius, dir) in corners {
-            // Same clamping as the tessellator, so we agree with the rendered shape:
-            let radius = radius.min(max_radius);
             let arc_center = rect.center() + dir * (rect.size() / 2.0 - Vec2::splat(radius));
             let offset = pos - arc_center;
             if 0.0 < offset.x * dir.x && 0.0 < offset.y * dir.y && radius < offset.length() {
@@ -100,13 +120,24 @@ mod tests {
     }
 
     #[test]
-    fn clamp_pos_oversized_radius() {
+    fn expand() {
+        let rect = Rect::from_min_max(pos2(10.0, 10.0), pos2(90.0, 90.0));
+        let expanded = RoundedRect::new(rect, 20).expand(10);
+        assert_eq!(
+            expanded.rect(),
+            Rect::from_min_max(pos2(0.0, 0.0), pos2(100.0, 100.0))
+        );
+        assert_eq!(expanded.corner_radius(), CornerRadius::same(30));
+    }
+
+    #[test]
+    fn oversized_radius_is_clamped() {
         // A radius larger than half the rect is clamped, like in the tessellator:
         let rect = Rect::from_min_max(pos2(0.0, 0.0), pos2(100.0, 100.0));
-        let oversized = RoundedRect::new(rect, 200);
-        let clamped_radius = RoundedRect::new(rect, 50);
-        for pos in [pos2(0.0, 0.0), pos2(100.0, 0.0), pos2(30.0, -10.0)] {
-            assert_eq!(oversized.clamp_pos(pos), clamped_radius.clamp_pos(pos));
-        }
+        assert_eq!(RoundedRect::new(rect, 200), RoundedRect::new(rect, 50));
+        assert_eq!(
+            RoundedRect::new(rect, 200).corner_radius(),
+            CornerRadius::same(50)
+        );
     }
 }

--- a/crates/epaint/src/rounded_rect.rs
+++ b/crates/epaint/src/rounded_rect.rs
@@ -1,26 +1,26 @@
 use emath::{Pos2, Rect, Vec2, vec2};
 
-use crate::CornerRadius;
+use crate::CornerRadiusF32;
 
 /// A rectangle geometry with rounded corners.
 ///
 /// Not a painting primitive. For that, see [`crate::RectShape`].
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct RoundedRect {
     rect: Rect,
-    corner_radius: CornerRadius,
+    corner_radius: CornerRadiusF32,
 }
 
 impl RoundedRect {
     /// The corner radius is clamped to half the size of the rectangle,
     /// like in the tessellator, so that we agree with the rendered shape.
     #[inline]
-    pub fn new(rect: Rect, corner_radius: impl Into<CornerRadius>) -> Self {
-        let max_radius = (0.5 * rect.size().min_elem()).clamp(0.0, 255.0) as u8;
+    pub fn new(rect: Rect, corner_radius: impl Into<CornerRadiusF32>) -> Self {
+        let max_radius = 0.5 * rect.size().min_elem();
         Self {
             rect,
-            corner_radius: corner_radius.into().at_most(max_radius),
+            corner_radius: corner_radius.into().at_most(max_radius).at_least(0.0),
         }
     }
 
@@ -30,13 +30,13 @@ impl RoundedRect {
     }
 
     #[inline]
-    pub fn corner_radius(&self) -> CornerRadius {
+    pub fn corner_radius(&self) -> CornerRadiusF32 {
         self.corner_radius
     }
 
     /// Split into the rectangle and the corner radius.
     #[inline]
-    pub fn into_parts(self) -> (Rect, CornerRadius) {
+    pub fn into_parts(self) -> (Rect, CornerRadiusF32) {
         let Self {
             rect,
             corner_radius,
@@ -47,10 +47,10 @@ impl RoundedRect {
     /// Expand the rectangle and the corner radii by the given amount.
     #[inline]
     #[must_use]
-    pub fn expand(self, amount: u8) -> Self {
+    pub fn expand(self, amount: f32) -> Self {
         Self::new(
-            self.rect.expand(f32::from(amount)),
-            self.corner_radius + amount,
+            self.rect.expand(amount),
+            self.corner_radius + CornerRadiusF32::same(amount),
         )
     }
 
@@ -64,10 +64,10 @@ impl RoundedRect {
         } = *self;
         let pos = rect.clamp(pos);
         let corners = [
-            (f32::from(corner_radius.nw), vec2(-1.0, -1.0)),
-            (f32::from(corner_radius.ne), vec2(1.0, -1.0)),
-            (f32::from(corner_radius.sw), vec2(-1.0, 1.0)),
-            (f32::from(corner_radius.se), vec2(1.0, 1.0)),
+            (corner_radius.nw, vec2(-1.0, -1.0)),
+            (corner_radius.ne, vec2(1.0, -1.0)),
+            (corner_radius.sw, vec2(-1.0, 1.0)),
+            (corner_radius.se, vec2(1.0, 1.0)),
         ];
         for (radius, dir) in corners {
             let arc_center = rect.center() + dir * (rect.size() / 2.0 - Vec2::splat(radius));
@@ -85,7 +85,7 @@ impl From<Rect> for RoundedRect {
     fn from(rect: Rect) -> Self {
         Self {
             rect,
-            corner_radius: CornerRadius::ZERO,
+            corner_radius: CornerRadiusF32::ZERO,
         }
     }
 }
@@ -101,11 +101,11 @@ mod tests {
         let rect = Rect::from_min_max(pos2(0.0, 0.0), pos2(100.0, 100.0));
         let rounded = RoundedRect::new(
             rect,
-            CornerRadius {
-                nw: 10,
-                ne: 0,
-                sw: 0,
-                se: 20,
+            CornerRadiusF32 {
+                nw: 10.0,
+                ne: 0.0,
+                sw: 0.0,
+                se: 20.0,
             },
         );
 
@@ -132,22 +132,22 @@ mod tests {
     #[test]
     fn expand() {
         let rect = Rect::from_min_max(pos2(10.0, 10.0), pos2(90.0, 90.0));
-        let expanded = RoundedRect::new(rect, 20).expand(10);
+        let expanded = RoundedRect::new(rect, 20.0).expand(10.0);
         assert_eq!(
             expanded.rect(),
             Rect::from_min_max(pos2(0.0, 0.0), pos2(100.0, 100.0))
         );
-        assert_eq!(expanded.corner_radius(), CornerRadius::same(30));
+        assert_eq!(expanded.corner_radius(), CornerRadiusF32::same(30.0));
     }
 
     #[test]
     fn oversized_radius_is_clamped() {
         // A radius larger than half the rect is clamped, like in the tessellator:
         let rect = Rect::from_min_max(pos2(0.0, 0.0), pos2(100.0, 100.0));
-        assert_eq!(RoundedRect::new(rect, 200), RoundedRect::new(rect, 50));
+        assert_eq!(RoundedRect::new(rect, 200.0), RoundedRect::new(rect, 50.0));
         assert_eq!(
-            RoundedRect::new(rect, 200).corner_radius(),
-            CornerRadius::same(50)
+            RoundedRect::new(rect, 200.0).corner_radius(),
+            CornerRadiusF32::same(50.0)
         );
     }
 }

--- a/crates/epaint/src/rounded_rect.rs
+++ b/crates/epaint/src/rounded_rect.rs
@@ -1,0 +1,93 @@
+use emath::{Pos2, Rect, Vec2, vec2};
+
+use crate::CornerRadius;
+
+/// A rectangle with rounded corners.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct RoundedRect {
+    pub rect: Rect,
+    pub rounding: CornerRadius,
+}
+
+impl RoundedRect {
+    #[inline]
+    pub fn new(rect: Rect, rounding: impl Into<CornerRadius>) -> Self {
+        Self {
+            rect,
+            rounding: rounding.into(),
+        }
+    }
+
+    /// Clamp the given position to lie within this rounded rectangle.
+    ///
+    /// Positions in the corner regions are projected onto the corner arcs.
+    pub fn clamp_pos(&self, pos: Pos2) -> Pos2 {
+        let Self { rect, rounding } = *self;
+        let pos = rect.clamp(pos);
+        let corners = [
+            (f32::from(rounding.nw), vec2(-1.0, -1.0)),
+            (f32::from(rounding.ne), vec2(1.0, -1.0)),
+            (f32::from(rounding.sw), vec2(-1.0, 1.0)),
+            (f32::from(rounding.se), vec2(1.0, 1.0)),
+        ];
+        for (radius, dir) in corners {
+            let arc_center = rect.center() + dir * (rect.size() / 2.0 - Vec2::splat(radius));
+            let offset = pos - arc_center;
+            if 0.0 < offset.x * dir.x && 0.0 < offset.y * dir.y && radius < offset.length() {
+                return arc_center + (radius / offset.length()) * offset;
+            }
+        }
+        pos
+    }
+}
+
+impl From<Rect> for RoundedRect {
+    #[inline]
+    fn from(rect: Rect) -> Self {
+        Self {
+            rect,
+            rounding: CornerRadius::ZERO,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use emath::pos2;
+
+    use super::*;
+
+    #[test]
+    fn clamp_pos() {
+        let rect = Rect::from_min_max(pos2(0.0, 0.0), pos2(100.0, 100.0));
+        let rounded = RoundedRect::new(
+            rect,
+            CornerRadius {
+                nw: 10,
+                ne: 0,
+                sw: 0,
+                se: 20,
+            },
+        );
+
+        // Interior point is untouched:
+        assert_eq!(rounded.clamp_pos(pos2(50.0, 50.0)), pos2(50.0, 50.0));
+
+        // Sharp corner is untouched:
+        assert_eq!(rounded.clamp_pos(pos2(100.0, 0.0)), pos2(100.0, 0.0));
+
+        // Outside the rect is clamped to the edge:
+        assert_eq!(rounded.clamp_pos(pos2(-10.0, 50.0)), pos2(0.0, 50.0));
+
+        // Rounded corner is projected onto the arc:
+        let clamped = rounded.clamp_pos(pos2(0.0, 0.0));
+        let arc_center = pos2(10.0, 10.0);
+        assert!((clamped - arc_center).length() - 10.0 < 0.001);
+        let expected = 10.0 - 10.0 / core::f32::consts::SQRT_2;
+        assert!((clamped - pos2(expected, expected)).length() < 0.001);
+
+        // Point on the arc stays put:
+        assert_eq!(rounded.clamp_pos(pos2(10.0, 0.0)), pos2(10.0, 0.0));
+    }
+}

--- a/crates/epaint/src/rounded_rect.rs
+++ b/crates/epaint/src/rounded_rect.rs
@@ -13,8 +13,7 @@ pub struct RoundedRect {
 }
 
 impl RoundedRect {
-    /// The corner radius is clamped to half the size of the rectangle,
-    /// like in the tessellator, so that we agree with the rendered shape.
+    /// The corner radius is clamped to half the size of the rectangle.
     #[inline]
     pub fn new(rect: Rect, corner_radius: impl Into<CornerRadiusF32>) -> Self {
         let max_radius = 0.5 * rect.size().min_elem();

--- a/crates/epaint/src/rounded_rect.rs
+++ b/crates/epaint/src/rounded_rect.rs
@@ -2,7 +2,9 @@ use emath::{Pos2, Rect, Vec2, vec2};
 
 use crate::CornerRadius;
 
-/// A rectangle with rounded corners.
+/// A rectangle shape with rounded corners.
+///
+/// Not a painting primitive. For that, see [`crate::RectShape`].
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct RoundedRect {

--- a/crates/epaint/src/rounded_rect.rs
+++ b/crates/epaint/src/rounded_rect.rs
@@ -2,7 +2,7 @@ use emath::{Pos2, Rect, Vec2, vec2};
 
 use crate::CornerRadius;
 
-/// A rectangle shape with rounded corners.
+/// A rectangle geometry with rounded corners.
 ///
 /// Not a painting primitive. For that, see [`crate::RectShape`].
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -32,6 +32,16 @@ impl RoundedRect {
     #[inline]
     pub fn corner_radius(&self) -> CornerRadius {
         self.corner_radius
+    }
+
+    /// Split into the rectangle and the corner radius.
+    #[inline]
+    pub fn into_parts(self) -> (Rect, CornerRadius) {
+        let Self {
+            rect,
+            corner_radius,
+        } = self;
+        (rect, corner_radius)
     }
 
     /// Expand the rectangle and the corner radii by the given amount.

--- a/crates/epaint/src/rounded_rect.rs
+++ b/crates/epaint/src/rounded_rect.rs
@@ -30,6 +30,7 @@ impl RoundedRect {
             corner_radius,
         } = *self;
         let pos = rect.clamp(pos);
+        let max_radius = 0.5 * rect.size().min_elem();
         let corners = [
             (f32::from(corner_radius.nw), vec2(-1.0, -1.0)),
             (f32::from(corner_radius.ne), vec2(1.0, -1.0)),
@@ -37,6 +38,8 @@ impl RoundedRect {
             (f32::from(corner_radius.se), vec2(1.0, 1.0)),
         ];
         for (radius, dir) in corners {
+            // Same clamping as the tessellator, so we agree with the rendered shape:
+            let radius = radius.min(max_radius);
             let arc_center = rect.center() + dir * (rect.size() / 2.0 - Vec2::splat(radius));
             let offset = pos - arc_center;
             if 0.0 < offset.x * dir.x && 0.0 < offset.y * dir.y && radius < offset.length() {
@@ -94,5 +97,16 @@ mod tests {
 
         // Point on the arc stays put:
         assert_eq!(rounded.clamp_pos(pos2(10.0, 0.0)), pos2(10.0, 0.0));
+    }
+
+    #[test]
+    fn clamp_pos_oversized_radius() {
+        // A radius larger than half the rect is clamped, like in the tessellator:
+        let rect = Rect::from_min_max(pos2(0.0, 0.0), pos2(100.0, 100.0));
+        let oversized = RoundedRect::new(rect, 200);
+        let clamped_radius = RoundedRect::new(rect, 50);
+        for pos in [pos2(0.0, 0.0), pos2(100.0, 0.0), pos2(30.0, -10.0)] {
+            assert_eq!(oversized.clamp_pos(pos), clamped_radius.clamp_pos(pos));
+        }
     }
 }

--- a/crates/epaint/src/rounded_rect.rs
+++ b/crates/epaint/src/rounded_rect.rs
@@ -7,15 +7,15 @@ use crate::CornerRadius;
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct RoundedRect {
     pub rect: Rect,
-    pub rounding: CornerRadius,
+    pub corner_radius: CornerRadius,
 }
 
 impl RoundedRect {
     #[inline]
-    pub fn new(rect: Rect, rounding: impl Into<CornerRadius>) -> Self {
+    pub fn new(rect: Rect, corner_radius: impl Into<CornerRadius>) -> Self {
         Self {
             rect,
-            rounding: rounding.into(),
+            corner_radius: corner_radius.into(),
         }
     }
 
@@ -23,13 +23,16 @@ impl RoundedRect {
     ///
     /// Positions in the corner regions are projected onto the corner arcs.
     pub fn clamp_pos(&self, pos: Pos2) -> Pos2 {
-        let Self { rect, rounding } = *self;
+        let Self {
+            rect,
+            corner_radius,
+        } = *self;
         let pos = rect.clamp(pos);
         let corners = [
-            (f32::from(rounding.nw), vec2(-1.0, -1.0)),
-            (f32::from(rounding.ne), vec2(1.0, -1.0)),
-            (f32::from(rounding.sw), vec2(-1.0, 1.0)),
-            (f32::from(rounding.se), vec2(1.0, 1.0)),
+            (f32::from(corner_radius.nw), vec2(-1.0, -1.0)),
+            (f32::from(corner_radius.ne), vec2(1.0, -1.0)),
+            (f32::from(corner_radius.sw), vec2(-1.0, 1.0)),
+            (f32::from(corner_radius.se), vec2(1.0, 1.0)),
         ];
         for (radius, dir) in corners {
             let arc_center = rect.center() + dir * (rect.size() / 2.0 - Vec2::splat(radius));
@@ -47,7 +50,7 @@ impl From<Rect> for RoundedRect {
     fn from(rect: Rect) -> Self {
         Self {
             rect,
-            rounding: CornerRadius::ZERO,
+            corner_radius: CornerRadius::ZERO,
         }
     }
 }

--- a/crates/epaint/src/shadow.rs
+++ b/crates/epaint/src/shadow.rs
@@ -56,14 +56,14 @@ impl Shadow {
         } = *self;
         let [offset_x, offset_y] = offset;
 
-        let rounded_rect = RoundedRect::new(
+        let (rect, corner_radius) = RoundedRect::new(
             rect.translate(Vec2::new(offset_x as _, offset_y as _)),
             corner_radius,
         )
-        .expand(spread);
+        .expand(spread)
+        .into_parts();
 
-        RectShape::filled(rounded_rect.rect(), rounded_rect.corner_radius(), color)
-            .with_blur_width(blur as _)
+        RectShape::filled(rect, corner_radius, color).with_blur_width(blur as _)
     }
 
     /// How much larger than the parent rect are we in each direction?

--- a/crates/epaint/src/shadow.rs
+++ b/crates/epaint/src/shadow.rs
@@ -58,9 +58,9 @@ impl Shadow {
 
         let (rect, corner_radius) = RoundedRect::new(
             rect.translate(Vec2::new(offset_x as _, offset_y as _)),
-            corner_radius,
+            corner_radius.into(),
         )
-        .expand(spread)
+        .expand(f32::from(spread))
         .into_parts();
 
         RectShape::filled(rect, corner_radius, color).with_blur_width(blur as _)

--- a/crates/epaint/src/shadow.rs
+++ b/crates/epaint/src/shadow.rs
@@ -1,4 +1,4 @@
-use crate::{Color32, CornerRadius, MarginF32, Rect, RectShape, Vec2};
+use crate::{Color32, CornerRadius, MarginF32, Rect, RectShape, RoundedRect, Vec2};
 
 /// The color and fuzziness of a fuzzy shape.
 ///
@@ -56,12 +56,14 @@ impl Shadow {
         } = *self;
         let [offset_x, offset_y] = offset;
 
-        let rect = rect
-            .translate(Vec2::new(offset_x as _, offset_y as _))
-            .expand(spread as _);
-        let corner_radius = corner_radius.into() + CornerRadius::from(spread);
+        let rounded_rect = RoundedRect::new(
+            rect.translate(Vec2::new(offset_x as _, offset_y as _)),
+            corner_radius,
+        )
+        .expand(spread);
 
-        RectShape::filled(rect, corner_radius, color).with_blur_width(blur as _)
+        RectShape::filled(rounded_rect.rect(), rounded_rect.corner_radius(), color)
+            .with_blur_width(blur as _)
     }
 
     /// How much larger than the parent rect are we in each direction?

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -11,8 +11,8 @@ use emath::{
 
 use crate::{
     CircleShape, ClippedPrimitive, ClippedShape, Color32, CornerRadiusF32, CubicBezierShape,
-    EllipseShape, Mesh, PathShape, Primitive, QuadraticBezierShape, RectShape, Shape, Stroke,
-    StrokeKind, TextShape, TextureId, Vertex, color::ColorMode, emath, stroke::PathStroke,
+    EllipseShape, Mesh, PathShape, Primitive, QuadraticBezierShape, RectShape, RoundedRect, Shape,
+    Stroke, StrokeKind, TextShape, TextureId, Vertex, color::ColorMode, emath, stroke::PathStroke,
     texture_atlas::PreparedDisc,
 };
 
@@ -536,17 +536,18 @@ impl Path {
 
 pub mod path {
     //! Helpers for constructing paths
-    use crate::CornerRadiusF32;
-    use emath::{Pos2, Rect, pos2};
+    use crate::{CornerRadiusF32, RoundedRect};
+    use emath::{Pos2, pos2};
 
     /// overwrites existing points
-    pub fn rounded_rectangle(path: &mut Vec<Pos2>, rect: Rect, cr: CornerRadiusF32) {
+    pub fn rounded_rectangle(path: &mut Vec<Pos2>, rounded_rect: RoundedRect) {
         path.clear();
+
+        // The corner radius is already clamped to half the rect size by `RoundedRect`:
+        let (rect, cr) = rounded_rect.into_parts();
 
         let min = rect.min;
         let max = rect.max;
-
-        let cr = clamp_corner_radius(cr, rect);
 
         if cr == CornerRadiusF32::ZERO {
             path.reserve(4);
@@ -632,14 +633,6 @@ pub mod path {
             let quadrant_vertices = &CIRCLE_128[offset..=offset + 32];
             path.extend(quadrant_vertices.iter().map(|&n| center + radius * n));
         }
-    }
-
-    // Ensures the radius of each corner is within a valid range
-    fn clamp_corner_radius(cr: CornerRadiusF32, rect: Rect) -> CornerRadiusF32 {
-        let half_width = rect.width() * 0.5;
-        let half_height = rect.height() * 0.5;
-        let max_cr = half_width.min(half_height);
-        cr.at_most(max_cr).at_least(0.0)
     }
 }
 
@@ -1938,7 +1931,10 @@ impl Tessellator {
 
         let path = &mut self.scratchpad_path;
         path.clear();
-        path::rounded_rectangle(&mut self.scratchpad_points, rect, corner_radius);
+        path::rounded_rectangle(
+            &mut self.scratchpad_points,
+            RoundedRect::new(rect, corner_radius),
+        );
 
         // Apply rotation if angle is non-zero
         if angle != 0.0 {


### PR DESCRIPTION
A rectangle with rounded corners. A very useful primitive.

This probably belong in `emath`, but then we also need to move `CornerRadiusF32` 🤔 