### PR TITLE
Don't switch the GL context twice per frame on Windows with one viewport

### DIFF
--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -707,6 +707,7 @@ impl GlowWinitRunning<'_> {
                 not_current_gl_context,
                 ..
             } = &mut *glutin;
+            let single_viewport = viewports.len() == 1;
             let viewport = &viewports[&viewport_id];
             let Some(window) = viewport.window.as_ref() else {
                 return Ok(EventResult::Wait);
@@ -719,7 +720,12 @@ impl GlowWinitRunning<'_> {
 
             {
                 frame_timer.pause();
-                change_gl_context(current_gl_context, not_current_gl_context, gl_surface);
+                change_gl_context(
+                    current_gl_context,
+                    not_current_gl_context,
+                    gl_surface,
+                    single_viewport,
+                );
                 frame_timer.resume();
             }
 
@@ -768,6 +774,7 @@ impl GlowWinitRunning<'_> {
             ..
         } = &mut *glutin;
 
+        let single_viewport = viewports.len() == 1;
         let Some(viewport) = viewports.get_mut(&viewport_id) else {
             return Ok(EventResult::Wait);
         };
@@ -785,7 +792,12 @@ impl GlowWinitRunning<'_> {
             {
                 // We may need to switch contexts again, because of immediate viewports:
                 frame_timer.pause();
-                change_gl_context(current_gl_context, not_current_gl_context, gl_surface);
+                change_gl_context(
+                    current_gl_context,
+                    not_current_gl_context,
+                    gl_surface,
+                    single_viewport,
+                );
                 frame_timer.resume();
             }
 
@@ -1005,20 +1017,28 @@ fn change_gl_context(
     current_gl_context: &mut Option<glutin::context::PossiblyCurrentContext>,
     not_current_gl_context: &mut Option<glutin::context::NotCurrentContext>,
     gl_surface: &glutin::surface::Surface<glutin::surface::WindowSurface>,
+    single_viewport: bool,
 ) {
     profiling::function_scope!();
 
-    if !cfg!(target_os = "windows") {
-        // According to https://github.com/emilk/egui/issues/4289
-        // we cannot do this early-out on Windows.
-        // TODO(emilk): optimize context switching on Windows too.
-        // See https://github.com/emilk/egui/issues/4173
-
-        if let Some(current_gl_context) = current_gl_context {
-            profiling::scope!("is_current");
-            if gl_surface.is_current(current_gl_context) {
-                return; // Early-out to save a lot of time.
-            }
+    // On Windows the early-out below was disabled entirely because it broke
+    // rendering when several viewports share one context:
+    // https://github.com/emilk/egui/issues/4289
+    //
+    // The cost of that blanket refusal is two `wglMakeCurrent` calls on every
+    // frame, which dominates the frame time of a light application:
+    // https://github.com/emilk/egui/issues/4173
+    //
+    // `single_viewport` narrows the refusal to the case #4289 is actually
+    // about. With one viewport there is one surface and one context, nothing
+    // can be swapped out from under us, and the early-out is safe; as soon as a
+    // second viewport exists we take the old path again.
+    if (!cfg!(target_os = "windows") || single_viewport)
+        && let Some(current_gl_context) = current_gl_context
+    {
+        profiling::scope!("is_current");
+        if gl_surface.is_current(current_gl_context) {
+            return; // Early-out to save a lot of time.
         }
     }
 
@@ -1412,6 +1432,7 @@ impl GlutinWindowContext {
     }
 
     fn resize(&mut self, viewport_id: ViewportId, physical_size: winit::dpi::PhysicalSize<u32>) {
+        let single_viewport = self.viewports.len() == 1;
         let width_px = NonZeroU32::new(physical_size.width).unwrap_or(NonZeroU32::MIN);
         let height_px = NonZeroU32::new(physical_size.height).unwrap_or(NonZeroU32::MIN);
 
@@ -1422,6 +1443,7 @@ impl GlutinWindowContext {
                 &mut self.current_gl_context,
                 &mut self.not_current_gl_context,
                 gl_surface,
+                single_viewport,
             );
             gl_surface.resize(
                 self.current_gl_context
@@ -1688,6 +1710,7 @@ fn render_immediate_viewport(
         ..
     } = &mut *glutin;
 
+    let single_viewport = viewports.len() == 1;
     let Some(viewport) = viewports.get_mut(&viewport_id) else {
         warn!("Viewport disappeared unexpectedly!");
         return;
@@ -1706,7 +1729,12 @@ fn render_immediate_viewport(
 
     let screen_size_in_pixels: [u32; 2] = window.inner_size().into();
 
-    change_gl_context(current_gl_context, not_current_gl_context, gl_surface);
+    change_gl_context(
+        current_gl_context,
+        not_current_gl_context,
+        gl_surface,
+        single_viewport,
+    );
 
     let current_gl_context = current_gl_context.as_ref().unwrap();
 


### PR DESCRIPTION
Closes #4173.

## The problem

`change_gl_context` takes an early-out when the surface is already current, but that early-out is disabled on Windows for **every** case:

```rust
if !cfg!(target_os = "windows") {
    // According to https://github.com/emilk/egui/issues/4289
    // we cannot do this early-out on Windows.
```

So on Windows every frame pays `make_not_current` + `make_current` — two `wglMakeCurrent` calls — whether or not anything changed.

## What this changes

`change_gl_context` takes a `single_viewport: bool`, and the early-out is allowed on Windows when it is true. Call sites compute it as `viewports.len() == 1`.

With a second viewport present the condition is false and the old path runs unchanged, so the corruption #4289 describes is out of scope by construction. On the `render_immediate_viewport` path the count is two or more by definition, so it is never affected.

## Measurements

Windows 11, RTX 3060 (NVIDIA 610.74), release builds, window focused, pointer parked off the window.

A minimal app — one viewport, one label, `request_repaint()` every frame, i.e. the "light application" from #4173:

```rust
fn main() -> eframe::Result {
    eframe::run_ui_native("bench", eframe::NativeOptions::default(), |ui, _frame| {
        ui.label("bench");
        ui.ctx().request_repaint();
    })
}
```

Interleaved runs, alternating binaries, 8 s samples, process CPU:

| | runs (% of one core) | median |
|---|---|---|
| `main` | 104.1, 100.0, 97.0, 96.0, 98.3 | **98.3** |
| this PR | 2.3, 10.1, 20.2, 9.3, 3.1 | **9.3** |

The two sets do not overlap. `main` sits at a whole core for an application that draws one label.

Per-scope numbers from a real application (a launcher with an animated panel, 30 fps, `profiling` + puffin), µs of CPU per frame:

| scope | `main` | this PR |
|---|---|---|
| `change_gl_context` | 550 | **1.0** |
| egui pass (incl. the app's own `ui`) | 152 | 141 |
| `swap_buffers` | 21 | 103 |
| `update_viewport_info` | 65 | 65 |
| tessellation | 59 | 53 |
| painting | 26 | 22 |
| **whole frame** | **917** | **422** |

`swap_buffers` rises because it now does the waiting the context switch used to absorb — a blocking wait, not work. That application went from 7.4–11.3% to 2.7–3.5% of one core.

## Checking #4289 has not come back

`examples/multiple_viewports`, forced onto the glow backend, with both the immediate and the deferred child viewport opened from the first frame, plus a temporary log of which branch `change_gl_context` took:

```
Count Name
----- ----
   22 single_viewport=false     <- three viewports open: old path
    1 single_viewport=true      <- first frame, before the children exist
```

Ran for 7 s with three viewports, no crash, no flicker, nothing on stderr. Neither the log nor the forced-open change is part of this PR.

## Caveats, honestly

- One machine, one GPU vendor, one Windows version. I have no way to test AMD or Intel, or an older Windows.
- In #4173, @gerwin3 reported that #4284 — which enabled this early-out without the viewport-count guard — "did not noticeably decrease" CPU for them. I cannot reproduce that; the numbers above are unambiguous on my machine. My guess is that they were also hitting a second, unrelated thing: `Context::request_repaint_after` subtracts `predicted_dt`, and nothing in `egui-winit` ever assigns it, so it stays at its `1/60` default and a throttled application still runs at vsync (see #5353). That would put a `hello_world` measurement at the display's rate regardless of this change. That is a hypothesis, not something I have verified on their setup.
- `cargo fmt --all --check` is clean and `cargo clippy -p eframe --no-default-features --features glow,default_fonts --all-targets` reports no warnings. I have not run the full `scripts/check.sh` (wasm toolchain).

Happy to reshape this if you would rather thread the flag differently, or gate it on something other than the viewport count.
