### PR TITLE
Fix widgets shifting around on hover in interactive container demo

### DIFF
--- a/crates/egui_demo_lib/src/demo/interactive_container.rs
+++ b/crates/egui_demo_lib/src/demo/interactive_container.rs
@@ -1,4 +1,4 @@
-use egui::{Frame, Label, RichText, Sense, UiBuilder, Widget as _};
+use egui::{Frame, Label, RichText, Sense, Stroke, UiBuilder, Widget as _};
 
 /// Showcase [`egui::Ui::response`].
 #[derive(PartialEq, Eq, Default)]
@@ -51,7 +51,7 @@ impl crate::View for InteractiveContainerDemo {
 
                     Frame::canvas(ui.style())
                         .fill(visuals.bg_fill.gamma_multiply(0.3))
-                        .stroke(visuals.bg_stroke)
+                        .stroke(Stroke::new(1.0, visuals.bg_stroke.color))
                         .inner_margin(ui.spacing().menu_margin)
                         .show(ui, |ui| {
                             ui.set_width(ui.available_width());

--- a/crates/egui_demo_lib/tests/snapshots/demos/Interactive Container.png
+++ b/crates/egui_demo_lib/tests/snapshots/demos/Interactive Container.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d70cd39499c8f9e0edf689b642ef7cc98115c751bf787305f92323f42aae3fd4
-size 21814
+oid sha256:62321b3e15d7b6e2bd47d6ad053a02aa23b42730147e504c406338a257f4de4b
+size 22002


### PR DESCRIPTION
This happens because `bg_stroke`'s width isn't constant.

| Before | After |
|--------|--------|
| <img width="320" height="320" alt="before" src="https://github.com/user-attachments/assets/0101e5fb-0781-4867-9891-c91d49dbb969" /> | <img width="320" height="320" alt="after" src="https://github.com/user-attachments/assets/4223218a-2f5f-4542-9fe2-67be5799ca81" /> | 

---

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* Keep PR description short and to the point! No long LLM slop.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until a human has reviewed it
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* [x] I have followed the instructions in the PR template
