### PR TITLE
fix(deps): bump event-listener to 5.4.2 to patch RUSTSEC-2026-0221

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1665,11 +1665,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]


### PR DESCRIPTION
Automated dependency bump to address a disclosed RustSec advisory.

- **Advisory:** [RUSTSEC-2026-0221](https://rustsec.org/advisories/RUSTSEC-2026-0221)
- **Severity:** unsound (informational) — `StackSlot` incorrectly implemented `Send`/`Sync`, allowing `!Send` tags to cross threads (data race in safe code)
- **Package:** `event-listener` `5.4.1` → `5.4.2`
- **Path:** `egui-winit` → `accesskit_winit` → `accesskit_unix` → `zbus` → `async-broadcast` → `event-listener`

### Verification
- Reproduced locally: yes
- Command: `osv-scanner scan source --recursive --no-ignore .` before/after; `cargo update -p event-listener --precise 5.4.2`
- Before: `event-listener@5.4.1` flagged as RUSTSEC-2026-0221
- After: advisory cleared; only pre-existing ignored unmaintained advisories remain (bincode/rustybuzz/ttf-parser/yaml-rust, already listed in `deny.toml`)
- Environment: osv-scanner latest linux_amd64; Cargo.lock-only change

Detected by [osv-scanner](https://google.github.io/osv-scanner/). No code changes outside the lockfile.