### PR TITLE
Fix rendering of thin, angled rectangles

### DIFF
--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -1800,7 +1800,7 @@ impl Tessellator {
             }
         }
 
-        if stroke.is_empty() && out.texture_id == TextureId::default() {
+        if angle == 0.0 && stroke.is_empty() && out.texture_id == TextureId::default() {
             // Approximate thin rectangles with line segments.
             // This is important so that thin rectangles look good.
             if rect.width() <= 2.0 * self.feathering {


### PR DESCRIPTION
We had a fast path for very thin rectangles, but it did not heed the angle of the rect