### PR TITLE
Fix zero-duration value animations returning the previous value

### DIFF
--- a/crates/egui/src/animation_manager.rs
+++ b/crates/egui/src/animation_manager.rs
@@ -85,6 +85,13 @@ impl AnimationManager {
                 value
             }
             Some(anim) => {
+                if animation_time == 0.0 {
+                    anim.from_value = value;
+                    anim.to_value = value;
+                    anim.toggle_time = input.time;
+                    return value;
+                }
+
                 let time_since_toggle = (input.time - anim.toggle_time) as f32;
                 // On the frame we toggle we don't want to return the old value,
                 // so we extrapolate forwards by half a frame:
@@ -99,12 +106,25 @@ impl AnimationManager {
                     anim.to_value = value;
                     anim.toggle_time = input.time;
                 }
-                if animation_time == 0.0 {
-                    anim.from_value = value;
-                    anim.to_value = value;
-                }
                 current_value
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AnimationManager;
+    use crate::{Id, InputState};
+
+    #[test]
+    fn zero_duration_value_animation_reaches_target_immediately() {
+        let mut animations = AnimationManager::default();
+        let input = InputState::default();
+        let id = Id::new("value_animation");
+
+        assert_eq!(animations.animate_value(&input, 0.0, id, 0.0), 0.0);
+        assert_eq!(animations.animate_value(&input, 0.0, id, 1.0), 1.0);
+        assert_eq!(animations.animate_value(&input, 0.0, id, 2.0), 2.0);
     }
 }


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* Keep PR description short and to the point! No long LLM slop.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until a human has reviewed it
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

animate_value_with_time returned the previous value for one frame when called with a zero duration because it calculated the current value before updating the animation target.

Handle zero-duration animations before interpolation so they immediately return and store the target value. Add a regression test covering consecutive target changes.


* Closes <https://github.com/emilk/egui/issues/THE_RELEVANT_ISSUE>
* [x] I have followed the instructions in the PR template
