### PR TITLE
Recover rendering instead of panicking after wgpu failures

### DIFF
--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -31,9 +31,7 @@ use crate::{
     App, AppCreator, CreationContext, NativeOptions, Result, Storage,
     native::{
         epi_integration::EpiIntegration,
-        winit_integration::{
-            EventResult, ViewportWindow, ViewportWindowKind, sleep_if_invisible_or_minimized,
-        },
+        winit_integration::{EventResult, sleep_if_invisible_or_minimized},
     },
 };
 
@@ -415,36 +413,6 @@ impl WinitApp for WgpuWinitApp<'_> {
                 .as_ref()?
                 .id(),
         )
-    }
-
-    fn viewport_windows(&self) -> Vec<ViewportWindow> {
-        self.running
-            .as_ref()
-            .map(|running| {
-                running
-                    .shared
-                    .borrow()
-                    .viewports
-                    .iter()
-                    .filter_map(|(viewport_id, viewport)| {
-                        let window_id = viewport.window.as_ref()?.id();
-                        let kind = if *viewport_id == ViewportId::ROOT {
-                            ViewportWindowKind::Root
-                        } else if viewport.viewport_ui_cb.is_some() {
-                            ViewportWindowKind::Deferred
-                        } else {
-                            ViewportWindowKind::Immediate
-                        };
-
-                        Some(ViewportWindow {
-                            viewport_id: *viewport_id,
-                            window_id,
-                            kind,
-                        })
-                    })
-                    .collect()
-            })
-            .unwrap_or_default()
     }
 
     fn save(&mut self) {

--- a/crates/eframe/src/native/wgpu_integration.rs
+++ b/crates/eframe/src/native/wgpu_integration.rs
@@ -31,7 +31,9 @@ use crate::{
     App, AppCreator, CreationContext, NativeOptions, Result, Storage,
     native::{
         epi_integration::EpiIntegration,
-        winit_integration::{EventResult, sleep_if_invisible_or_minimized},
+        winit_integration::{
+            EventResult, ViewportWindow, ViewportWindowKind, sleep_if_invisible_or_minimized,
+        },
     },
 };
 
@@ -415,6 +417,36 @@ impl WinitApp for WgpuWinitApp<'_> {
         )
     }
 
+    fn viewport_windows(&self) -> Vec<ViewportWindow> {
+        self.running
+            .as_ref()
+            .map(|running| {
+                running
+                    .shared
+                    .borrow()
+                    .viewports
+                    .iter()
+                    .filter_map(|(viewport_id, viewport)| {
+                        let window_id = viewport.window.as_ref()?.id();
+                        let kind = if *viewport_id == ViewportId::ROOT {
+                            ViewportWindowKind::Root
+                        } else if viewport.viewport_ui_cb.is_some() {
+                            ViewportWindowKind::Deferred
+                        } else {
+                            ViewportWindowKind::Immediate
+                        };
+
+                        Some(ViewportWindow {
+                            viewport_id: *viewport_id,
+                            window_id,
+                            kind,
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     fn save(&mut self) {
         log::debug!("WinitApp::save called");
         if let Some(running) = self.running.as_mut() {
@@ -675,6 +707,7 @@ impl WgpuWinitRunning<'_> {
                 profiling::scope!("set_window");
                 pollster::block_on(painter.set_window(viewport_id, Some(Arc::clone(window))))?;
             }
+            integration.frame.wgpu_render_state = painter.render_state();
 
             let Some(egui_winit) = egui_winit.as_mut() else {
                 return Ok(EventResult::Wait);

--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -294,60 +294,6 @@ impl RenderState {
             surface_config: config.surface,
         })
     }
-
-    /// Recreates render state from an already selected adapter, avoiding adapter enumeration.
-    ///
-    /// Intended for native recovery. If this fails, callers should use [`Self::create`]
-    /// to repeat the normal adapter discovery and selection path.
-    pub async fn create_with_adapter(
-        config: &WgpuConfiguration,
-        instance: &wgpu::Instance,
-        compatible_surface: Option<&wgpu::Surface<'static>>,
-        options: RendererOptions,
-        adapter: wgpu::Adapter,
-    ) -> Result<Self, WgpuError> {
-        profiling::scope!("RenderState::create_with_adapter");
-
-        let WgpuSetup::CreateNew(WgpuSetupCreateNew {
-            device_descriptor, ..
-        }) = config.wgpu_setup.clone()
-        else {
-            return Self::create(config, instance, compatible_surface, options).await;
-        };
-
-        let (device, queue) = {
-            profiling::scope!("request_device");
-            adapter
-                .request_device(&(*device_descriptor)(&adapter))
-                .await?
-        };
-
-        log::info!("Recreating egui-wgpu render state with the previously selected adapter");
-        log_adapter_info(&adapter.get_info());
-
-        let surface_formats = {
-            profiling::scope!("get_capabilities");
-            compatible_surface.map_or_else(
-                || vec![wgpu::TextureFormat::Rgba8Unorm],
-                |surface| surface.get_capabilities(&adapter).formats,
-            )
-        };
-        let target_format = crate::preferred_framebuffer_format(&surface_formats)?;
-        let renderer = Renderer::new(&device, target_format, options);
-
-        #[allow(clippy::allow_attributes, clippy::arc_with_non_send_sync)]
-        Ok(Self {
-            instance: instance.clone(),
-            adapter,
-            #[cfg(not(target_arch = "wasm32"))]
-            available_adapters: Vec::new(),
-            device,
-            queue,
-            target_format,
-            renderer: Arc::new(RwLock::new(renderer)),
-            surface_config: config.surface,
-        })
-    }
 }
 
 fn describe_adapters(adapters: &[wgpu::Adapter]) -> String {

--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -294,6 +294,60 @@ impl RenderState {
             surface_config: config.surface,
         })
     }
+
+    /// Recreates render state from an already selected adapter, avoiding adapter enumeration.
+    ///
+    /// Intended for native recovery. If this fails, callers should use [`Self::create`]
+    /// to repeat the normal adapter discovery and selection path.
+    pub async fn create_with_adapter(
+        config: &WgpuConfiguration,
+        instance: &wgpu::Instance,
+        compatible_surface: Option<&wgpu::Surface<'static>>,
+        options: RendererOptions,
+        adapter: wgpu::Adapter,
+    ) -> Result<Self, WgpuError> {
+        profiling::scope!("RenderState::create_with_adapter");
+
+        let WgpuSetup::CreateNew(WgpuSetupCreateNew {
+            device_descriptor, ..
+        }) = config.wgpu_setup.clone()
+        else {
+            return Self::create(config, instance, compatible_surface, options).await;
+        };
+
+        let (device, queue) = {
+            profiling::scope!("request_device");
+            adapter
+                .request_device(&(*device_descriptor)(&adapter))
+                .await?
+        };
+
+        log::info!("Recreating egui-wgpu render state with the previously selected adapter");
+        log_adapter_info(&adapter.get_info());
+
+        let surface_formats = {
+            profiling::scope!("get_capabilities");
+            compatible_surface.map_or_else(
+                || vec![wgpu::TextureFormat::Rgba8Unorm],
+                |surface| surface.get_capabilities(&adapter).formats,
+            )
+        };
+        let target_format = crate::preferred_framebuffer_format(&surface_formats)?;
+        let renderer = Renderer::new(&device, target_format, options);
+
+        #[allow(clippy::allow_attributes, clippy::arc_with_non_send_sync)]
+        Ok(Self {
+            instance: instance.clone(),
+            adapter,
+            #[cfg(not(target_arch = "wasm32"))]
+            available_adapters: Vec::new(),
+            device,
+            queue,
+            target_format,
+            renderer: Arc::new(RwLock::new(renderer)),
+            surface_config: config.surface,
+        })
+    }
 }
 
 fn describe_adapters(adapters: &[wgpu::Adapter]) -> String {

--- a/crates/egui-wgpu/src/renderer.rs
+++ b/crates/egui-wgpu/src/renderer.rs
@@ -245,12 +245,6 @@ pub struct Renderer {
     uniform_bind_group: wgpu::BindGroup,
     texture_bind_group_layout: wgpu::BindGroupLayout,
 
-    /// Uniform buffers each holding a single `u32`:
-    /// 1 if the texture sampler uses nearest filtering, 0 otherwise.
-    /// Indexed by that flag value.
-    /// Read by the shader when `predictable_texture_filtering` is on.
-    nearest_filtering_flag_buffers: [wgpu::Buffer; 2],
-
     /// Map of egui texture IDs to textures and their associated bindgroups (texture view +
     /// sampler). The texture may be None if the `TextureId` is just a handle to a user-provided
     /// sampler.
@@ -353,27 +347,9 @@ impl Renderer {
                         ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                         count: None,
                     },
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 2,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Buffer {
-                            has_dynamic_offset: false,
-                            min_binding_size: NonZeroU64::new(core::mem::size_of::<u32>() as _),
-                            ty: wgpu::BufferBindingType::Uniform,
-                        },
-                        count: None,
-                    },
                 ],
             })
         };
-
-        let nearest_filtering_flag_buffers = [0_u32, 1_u32].map(|flag| {
-            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some(&format!("egui_nearest_filtering_flag_{flag}")),
-                contents: bytemuck::bytes_of(&flag),
-                usage: wgpu::BufferUsages::UNIFORM,
-            })
-        });
 
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("egui_pipeline_layout"),
@@ -482,7 +458,6 @@ impl Renderer {
             previous_uniform_buffer_content: UniformBuffer::zeroed(),
             uniform_bind_group,
             texture_bind_group_layout,
-            nearest_filtering_flag_buffers,
             textures: HashMap::default(),
             next_user_texture_id: 0,
             samplers: HashMap::default(),
@@ -734,8 +709,6 @@ impl Renderer {
         };
 
         let bind_group = bind_group.unwrap_or_else(|| {
-            let nearest =
-                image_delta.options.magnification == epaint::textures::TextureFilter::Nearest;
             let sampler = self
                 .samplers
                 .entry(image_delta.options)
@@ -753,11 +726,6 @@ impl Renderer {
                     wgpu::BindGroupEntry {
                         binding: 1,
                         resource: wgpu::BindingResource::Sampler(sampler),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 2,
-                        resource: self.nearest_filtering_flag_buffers[usize::from(nearest)]
-                            .as_entire_binding(),
                     },
                 ],
             })
@@ -861,7 +829,6 @@ impl Renderer {
     ) -> epaint::TextureId {
         profiling::function_scope!();
 
-        let nearest = sampler_descriptor.mag_filter == wgpu::FilterMode::Nearest;
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             compare: None,
             ..sampler_descriptor
@@ -878,11 +845,6 @@ impl Renderer {
                 wgpu::BindGroupEntry {
                     binding: 1,
                     resource: wgpu::BindingResource::Sampler(&sampler),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 2,
-                    resource: self.nearest_filtering_flag_buffers[usize::from(nearest)]
-                        .as_entire_binding(),
                 },
             ],
         });
@@ -923,7 +885,6 @@ impl Renderer {
             .get_mut(&id)
             .expect("Tried to update a texture that has not been allocated yet.");
 
-        let nearest = sampler_descriptor.mag_filter == wgpu::FilterMode::Nearest;
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             compare: None,
             ..sampler_descriptor
@@ -940,11 +901,6 @@ impl Renderer {
                 wgpu::BindGroupEntry {
                     binding: 1,
                     resource: wgpu::BindingResource::Sampler(&sampler),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 2,
-                    resource: self.nearest_filtering_flag_buffers[usize::from(nearest)]
-                        .as_entire_binding(),
                 },
             ],
         });
@@ -1024,28 +980,44 @@ impl Renderer {
                 NonZeroU64::new(required_index_buffer_size).unwrap(),
             );
 
-            let Some(mut index_buffer_staging) = index_buffer_staging else {
-                panic!(
-                    "Failed to create staging buffer for index data. Index count: {index_count}. Required index buffer size: {required_index_buffer_size}. Actual size {} and capacity: {} (bytes)",
+            let mut index_offset = 0;
+            if let Some(mut index_buffer_staging) = index_buffer_staging {
+                for epaint::ClippedPrimitive { primitive, .. } in paint_jobs {
+                    match primitive {
+                        Primitive::Mesh(mesh) => {
+                            let size = mesh.indices.len() * core::mem::size_of::<u32>();
+                            let slice = index_offset..(size + index_offset);
+                            index_buffer_staging
+                                .slice(slice.clone())
+                                .copy_from_slice(bytemuck::cast_slice(&mesh.indices));
+                            self.index_buffer.slices.push(slice);
+                            index_offset += size;
+                        }
+                        Primitive::Callback(_) => {}
+                    }
+                }
+            } else {
+                log::warn!(
+                    "Failed to create staging buffer for index data; falling back to queue.write_buffer. Index count: {index_count}. Required index buffer size: {required_index_buffer_size}. Actual size {} and capacity: {} (bytes)",
                     self.index_buffer.buffer.size(),
                     self.index_buffer.capacity
                 );
-            };
 
-            let mut index_offset = 0;
-            for epaint::ClippedPrimitive { primitive, .. } in paint_jobs {
-                match primitive {
-                    Primitive::Mesh(mesh) => {
-                        let size = mesh.indices.len() * core::mem::size_of::<u32>();
-                        let slice = index_offset..(size + index_offset);
-                        index_buffer_staging
-                            .slice(slice.clone())
-                            .copy_from_slice(bytemuck::cast_slice(&mesh.indices));
-                        self.index_buffer.slices.push(slice);
-                        index_offset += size;
+                let mut index_data = Vec::with_capacity(required_index_buffer_size as usize);
+                for epaint::ClippedPrimitive { primitive, .. } in paint_jobs {
+                    match primitive {
+                        Primitive::Mesh(mesh) => {
+                            let bytes = bytemuck::cast_slice(&mesh.indices);
+                            let size = bytes.len();
+                            let slice = index_offset..(size + index_offset);
+                            index_data.extend_from_slice(bytes);
+                            self.index_buffer.slices.push(slice);
+                            index_offset += size;
+                        }
+                        Primitive::Callback(_) => {}
                     }
-                    Primitive::Callback(_) => {}
                 }
+                queue.write_buffer(&self.index_buffer.buffer, 0, &index_data);
             }
         }
         if vertex_count > 0 {
@@ -1070,28 +1042,44 @@ impl Renderer {
                 NonZeroU64::new(required_vertex_buffer_size).unwrap(),
             );
 
-            let Some(mut vertex_buffer_staging) = vertex_buffer_staging else {
-                panic!(
-                    "Failed to create staging buffer for vertex data. Vertex count: {vertex_count}. Required vertex buffer size: {required_vertex_buffer_size}. Actual size {} and capacity: {} (bytes)",
+            let mut vertex_offset = 0;
+            if let Some(mut vertex_buffer_staging) = vertex_buffer_staging {
+                for epaint::ClippedPrimitive { primitive, .. } in paint_jobs {
+                    match primitive {
+                        Primitive::Mesh(mesh) => {
+                            let size = mesh.vertices.len() * core::mem::size_of::<Vertex>();
+                            let slice = vertex_offset..(size + vertex_offset);
+                            vertex_buffer_staging
+                                .slice(slice.clone())
+                                .copy_from_slice(bytemuck::cast_slice(&mesh.vertices));
+                            self.vertex_buffer.slices.push(slice);
+                            vertex_offset += size;
+                        }
+                        Primitive::Callback(_) => {}
+                    }
+                }
+            } else {
+                log::warn!(
+                    "Failed to create staging buffer for vertex data; falling back to queue.write_buffer. Vertex count: {vertex_count}. Required vertex buffer size: {required_vertex_buffer_size}. Actual size {} and capacity: {} (bytes)",
                     self.vertex_buffer.buffer.size(),
                     self.vertex_buffer.capacity
                 );
-            };
 
-            let mut vertex_offset = 0;
-            for epaint::ClippedPrimitive { primitive, .. } in paint_jobs {
-                match primitive {
-                    Primitive::Mesh(mesh) => {
-                        let size = mesh.vertices.len() * core::mem::size_of::<Vertex>();
-                        let slice = vertex_offset..(size + vertex_offset);
-                        vertex_buffer_staging
-                            .slice(slice.clone())
-                            .copy_from_slice(bytemuck::cast_slice(&mesh.vertices));
-                        self.vertex_buffer.slices.push(slice);
-                        vertex_offset += size;
+                let mut vertex_data = Vec::with_capacity(required_vertex_buffer_size as usize);
+                for epaint::ClippedPrimitive { primitive, .. } in paint_jobs {
+                    match primitive {
+                        Primitive::Mesh(mesh) => {
+                            let bytes = bytemuck::cast_slice(&mesh.vertices);
+                            let size = bytes.len();
+                            let slice = vertex_offset..(size + vertex_offset);
+                            vertex_data.extend_from_slice(bytes);
+                            self.vertex_buffer.slices.push(slice);
+                            vertex_offset += size;
+                        }
+                        Primitive::Callback(_) => {}
                     }
-                    Primitive::Callback(_) => {}
                 }
+                queue.write_buffer(&self.vertex_buffer.buffer, 0, &vertex_data);
             }
         }
 

--- a/crates/egui-wgpu/src/renderer.rs
+++ b/crates/egui-wgpu/src/renderer.rs
@@ -245,6 +245,12 @@ pub struct Renderer {
     uniform_bind_group: wgpu::BindGroup,
     texture_bind_group_layout: wgpu::BindGroupLayout,
 
+    /// Uniform buffers each holding a single `u32`:
+    /// 1 if the texture sampler uses nearest filtering, 0 otherwise.
+    /// Indexed by that flag value.
+    /// Read by the shader when `predictable_texture_filtering` is on.
+    nearest_filtering_flag_buffers: [wgpu::Buffer; 2],
+
     /// Map of egui texture IDs to textures and their associated bindgroups (texture view +
     /// sampler). The texture may be None if the `TextureId` is just a handle to a user-provided
     /// sampler.
@@ -347,9 +353,27 @@ impl Renderer {
                         ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                         count: None,
                     },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Buffer {
+                            has_dynamic_offset: false,
+                            min_binding_size: NonZeroU64::new(core::mem::size_of::<u32>() as _),
+                            ty: wgpu::BufferBindingType::Uniform,
+                        },
+                        count: None,
+                    },
                 ],
             })
         };
+
+        let nearest_filtering_flag_buffers = [0_u32, 1_u32].map(|flag| {
+            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some(&format!("egui_nearest_filtering_flag_{flag}")),
+                contents: bytemuck::bytes_of(&flag),
+                usage: wgpu::BufferUsages::UNIFORM,
+            })
+        });
 
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("egui_pipeline_layout"),
@@ -458,6 +482,7 @@ impl Renderer {
             previous_uniform_buffer_content: UniformBuffer::zeroed(),
             uniform_bind_group,
             texture_bind_group_layout,
+            nearest_filtering_flag_buffers,
             textures: HashMap::default(),
             next_user_texture_id: 0,
             samplers: HashMap::default(),
@@ -709,6 +734,8 @@ impl Renderer {
         };
 
         let bind_group = bind_group.unwrap_or_else(|| {
+            let nearest =
+                image_delta.options.magnification == epaint::textures::TextureFilter::Nearest;
             let sampler = self
                 .samplers
                 .entry(image_delta.options)
@@ -726,6 +753,11 @@ impl Renderer {
                     wgpu::BindGroupEntry {
                         binding: 1,
                         resource: wgpu::BindingResource::Sampler(sampler),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: self.nearest_filtering_flag_buffers[usize::from(nearest)]
+                            .as_entire_binding(),
                     },
                 ],
             })
@@ -829,6 +861,7 @@ impl Renderer {
     ) -> epaint::TextureId {
         profiling::function_scope!();
 
+        let nearest = sampler_descriptor.mag_filter == wgpu::FilterMode::Nearest;
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             compare: None,
             ..sampler_descriptor
@@ -845,6 +878,11 @@ impl Renderer {
                 wgpu::BindGroupEntry {
                     binding: 1,
                     resource: wgpu::BindingResource::Sampler(&sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: self.nearest_filtering_flag_buffers[usize::from(nearest)]
+                        .as_entire_binding(),
                 },
             ],
         });
@@ -885,6 +923,7 @@ impl Renderer {
             .get_mut(&id)
             .expect("Tried to update a texture that has not been allocated yet.");
 
+        let nearest = sampler_descriptor.mag_filter == wgpu::FilterMode::Nearest;
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             compare: None,
             ..sampler_descriptor
@@ -901,6 +940,11 @@ impl Renderer {
                 wgpu::BindGroupEntry {
                     binding: 1,
                     resource: wgpu::BindingResource::Sampler(&sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: self.nearest_filtering_flag_buffers[usize::from(nearest)]
+                        .as_entire_binding(),
                 },
             ],
         });

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -36,7 +36,6 @@ pub struct Painter {
 
     instance: wgpu::Instance,
     render_state: Option<RenderState>,
-    recovery_adapter: Option<wgpu::Adapter>,
     needs_render_state_recreate: bool,
 
     // Per viewport/window:

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -36,6 +36,7 @@ pub struct Painter {
 
     instance: wgpu::Instance,
     render_state: Option<RenderState>,
+    recovery_adapter: Option<wgpu::Adapter>,
     needs_render_state_recreate: bool,
 
     // Per viewport/window:
@@ -77,6 +78,7 @@ impl Painter {
 
             instance,
             render_state: None,
+            recovery_adapter: None,
             needs_render_state_recreate: false,
 
             depth_texture_view: Default::default(),
@@ -263,9 +265,35 @@ impl Painter {
         size: winit::dpi::PhysicalSize<u32>,
     ) -> Result<(), crate::WgpuError> {
         if self.render_state.is_none() {
-            let render_state =
+            let render_state = if let Some(adapter) = self.recovery_adapter.clone() {
+                match RenderState::create_with_adapter(
+                    &self.config,
+                    &self.instance,
+                    Some(&surface),
+                    self.options,
+                    adapter,
+                )
+                .await
+                {
+                    Ok(render_state) => render_state,
+                    Err(error) => {
+                        log::warn!(
+                            "Recreating egui-wgpu render state with the previous adapter failed: {error}. Falling back to adapter discovery"
+                        );
+                        RenderState::create(
+                            &self.config,
+                            &self.instance,
+                            Some(&surface),
+                            self.options,
+                        )
+                        .await?
+                    }
+                }
+            } else {
                 RenderState::create(&self.config, &self.instance, Some(&surface), self.options)
-                    .await?;
+                    .await?
+            };
+            self.recovery_adapter = Some(render_state.adapter.clone());
             self.render_state = Some(render_state);
         }
         self.install_surface(surface, viewport_id, size.width, size.height, false);

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -78,7 +78,6 @@ impl Painter {
 
             instance,
             render_state: None,
-            recovery_adapter: None,
             needs_render_state_recreate: false,
 
             depth_texture_view: Default::default(),
@@ -265,35 +264,9 @@ impl Painter {
         size: winit::dpi::PhysicalSize<u32>,
     ) -> Result<(), crate::WgpuError> {
         if self.render_state.is_none() {
-            let render_state = if let Some(adapter) = self.recovery_adapter.clone() {
-                match RenderState::create_with_adapter(
-                    &self.config,
-                    &self.instance,
-                    Some(&surface),
-                    self.options,
-                    adapter,
-                )
-                .await
-                {
-                    Ok(render_state) => render_state,
-                    Err(error) => {
-                        log::warn!(
-                            "Recreating egui-wgpu render state with the previous adapter failed: {error}. Falling back to adapter discovery"
-                        );
-                        RenderState::create(
-                            &self.config,
-                            &self.instance,
-                            Some(&surface),
-                            self.options,
-                        )
-                        .await?
-                    }
-                }
-            } else {
+            let render_state =
                 RenderState::create(&self.config, &self.instance, Some(&surface), self.options)
-                    .await?
-            };
-            self.recovery_adapter = Some(render_state.adapter.clone());
+                    .await?;
             self.render_state = Some(render_state);
         }
         self.install_surface(surface, viewport_id, size.width, size.height, false);

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -36,6 +36,7 @@ pub struct Painter {
 
     instance: wgpu::Instance,
     render_state: Option<RenderState>,
+    needs_render_state_recreate: bool,
 
     // Per viewport/window:
     depth_texture_view: ViewportIdMap<wgpu::TextureView>,
@@ -76,6 +77,7 @@ impl Painter {
 
             instance,
             render_state: None,
+            needs_render_state_recreate: false,
 
             depth_texture_view: Default::default(),
             surfaces: Default::default(),
@@ -165,6 +167,14 @@ impl Painter {
         Ok(())
     }
 
+    fn clear_render_state_for_recreate(&mut self) {
+        self.screen_capture_state = None;
+        self.render_state = None;
+        self.depth_texture_view.clear();
+        self.msaa_texture_view.clear();
+        self.surfaces.clear();
+    }
+
     /// Updates (or clears) the [`winit::window::Window`] associated with the [`Painter`]
     ///
     /// This creates a [`wgpu::Surface`] for the given Window (as well as initializing render
@@ -195,9 +205,20 @@ impl Painter {
 
         if let Some(window) = window {
             let size = window.inner_size();
+            let recreate_render_state = self.needs_render_state_recreate;
+            if recreate_render_state {
+                log::warn!(
+                    "Recreating egui-wgpu render state after device/surface recovery request"
+                );
+                self.clear_render_state_for_recreate();
+            }
             if !self.surfaces.contains_key(&viewport_id) {
                 let surface = self.instance.create_surface(window)?;
                 self.add_surface(surface, viewport_id, size).await?;
+            }
+            if recreate_render_state {
+                self.context.request_full_texture_reupload();
+                self.needs_render_state_recreate = false;
             }
         } else {
             log::warn!("No window - clearing all surfaces");
@@ -571,12 +592,22 @@ impl Painter {
                 frame
             }
             other => {
-                let surface_error_action =
-                    if matches!(&other, wgpu::CurrentSurfaceTexture::Validation) {
-                        SurfaceErrorAction::Reconfigure
-                    } else {
-                        (*self.config.on_surface_status)(&other)
-                    };
+                let needs_render_state_recreate = matches!(
+                    &other,
+                    wgpu::CurrentSurfaceTexture::Validation | wgpu::CurrentSurfaceTexture::Lost
+                );
+                let surface_error_action = if needs_render_state_recreate {
+                    SurfaceErrorAction::SkipFrame
+                } else {
+                    (*self.config.on_surface_status)(&other)
+                };
+                if needs_render_state_recreate {
+                    log::warn!(
+                        "Requesting egui-wgpu render-state recreation after surface status for {viewport_id:?}"
+                    );
+                    self.needs_render_state_recreate = true;
+                    self.context.request_repaint_of(viewport_id);
+                }
                 match surface_error_action {
                     SurfaceErrorAction::Reconfigure => {
                         Self::configure_surface(surface_state, render_state, &self.config.surface);

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -550,6 +550,54 @@ impl Painter {
             return vsync_sec;
         };
 
+        if surface_state.needs_reconfigure {
+            Self::configure_surface(surface_state, render_state, &self.config.surface);
+            surface_state.needs_reconfigure = false;
+        }
+
+        let output_frame = {
+            profiling::scope!("get_current_texture");
+            // This is what vsync-waiting happens on my Mac.
+            let start = web_time::Instant::now();
+            let output_frame = surface_state.surface.get_current_texture();
+            vsync_sec += start.elapsed().as_secs_f32();
+            output_frame
+        };
+
+        let output_frame = match output_frame {
+            wgpu::CurrentSurfaceTexture::Success(frame) => frame,
+            wgpu::CurrentSurfaceTexture::Suboptimal(frame) => {
+                surface_state.needs_reconfigure = true;
+                frame
+            }
+            other => {
+                let surface_error_action =
+                    if matches!(&other, wgpu::CurrentSurfaceTexture::Validation) {
+                        SurfaceErrorAction::Reconfigure
+                    } else {
+                        (*self.config.on_surface_status)(&other)
+                    };
+                match surface_error_action {
+                    SurfaceErrorAction::Reconfigure => {
+                        Self::configure_surface(surface_state, render_state, &self.config.surface);
+                        self.context.request_repaint_of(viewport_id);
+                    }
+                    SurfaceErrorAction::RecreateSurface => {
+                        // Because of ownership, I could not find an easy way to do a full recovery here,
+                        // as that would involve dropping the old surface and creating a new one.
+                        // For now, we defer the recreation to the beginning of the next frame (which
+                        // we ensure to arrive via `request_repaint_of`). A cleaner solution would be
+                        // to untangle the ownership of `RenderState`.
+                        surface_state.needs_recreate = true;
+                        self.context.request_repaint_of(viewport_id);
+                    }
+                    SurfaceErrorAction::SkipFrame => {}
+                }
+                return vsync_sec;
+            }
+        };
+
+        let mut capture_buffer = None;
         let mut encoder =
             render_state
                 .device
@@ -585,49 +633,6 @@ impl Painter {
                 &screen_descriptor,
             )
         };
-
-        if surface_state.needs_reconfigure {
-            Self::configure_surface(surface_state, render_state, &self.config.surface);
-            surface_state.needs_reconfigure = false;
-        }
-
-        let output_frame = {
-            profiling::scope!("get_current_texture");
-            // This is what vsync-waiting happens on my Mac.
-            let start = web_time::Instant::now();
-            let output_frame = surface_state.surface.get_current_texture();
-            vsync_sec += start.elapsed().as_secs_f32();
-            output_frame
-        };
-
-        let output_frame = match output_frame {
-            wgpu::CurrentSurfaceTexture::Success(frame) => frame,
-            wgpu::CurrentSurfaceTexture::Suboptimal(frame) => {
-                surface_state.needs_reconfigure = true;
-                frame
-            }
-            other => {
-                match (*self.config.on_surface_status)(&other) {
-                    SurfaceErrorAction::Reconfigure => {
-                        Self::configure_surface(surface_state, render_state, &self.config.surface);
-                        self.context.request_repaint_of(viewport_id);
-                    }
-                    SurfaceErrorAction::RecreateSurface => {
-                        // Because of ownership, I could not find an easy way to do a full recovery here,
-                        // as that would involve dropping the old surface and creating a new one.
-                        // For now, we defer the recreation to the beginning of the next frame (which
-                        // we ensure to arrive via `request_repaint_of`). A cleaner solution would be
-                        // to untangle the ownership of `RenderState`.
-                        surface_state.needs_recreate = true;
-                        self.context.request_repaint_of(viewport_id);
-                    }
-                    SurfaceErrorAction::SkipFrame => {}
-                }
-                return vsync_sec;
-            }
-        };
-
-        let mut capture_buffer = None;
         {
             let renderer = render_state.renderer.read();
 

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2452,6 +2452,14 @@ impl Context {
         TextureHandle::new(tex_mngr, tex_id)
     }
 
+    /// Request full uploads of all managed textures after a renderer recovery.
+    ///
+    /// Integrations that recreate their GPU renderer while keeping this context need this
+    /// so live texture handles are restored in the new backend texture map.
+    pub fn request_full_texture_reupload(&self) {
+        self.tex_manager().write().request_full_reupload();
+    }
+
     /// Low-level texture manager.
     ///
     /// In general it is easier to use [`Self::load_texture`] and [`TextureHandle`].

--- a/crates/epaint/src/textures.rs
+++ b/crates/epaint/src/textures.rs
@@ -82,6 +82,17 @@ impl TextureManager {
         }
     }
 
+    /// Request full uploads of all live managed textures after renderer recovery.
+    pub fn request_full_reupload(&mut self) {
+        self.delta.set.clear();
+        for (id, image) in &self.images {
+            if let Some(meta) = self.metas.get(id) {
+                self.delta
+                    .push(*id, ImageDelta::full(image.clone(), meta.options));
+            }
+        }
+    }
+
     /// Increase the retain-count of the given texture.
     ///
     /// For each time you call [`Self::retain`] you must call [`Self::free`] on additional time.

--- a/crates/epaint/src/textures.rs
+++ b/crates/epaint/src/textures.rs
@@ -152,6 +152,7 @@ fn apply_partial_delta(image: &mut ImageData, pos: [usize; 2], patch: &ImageData
         }
     }
 }
+
 impl Drop for TextureManager {
     fn drop(&mut self) {
         self.delta.clear(); // Prevent a debug panic on application shutdown

--- a/crates/epaint/src/textures.rs
+++ b/crates/epaint/src/textures.rs
@@ -95,10 +95,14 @@ impl TextureManager {
     /// Request full uploads of all live managed textures after renderer recovery.
     pub fn request_full_reupload(&mut self) {
         self.delta.set.clear();
-        for (id, image) in &self.images {
-            if let Some(meta) = self.metas.get(id) {
+
+        let mut ids = self.images.keys().copied().collect::<Vec<_>>();
+        ids.sort();
+
+        for id in ids {
+            if let (Some(image), Some(meta)) = (self.images.get(&id), self.metas.get(&id)) {
                 self.delta
-                    .push(*id, ImageDelta::full(image.clone(), meta.options));
+                    .push(id, ImageDelta::full(image.clone(), meta.options));
             }
         }
     }

--- a/crates/epaint/src/textures.rs
+++ b/crates/epaint/src/textures.rs
@@ -16,6 +16,8 @@ pub struct TextureManager {
     /// Information about currently allocated textures.
     metas: ahash::HashMap<TextureId, TextureMeta>,
 
+    /// CPU-side copies of live managed textures, retained for renderer recovery.
+    images: ahash::HashMap<TextureId, ImageData>,
     delta: TexturesDelta,
 }
 
@@ -43,6 +45,7 @@ impl TextureManager {
             options,
         });
 
+        self.images.insert(id, image.clone());
         self.delta.push(id, ImageDelta::full(image, options));
         id
     }
@@ -61,6 +64,12 @@ impl TextureManager {
                 // whole update
                 meta.size = delta.image.size();
                 meta.bytes_per_pixel = delta.image.bytes_per_pixel();
+                self.images.insert(id, delta.image.clone());
+            }
+            if let Some(pos) = delta.pos
+                && let Some(image) = self.images.get_mut(&id)
+            {
+                apply_partial_delta(image, pos, &delta.image);
             }
             self.delta.push(id, delta);
         } else {
@@ -75,6 +84,7 @@ impl TextureManager {
             meta.retain_count -= 1;
             if meta.retain_count == 0 {
                 entry.remove();
+                self.images.remove(&id);
                 self.delta.free(id);
             }
         } else {
@@ -130,6 +140,18 @@ impl TextureManager {
     }
 }
 
+fn apply_partial_delta(image: &mut ImageData, pos: [usize; 2], patch: &ImageData) {
+    match (image, patch) {
+        (ImageData::Color(image), ImageData::Color(patch)) => {
+            let image = std::sync::Arc::make_mut(image);
+            let [x, y] = pos;
+            for (patch_y, patch_row) in patch.pixels.chunks(patch.width()).enumerate() {
+                let start = (y + patch_y) * image.width() + x;
+                image.pixels[start..start + patch.width()].copy_from_slice(patch_row);
+            }
+        }
+    }
+}
 impl Drop for TextureManager {
     fn drop(&mut self) {
         self.delta.clear(); // Prevent a debug panic on application shutdown


### PR DESCRIPTION
Recover rendering instead of panicking after wgpu failures

**Description**

This PR prevents `egui-wgpu` from panicking when `Queue::write_buffer_with` cannot provide a staging buffer for index or vertex uploads. It keeps the existing fast path and falls back to `queue.write_buffer` when needed.

It also avoids uploading GPU resources after surface frame acquisition has already failed.

For `Validation` and `Lost` surface errors, egui-wgpu recreates the invalid GPU render state and reuploads managed textures on the next window setup. This allows rendering to resume instead of leaving the application with a frozen or invalid render path.

* Related #5063
* Related #8265
* Related #8292
* Closes #8450
