### PR TITLE
Make `widget_style` public again

### DIFF
--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -427,10 +427,7 @@ mod ui_stack;
 pub mod util;
 pub mod viewport;
 mod widget_rect;
-#[cfg(feature = "experimental")]
 pub mod widget_style;
-#[cfg(not(feature = "experimental"))]
-mod widget_style;
 pub mod widget_text;
 pub mod widgets;
 


### PR DESCRIPTION
It was accidentally made private in #8153 unless experimental, even though it was already public before. Make it public again.