### PR TITLE
Render any glyph on native

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -30,4 +30,4 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "CI, dependencies, docs and examples, ecolor, eframe, egui_extras, egui_glow, egui_inspection, egui_kittest, egui-wgpu, egui-winit, egui, emath, epaint, epaint_default_fonts, exclude from changelog, typo"
+          labels: "CI, dependencies, docs and examples, ecolor, eframe, egui_extras, egui_glow, egui_inspection, egui_kittest, egui_system_fonts, egui-wgpu, egui-winit, egui, emath, epaint, epaint_default_fonts, exclude from changelog, typo"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,6 +1470,7 @@ dependencies = [
  "epaint",
  "fontique",
  "log",
+ "poll-promise",
  "skrifa",
  "sys-locale",
  "unicode-script",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,7 @@ dependencies = [
  "egui-winit",
  "egui_glow",
  "egui_inspection",
+ "egui_system_fonts",
  "glow",
  "glutin",
  "glutin-winit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,6 +1462,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_system_fonts"
+version = "0.36.1"
+dependencies = [
+ "egui",
+ "epaint",
+ "fontique",
+ "log",
+ "skrifa",
+ "sys-locale",
+ "unicode-script",
+]
+
+[[package]]
 name = "egui_tests"
 version = "0.36.1"
 dependencies = [
@@ -1804,7 +1817,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
 dependencies = [
- "roxmltree",
+ "roxmltree 0.20.0",
 ]
 
 [[package]]
@@ -1818,6 +1831,28 @@ dependencies = [
  "slotmap",
  "tinyvec",
  "ttf-parser",
+]
+
+[[package]]
+name = "fontique"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6688bc1294fe7117d788937b6c53480169b29c566954af490830d4c09da9516a"
+dependencies = [
+ "hashbrown 0.17.1",
+ "linebender_resource_handle",
+ "memmap2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-text",
+ "objc2-foundation 0.3.2",
+ "parlance",
+ "read-fonts",
+ "roxmltree 0.21.1",
+ "smallvec",
+ "windows",
+ "windows-core",
+ "yeslogic-fontconfig-sys",
 ]
 
 [[package]]
@@ -3060,6 +3095,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3350,6 +3395,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "parlance"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
 
 [[package]]
 name = "peniko"
@@ -4040,6 +4091,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4548,6 +4608,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5037,7 +5106,7 @@ dependencies = [
  "kurbo 0.11.3",
  "log",
  "pico-args",
- "roxmltree",
+ "roxmltree 0.20.0",
  "rustybuzz",
  "simplecss",
  "siphasher",
@@ -5911,6 +5980,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yeslogic-fontconfig-sys"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8b8abf912b9a29ff112e1671c97c33636903d13a69712037190e6805af4f76"
+dependencies = [
+ "dlib",
+ "once_cell",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "crates/egui_glow",
   "crates/egui_inspection",
   "crates/egui_kittest",
+  "crates/egui_system_fonts",
   "crates/egui-wgpu",
   "crates/egui-winit",
   "crates/egui",
@@ -68,6 +69,7 @@ egui_demo_lib = { version = "0.36.1", path = "crates/egui_demo_lib", default-fea
 egui_glow = { version = "0.36.1", path = "crates/egui_glow", default-features = false }
 egui_inspection = { version = "0.36.1", path = "crates/egui_inspection", default-features = false }
 egui_kittest = { version = "0.36.1", path = "crates/egui_kittest", default-features = false }
+egui_system_fonts = { version = "0.36.1", path = "crates/egui_system_fonts", default-features = false }
 eframe = { version = "0.36.1", path = "crates/eframe", default-features = false }
 
 accesskit = "0.24.1"
@@ -92,6 +94,10 @@ ehttp = { version = "0.7.1", default-features = false }
 enum-map = "2.7" # Can't update to 3.1: its `enum-map-derive` moved to syn 3, duplicating the syn 2 that most other proc-macro crates still use
 env_logger = { version = "0.11.8", default-features = false } # 0.11.9+ pulls env_filter 1.x/2.x, duplicating the 0.1.x that android_logger needs
 font-types = { version = "0.12.2", default-features = false, features = ["std"] }
+fontique = { version = "0.11.1", default-features = false, features = [
+  "system",
+  "fontconfig-dlopen", # Load libfontconfig at runtime, so builds don't need its headers
+] }
 glow = "0.17.0" # Can't update to 0.18: wgpu 30's wgpu-hal pins glow 0.17, so bumping splits it into two versions
 glutin = { version = "0.32.3", default-features = false }
 glutin-winit = { version = "0.5.0", default-features = false }
@@ -138,6 +144,7 @@ smallvec = "1.15"
 smithay-clipboard = "0.7.2" # 0.7.3 pulls smithay-client-toolkit 0.20 (calloop 0.14), duplicating the 0.19/0.13 that winit 0.30 needs
 static_assertions = "1.1"
 syntect = { version = "5.3", default-features = false }
+sys-locale = "0.3.2"
 tempfile = "3.27"
 thiserror = "2.0" # Held at 2.0.18 in `Cargo.lock`: `thiserror-impl` 2.0.19 moved to syn 3, duplicating the syn 2 that most other proc-macro crates still use
 tokio = "1.53"
@@ -146,6 +153,7 @@ type-map = "0.5.1"
 unicode_names2 = { version = "3.1", default-features = false }
 unicode-general-category = "1.1"
 unicode-properties = { version = "0.1.4", default-features = false, features = ["emoji"] }
+unicode-script = "0.5.8"
 unicode-segmentation = "1.13"
 vello_cpu = { version = "0.2.0", default-features = false, features = [
   "std",

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -29,6 +29,7 @@ default = [
   "accesskit",
   "default_fonts",
   "links",
+  "system_fonts",
   "wayland", # Required for Linux support (including CI!)
   "web_screen_reader",
   "wgpu",
@@ -79,6 +80,11 @@ wayland = [
   "glutin?/wayland",
   "glutin-winit?/wayland",
 ]
+
+## Load system fonts on demand for characters that the installed fonts lack (native only).
+##
+## Turn it off at runtime with [`NativeOptions::system_font_fallback`].
+system_fonts = ["dep:egui_system_fonts"]
 
 ## Enable screen reader support (requires `ctx.options_mut(|o| o.screen_reader = true);`) on web.
 ##
@@ -160,6 +166,7 @@ image = { workspace = true, features = ["png"] } # Needed for app icon
 winit = { workspace = true, default-features = false, features = ["rwh_06"] }
 
 # optional native:
+egui_system_fonts = { workspace = true, optional = true }
 egui-wgpu = { workspace = true, optional = true, features = [
   "winit",
   "capture",

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -378,6 +378,15 @@ pub struct NativeOptions {
     /// persisted (only if the "persistence" feature is enabled).
     pub persist_window: bool,
 
+    /// Load system fonts on demand for characters that the installed fonts lack,
+    /// e.g. CJK, Arabic, or Devanagari (only if the `system_fonts` feature is enabled).
+    ///
+    /// Turn this off if you bundle fonts that cover everything your app shows,
+    /// or if you need identical text rendering on all machines.
+    ///
+    /// Default: `true`.
+    pub system_font_fallback: bool,
+
     /// The folder where `eframe` will store the app state. If not set, eframe will use a default
     /// data storage path for each target system.
     pub persistence_path: Option<std::path::PathBuf>,
@@ -461,6 +470,8 @@ impl Default for NativeOptions {
                 .with_surface_config(egui_wgpu::SurfaceConfig::LOW_LATENCY),
 
             persist_window: true,
+
+            system_font_fallback: true,
 
             persistence_path: None,
 

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -217,6 +217,11 @@ impl EpiIntegration {
             Some(icon),
         );
 
+        #[cfg(feature = "system_fonts")]
+        if native_options.system_font_fallback {
+            egui_ctx.add_font_provider(Arc::new(egui_system_fonts::SystemFontProvider::new()));
+        }
+
         Self {
             frame,
             last_auto_save: Instant::now(),

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -811,9 +811,11 @@ impl Context {
     }
 
     /// Decide where to look first for the glyphs of each grapheme cluster:
-    /// the fonts in the [`FontDefinitions`], or what the platform offers (e.g. the browser on web).
+    /// the fonts in the [`FontDefinitions`], or what the platform offers
+    /// (system fonts from a [`FontProvider`], and the browser on web).
     ///
-    /// By default, color emoji come from the platform, and everything else from the fonts.
+    /// By default, color emoji come from the platform, so that they keep their colors,
+    /// and everything else from the fonts, so that it looks the same on every computer.
     /// Use `|_| GlyphSource::Fonts` to only use the platform for characters no installed font has.
     ///
     /// See [`GlyphSourcePreference`].

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -16,13 +16,13 @@ use epaint::{
 };
 
 use crate::{
-    Align2, CursorIcon, DeferredViewportUiCallback, FontDefinitions, GlyphRasterizer, GlyphSource,
-    GlyphSourcePreference, Grid, Id, ImmediateViewport, ImmediateViewportRendererCallback, Key,
-    KeyboardShortcut, Label, LayerId, Memory, ModifierNames, Modifiers, NumExt as _, Order,
-    Painter, RawInput, Response, RichText, SafeAreaInsets, ScrollArea, Sense, Style, TextStyle,
-    TextureHandle, TextureOptions, Ui, UiBuilder, ViewportBuilder, ViewportCommand, ViewportId,
-    ViewportIdMap, ViewportIdPair, ViewportIdSet, ViewportOutput, Visuals, Widget as _, WidgetRect,
-    WidgetText,
+    Align2, CursorIcon, DeferredViewportUiCallback, FontDefinitions, FontProvider, GlyphRasterizer,
+    GlyphSource, GlyphSourcePreference, Grid, Id, ImmediateViewport,
+    ImmediateViewportRendererCallback, Key, KeyboardShortcut, Label, LayerId, Memory,
+    ModifierNames, Modifiers, NumExt as _, Order, Painter, RawInput, Response, RichText,
+    SafeAreaInsets, ScrollArea, Sense, Style, TextStyle, TextureHandle, TextureOptions, Ui,
+    UiBuilder, ViewportBuilder, ViewportCommand, ViewportId, ViewportIdMap, ViewportIdPair,
+    ViewportIdSet, ViewportOutput, Visuals, Widget as _, WidgetRect, WidgetText,
     animation_manager::AnimationManager,
     containers::{self, area::AreaState},
     data::output::PlatformOutput,
@@ -377,6 +377,7 @@ struct ContextImpl {
     fonts: Option<Fonts>,
     font_definitions: FontDefinitions,
     glyph_rasterizer: Option<GlyphRasterizer>,
+    font_providers: Vec<Arc<dyn FontProvider>>,
     glyph_source_preference: Option<GlyphSourcePreference>,
 
     memory: Memory,
@@ -594,7 +595,8 @@ impl ContextImpl {
 
             is_new = true;
             profiling::scope!("Fonts::new");
-            let mut fonts = Fonts::new(text_options, self.font_definitions.clone());
+            let mut fonts = Fonts::new(text_options, self.font_definitions.clone())
+                .with_font_providers(self.font_providers.clone());
             if let Some(glyph_rasterizer) = &self.glyph_rasterizer {
                 fonts = fonts.with_glyph_rasterizer(glyph_rasterizer.clone());
             }
@@ -781,6 +783,29 @@ impl Context {
     pub fn set_glyph_rasterizer(&self, glyph_rasterizer: Option<GlyphRasterizer>) {
         self.write(|ctx| {
             ctx.glyph_rasterizer = glyph_rasterizer;
+            ctx.fonts = None;
+        });
+    }
+
+    /// Add a [`FontProvider`], asked for fonts for characters that no installed font has.
+    ///
+    /// Fonts it finds are appended to the fallback chain of the requested font family.
+    /// Providers are asked in the order they were added.
+    ///
+    /// `eframe` adds a system font provider on native (see its `system_fonts` feature).
+    pub fn add_font_provider(&self, font_provider: Arc<dyn FontProvider>) {
+        self.write(|ctx| {
+            ctx.font_providers.push(font_provider);
+            ctx.fonts = None;
+        });
+    }
+
+    /// Replace all [`FontProvider`]s. See [`Self::add_font_provider`].
+    ///
+    /// Pass an empty list to only use the installed fonts.
+    pub fn set_font_providers(&self, font_providers: Vec<Arc<dyn FontProvider>>) {
+        self.write(|ctx| {
+            ctx.font_providers = font_providers;
             ctx.fonts = None;
         });
     }

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -453,9 +453,10 @@ pub use epaint::{
     ClippedPrimitive, ColorImage, CornerRadius, Direction, ImageData, Margin, Mesh, PaintCallback,
     PaintCallbackInfo, Shadow, Shape, Stroke, StrokeKind, TextureHandle, TextureId, mutex,
     text::{
-        FontData, FontDefinitions, FontFamily, FontId, FontTweak, GlyphRasterizer,
-        GlyphRasterizerRequest, GlyphSource, GlyphSourcePreference, MAX_GLYPH_SIZE,
-        RasterizedGlyph, default_glyph_source, has_emoji_presentation,
+        FallbackRequest, FontData, FontDefinitions, FontFamily, FontId, FontInsert, FontPriority,
+        FontProvider, FontTweak, GlyphRasterizer, GlyphRasterizerRequest, GlyphSource,
+        GlyphSourcePreference, InsertFontFamily, MAX_GLYPH_SIZE, RasterizedGlyph,
+        default_glyph_source, has_emoji_presentation,
     },
     textures::{TextureFilter, TextureOptions, TextureWrapMode, TexturesDelta},
 };

--- a/crates/egui_system_fonts/CHANGELOG.md
+++ b/crates/egui_system_fonts/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog for egui_system_fonts
+All notable changes to the `egui_system_fonts` crate will be noted in this file.
+
+
+This file is updated upon each release.
+Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
+
+
+## Unreleased - Initial release

--- a/crates/egui_system_fonts/Cargo.toml
+++ b/crates/egui_system_fonts/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "egui_system_fonts"
+version.workspace = true
+authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
+description = "Load system fonts on demand for characters the egui fonts lack"
+edition.workspace = true
+rust-version.workspace = true
+homepage = "https://github.com/emilk/egui/tree/main/crates/egui_system_fonts"
+license.workspace = true
+readme = "README.md"
+repository = "https://github.com/emilk/egui/tree/main/crates/egui_system_fonts"
+categories = ["gui"]
+keywords = ["egui", "gui", "fonts", "text"]
+include = ["../../LICENSE-APACHE", "../../LICENSE-MIT", "**/*.rs", "Cargo.toml"]
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--generate-link-to-definition"]
+
+[lib]
+
+
+[dependencies]
+epaint.workspace = true
+
+fontique.workspace = true
+log.workspace = true
+skrifa.workspace = true
+sys-locale.workspace = true
+unicode-script.workspace = true
+
+[dev-dependencies]
+egui.workspace = true

--- a/crates/egui_system_fonts/Cargo.toml
+++ b/crates/egui_system_fonts/Cargo.toml
@@ -28,6 +28,7 @@ epaint.workspace = true
 
 fontique.workspace = true
 log.workspace = true
+poll-promise.workspace = true
 skrifa.workspace = true
 sys-locale.workspace = true
 unicode-script.workspace = true

--- a/crates/egui_system_fonts/README.md
+++ b/crates/egui_system_fonts/README.md
@@ -1,0 +1,16 @@
+# egui_system_fonts
+
+[![Latest version](https://img.shields.io/crates/v/egui_system_fonts.svg)](https://crates.io/crates/egui_system_fonts)
+[![Documentation](https://docs.rs/egui_system_fonts/badge.svg)](https://docs.rs/egui_system_fonts)
+
+Load system fonts on demand for characters that the fonts installed in [egui](https://github.com/emilk/egui) lack.
+
+The default egui fonts cover Latin, Greek, and Cyrillic. When egui is asked to render e.g. Japanese, Arabic, or Devanagari, it draws `◻`. `egui_system_fonts` provides a [`SystemFontProvider`] that asks the operating system for a font that covers the character, using the same font fallback as native apps (CoreText, DirectWrite, fontconfig, or Android's `fonts.xml`, via [`fontique`](https://crates.io/crates/fontique)). The font file is memory-mapped and installed as a fallback font in egui.
+
+`eframe` installs it on native by default (feature `system_fonts`). Other integrations can add it themselves:
+
+```rust
+egui_ctx.add_font_provider(std::sync::Arc::new(egui_system_fonts::SystemFontProvider::new()));
+```
+
+System emoji fonts are skipped for now, since they contain bitmaps or color glyphs that epaint cannot render yet.

--- a/crates/egui_system_fonts/src/lib.rs
+++ b/crates/egui_system_fonts/src/lib.rs
@@ -247,4 +247,22 @@ mod tests {
             assert!(insert.name.starts_with("system:"));
         }
     }
+
+    #[test]
+    #[ignore = "Depends on which fonts are installed on this machine"]
+    fn renders_cjk_through_egui_context() {
+        let ctx = egui::Context::default();
+        let font_id = egui::FontId::proportional(14.0);
+        let mut output = ctx.run_ui(Default::default(), |ui| {
+            ui.fonts_mut(|fonts| assert!(!fonts.has_glyph(&font_id, '日')));
+        });
+        output.textures_delta.clear();
+
+        ctx.add_font_provider(Arc::new(SystemFontProvider::new()));
+        let mut output = ctx.run_ui(Default::default(), |ui| {
+            ui.fonts_mut(|fonts| assert!(fonts.has_glyph(&font_id, '日')));
+            assert_eq!(ui.fonts(|fonts| fonts.provided_fonts().len()), 1);
+        });
+        output.textures_delta.clear();
+    }
 }

--- a/crates/egui_system_fonts/src/lib.rs
+++ b/crates/egui_system_fonts/src/lib.rs
@@ -9,8 +9,6 @@
 //! egui_ctx.add_font_provider(std::sync::Arc::new(egui_system_fonts::SystemFontProvider::new()));
 //! ```
 
-use std::sync::{Arc, OnceLock};
-
 use epaint::{
     mutex::Mutex,
     text::{
@@ -22,6 +20,7 @@ use fontique::{
     Collection, CollectionOptions, FallbackKey, GenericFamily, Language, QueryFamily, QueryFont,
     QueryStatus, Script, SourceCache, SourceCacheOptions,
 };
+use poll_promise::Promise;
 
 struct SystemFonts {
     collection: Collection,
@@ -41,7 +40,8 @@ struct SystemFonts {
 /// so [`Self::new`] starts doing that on a background thread.
 /// A lookup before it is done blocks until it is.
 pub struct SystemFontProvider {
-    fonts: Arc<OnceLock<Mutex<SystemFonts>>>,
+    /// Loaded on a background thread by [`Self::new`].
+    fonts: Mutex<Promise<SystemFonts>>,
     locale: Option<Language>,
 }
 
@@ -56,22 +56,13 @@ impl SystemFontProvider {
     ///
     /// Uses the system locale to pick between fonts (see [`Self::with_locale`]).
     pub fn new() -> Self {
-        let fonts = Arc::new(OnceLock::new());
-        {
-            let fonts = Arc::clone(&fonts);
-            let spawned = std::thread::Builder::new()
-                .name("egui_system_fonts".to_owned())
-                .spawn(move || {
-                    fonts.get_or_init(load_system_fonts);
-                });
-            if let Err(err) = spawned {
-                log::warn!("Failed to spawn thread for enumerating system fonts: {err}");
-            }
+        Self {
+            fonts: Mutex::new(Promise::spawn_thread(
+                "egui_system_fonts",
+                load_system_fonts,
+            )),
+            locale: sys_locale::get_locale().and_then(|locale| parse_locale(&locale)),
         }
-
-        let locale = sys_locale::get_locale().and_then(|locale| parse_locale(&locale));
-
-        Self { fonts, locale }
     }
 
     /// The locale used to pick between fonts for the same script,
@@ -97,17 +88,17 @@ fn parse_locale(locale: &str) -> Option<Language> {
     }
 }
 
-fn load_system_fonts() -> Mutex<SystemFonts> {
+fn load_system_fonts() -> SystemFonts {
     let start = std::time::Instant::now();
     let collection = Collection::new(CollectionOptions {
         shared: false,
         system_fonts: true,
     });
     log::debug!("Enumerated system fonts in {:?}", start.elapsed());
-    Mutex::new(SystemFonts {
+    SystemFonts {
         collection,
         source_cache: SourceCache::new(SourceCacheOptions::default()),
-    })
+    }
 }
 
 impl FontProvider for SystemFontProvider {
@@ -115,11 +106,12 @@ impl FontProvider for SystemFontProvider {
         let FallbackRequest { cluster, family } = request;
         let base_char = cluster.chars().next()?;
 
-        let mut fonts = self.fonts.get_or_init(load_system_fonts).lock();
+        // Blocks if the background thread is not done enumerating the system fonts yet:
+        let mut fonts = self.fonts.lock();
         let SystemFonts {
             collection,
             source_cache,
-        } = &mut *fonts;
+        } = fonts.block_until_ready_mut();
 
         let generic = match family {
             FontFamily::Monospace => GenericFamily::Monospace,
@@ -206,6 +198,8 @@ fn has_outline_for(font: &QueryFont, c: char) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
 
     #[test]

--- a/crates/egui_system_fonts/src/lib.rs
+++ b/crates/egui_system_fonts/src/lib.rs
@@ -80,6 +80,7 @@ impl SystemFontProvider {
     /// A BCP-47 language tag like `"ja"` or `"zh-Hans"`, or `None` for the platform default.
     ///
     /// Default: the system locale.
+    #[inline]
     pub fn with_locale(mut self, locale: Option<&str>) -> Self {
         self.locale = locale.and_then(parse_locale);
         self

--- a/crates/egui_system_fonts/src/lib.rs
+++ b/crates/egui_system_fonts/src/lib.rs
@@ -251,7 +251,7 @@ mod tests {
         ctx.add_font_provider(Arc::new(SystemFontProvider::new()));
         let mut output = ctx.run_ui(Default::default(), |ui| {
             ui.fonts_mut(|fonts| assert!(fonts.has_glyph(&font_id, '日')));
-            assert_eq!(ui.fonts(|fonts| fonts.provided_fonts().len()), 1);
+            assert_eq!(ui.fonts(|fonts| fonts.discovered_fonts().len()), 1);
         });
         output.textures_delta.clear();
     }

--- a/crates/egui_system_fonts/src/lib.rs
+++ b/crates/egui_system_fonts/src/lib.rs
@@ -1,0 +1,250 @@
+//! Load system fonts on demand for characters that the fonts installed in egui lack.
+//!
+//! [`SystemFontProvider`] is an [`epaint::text::FontProvider`] backed by [`fontique`],
+//! which uses the operating system's own font fallback (CoreText, DirectWrite, fontconfig,
+//! or Android's `fonts.xml`) to find an installed font for a script and locale.
+//!
+//! ```no_run
+//! # let egui_ctx = egui::Context::default();
+//! egui_ctx.add_font_provider(std::sync::Arc::new(egui_system_fonts::SystemFontProvider::new()));
+//! ```
+
+use std::sync::{Arc, OnceLock};
+
+use epaint::{
+    mutex::Mutex,
+    text::{
+        FallbackRequest, FontData, FontFamily, FontInsert, FontPriority, FontProvider,
+        InsertFontFamily,
+    },
+};
+use fontique::{
+    Collection, CollectionOptions, FallbackKey, GenericFamily, Language, QueryFamily, QueryFont,
+    QueryStatus, Script, SourceCache, SourceCacheOptions,
+};
+
+struct SystemFonts {
+    collection: Collection,
+    source_cache: SourceCache,
+}
+
+/// Finds installed system fonts for characters that the egui fonts lack.
+///
+/// Uses the operating system's own font fallback via [`fontique`],
+/// so e.g. 日本語 gets a Japanese font and العربية an Arabic font.
+/// The font files are memory-mapped, not copied.
+///
+/// Only fonts with outline glyphs are returned. System emoji fonts contain
+/// bitmaps or color glyphs, which epaint cannot render yet, so they are skipped.
+///
+/// Enumerating the system fonts can take hundreds of milliseconds,
+/// so [`Self::new`] starts doing that on a background thread.
+/// A lookup before it is done blocks until it is.
+pub struct SystemFontProvider {
+    fonts: Arc<OnceLock<Mutex<SystemFonts>>>,
+    locale: Option<Language>,
+}
+
+impl Default for SystemFontProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SystemFontProvider {
+    /// Start enumerating the system fonts on a background thread.
+    ///
+    /// Uses the system locale to pick between fonts (see [`Self::with_locale`]).
+    pub fn new() -> Self {
+        let fonts = Arc::new(OnceLock::new());
+        {
+            let fonts = Arc::clone(&fonts);
+            let spawned = std::thread::Builder::new()
+                .name("egui_system_fonts".to_owned())
+                .spawn(move || {
+                    fonts.get_or_init(load_system_fonts);
+                });
+            if let Err(err) = spawned {
+                log::warn!("Failed to spawn thread for enumerating system fonts: {err}");
+            }
+        }
+
+        let locale = sys_locale::get_locale().and_then(|locale| parse_locale(&locale));
+
+        Self { fonts, locale }
+    }
+
+    /// The locale used to pick between fonts for the same script,
+    /// e.g. between a Japanese and a Simplified Chinese font for CJK ideographs.
+    ///
+    /// A BCP-47 language tag like `"ja"` or `"zh-Hans"`, or `None` for the platform default.
+    ///
+    /// Default: the system locale.
+    pub fn with_locale(mut self, locale: Option<&str>) -> Self {
+        self.locale = locale.and_then(parse_locale);
+        self
+    }
+}
+
+fn parse_locale(locale: &str) -> Option<Language> {
+    match Language::parse(locale) {
+        Ok(language) => Some(language),
+        Err(err) => {
+            log::warn!("Failed to parse locale {locale:?}: {err:?}");
+            None
+        }
+    }
+}
+
+fn load_system_fonts() -> Mutex<SystemFonts> {
+    let start = std::time::Instant::now();
+    let collection = Collection::new(CollectionOptions {
+        shared: false,
+        system_fonts: true,
+    });
+    log::debug!("Enumerated system fonts in {:?}", start.elapsed());
+    Mutex::new(SystemFonts {
+        collection,
+        source_cache: SourceCache::new(SourceCacheOptions::default()),
+    })
+}
+
+impl FontProvider for SystemFontProvider {
+    fn font_for(&self, request: &FallbackRequest<'_>) -> Option<FontInsert> {
+        let FallbackRequest {
+            cluster: _,
+            base_char,
+            family,
+        } = request;
+        let base_char = *base_char;
+
+        let mut fonts = self.fonts.get_or_init(load_system_fonts).lock();
+        let SystemFonts {
+            collection,
+            source_cache,
+        } = &mut *fonts;
+
+        let generic = match family {
+            FontFamily::Monospace => GenericFamily::Monospace,
+            FontFamily::Proportional | FontFamily::Name(_) => GenericFamily::SansSerif,
+        };
+
+        let mut query = collection.query(source_cache);
+        if let Some(script) = script_of(base_char) {
+            query.set_families([QueryFamily::Generic(generic)]);
+            query.set_fallbacks(FallbackKey::new(script, self.locale.as_ref()));
+        } else {
+            // Punctuation, symbols, etc. belong to no script, so there is no fallback for them.
+            // Try the generic families instead.
+            query.set_families(
+                [
+                    generic,
+                    GenericFamily::SystemUi,
+                    GenericFamily::Math,
+                    GenericFamily::Serif,
+                    GenericFamily::Monospace,
+                ]
+                .map(QueryFamily::Generic),
+            );
+        }
+
+        let mut found = None;
+        query.matches_with(|font| {
+            if has_outline_for(font, base_char) {
+                found = Some(font.clone());
+                QueryStatus::Stop
+            } else {
+                QueryStatus::Continue
+            }
+        });
+        drop(query);
+        let font = found?;
+
+        let family_name = collection.family_name(font.family.0).unwrap_or("unknown");
+        let name = format!("system:{family_name}:{}:{}", font.family.1, font.index);
+        log::debug!("Using {name:?} for {base_char:?}");
+
+        let (blob, _blob_id) = font.blob.into_raw_parts();
+        Some(FontInsert {
+            name,
+            data: FontData::from_blob(blob, font.index),
+            families: vec![InsertFontFamily {
+                family: (*family).clone(),
+                priority: FontPriority::Lowest,
+            }],
+        })
+    }
+}
+
+/// The script of a character, or `None` for characters shared between scripts (punctuation, symbols, …).
+fn script_of(c: char) -> Option<Script> {
+    use unicode_script::UnicodeScript as _;
+
+    match c.script() {
+        unicode_script::Script::Common
+        | unicode_script::Script::Inherited
+        | unicode_script::Script::Unknown => None,
+        script => Script::parse(script.short_name()).ok(),
+    }
+}
+
+/// Does the font have an outline glyph for the character?
+///
+/// False for bitmap and color glyphs, which epaint cannot render yet.
+fn has_outline_for(font: &QueryFont, c: char) -> bool {
+    use skrifa::MetadataProvider as _;
+
+    let Some(glyph_id) = font.charmap().and_then(|charmap| charmap.map(c)) else {
+        return false;
+    };
+    let glyph_id = skrifa::GlyphId::new(glyph_id);
+    if glyph_id == skrifa::GlyphId::NOTDEF {
+        return false;
+    }
+    let Ok(font_ref) = skrifa::FontRef::from_index(font.blob.as_ref(), font.index) else {
+        return false;
+    };
+    font_ref.outline_glyphs().get(glyph_id).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scripts() {
+        assert_eq!(script_of('a'), Some(Script::from_bytes(*b"Latn")));
+        assert_eq!(script_of('日'), Some(Script::from_bytes(*b"Hani")));
+        assert_eq!(script_of('ع'), Some(Script::from_bytes(*b"Arab")));
+        assert_eq!(script_of('1'), None);
+        assert_eq!(script_of('⌥'), None);
+        assert_eq!(script_of('\u{0301}'), None); // combining acute accent
+    }
+
+    #[test]
+    #[ignore = "Depends on which fonts are installed on this machine"]
+    #[expect(clippy::print_stdout)]
+    fn finds_system_fonts() {
+        let provider = SystemFontProvider::new();
+        for (c, script) in [
+            ('日', "CJK"),
+            ('ع', "Arabic"),
+            ('א', "Hebrew"),
+            ('क', "Devanagari"),
+            ('ก', "Thai"),
+            ('⌥', "Symbol"),
+        ] {
+            let cluster = c.to_string();
+            let request = FallbackRequest {
+                cluster: &cluster,
+                base_char: c,
+                family: &FontFamily::Proportional,
+            };
+            let Some(insert) = provider.font_for(&request) else {
+                panic!("No system font for {script} {c:?}");
+            };
+            println!("{script} {c:?}: {}", insert.name);
+            assert!(insert.name.starts_with("system:"));
+        }
+    }
+}

--- a/crates/egui_system_fonts/src/lib.rs
+++ b/crates/egui_system_fonts/src/lib.rs
@@ -112,12 +112,8 @@ fn load_system_fonts() -> Mutex<SystemFonts> {
 
 impl FontProvider for SystemFontProvider {
     fn font_for(&self, request: &FallbackRequest<'_>) -> Option<FontInsert> {
-        let FallbackRequest {
-            cluster: _,
-            base_char,
-            family,
-        } = request;
-        let base_char = *base_char;
+        let FallbackRequest { cluster, family } = request;
+        let base_char = cluster.chars().next()?;
 
         let mut fonts = self.fonts.get_or_init(load_system_fonts).lock();
         let SystemFonts {
@@ -238,7 +234,6 @@ mod tests {
             let cluster = c.to_string();
             let request = FallbackRequest {
                 cluster: &cluster,
-                base_char: c,
                 family: &FontFamily::Proportional,
             };
             let Some(insert) = provider.font_for(&request) else {

--- a/crates/epaint/src/text/face_store.rs
+++ b/crates/epaint/src/text/face_store.rs
@@ -1,4 +1,5 @@
 use core::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 use nohash_hasher::IntMap;
 
@@ -63,7 +64,7 @@ impl FaceStore {
         let font_face = FontFace::new(
             self.options,
             name.to_owned(),
-            font_data.blob(),
+            Arc::clone(&font_data.font),
             font_data.index,
             font_data.tweak.clone(),
         )?;

--- a/crates/epaint/src/text/family.rs
+++ b/crates/epaint/src/text/family.rs
@@ -15,7 +15,7 @@ pub(crate) struct FamilyKey(pub(crate) usize);
 /// The fallback chain of one [`FontFamily`], and the caches for resolving chars against it.
 ///
 /// This is the only place that decides which face renders a given char:
-/// first the fonts from [`FontDefinitions`], then fonts found by the [`FontProviders`],
+/// first the configured fonts (from [`FontDefinitions`]), then fonts discovered by the [`FontProviders`],
 /// then the replacement glyph.
 #[derive(Debug)]
 pub(crate) struct Family {
@@ -23,7 +23,7 @@ pub(crate) struct Family {
 
     /// Faces in priority order: the primary first, then the fallbacks.
     ///
-    /// Fonts from [`FontDefinitions`] first, then any found by the [`FontProviders`].
+    /// Configured fonts (from [`FontDefinitions`]) first, then any discovered by the [`FontProviders`].
     chain: Vec<FontFaceKey>,
 
     /// The face used when no face in [`Self::chain`] supports a char.
@@ -49,8 +49,8 @@ impl Family {
     const PRIMARY_REPLACEMENT_CHAR: char = '◻'; // white medium square
     const FALLBACK_REPLACEMENT_CHAR: char = '?'; // fallback for the fallback
 
-    /// Look up the fallback chain of `name` in the definitions,
-    /// followed by the fonts the providers have already found for it.
+    /// Look up the configured fallback chain of `name` in the definitions,
+    /// followed by the fonts the providers have already discovered for it.
     ///
     /// Panics if the family or one of its fonts is missing from the definitions.
     pub fn new(
@@ -74,8 +74,8 @@ impl Family {
             })
             .collect();
 
-        // Fonts found by the providers come after the ones in the definitions:
-        for key in providers.provided_keys_for(name, faces) {
+        // Discovered fonts come after the configured ones:
+        for key in providers.discovered_keys_for(name, faces) {
             if !chain.contains(&key) {
                 chain.push(key);
             }
@@ -179,7 +179,7 @@ impl Family {
         let font_key = self
             .find_face_for_char(c, faces)
             .or_else(|| {
-                let key = providers.provide(faces, &self.name, cluster, c)?;
+                let key = providers.discover(faces, &self.name, cluster, c)?;
                 if !self.chain.contains(&key) {
                     self.chain.push(key);
                     self.characters = None;

--- a/crates/epaint/src/text/family.rs
+++ b/crates/epaint/src/text/family.rs
@@ -158,8 +158,10 @@ impl Family {
         faces: &mut FaceStore,
         providers: &mut FontProviders,
         cluster: &str,
-        base_char: char,
     ) -> FontFaceKey {
+        let Some(base_char) = cluster.chars().next() else {
+            return self.replacement_face_key;
+        };
         if let Some(font_key) = self.face_cache.get(&base_char) {
             return *font_key;
         }

--- a/crates/epaint/src/text/family.rs
+++ b/crates/epaint/src/text/family.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use crate::text::{
     FontDefinitions, FontFamily,
     face_store::{FaceStore, FontFaceKey},
+    font_provider::FontProviders,
 };
 
 /// Index of a [`Family`] in `FontsImpl`.
@@ -13,12 +14,16 @@ pub(crate) struct FamilyKey(pub(crate) usize);
 
 /// The fallback chain of one [`FontFamily`], and the caches for resolving chars against it.
 ///
-/// This is the only place that decides which face renders a given char.
+/// This is the only place that decides which face renders a given char:
+/// first the fonts from [`FontDefinitions`], then fonts found by the [`FontProviders`],
+/// then the replacement glyph.
 #[derive(Debug)]
 pub(crate) struct Family {
     name: FontFamily,
 
     /// Faces in priority order: the primary first, then the fallbacks.
+    ///
+    /// Fonts from [`FontDefinitions`] first, then any found by the [`FontProviders`].
     chain: Vec<FontFaceKey>,
 
     /// The face used when no face in [`Self::chain`] supports a char.
@@ -44,16 +49,22 @@ impl Family {
     const PRIMARY_REPLACEMENT_CHAR: char = '◻'; // white medium square
     const FALLBACK_REPLACEMENT_CHAR: char = '?'; // fallback for the fallback
 
-    /// Look up the fallback chain of `name` in the definitions.
+    /// Look up the fallback chain of `name` in the definitions,
+    /// followed by the fonts the providers have already found for it.
     ///
     /// Panics if the family or one of its fonts is missing from the definitions.
-    pub fn new(name: &FontFamily, definitions: &FontDefinitions, faces: &mut FaceStore) -> Self {
+    pub fn new(
+        name: &FontFamily,
+        definitions: &FontDefinitions,
+        faces: &mut FaceStore,
+        providers: &FontProviders,
+    ) -> Self {
         let font_names = definitions
             .families
             .get(name)
             .unwrap_or_else(|| panic!("FontFamily::{name:?} is not bound to any fonts"));
 
-        let chain: Vec<FontFaceKey> = font_names
+        let mut chain: Vec<FontFaceKey> = font_names
             .iter()
             .map(|font_name| {
                 faces.key_by_name(font_name).unwrap_or_else(|| {
@@ -62,6 +73,13 @@ impl Family {
                 })
             })
             .collect();
+
+        // Fonts found by the providers come after the ones in the definitions:
+        for key in providers.provided_keys_for(name, faces) {
+            if !chain.contains(&key) {
+                chain.push(key);
+            }
+        }
 
         let mut slf = Self {
             name: name.clone(),
@@ -106,12 +124,6 @@ impl Family {
         self.chain.first().copied()
     }
 
-    /// The face used for chars no face in the chain has.
-    #[inline]
-    pub fn replacement_face_key(&self) -> FontFaceKey {
-        self.replacement_face_key
-    }
-
     /// The char rendered in place of chars no face in the chain has.
     #[inline]
     pub fn replacement_char(&self) -> char {
@@ -121,19 +133,57 @@ impl Family {
     /// Find which face in the fallback chain owns `c`.
     ///
     /// Location-independent: fallback choice depends only on charmap support.
-    /// Falls back to the replacement-glyph face when no face has `c`.
+    /// Asks the [`FontProviders`] when no face has `c`,
+    /// and falls back to the replacement-glyph face when they have no font for it either.
     #[inline]
-    pub fn resolve(&mut self, faces: &mut FaceStore, c: char) -> FontFaceKey {
+    pub fn resolve(
+        &mut self,
+        faces: &mut FaceStore,
+        providers: &mut FontProviders,
+        c: char,
+    ) -> FontFaceKey {
         if let Some(font_key) = self.face_cache.get(&c) {
             return *font_key;
         }
-        self.resolve_slow(faces, c)
+        let mut utf8 = [0_u8; 4];
+        let cluster = c.encode_utf8(&mut utf8);
+        self.resolve_slow(faces, providers, cluster, c)
+    }
+
+    /// Like [`Self::resolve`] for the first char of `cluster`,
+    /// but lets the [`FontProviders`] see the whole grapheme cluster.
+    #[inline]
+    pub fn resolve_cluster(
+        &mut self,
+        faces: &mut FaceStore,
+        providers: &mut FontProviders,
+        cluster: &str,
+        base_char: char,
+    ) -> FontFaceKey {
+        if let Some(font_key) = self.face_cache.get(&base_char) {
+            return *font_key;
+        }
+        self.resolve_slow(faces, providers, cluster, base_char)
     }
 
     #[cold]
-    fn resolve_slow(&mut self, faces: &mut FaceStore, c: char) -> FontFaceKey {
+    fn resolve_slow(
+        &mut self,
+        faces: &mut FaceStore,
+        providers: &mut FontProviders,
+        cluster: &str,
+        c: char,
+    ) -> FontFaceKey {
         let font_key = self
             .find_face_for_char(c, faces)
+            .or_else(|| {
+                let key = providers.provide(faces, &self.name, cluster, c)?;
+                if !self.chain.contains(&key) {
+                    self.chain.push(key);
+                    self.characters = None;
+                }
+                Some(key)
+            })
             .unwrap_or(self.replacement_face_key);
         self.face_cache.insert(c, font_key);
         font_key

--- a/crates/epaint/src/text/font_data.rs
+++ b/crates/epaint/src/text/font_data.rs
@@ -1,15 +1,23 @@
-use std::{borrow::Cow, sync::Arc};
+use std::sync::Arc;
 
 use emath::Rangef;
 
 use crate::text::{FontTweak, Tag};
 
+/// Shared, immutable bytes of a font file.
+///
+/// Cheap to clone. Can wrap static bytes, a `Vec<u8>`, or a memory-mapped file.
+pub type Blob = Arc<dyn AsRef<[u8]> + Send + Sync>;
+
 /// A `.ttf` or `.otf` file and a font face index.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FontData {
     /// The content of a `.ttf` or `.otf` file.
-    pub font: Cow<'static, [u8]>,
+    ///
+    /// Shared, so that cloning a [`FontData`] does not copy the file.
+    #[cfg_attr(feature = "serde", serde(with = "blob_serde"))]
+    pub font: Blob,
 
     /// Which font face in the file to use.
     /// When in doubt, use `0`.
@@ -21,19 +29,26 @@ pub struct FontData {
 
 impl FontData {
     pub fn from_static(font: &'static [u8]) -> Self {
+        Self::from_blob(Arc::new(font), 0)
+    }
+
+    pub fn from_owned(font: Vec<u8>) -> Self {
+        Self::from_blob(Arc::new(font), 0)
+    }
+
+    /// Use already shared bytes, e.g. a memory-mapped system font file, without copying them.
+    pub fn from_blob(font: Blob, index: u32) -> Self {
         Self {
-            font: Cow::Borrowed(font),
-            index: 0,
+            font,
+            index,
             tweak: Default::default(),
         }
     }
 
-    pub fn from_owned(font: Vec<u8>) -> Self {
-        Self {
-            font: Cow::Owned(font),
-            index: 0,
-            tweak: Default::default(),
-        }
+    /// The content of the font file.
+    #[inline]
+    pub fn bytes(&self) -> &[u8] {
+        (*self.font).as_ref()
     }
 
     pub fn tweak(self, tweak: FontTweak) -> Self {
@@ -51,7 +66,7 @@ impl FontData {
     pub fn variation_axes(&self) -> Vec<FontVariationAxis> {
         use skrifa::MetadataProvider as _;
 
-        let Ok(font) = skrifa::FontRef::from_index(self.font.as_ref(), self.index) else {
+        let Ok(font) = skrifa::FontRef::from_index(self.bytes(), self.index) else {
             return Vec::new();
         };
 
@@ -94,21 +109,42 @@ pub struct FontVariationAxis {
 
 impl AsRef<[u8]> for FontData {
     fn as_ref(&self) -> &[u8] {
-        self.font.as_ref()
+        self.bytes()
     }
 }
 
-// ----------------------------------------------------------------------------
+impl PartialEq for FontData {
+    fn eq(&self, other: &Self) -> bool {
+        let Self { font, index, tweak } = self;
+        *index == other.index
+            && *tweak == other.tweak
+            && (Arc::ptr_eq(font, &other.font) || self.bytes() == other.bytes())
+    }
+}
 
-/// Shared, immutable bytes of a font file.
-pub type Blob = Arc<dyn AsRef<[u8]> + Send + Sync>;
+impl core::fmt::Debug for FontData {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let Self { font, index, tweak } = self;
+        f.debug_struct("FontData")
+            .field("font", &format_args!("{} bytes", (**font).as_ref().len()))
+            .field("index", index)
+            .field("tweak", tweak)
+            .finish()
+    }
+}
 
-impl FontData {
-    /// The font file bytes as a shared blob.
-    pub(crate) fn blob(&self) -> Blob {
-        match self.font.clone() {
-            Cow::Borrowed(bytes) => Arc::new(bytes) as Blob,
-            Cow::Owned(bytes) => Arc::new(bytes) as Blob,
-        }
+#[cfg(feature = "serde")]
+mod blob_serde {
+    use super::Blob;
+
+    pub fn serialize<S: serde::Serializer>(blob: &Blob, serializer: S) -> Result<S::Ok, S::Error> {
+        serde::Serialize::serialize((**blob).as_ref(), serializer)
+    }
+
+    pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Blob, D::Error> {
+        let bytes: Vec<u8> = serde::Deserialize::deserialize(deserializer)?;
+        Ok(std::sync::Arc::new(bytes))
     }
 }

--- a/crates/epaint/src/text/font_provider.rs
+++ b/crates/epaint/src/text/font_provider.rs
@@ -35,8 +35,8 @@ pub trait FontProvider: Send + Sync {
     ///
     /// The font is appended to the fallback chain of `request.family`
     /// and of the families in [`FontInsert::families`].
-    /// The [`FontPriority`] is ignored: provided fonts always come after the fonts in
-    /// [`FontDefinitions`](crate::text::FontDefinitions).
+    /// The [`FontPriority`] is ignored: discovered fonts always come after the configured ones
+    /// (the fonts in [`FontDefinitions`](crate::text::FontDefinitions)).
     fn font_for(&self, request: &FallbackRequest<'_>) -> Option<FontInsert>;
 }
 
@@ -49,7 +49,7 @@ where
     }
 }
 
-/// The installed [`FontProvider`]s, and what they have found so far.
+/// The installed [`FontProvider`]s, and what they have discovered so far.
 ///
 /// Survives atlas clears and `TextOptions` changes,
 /// so the providers are asked at most once per (family, char).
@@ -58,8 +58,8 @@ pub(crate) struct FontProviders {
     /// Asked in order; the first font found wins.
     providers: Vec<Arc<dyn FontProvider>>,
 
-    /// Fonts found so far, in the order they were found.
-    provided: Vec<FontInsert>,
+    /// Fonts discovered so far, in the order they were found.
+    discovered: Vec<FontInsert>,
 
     /// No provider had a font for these.
     misses: ahash::HashSet<(FontFamily, char)>,
@@ -69,32 +69,32 @@ impl FontProviders {
     pub fn new(providers: Vec<Arc<dyn FontProvider>>) -> Self {
         Self {
             providers,
-            provided: Vec::new(),
+            discovered: Vec::new(),
             misses: Default::default(),
         }
     }
 
-    /// Fonts found so far, in the order they were found.
-    pub fn provided(&self) -> &[FontInsert] {
-        &self.provided
+    /// Fonts discovered so far, in the order they were found.
+    pub fn discovered(&self) -> &[FontInsert] {
+        &self.discovered
     }
 
-    /// Parse the provided fonts into `faces`, e.g. after `faces` was rebuilt.
-    pub fn install_provided(&self, faces: &mut FaceStore) {
-        for insert in &self.provided {
+    /// Parse the discovered fonts into `faces`, e.g. after `faces` was rebuilt.
+    pub fn install_discovered(&self, faces: &mut FaceStore) {
+        for insert in &self.discovered {
             if let Err(err) = faces.install(&insert.name, &insert.data) {
-                log::warn!("Failed to parse provided font {:?}: {err}", insert.name);
+                log::warn!("Failed to parse discovered font {:?}: {err}", insert.name);
             }
         }
     }
 
-    /// The provided fonts that belong in the fallback chain of `family`.
-    pub fn provided_keys_for<'a>(
+    /// The discovered fonts that belong in the fallback chain of `family`.
+    pub fn discovered_keys_for<'a>(
         &'a self,
         family: &'a FontFamily,
         faces: &'a FaceStore,
     ) -> impl Iterator<Item = FontFaceKey> + 'a {
-        self.provided
+        self.discovered
             .iter()
             .filter(move |insert| insert.families.iter().any(|f| f.family == *family))
             .filter_map(move |insert| faces.key_by_name(&insert.name))
@@ -102,8 +102,11 @@ impl FontProviders {
 
     /// Ask the providers for a font with a glyph for `base_char`, and install it into `faces`.
     ///
+    /// A font found this way is a *discovered* font, as opposed to the *configured* ones in
+    /// [`FontDefinitions`](crate::text::FontDefinitions).
+    ///
     /// Misses are remembered, so each provider is asked at most once per (family, char).
-    pub fn provide(
+    pub fn discover(
         &mut self,
         faces: &mut FaceStore,
         family: &FontFamily,
@@ -151,7 +154,7 @@ impl FontProviders {
                     priority: FontPriority::Lowest,
                 });
             }
-            self.provided.push(insert);
+            self.discovered.push(insert);
             return Some(key);
         }
 
@@ -208,7 +211,7 @@ mod tests {
                 .push((request.family.clone(), request.cluster.to_owned()));
             provide.then(|| {
                 FontInsert::new(
-                    "provided:NotoEmoji",
+                    "discovered:NotoEmoji",
                     FontData::from_static(NOTO_EMOJI_REGULAR),
                     vec![InsertFontFamily {
                         family: request.family.clone(),
@@ -259,7 +262,7 @@ mod tests {
             *requests.lock(),
             vec![(FontFamily::Proportional, EMOJI.to_string())]
         );
-        assert_eq!(fonts.provided_fonts().len(), 1);
+        assert_eq!(fonts.discovered_fonts().len(), 1);
 
         let glyph = first_glyph(&mut fonts, EMOJI);
         assert!(!glyph.uv_rect.is_nothing());
@@ -271,7 +274,7 @@ mod tests {
                 .with_pixels_per_point(1.0)
                 .characters(&FontFamily::Proportional)
                 .get(&EMOJI),
-            Some(&vec!["provided:NotoEmoji".to_owned()])
+            Some(&vec!["discovered:NotoEmoji".to_owned()])
         );
     }
 
@@ -290,7 +293,7 @@ mod tests {
                 (FontFamily::Monospace, HANGUL.to_string()),
             ]
         );
-        assert!(fonts.provided_fonts().is_empty());
+        assert!(fonts.discovered_fonts().is_empty());
     }
 
     #[test]
@@ -305,7 +308,7 @@ mod tests {
     }
 
     #[test]
-    fn provided_fonts_and_misses_survive_a_rebuild() {
+    fn discovered_fonts_and_misses_survive_a_rebuild() {
         let requests = Arc::new(Mutex::new(Vec::new()));
         let mut fonts = fonts_with(recording_provider(&requests, true), None);
         let font_id = FontId::proportional(14.0);
@@ -314,7 +317,7 @@ mod tests {
         // The provider returns NotoEmoji for this too, but it has no glyph for it:
         assert!(!fonts.has_glyph(&font_id, HANGUL));
         assert_eq!(requests.lock().len(), 2);
-        assert_eq!(fonts.provided_fonts().len(), 1);
+        assert_eq!(fonts.discovered_fonts().len(), 1);
 
         // Force a rebuild by changing the text options:
         let options = TextOptions {
@@ -330,11 +333,11 @@ mod tests {
             2,
             "The provider should not be asked again"
         );
-        assert_eq!(fonts.provided_fonts().len(), 1);
+        assert_eq!(fonts.discovered_fonts().len(), 1);
     }
 
     #[test]
-    fn provided_font_beats_the_rasterizer() {
+    fn discovered_font_beats_the_rasterizer() {
         let requests = Arc::new(Mutex::new(Vec::new()));
         let mut fonts = fonts_with(
             recording_provider(&requests, true),
@@ -343,7 +346,7 @@ mod tests {
         .with_glyph_source_preference(|_| GlyphSource::Fonts);
 
         let glyph = first_glyph(&mut fonts, EMOJI);
-        assert!(!glyph.is_color, "Should come from the provided font");
+        assert!(!glyph.is_color, "Should come from the discovered font");
         assert_eq!(requests.lock().len(), 1);
     }
 

--- a/crates/epaint/src/text/font_provider.rs
+++ b/crates/epaint/src/text/font_provider.rs
@@ -1,0 +1,362 @@
+use std::sync::Arc;
+
+use crate::text::{
+    FontFamily, FontInsert, FontPriority, InsertFontFamily,
+    face_store::{FaceStore, FontFaceKey},
+    unicode::is_combining_mark,
+};
+
+/// Input to a [`FontProvider`].
+pub struct FallbackRequest<'a> {
+    /// A grapheme cluster that no installed font can render.
+    ///
+    /// The returned font must have a glyph for its first character.
+    pub cluster: &'a str,
+
+    /// The requested font family.
+    pub family: &'a FontFamily,
+}
+
+/// Finds a font file for text that no installed font covers, e.g. among the system fonts.
+///
+/// The returned font is appended to the fallback chain of the requested family,
+/// after the fonts in [`FontDefinitions`](crate::text::FontDefinitions), and is then used like any other font:
+/// shaped, hinted, and kerned.
+///
+/// Install one with `egui::Context::add_font_provider` or [`Fonts::with_font_providers`](crate::text::Fonts::with_font_providers).
+/// `eframe` installs one on native (behind its `system_fonts` feature).
+///
+/// Any `Fn(&FallbackRequest<'_>) -> Option<FontInsert>` is a [`FontProvider`].
+pub trait FontProvider: Send + Sync {
+    /// Find a font with a glyph for the first character of `request.cluster`.
+    ///
+    /// Called at most once per (family, character), also when returning `None`,
+    /// until the [`FontDefinitions`](crate::text::FontDefinitions) change.
+    ///
+    /// The font is appended to the fallback chain of `request.family`
+    /// and of the families in [`FontInsert::families`].
+    /// The [`FontPriority`] is ignored: provided fonts always come after the fonts in
+    /// [`FontDefinitions`](crate::text::FontDefinitions).
+    fn font_for(&self, request: &FallbackRequest<'_>) -> Option<FontInsert>;
+}
+
+impl<F> FontProvider for F
+where
+    F: Fn(&FallbackRequest<'_>) -> Option<FontInsert> + Send + Sync,
+{
+    fn font_for(&self, request: &FallbackRequest<'_>) -> Option<FontInsert> {
+        self(request)
+    }
+}
+
+/// The installed [`FontProvider`]s, and what they have found so far.
+///
+/// Survives atlas clears and `TextOptions` changes,
+/// so the providers are asked at most once per (family, char).
+#[derive(Default)]
+pub(crate) struct FontProviders {
+    /// Asked in order; the first font found wins.
+    providers: Vec<Arc<dyn FontProvider>>,
+
+    /// Fonts found so far, in the order they were found.
+    provided: Vec<FontInsert>,
+
+    /// No provider had a font for these.
+    misses: ahash::HashSet<(FontFamily, char)>,
+}
+
+impl FontProviders {
+    pub fn new(providers: Vec<Arc<dyn FontProvider>>) -> Self {
+        Self {
+            providers,
+            provided: Vec::new(),
+            misses: Default::default(),
+        }
+    }
+
+    /// Fonts found so far, in the order they were found.
+    pub fn provided(&self) -> &[FontInsert] {
+        &self.provided
+    }
+
+    /// Parse the provided fonts into `faces`, e.g. after `faces` was rebuilt.
+    pub fn install_provided(&self, faces: &mut FaceStore) {
+        for insert in &self.provided {
+            if let Err(err) = faces.install(&insert.name, &insert.data) {
+                log::warn!("Failed to parse provided font {:?}: {err}", insert.name);
+            }
+        }
+    }
+
+    /// The provided fonts that belong in the fallback chain of `family`.
+    pub fn provided_keys_for<'a>(
+        &'a self,
+        family: &'a FontFamily,
+        faces: &'a FaceStore,
+    ) -> impl Iterator<Item = FontFaceKey> + 'a {
+        self.provided
+            .iter()
+            .filter(move |insert| insert.families.iter().any(|f| f.family == *family))
+            .filter_map(move |insert| faces.key_by_name(&insert.name))
+    }
+
+    /// Ask the providers for a font with a glyph for `base_char`, and install it into `faces`.
+    ///
+    /// Misses are remembered, so each provider is asked at most once per (family, char).
+    pub fn provide(
+        &mut self,
+        faces: &mut FaceStore,
+        family: &FontFamily,
+        cluster: &str,
+        base_char: char,
+    ) -> Option<FontFaceKey> {
+        if self.providers.is_empty()
+            || base_char.is_control()
+            || is_combining_mark(base_char)
+            || self.misses.contains(&(family.clone(), base_char))
+        {
+            return None;
+        }
+
+        let request = FallbackRequest { cluster, family };
+
+        for provider in &self.providers {
+            let Some(mut insert) = provider.font_for(&request) else {
+                continue;
+            };
+            let key = match faces.install(&insert.name, &insert.data) {
+                Ok(key) => key,
+                Err(err) => {
+                    log::warn!(
+                        "Failed to parse font {:?} from a font provider: {err}",
+                        insert.name
+                    );
+                    continue;
+                }
+            };
+            let has_glyph = faces
+                .get_mut(key)
+                .is_some_and(|face| face.glyph_id_resolution(base_char).is_some());
+            if !has_glyph {
+                log::warn!(
+                    "Font {:?} from a font provider has no glyph for {base_char:?}",
+                    insert.name
+                );
+                continue;
+            }
+
+            if !insert.families.iter().any(|f| f.family == *family) {
+                insert.families.push(InsertFontFamily {
+                    family: family.clone(),
+                    priority: FontPriority::Lowest,
+                });
+            }
+            self.provided.push(insert);
+            return Some(key);
+        }
+
+        self.misses.insert((family.clone(), base_char));
+        None
+    }
+}
+
+#[cfg(feature = "default_fonts")]
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use epaint_default_fonts::{HACK_REGULAR, NOTO_EMOJI_REGULAR};
+
+    use super::*;
+    use crate::{
+        Color32, ColorImage,
+        mutex::Mutex,
+        text::{
+            FontData, FontDefinitions, FontId, Fonts, GlyphRasterizer, GlyphRasterizerRequest,
+            GlyphSource, RasterizedGlyph, TextOptions,
+        },
+    };
+
+    const EMOJI: char = '😀'; // In NotoEmoji, but not in Hack.
+    const HANGUL: char = '한'; // In neither.
+
+    /// Only Hack, so that emoji are missing.
+    fn hack_only() -> FontDefinitions {
+        let mut definitions = FontDefinitions::empty();
+        definitions.font_data.insert(
+            "Hack".to_owned(),
+            Arc::new(FontData::from_static(HACK_REGULAR)),
+        );
+        definitions
+            .families
+            .insert(FontFamily::Proportional, vec!["Hack".to_owned()]);
+        definitions
+            .families
+            .insert(FontFamily::Monospace, vec!["Hack".to_owned()]);
+        definitions
+    }
+
+    /// A provider that records its requests, and returns `NotoEmoji` for everything if `provide`.
+    fn recording_provider(
+        requests: &Arc<Mutex<Vec<(FontFamily, String)>>>,
+        provide: bool,
+    ) -> Arc<dyn FontProvider> {
+        let requests = Arc::clone(requests);
+        Arc::new(move |request: &FallbackRequest<'_>| {
+            requests
+                .lock()
+                .push((request.family.clone(), request.cluster.to_owned()));
+            provide.then(|| {
+                FontInsert::new(
+                    "provided:NotoEmoji",
+                    FontData::from_static(NOTO_EMOJI_REGULAR),
+                    vec![InsertFontFamily {
+                        family: request.family.clone(),
+                        priority: FontPriority::Lowest,
+                    }],
+                )
+            })
+        })
+    }
+
+    fn color_rasterizer() -> GlyphRasterizer {
+        GlyphRasterizer::new(|_: &GlyphRasterizerRequest<'_>| {
+            Some(RasterizedGlyph {
+                image: ColorImage::new([1, 1], vec![Color32::RED]),
+                offset_px: emath::Vec2::ZERO,
+                advance_px: 10.0,
+                is_color: true,
+            })
+        })
+    }
+
+    fn fonts_with(provider: Arc<dyn FontProvider>, rasterizer: Option<GlyphRasterizer>) -> Fonts {
+        let mut fonts =
+            Fonts::new(TextOptions::default(), hack_only()).with_font_providers(vec![provider]);
+        fonts.set_glyph_rasterizer(rasterizer);
+        fonts
+    }
+
+    fn first_glyph(fonts: &mut Fonts, c: char) -> crate::text::Glyph {
+        let galley = fonts.with_pixels_per_point(1.0).layout_no_wrap(
+            c.to_string(),
+            FontId::proportional(14.0),
+            Color32::WHITE,
+        );
+        galley.rows[0].row.glyphs[0]
+    }
+
+    #[test]
+    fn provider_hit_installs_the_font_once() {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let mut fonts = fonts_with(recording_provider(&requests, true), None);
+        let font_id = FontId::proportional(14.0);
+
+        assert!(fonts.has_glyph(&font_id, EMOJI));
+        assert!(fonts.has_glyph(&font_id, EMOJI));
+        assert!(fonts.has_glyph(&font_id, 'a'));
+        assert_eq!(
+            *requests.lock(),
+            vec![(FontFamily::Proportional, EMOJI.to_string())]
+        );
+        assert_eq!(fonts.provided_fonts().len(), 1);
+
+        let glyph = first_glyph(&mut fonts, EMOJI);
+        assert!(!glyph.uv_rect.is_nothing());
+        assert!(!glyph.is_color);
+        assert_eq!(requests.lock().len(), 1);
+
+        assert_eq!(
+            fonts
+                .with_pixels_per_point(1.0)
+                .characters(&FontFamily::Proportional)
+                .get(&EMOJI),
+            Some(&vec!["provided:NotoEmoji".to_owned()])
+        );
+    }
+
+    #[test]
+    fn provider_miss_is_remembered_per_family() {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let mut fonts = fonts_with(recording_provider(&requests, false), None);
+
+        assert!(!fonts.has_glyph(&FontId::proportional(14.0), HANGUL));
+        assert!(!fonts.has_glyph(&FontId::proportional(14.0), HANGUL));
+        assert!(!fonts.has_glyph(&FontId::monospace(14.0), HANGUL));
+        assert_eq!(
+            *requests.lock(),
+            vec![
+                (FontFamily::Proportional, HANGUL.to_string()),
+                (FontFamily::Monospace, HANGUL.to_string()),
+            ]
+        );
+        assert!(fonts.provided_fonts().is_empty());
+    }
+
+    #[test]
+    fn provider_is_not_asked_for_control_chars_and_combining_marks() {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let mut fonts = fonts_with(recording_provider(&requests, true), None);
+        let font_id = FontId::proportional(14.0);
+
+        fonts.has_glyph(&font_id, '\n');
+        fonts.has_glyph(&font_id, '\u{1AB0}'); // COMBINING DOUBLED CIRCUMFLEX ACCENT
+        assert!(requests.lock().is_empty());
+    }
+
+    #[test]
+    fn provided_fonts_and_misses_survive_a_rebuild() {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let mut fonts = fonts_with(recording_provider(&requests, true), None);
+        let font_id = FontId::proportional(14.0);
+
+        assert!(fonts.has_glyph(&font_id, EMOJI));
+        // The provider returns NotoEmoji for this too, but it has no glyph for it:
+        assert!(!fonts.has_glyph(&font_id, HANGUL));
+        assert_eq!(requests.lock().len(), 2);
+        assert_eq!(fonts.provided_fonts().len(), 1);
+
+        // Force a rebuild by changing the text options:
+        let options = TextOptions {
+            font_hinting: !TextOptions::default().font_hinting,
+            ..Default::default()
+        };
+        fonts.begin_pass(options);
+
+        assert!(fonts.has_glyph(&font_id, EMOJI));
+        assert!(!fonts.has_glyph(&font_id, HANGUL));
+        assert_eq!(
+            requests.lock().len(),
+            2,
+            "The provider should not be asked again"
+        );
+        assert_eq!(fonts.provided_fonts().len(), 1);
+    }
+
+    #[test]
+    fn provided_font_beats_the_rasterizer() {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let mut fonts = fonts_with(
+            recording_provider(&requests, true),
+            Some(color_rasterizer()),
+        )
+        .with_glyph_source_preference(|_| GlyphSource::Fonts);
+
+        let glyph = first_glyph(&mut fonts, EMOJI);
+        assert!(!glyph.is_color, "Should come from the provided font");
+        assert_eq!(requests.lock().len(), 1);
+    }
+
+    #[test]
+    fn rasterizer_is_used_when_the_provider_misses() {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let mut fonts = fonts_with(
+            recording_provider(&requests, false),
+            Some(color_rasterizer()),
+        );
+
+        let glyph = first_glyph(&mut fonts, HANGUL);
+        assert!(glyph.is_color, "Should come from the rasterizer");
+        assert_eq!(requests.lock().len(), 1);
+    }
+}

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -92,11 +92,11 @@ impl Fonts {
         self
     }
 
-    /// The fonts found by the [`FontProvider`]s so far, in the order they were found.
+    /// The fonts discovered by the [`FontProvider`]s so far, in the order they were found.
     ///
     /// These are not part of [`Self::definitions`].
-    pub fn provided_fonts(&self) -> &[FontInsert] {
-        self.fonts.provided_fonts()
+    pub fn discovered_fonts(&self) -> &[FontInsert] {
+        self.fonts.discovered_fonts()
     }
 
     /// Call at the start of each frame with the latest known [`TextOptions`].
@@ -285,11 +285,11 @@ impl FontsView<'_> {
         self.fonts.definitions.families.keys().cloned().collect()
     }
 
-    /// The fonts found by the [`FontProvider`]s so far, in the order they were found.
+    /// The fonts discovered by the [`FontProvider`]s so far, in the order they were found.
     ///
     /// These are not part of [`Self::definitions`].
-    pub fn provided_fonts(&self) -> &[FontInsert] {
-        self.fonts.provided_fonts()
+    pub fn discovered_fonts(&self) -> &[FontInsert] {
+        self.fonts.discovered_fonts()
     }
 
     /// Layout some text.
@@ -402,18 +402,18 @@ impl FontsImpl {
 
     /// Ask these for fonts for characters that no font in the [`FontDefinitions`] has.
     ///
-    /// Fonts the providers found earlier are installed right away.
+    /// Fonts the providers discovered earlier are installed right away.
     pub fn set_font_providers(&mut self, font_providers: FontProviders) {
-        font_providers.install_provided(&mut self.faces);
+        font_providers.install_discovered(&mut self.faces);
         self.font_providers = font_providers;
         // The fallback chains may have changed:
         self.families.clear();
         self.family_keys.clear();
     }
 
-    /// The fonts found by the [`FontProvider`]s so far, in the order they were found.
-    pub fn provided_fonts(&self) -> &[FontInsert] {
-        self.font_providers.provided()
+    /// The fonts discovered by the [`FontProvider`]s so far, in the order they were found.
+    pub fn discovered_fonts(&self) -> &[FontInsert] {
+        self.font_providers.discovered()
     }
 
     /// Use this platform glyph rasterizer, e.g. the browser on web.

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -3,11 +3,12 @@ use std::{collections::BTreeMap, sync::Arc};
 use crate::{
     Color32, TextureAtlas,
     text::{
-        FontDefinitions, FontFamily, FontId, Galley, GlyphRasterizer, GlyphSource,
-        GlyphSourcePreference, LayoutJob, TextOptions, VariationCoords,
+        FontDefinitions, FontFamily, FontId, FontInsert, FontProvider, Galley, GlyphRasterizer,
+        GlyphSource, GlyphSourcePreference, LayoutJob, TextOptions, VariationCoords,
         face_store::{FaceStore, FontFaceKey},
         family::{Family, FamilyKey},
         font_face::{FontFace, GlyphInfo, ShapedGlyph},
+        font_provider::FontProviders,
         galley_cache::GalleyCache,
         glyph_atlas::{GlyphAtlas, OutlineGlyph, RasterGlyphAllocation},
         glyph_rasterizer::default_glyph_source,
@@ -81,6 +82,23 @@ impl Fonts {
         self
     }
 
+    /// Ask these for fonts for characters that no font in the [`FontDefinitions`] has.
+    ///
+    /// The providers are asked in order, and the first font found is used.
+    #[inline]
+    pub fn with_font_providers(mut self, font_providers: Vec<Arc<dyn FontProvider>>) -> Self {
+        self.fonts
+            .set_font_providers(FontProviders::new(font_providers));
+        self
+    }
+
+    /// The fonts found by the [`FontProvider`]s so far, in the order they were found.
+    ///
+    /// These are not part of [`Self::definitions`].
+    pub fn provided_fonts(&self) -> &[FontInsert] {
+        self.fonts.provided_fonts()
+    }
+
     /// Call at the start of each frame with the latest known [`TextOptions`].
     ///
     /// Call after painting the previous frame, but before using [`Fonts`] for the new frame.
@@ -94,6 +112,7 @@ impl Fonts {
             let mut fonts = FontsImpl::new(options, definitions);
             fonts.set_glyph_rasterizer(self.fonts.glyph_rasterizer.take());
             fonts.glyph_source_preference = Arc::clone(&self.fonts.glyph_source_preference);
+            fonts.set_font_providers(core::mem::take(&mut self.fonts.font_providers));
             self.fonts = fonts;
             self.galley_cache = Default::default();
         } else if 0.8 < self.fonts.glyphs.fill_ratio() {
@@ -266,6 +285,13 @@ impl FontsView<'_> {
         self.fonts.definitions.families.keys().cloned().collect()
     }
 
+    /// The fonts found by the [`FontProvider`]s so far, in the order they were found.
+    ///
+    /// These are not part of [`Self::definitions`].
+    pub fn provided_fonts(&self) -> &[FontInsert] {
+        self.fonts.provided_fonts()
+    }
+
     /// Layout some text.
     ///
     /// This is the most advanced layout function.
@@ -351,6 +377,7 @@ pub(crate) struct FontsImpl {
     /// Recycled `harfrust` shaping buffer to avoid per-layout allocations.
     shape_buffer: Option<harfrust::UnicodeBuffer>,
     glyph_rasterizer: Option<GlyphRasterizer>,
+    font_providers: FontProviders,
     glyph_source_preference: GlyphSourcePreference,
 }
 
@@ -368,8 +395,25 @@ impl FontsImpl {
             family_keys: Default::default(),
             shape_buffer: Some(harfrust::UnicodeBuffer::new()),
             glyph_rasterizer: None,
+            font_providers: Default::default(),
             glyph_source_preference: Arc::new(default_glyph_source),
         }
+    }
+
+    /// Ask these for fonts for characters that no font in the [`FontDefinitions`] has.
+    ///
+    /// Fonts the providers found earlier are installed right away.
+    pub fn set_font_providers(&mut self, font_providers: FontProviders) {
+        font_providers.install_provided(&mut self.faces);
+        self.font_providers = font_providers;
+        // The fallback chains may have changed:
+        self.families.clear();
+        self.family_keys.clear();
+    }
+
+    /// The fonts found by the [`FontProvider`]s so far, in the order they were found.
+    pub fn provided_fonts(&self) -> &[FontInsert] {
+        self.font_providers.provided()
     }
 
     /// Use this platform glyph rasterizer, e.g. the browser on web.
@@ -425,8 +469,12 @@ impl FontsImpl {
             return *key;
         }
         let key = FamilyKey(self.families.len());
-        self.families
-            .push(Family::new(family, &self.definitions, &mut self.faces));
+        self.families.push(Family::new(
+            family,
+            &self.definitions,
+            &mut self.faces,
+            &self.font_providers,
+        ));
         self.family_keys.insert(family.clone(), key);
         key
     }
@@ -441,7 +489,24 @@ impl FontsImpl {
     /// See [`Family::resolve`].
     #[inline]
     pub fn resolve_face(&mut self, family: FamilyKey, c: char) -> FontFaceKey {
-        self.families[family.0].resolve(&mut self.faces, c)
+        self.families[family.0].resolve(&mut self.faces, &mut self.font_providers, c)
+    }
+
+    /// Like [`Self::resolve_face`] for the first char of `cluster`,
+    /// but lets the [`FontProvider`]s see the whole grapheme cluster.
+    #[inline]
+    pub fn resolve_cluster_face(
+        &mut self,
+        family: FamilyKey,
+        cluster: &str,
+        base_char: char,
+    ) -> FontFaceKey {
+        self.families[family.0].resolve_cluster(
+            &mut self.faces,
+            &mut self.font_providers,
+            cluster,
+            base_char,
+        )
     }
 
     /// Resolve `c` to its (face, [`GlyphInfo`]) at the given face's location.
@@ -520,8 +585,10 @@ impl FontsImpl {
     /// for a character that would still render via the rasterizer (e.g. the browser on web).
     pub fn has_glyph(&mut self, family: &FontFamily, c: char) -> bool {
         let family = self.family_key(family);
-        // TODO(emilk): this is a false negative if the user asks about the replacement character itself 🤦‍♂️
-        self.resolve_face(family, c) != self.family(family).replacement_face_key()
+        let face_key = self.resolve_face(family, c);
+        self.faces
+            .get_mut(face_key)
+            .is_some_and(|face| face.glyph_id_resolution(c).is_some())
     }
 
     /// Do the installed fonts have all the glyphs in this text?

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -495,18 +495,8 @@ impl FontsImpl {
     /// Like [`Self::resolve_face`] for the first char of `cluster`,
     /// but lets the [`FontProvider`]s see the whole grapheme cluster.
     #[inline]
-    pub fn resolve_cluster_face(
-        &mut self,
-        family: FamilyKey,
-        cluster: &str,
-        base_char: char,
-    ) -> FontFaceKey {
-        self.families[family.0].resolve_cluster(
-            &mut self.faces,
-            &mut self.font_providers,
-            cluster,
-            base_char,
-        )
+    pub fn resolve_cluster_face(&mut self, family: FamilyKey, cluster: &str) -> FontFaceKey {
+        self.families[family.0].resolve_cluster(&mut self.faces, &mut self.font_providers, cluster)
     }
 
     /// Resolve `c` to its (face, [`GlyphInfo`]) at the given face's location.

--- a/crates/epaint/src/text/glyph_rasterizer.rs
+++ b/crates/epaint/src/text/glyph_rasterizer.rs
@@ -48,7 +48,8 @@ pub enum GlyphSource {
     /// Predictable: looks the same everywhere, both on native and on web.
     Fonts,
 
-    /// What the platform offers, e.g. the [`GlyphRasterizer`] (the browser on web).
+    /// What the platform offers: fonts from the [`FontProvider`](crate::text::FontProvider)s
+    /// (e.g. the system fonts on native), and the [`GlyphRasterizer`] (e.g. the browser on web).
     ///
     /// Supports colored emojis.
     /// Unpredictable: may look different on different computers.

--- a/crates/epaint/src/text/mod.rs
+++ b/crates/epaint/src/text/mod.rs
@@ -19,7 +19,7 @@ mod text_layout_types;
 mod unicode;
 
 pub use {
-    font_data::{FontData, FontVariationAxis},
+    font_data::{Blob, FontData, FontVariationAxis},
     font_definitions::{FontDefinitions, FontInsert, FontPriority, InsertFontFamily},
     font_id::{FontFamily, FontId},
     font_tweak::{FontTweak, HintingTarget, SmoothHinting},

--- a/crates/epaint/src/text/mod.rs
+++ b/crates/epaint/src/text/mod.rs
@@ -7,6 +7,7 @@ mod font_data;
 mod font_definitions;
 mod font_face;
 mod font_id;
+mod font_provider;
 mod font_tweak;
 mod fonts;
 mod galley_cache;
@@ -22,6 +23,7 @@ pub use {
     font_data::{Blob, FontData, FontVariationAxis},
     font_definitions::{FontDefinitions, FontInsert, FontPriority, InsertFontFamily},
     font_id::{FontFamily, FontId},
+    font_provider::{FallbackRequest, FontProvider},
     font_tweak::{FontTweak, HintingTarget, SmoothHinting},
     fonts::{Fonts, FontsView, MAX_GLYPH_SIZE},
     glyph_rasterizer::{

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -14,7 +14,7 @@ use crate::{
         fonts::FontsImpl,
         glyph_atlas::UvRect,
         styled_metrics::StyledMetrics,
-        unicode::{is_cjk, is_cjk_break_allowed},
+        unicode::{is_cjk, is_cjk_break_allowed, is_combining_mark},
     },
 };
 
@@ -27,21 +27,6 @@ use super::{
 };
 
 // ----------------------------------------------------------------------------
-
-/// Returns `true` if the character is a Unicode combining mark (categories Mn, Mc, Me).
-///
-/// These characters modify the preceding base character and should not be
-/// rendered as standalone replacement glyphs when the shaper can't handle them.
-#[inline]
-fn is_combining_mark(c: char) -> bool {
-    use unicode_general_category::{GeneralCategory, get_general_category};
-    matches!(
-        get_general_category(c),
-        GeneralCategory::NonspacingMark
-            | GeneralCategory::SpacingMark
-            | GeneralCategory::EnclosingMark
-    )
-}
 
 /// Represents GUI scale and convenience methods for rounding to pixels.
 #[derive(Clone, Copy)]
@@ -1511,7 +1496,7 @@ fn segment_into_runs(fonts: &mut FontsImpl, family: FamilyKey, text: &str, out: 
         let byte_end = byte_offset + grapheme_str.len();
 
         let base_char = grapheme_str.chars().next().unwrap_or(' ');
-        let font_key = fonts.resolve_face(family, base_char);
+        let font_key = fonts.resolve_cluster_face(family, grapheme_str, base_char);
         let source = fonts.glyph_source(grapheme_str);
 
         if let Some(last_run) = out.last_mut()

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -1495,8 +1495,7 @@ fn segment_into_runs(fonts: &mut FontsImpl, family: FamilyKey, text: &str, out: 
         let byte_offset = ByteIndex(byte_offset);
         let byte_end = byte_offset + grapheme_str.len();
 
-        let base_char = grapheme_str.chars().next().unwrap_or(' ');
-        let font_key = fonts.resolve_cluster_face(family, grapheme_str, base_char);
+        let font_key = fonts.resolve_cluster_face(family, grapheme_str);
         let source = fonts.glyph_source(grapheme_str);
 
         if let Some(last_run) = out.last_mut()

--- a/crates/epaint/src/text/unicode.rs
+++ b/crates/epaint/src/text/unicode.rs
@@ -69,3 +69,18 @@ pub(super) fn is_cjk_break_allowed(c: char) -> bool {
     // See: https://en.wikipedia.org/wiki/Line_breaking_rules_in_East_Asian_languages#Characters_not_permitted_on_the_start_of_a_line.
     !")]｝〕〉》」』】〙〗〟'\"｠»ヽヾーァィゥェォッャュョヮヵヶぁぃぅぇぉっゃゅょゎゕゖㇰㇱㇲㇳㇴㇵㇶㇷㇸㇹㇺㇻㇼㇽㇾㇿ々〻‐゠–〜?!‼⁇⁈⁉・、:;,。.".contains(c)
 }
+
+/// Returns `true` if the character is a Unicode combining mark (categories Mn, Mc, Me).
+///
+/// These characters modify the preceding base character and should not be
+/// rendered as standalone replacement glyphs when the shaper can't handle them.
+#[inline]
+pub(super) fn is_combining_mark(c: char) -> bool {
+    use unicode_general_category::{GeneralCategory, get_general_category};
+    matches!(
+        get_general_category(c),
+        GeneralCategory::NonspacingMark
+            | GeneralCategory::SpacingMark
+            | GeneralCategory::EnclosingMark
+    )
+}

--- a/deny.toml
+++ b/deny.toml
@@ -62,6 +62,7 @@ skip = [
   { name = "phf_shared" }, # same phf split as phf
   { name = "rand_core" }, # rand ecosystem is migrating 0.8 -> 0.10; phf_generator's rand 0.8 needs rand_core 0.6, getrandom 0.4/chacha20 need rand_core 0.10
   { name = "redox_syscall" }, # old version via winit
+  { name = "roxmltree" }, # fontique (Android backend) depends on 0.21, resvg's usvg on 0.20
   { name = "rustc-hash" }, # Small enough
   { name = "thiserror" }, # ecosystem is in the process of migrating from 1.x to 2.x
   { name = "thiserror-impl" }, # same as above

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -257,6 +257,7 @@ def main() -> None:
         "egui_glow",
         "egui_inspection",
         "egui_kittest",
+        "egui_system_fonts",
         "egui-wgpu",
         "egui-winit",
         "egui",

--- a/scripts/publish_crates.sh
+++ b/scripts/publish_crates.sh
@@ -8,6 +8,7 @@
 (cd crates/egui-winit           && cargo publish --quiet)  &&  echo "✅ egui-winit"
 (cd crates/egui_glow            && cargo publish --quiet)  &&  echo "✅ egui_glow"
 (cd crates/egui-wgpu            && cargo publish --quiet)  &&  echo "✅ egui-wgpu"
+(cd crates/egui_system_fonts    && cargo publish --quiet)  &&  echo "✅ egui_system_fonts"
 (cd crates/egui_inspection      && cargo publish --quiet)  &&  echo "✅ eframe"
 (cd crates/eframe               && cargo publish --quiet)  &&  echo "✅ eframe"
 (cd crates/egui_extras          && cargo publish --quiet)  &&  echo "✅ egui_extras"


### PR DESCRIPTION
* Closes <https://github.com/emilk/egui/issues/5233>
* Follows #8490 and the font refactor chain ending in #8504

This PR adds support for any (monochrome) glyph on Native: Korean, Thai, Chinese, Japanese, … as long as there is a font somewhere on the system that supports it (and there likely is).

Tested on macOS (日 → PingFang SC, ع → Geeza Pro, א → Lucida Grande). Untested on Windows, Linux, and Android.

Implemented by Claude.

PR chain, in order:
* #8490
* #8500
* #8501
* #8502
* #8503
* #8504
* #8491
* #8492
* #8493
* #8508
* #8509
* #8510
* #8511
