### PR TITLE
Point Rust Analyzer to `target/rust-analyzer`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
+# `target_ra` and `target_wasm` are legacy locations; they now live inside `target/`.
+# Keep them on their own lines: a trailing `#` is not a comment in .gitignore.
 **/target
-**/target_ra # legacy Rust Analyzer target dir
+**/target_ra
 **/target_wasm
 **/tests/snapshots/**/*.diff.png
 **/tests/snapshots/**/*.new.png

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 **/target
-**/target_ra
+**/target_ra # legacy Rust Analyzer target dir
 **/target_wasm
 **/tests/snapshots/**/*.diff.png
 **/tests/snapshots/**/*.new.png

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
         }
     },
     "files.exclude": {
-        "target_ra/**": true,
+        "target_ra/**": true, // legacy Rust Analyzer target dir
         "target_wasm/**": true,
         "target/**": true,
     },
@@ -18,7 +18,7 @@
     "rust-analyzer.cargo.allTargets": true,
     "rust-analyzer.cargo.features": "all",
     // Use a separate target directory for Rust Analyzer so it doesn't prevent cargo/clippy from doing things.
-    "rust-analyzer.cargo.targetDir": "target_ra",
+    "rust-analyzer.cargo.targetDir": true,
     "rust-analyzer.showUnlinkedFileNotification": false,
     // Uncomment the following options and restart rust-analyzer to get it to check code behind `cfg(target_arch=wasm32)`.
     // Don't forget to put it in a comment again before committing.

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -66,11 +66,8 @@ def lint_lines(filepath, lines_in):
                 )
                 lines_out.append("#[inline]")
 
-
         if re.search(r"TODO[^(]", line):
-            errors.append(
-                f"{filepath}:{line_nr}: write 'TODO(username):' instead"
-            )
+            errors.append(f"{filepath}:{line_nr}: write 'TODO(username):' instead")
 
         if re.search(r"\.zip\(", line):
             errors.append(
@@ -177,7 +174,11 @@ def main():
         root_dirpath = os.path.abspath(f"{script_dirpath}/..")
         os.chdir(root_dirpath)
 
-        exclude = set(["target", "target_ra", "target_wasm"])
+        exclude = {
+            "target",
+            "target_ra",  # legacy Rust Analyzer target dir
+            "target_wasm",
+        }
         for root, dirs, files in os.walk(".", topdown=True):
             dirs[:] = [d for d in dirs if d not in exclude]
             for filename in files:


### PR DESCRIPTION
So that `cargo clean`, `cargo sweep` etc clears it for us! And one less annoying folder in root.