### PR TITLE
Fix `Frame::set_wgpu_surface_config` being ignored

### DIFF
--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -679,6 +679,15 @@ pub struct Frame {
     #[doc(hidden)]
     pub wgpu_render_state: Option<egui_wgpu::RenderState>,
 
+    /// The surface config the app wants the `wgpu` renderer to use.
+    ///
+    /// `None` unless we are rendering with `wgpu`.
+    ///
+    /// eframe pushes this into the painter once per frame, before painting.
+    #[cfg(feature = "wgpu_no_default_features")]
+    #[doc(hidden)]
+    pub wgpu_surface_config: Option<egui_wgpu::SurfaceConfig>,
+
     /// The current [`winit::window::Window`] (i.e. the one the active viewport is rendered to).
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) window: Option<std::sync::Arc<winit::window::Window>>,
@@ -733,6 +742,8 @@ impl Frame {
             storage: None,
             #[cfg(feature = "wgpu_no_default_features")]
             wgpu_render_state: None,
+            #[cfg(feature = "wgpu_no_default_features")]
+            wgpu_surface_config: None,
         }
     }
 
@@ -804,25 +815,27 @@ impl Frame {
         self.wgpu_render_state.as_ref()
     }
 
-    /// The currently-applied runtime surface config (present mode, frame latency)
-    /// used by the `wgpu` renderer, if any.
+    /// The surface config (present mode, frame latency) the app wants the `wgpu`
+    /// renderer to use.
     ///
-    /// Returns `None` when not using the `wgpu` backend.
+    /// `None` unless we are rendering with `wgpu`.
     #[cfg(feature = "wgpu_no_default_features")]
     pub fn wgpu_surface_config(&self) -> Option<egui_wgpu::SurfaceConfig> {
-        self.wgpu_render_state
-            .as_ref()
-            .map(|state| state.surface_config)
+        self.wgpu_surface_config
     }
 
-    /// Set the runtime surface config (present mode, frame latency) for the `wgpu`
-    /// renderer. The surface is reconfigured on the next paint.
+    /// Set the surface config (present mode, frame latency) the app wants the `wgpu`
+    /// renderer to use.
     ///
-    /// No-op when not using the `wgpu` backend.
+    /// No-op unless we are rendering with `wgpu`.
+    ///
+    /// The config might not take effect if the surface does not support the
+    /// requested present mode. On web the config is ignored, since the browser
+    /// controls presentation via `requestAnimationFrame`.
     #[cfg(feature = "wgpu_no_default_features")]
     pub fn set_wgpu_surface_config(&mut self, config: egui_wgpu::SurfaceConfig) {
-        if let Some(state) = &mut self.wgpu_render_state {
-            state.surface_config = config;
+        if let Some(current) = &mut self.wgpu_surface_config {
+            *current = config;
         }
     }
 }

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -196,6 +196,11 @@ impl EpiIntegration {
             #[cfg(feature = "glow")]
             glow_register_native_texture,
             #[cfg(feature = "wgpu_no_default_features")]
+            // We only care about the surface config if we are using wgpu
+            wgpu_surface_config: wgpu_render_state
+                .is_some()
+                .then_some(native_options.wgpu_options.surface),
+            #[cfg(feature = "wgpu_no_default_features")]
             wgpu_render_state,
             window: Some(Arc::clone(window)),
             raw_display_handle: window.display_handle().map(|h| h.as_raw()),

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -779,6 +779,11 @@ impl WgpuWinitRunning<'_> {
 
         remove_viewports_not_in(viewports, painter, viewport_from_window, &viewport_output);
 
+        // Synchronization between the integration layer and the painter layer
+        if let Some(surface_config) = integration.frame.wgpu_surface_config {
+            painter.set_surface_config(surface_config);
+        }
+
         let Some(viewport) = viewports.get_mut(&viewport_id) else {
             return Ok(EventResult::Wait);
         };

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -137,6 +137,12 @@ impl AppRunner {
             gl,
 
             #[cfg(feature = "wgpu_no_default_features")]
+            // We only care about the surface config if we are using wgpu
+            wgpu_surface_config: wgpu_render_state
+                .is_some()
+                .then_some(web_options.wgpu_options.surface),
+
+            #[cfg(feature = "wgpu_no_default_features")]
             wgpu_render_state,
         };
 

--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -65,8 +65,6 @@ pub enum WgpuError {
 }
 
 /// Runtime-mutable subset of [`WgpuConfiguration`].
-///
-/// Edit any field to have the surface reconfigured on the next paint.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct SurfaceConfig {
     /// Present mode used for the primary surface.
@@ -129,11 +127,6 @@ pub struct RenderState {
 
     /// Egui renderer responsible for drawing the UI.
     pub renderer: Arc<RwLock<Renderer>>,
-
-    /// Runtime-mutable subset of the wgpu configuration.
-    ///
-    /// Update this to have the surface reconfigured on the next paint.
-    pub surface_config: SurfaceConfig,
 }
 
 async fn request_adapter(
@@ -291,7 +284,6 @@ impl RenderState {
             queue,
             target_format,
             renderer: Arc::new(RwLock::new(renderer)),
-            surface_config: config.surface,
         })
     }
 }
@@ -333,9 +325,6 @@ pub enum SurfaceErrorAction {
 #[derive(Clone)]
 pub struct WgpuConfiguration {
     /// Runtime-mutable configuration for the surface (present mode, frame latency).
-    ///
-    /// These are the fields exposed via [`RenderState::surface_config`] for live
-    /// reconfiguration at runtime.
     pub surface: SurfaceConfig,
 
     /// How to create the wgpu adapter & device

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -93,6 +93,29 @@ impl Painter {
         self.render_state.clone()
     }
 
+    /// The surface configuration (present mode, frame latency) the surfaces are configured with.
+    pub fn surface_config(&self) -> SurfaceConfig {
+        self.config.surface
+    }
+
+    /// Change the surface configuration (present mode, frame latency) at runtime.
+    ///
+    /// All surfaces are reconfigured before the next paint.
+    ///
+    /// This is cheap to call every frame.
+    pub fn set_surface_config(&mut self, surface_config: SurfaceConfig) {
+        if self.config.surface == surface_config {
+            return;
+        }
+
+        self.config.surface = surface_config;
+
+        #[expect(clippy::iter_over_hash_type)]
+        for surface in self.surfaces.values_mut() {
+            surface.needs_reconfigure = true;
+        }
+    }
+
     fn configure_surface(
         surface_state: &SurfaceState,
         render_state: &RenderState,
@@ -521,20 +544,6 @@ impl Painter {
         {
             log::error!("Failed to recreate surface for {viewport_id:?}: {err}");
             return vsync_sec;
-        }
-
-        // Apply any runtime changes requested via `RenderState::surface_config`.
-        // We diff against the already-applied values in `self.config.surface`
-        // and, if anything differs, mark every surface as needing reconfiguration so
-        // the existing `needs_reconfigure` pathway below picks them up.
-        if let Some(render_state) = self.render_state.as_ref()
-            && render_state.surface_config != self.config.surface
-        {
-            self.config.surface = render_state.surface_config;
-            #[expect(clippy::iter_over_hash_type)]
-            for surface in self.surfaces.values_mut() {
-                surface.needs_reconfigure = true;
-            }
         }
 
         let Some(render_state) = self.render_state.as_mut() else {


### PR DESCRIPTION
Fixes `eframe::Frame::set_wgpu_surface_config()` not changing the present mode or frame latency.

`eframe::Frame::set_wgpu_surface_config()` wrote to the `surface_config` of the `RenderState` inside `Frame` itself, but the one actually used to configure the window is `egui_wgpu::winit::Painter::config.surface`. Nothing ever propagated that write to the painter, so the two were never synchronized.

This PR also trims the number of `SurfaceConfig`s scattered across the structs.

## What was changed

- `RenderState` no longer stores `SurfaceConfig` **(BREAKING CHANGE)**;
- `Painter` gains `surface_config()` and `set_surface_config()`;
- `Frame::set_wgpu_surface_config()` and `Frame::wgpu_surface_config()` now use a new field, `wgpu_surface_config: Option<SurfaceConfig>`;
- `Painter::config.surface` is now the only source of truth for the applied `SurfaceConfig`.

* [X] I have followed the instructions in the PR template