### PR TITLE
Render colored emojis on native

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,6 +2040,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "log",
  "peniko",
+ "png 0.18.1",
  "skrifa",
  "smallvec",
  "vello_common",
@@ -2371,7 +2372,7 @@ dependencies = [
  "gif",
  "image-webp",
  "num-traits",
- "png",
+ "png 0.17.16",
  "tiff",
  "zune-core",
  "zune-jpeg",
@@ -3602,6 +3603,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "poll-promise"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4781,7 +4795,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
- "png",
+ "png 0.17.16",
  "tiny-skia-path",
 ]
 
@@ -5161,6 +5175,7 @@ dependencies = [
  "guillotiere",
  "log",
  "peniko",
+ "png 0.18.1",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -5174,6 +5189,7 @@ dependencies = [
  "bytemuck",
  "glifo",
  "hashbrown 0.17.1",
+ "png 0.18.1",
  "vello_common",
 ]
 

--- a/crates/eframe/src/web/canvas_glyphs.rs
+++ b/crates/eframe/src/web/canvas_glyphs.rs
@@ -8,8 +8,8 @@ use core::cell::RefCell;
 use std::collections::HashMap;
 
 use egui::{
-    ColorImage, GlyphRasterizer, GlyphRasterizerRequest, MAX_GLYPH_SIZE, RasterizedGlyph,
-    has_emoji_presentation, vec2,
+    ColorImage, GlyphBitmap, GlyphRasterizer, GlyphRasterizerRequest, MAX_GLYPH_SIZE,
+    RasterizedGlyph, has_emoji_presentation, vec2,
 };
 use wasm_bindgen::JsCast as _;
 use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement};
@@ -108,12 +108,14 @@ impl CanvasGlyphs {
         } = white;
 
         Some(RasterizedGlyph {
-            image: ColorImage::from_rgba_unmultiplied([width as _, height as _], &rgba),
-            // The pen sits at `(PADDING + left, PADDING + ascent)` in the image,
-            // so the image's top-left is this far from the pen:
-            offset_px: vec2(-(left + PADDING) as f32, -(ascent + PADDING) as f32),
+            bitmap: GlyphBitmap {
+                image: ColorImage::from_rgba_unmultiplied([width as _, height as _], &rgba),
+                // The pen sits at `(PADDING + left, PADDING + ascent)` in the image,
+                // so the image's top-left is this far from the pen:
+                offset_px: vec2(-(left + PADDING) as f32, -(ascent + PADDING) as f32),
+                is_color,
+            },
             advance_px: advance as f32,
-            is_color,
         })
     }
 

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -454,7 +454,7 @@ pub use epaint::{
     PaintCallbackInfo, Shadow, Shape, Stroke, StrokeKind, TextureHandle, TextureId, mutex,
     text::{
         FallbackRequest, FontData, FontDefinitions, FontFamily, FontId, FontInsert, FontPriority,
-        FontProvider, FontTweak, GlyphRasterizer, GlyphRasterizerRequest, GlyphSource,
+        FontProvider, FontTweak, GlyphBitmap, GlyphRasterizer, GlyphRasterizerRequest, GlyphSource,
         GlyphSourcePreference, InsertFontFamily, MAX_GLYPH_SIZE, RasterizedGlyph,
         default_glyph_source, has_emoji_presentation,
     },

--- a/crates/egui_system_fonts/Cargo.toml
+++ b/crates/egui_system_fonts/Cargo.toml
@@ -24,7 +24,7 @@ rustdoc-args = ["--generate-link-to-definition"]
 
 
 [dependencies]
-epaint.workspace = true
+epaint = { workspace = true, features = ["color_fonts"] }
 
 fontique.workspace = true
 log.workspace = true

--- a/crates/egui_system_fonts/src/lib.rs
+++ b/crates/egui_system_fonts/src/lib.rs
@@ -33,9 +33,6 @@ struct SystemFonts {
 /// so e.g. 日本語 gets a Japanese font and العربية an Arabic font.
 /// The font files are memory-mapped, not copied.
 ///
-/// Only fonts with outline glyphs are returned. System emoji fonts contain
-/// bitmaps or color glyphs, which epaint cannot render yet, so they are skipped.
-///
 /// Enumerating the system fonts can take hundreds of milliseconds,
 /// so [`Self::new`] starts doing that on a background thread.
 /// A lookup before it is done blocks until it is.
@@ -123,12 +120,13 @@ impl FontProvider for SystemFontProvider {
             query.set_families([QueryFamily::Generic(generic)]);
             query.set_fallbacks(FallbackKey::new(script, self.locale.as_ref()));
         } else {
-            // Punctuation, symbols, etc. belong to no script, so there is no fallback for them.
+            // Punctuation, symbols, emoji, etc. belong to no script, so there is no fallback for them.
             // Try the generic families instead.
             query.set_families(
                 [
                     generic,
                     GenericFamily::SystemUi,
+                    GenericFamily::Emoji,
                     GenericFamily::Math,
                     GenericFamily::Serif,
                     GenericFamily::Monospace,
@@ -139,7 +137,7 @@ impl FontProvider for SystemFontProvider {
 
         let mut found = None;
         query.matches_with(|font| {
-            if has_outline_for(font, base_char) {
+            if can_render(font, base_char) {
                 found = Some(font.clone());
                 QueryStatus::Stop
             } else {
@@ -177,10 +175,10 @@ fn script_of(c: char) -> Option<Script> {
     }
 }
 
-/// Does the font have an outline glyph for the character?
+/// Does the font have a glyph for the character that epaint can render?
 ///
-/// False for bitmap and color glyphs, which epaint cannot render yet.
-fn has_outline_for(font: &QueryFont, c: char) -> bool {
+/// That is an outline, a bitmap (`sbix`, `CBDT`), or a `COLR` glyph.
+fn can_render(font: &QueryFont, c: char) -> bool {
     use skrifa::MetadataProvider as _;
 
     let Some(glyph_id) = font.charmap().and_then(|charmap| charmap.map(c)) else {
@@ -194,6 +192,11 @@ fn has_outline_for(font: &QueryFont, c: char) -> bool {
         return false;
     };
     font_ref.outline_glyphs().get(glyph_id).is_some()
+        || font_ref.color_glyphs().get(glyph_id).is_some()
+        || font_ref
+            .bitmap_strikes()
+            .glyph_for_size(skrifa::instance::Size::unscaled(), glyph_id)
+            .is_some()
 }
 
 #[cfg(test)]
@@ -236,6 +239,26 @@ mod tests {
             println!("{script} {c:?}: {}", insert.name);
             assert!(insert.name.starts_with("system:"));
         }
+    }
+
+    #[test]
+    #[ignore = "Depends on which fonts are installed on this machine"]
+    fn renders_color_emoji_through_egui_context() {
+        let ctx = egui::Context::default();
+        ctx.add_font_provider(Arc::new(SystemFontProvider::new()));
+        let mut output = ctx.run_ui(Default::default(), |ui| {
+            let galley = ui.fonts_mut(|fonts| {
+                fonts.layout_no_wrap(
+                    "🦀".to_owned(),
+                    egui::FontId::proportional(32.0),
+                    egui::Color32::WHITE,
+                )
+            });
+            let glyph = &galley.rows[0].row.glyphs[0];
+            assert!(glyph.is_color, "Should come from a system color emoji font");
+            assert!(!glyph.uv_rect.is_nothing());
+        });
+        output.textures_delta.clear();
     }
 
     #[test]

--- a/crates/egui_system_fonts/src/lib.rs
+++ b/crates/egui_system_fonts/src/lib.rs
@@ -243,26 +243,6 @@ mod tests {
 
     #[test]
     #[ignore = "Depends on which fonts are installed on this machine"]
-    fn renders_color_emoji_through_egui_context() {
-        let ctx = egui::Context::default();
-        ctx.add_font_provider(Arc::new(SystemFontProvider::new()));
-        let mut output = ctx.run_ui(Default::default(), |ui| {
-            let galley = ui.fonts_mut(|fonts| {
-                fonts.layout_no_wrap(
-                    "🦀".to_owned(),
-                    egui::FontId::proportional(32.0),
-                    egui::Color32::WHITE,
-                )
-            });
-            let glyph = &galley.rows[0].row.glyphs[0];
-            assert!(glyph.is_color, "Should come from a system color emoji font");
-            assert!(!glyph.uv_rect.is_nothing());
-        });
-        output.textures_delta.clear();
-    }
-
-    #[test]
-    #[ignore = "Depends on which fonts are installed on this machine"]
     fn renders_cjk_through_egui_context() {
         let ctx = egui::Context::default();
         let font_id = egui::FontId::proportional(14.0);

--- a/crates/epaint/Cargo.toml
+++ b/crates/epaint/Cargo.toml
@@ -35,7 +35,7 @@ cint = ["ecolor/cint"]
 ## Enable the [`hex_color`] macro.
 color-hex = ["ecolor/color-hex"]
 
-## Render bitmap (`sbix`, `CBDT`) and `COLR` glyphs, i.e. color emoji fonts like Apple Color Emoji and Segoe UI Emoji.
+## Support bitmap (`sbix`, `CBDT`) and `COLR` glyphs, i.e. color emoji fonts like Apple Color Emoji and Segoe UI Emoji.
 ##
 ## Adds a PNG decoder to the binary, so it is off by default. `eframe` enables it on native via `egui_system_fonts`.
 color_fonts = ["vello_cpu/png", "vello_cpu/text"]

--- a/crates/epaint/Cargo.toml
+++ b/crates/epaint/Cargo.toml
@@ -35,6 +35,11 @@ cint = ["ecolor/cint"]
 ## Enable the [`hex_color`] macro.
 color-hex = ["ecolor/color-hex"]
 
+## Render bitmap (`sbix`, `CBDT`) and `COLR` glyphs, i.e. color emoji fonts like Apple Color Emoji and Segoe UI Emoji.
+##
+## Adds a PNG decoder to the binary, so it is off by default. `eframe` enables it on native via `egui_system_fonts`.
+color_fonts = ["vello_cpu/png", "vello_cpu/text"]
+
 ## If set, epaint will use `include_bytes!` to bundle some fonts.
 ## If you plan on specifying your own fonts you may disable this feature.
 default_fonts = ["epaint_default_fonts"]

--- a/crates/epaint/src/text/family.rs
+++ b/crates/epaint/src/text/family.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use crate::text::{
-    FontDefinitions, FontFamily,
+    FontDefinitions, FontFamily, GlyphSource,
     face_store::{FaceStore, FontFaceKey},
     font_provider::FontProviders,
 };
@@ -26,6 +26,9 @@ pub(crate) struct Family {
     /// Configured fonts (from [`FontDefinitions`]) first, then any discovered by the [`FontProviders`].
     chain: Vec<FontFaceKey>,
 
+    /// How many of [`Self::chain`] are configured fonts (from [`FontDefinitions`]).
+    num_configured_fonts: usize,
+
     /// The face used when no face in [`Self::chain`] supports a char.
     replacement_face_key: FontFaceKey,
 
@@ -35,11 +38,11 @@ pub(crate) struct Family {
     /// render this char in its place.
     replacement_char: char,
 
-    /// Cache: `char → which face in the fallback chain owns this char`.
+    /// Cache: `(where to look first, char) → which face in the fallback chain owns this char`.
     ///
     /// Location-independent (fallback choice depends only on charmap support,
     /// not on variation coordinates).
-    face_cache: ahash::HashMap<char, FontFaceKey>,
+    face_cache: ahash::HashMap<(GlyphSource, char), FontFaceKey>,
 
     /// Lazily calculated: every supported char, and the names of the faces that have it.
     characters: Option<BTreeMap<char, Vec<String>>>,
@@ -73,6 +76,7 @@ impl Family {
                 })
             })
             .collect();
+        let num_configured_fonts = chain.len();
 
         // Discovered fonts come after the configured ones:
         for key in providers.discovered_keys_for(name, faces) {
@@ -84,6 +88,7 @@ impl Family {
         let mut slf = Self {
             name: name.clone(),
             chain,
+            num_configured_fonts,
             replacement_face_key: FontFaceKey::INVALID,
             replacement_char: Self::PRIMARY_REPLACEMENT_CHAR,
             face_cache: Default::default(),
@@ -142,30 +147,34 @@ impl Family {
         providers: &mut FontProviders,
         c: char,
     ) -> FontFaceKey {
-        if let Some(font_key) = self.face_cache.get(&c) {
-            return *font_key;
-        }
         let mut utf8 = [0_u8; 4];
         let cluster = c.encode_utf8(&mut utf8);
-        self.resolve_slow(faces, providers, cluster, c)
+        self.resolve_cluster(faces, providers, cluster, GlyphSource::Fonts)
     }
 
     /// Like [`Self::resolve`] for the first char of `cluster`,
-    /// but lets the [`FontProviders`] see the whole grapheme cluster.
+    /// but lets the [`FontProviders`] see the whole grapheme cluster,
+    /// and lets the caller pick where to look first.
+    ///
+    /// [`GlyphSource::Fonts`]: the configured fonts (from [`FontDefinitions`]) first.
+    ///
+    /// [`GlyphSource::Platform`]: the discovered fonts first,
+    /// so that e.g. a color emoji from the system beats a configured monochrome one.
     #[inline]
     pub fn resolve_cluster(
         &mut self,
         faces: &mut FaceStore,
         providers: &mut FontProviders,
         cluster: &str,
+        source: GlyphSource,
     ) -> FontFaceKey {
         let Some(base_char) = cluster.chars().next() else {
             return self.replacement_face_key;
         };
-        if let Some(font_key) = self.face_cache.get(&base_char) {
+        if let Some(font_key) = self.face_cache.get(&(source, base_char)) {
             return *font_key;
         }
-        self.resolve_slow(faces, providers, cluster, base_char)
+        self.resolve_slow(faces, providers, cluster, base_char, source)
     }
 
     #[cold]
@@ -175,27 +184,65 @@ impl Family {
         providers: &mut FontProviders,
         cluster: &str,
         c: char,
+        source: GlyphSource,
     ) -> FontFaceKey {
-        let font_key = self
-            .find_face_for_char(c, faces)
-            .or_else(|| {
-                let key = providers.discover(faces, &self.name, cluster, c)?;
-                if !self.chain.contains(&key) {
-                    self.chain.push(key);
-                    self.characters = None;
-                }
-                Some(key)
-            })
-            .unwrap_or(self.replacement_face_key);
-        self.face_cache.insert(c, font_key);
+        let font_key = match source {
+            GlyphSource::Fonts => {
+                // All the fonts, i.e. the configured ones and then the discovered ones…
+                Self::find_face_for_char_in(&self.chain, c, faces)
+                    // …and if none of them has the char, ask the providers for a new font:
+                    .or_else(|| self.discover(faces, providers, cluster, c))
+            }
+
+            GlyphSource::Platform => {
+                // First the fonts we have already discovered…
+                Self::find_face_for_char_in(&self.chain[self.num_configured_fonts..], c, faces)
+                    // …then ask the providers for a new font, e.g. the system emoji font…
+                    .or_else(|| self.discover(faces, providers, cluster, c))
+                    // …and only then the configured fonts,
+                    // e.g. the bundled monochrome emoji font:
+                    .or_else(|| {
+                        let configured_fonts = &self.chain[..self.num_configured_fonts];
+                        Self::find_face_for_char_in(configured_fonts, c, faces)
+                    })
+            }
+        }
+        // No font has the char, so we will render the replacement glyph (e.g. `◻`):
+        .unwrap_or(self.replacement_face_key);
+        self.face_cache.insert((source, c), font_key);
         font_key
     }
 
-    /// Walk the fallback chain and return the first face whose charmap supports `c`.
+    /// Ask the providers for a new font with `c`, and append it to the chain.
+    fn discover(
+        &mut self,
+        faces: &mut FaceStore,
+        providers: &mut FontProviders,
+        cluster: &str,
+        c: char,
+    ) -> Option<FontFaceKey> {
+        let key = providers.discover(faces, &self.name, cluster, c)?;
+        if !self.chain.contains(&key) {
+            self.chain.push(key);
+            self.characters = None;
+        }
+        Some(key)
+    }
+
+    /// The first face in the whole chain whose charmap supports `c`.
+    fn find_face_for_char(&self, c: char, faces: &mut FaceStore) -> Option<FontFaceKey> {
+        Self::find_face_for_char_in(&self.chain, c, faces)
+    }
+
+    /// The first of `chain` whose charmap supports `c`.
     ///
     /// Does not touch [`Self::face_cache`].
-    fn find_face_for_char(&self, c: char, faces: &mut FaceStore) -> Option<FontFaceKey> {
-        self.chain.iter().copied().find(|&key| {
+    fn find_face_for_char_in(
+        chain: &[FontFaceKey],
+        c: char,
+        faces: &mut FaceStore,
+    ) -> Option<FontFaceKey> {
+        chain.iter().copied().find(|&key| {
             faces
                 .get_mut(key)
                 .is_some_and(|face| face.glyph_id_resolution(c).is_some())

--- a/crates/epaint/src/text/font_face.rs
+++ b/crates/epaint/src/text/font_face.rs
@@ -111,7 +111,7 @@ impl FontCell {
         // so try those first:
         core::cfg_select! {
             feature = "color_fonts" => {
-                if let Some(bitmap) = self.rasterize_color_glyph(metrics, glyph_id, bin, location) {
+                if let Some(bitmap) = self.rasterize_color_glyph(metrics, glyph_id, location) {
                     return Some(bitmap);
                 }
             }
@@ -195,12 +195,14 @@ impl FontCell {
     /// Rasterize a bitmap (`sbix`, `CBDT`) or `COLR` glyph, e.g. a color emoji.
     ///
     /// Returns `None` if the glyph has neither.
+    ///
+    /// Never sub-pixel positioned: [`crate::text::glyph_atlas::GlyphAtlas::allocate_outline`]
+    /// bins color glyphs to whole pixels.
     #[cfg(feature = "color_fonts")]
     fn rasterize_color_glyph(
         &self,
         metrics: &StyledMetrics,
         glyph_id: GlyphId,
-        bin: SubpixelBin,
         location: skrifa::instance::LocationRef<'_>,
     ) -> Option<GlyphBitmap> {
         use vello_cpu::peniko;
@@ -219,7 +221,7 @@ impl FontCell {
         let canvas_size = (3.0 * font_size_px)
             .ceil()
             .clamp(1.0, crate::text::MAX_GLYPH_SIZE as f32) as u16;
-        let origin_x = font_size_px as f64 + bin.as_float() as f64;
+        let origin_x = font_size_px as f64;
         let origin_y = 2.0 * font_size_px as f64;
 
         let font = peniko::FontData::new(

--- a/crates/epaint/src/text/font_face.rs
+++ b/crates/epaint/src/text/font_face.rs
@@ -1,5 +1,8 @@
 #![expect(clippy::mem_forget)]
 
+#[cfg(feature = "color_fonts")]
+use std::sync::Arc;
+
 use ahash::HashMap;
 use ecolor::Color32;
 use emath::{GuiRounding as _, OrderedFloat, vec2};
@@ -57,6 +60,7 @@ pub(super) enum GlyphIdResolution {
 struct DependentFontData<'a> {
     skrifa: skrifa::FontRef<'a>,
 
+    /// Index of this face in the font file (a font collection, e.g. `.ttc`, holds several).
     #[cfg(feature = "color_fonts")]
     index: u32,
 
@@ -213,7 +217,7 @@ impl FontCell {
         let origin_y = 2.0 * font_size_px as f64;
 
         let font = peniko::FontData::new(
-            peniko::Blob::new(std::sync::Arc::clone(self.borrow_owner())),
+            peniko::Blob::new(Arc::clone(self.borrow_owner())),
             font_data.index,
         );
         let coords: Vec<i16> = location.coords().iter().map(|c| c.to_bits()).collect();
@@ -258,6 +262,7 @@ impl FontCell {
             .flat_map(|y| (min[0]..max[0]).map(move |x| (x, y)))
             .map(|(x, y)| {
                 let i = 4 * (y * canvas_size + x);
+                // `vello_cpu::Pixmap` holds premultiplied RGBA8:
                 Color32::from_rgba_premultiplied(
                     pixels[i],
                     pixels[i + 1],

--- a/crates/epaint/src/text/font_face.rs
+++ b/crates/epaint/src/text/font_face.rs
@@ -111,9 +111,7 @@ impl FontCell {
         // so try those first:
         core::cfg_select! {
             feature = "color_fonts" => {
-                if self.borrow_dependent().has_color_glyphs
-                    && let Some(bitmap) = self.rasterize_color_glyph(metrics, glyph_id, bin, location)
-                {
+                if let Some(bitmap) = self.rasterize_color_glyph(metrics, glyph_id, bin, location) {
                     return Some(bitmap);
                 }
             }
@@ -181,6 +179,19 @@ impl FontCell {
         })
     }
 
+    /// Does this glyph have a color bitmap (`sbix`, `CBDT`) or a `COLR` paint graph?
+    #[cfg(feature = "color_fonts")]
+    fn has_color_glyph(&self, glyph_id: GlyphId, size: skrifa::instance::Size) -> bool {
+        let font_data = self.borrow_dependent();
+        font_data.has_color_glyphs
+            && (font_data.skrifa.color_glyphs().get(glyph_id).is_some()
+                || font_data
+                    .skrifa
+                    .bitmap_strikes()
+                    .glyph_for_size(size, glyph_id)
+                    .is_some())
+    }
+
     /// Rasterize a bitmap (`sbix`, `CBDT`) or `COLR` glyph, e.g. a color emoji.
     ///
     /// Returns `None` if the glyph has neither.
@@ -198,13 +209,8 @@ impl FontCell {
         let font_size_px = metrics.scale;
         let size = skrifa::instance::Size::new(font_size_px);
 
-        let has_color_glyph = font_data.skrifa.color_glyphs().get(glyph_id).is_some()
-            || font_data
-                .skrifa
-                .bitmap_strikes()
-                .glyph_for_size(size, glyph_id)
-                .is_some();
-        if !(has_color_glyph && 0.0 < font_size_px && font_size_px.is_finite()) {
+        if !self.has_color_glyph(glyph_id, size) || font_size_px == 0.0 || !font_size_px.is_finite()
+        {
             return None;
         }
 
@@ -598,6 +604,20 @@ impl FontFace {
     #[inline]
     pub(crate) fn subpixel_binning(&self) -> bool {
         self.subpixel_binning
+    }
+
+    /// Will this glyph be rendered as a color bitmap or `COLR` glyph, e.g. a color emoji?
+    pub(crate) fn is_color_glyph(&self, metrics: &StyledMetrics, glyph_id: GlyphId) -> bool {
+        core::cfg_select! {
+            feature = "color_fonts" => {
+                self.font
+                    .has_color_glyph(glyph_id, skrifa::instance::Size::new(metrics.scale))
+            }
+            _ => {
+                let _ = (self, metrics, glyph_id);
+                false
+            }
+        }
     }
 
     /// Render a glyph to a bitmap: a color glyph if the font has one, else the outline as coverage.

--- a/crates/epaint/src/text/font_face.rs
+++ b/crates/epaint/src/text/font_face.rs
@@ -56,6 +56,14 @@ pub(super) enum GlyphIdResolution {
 /// The parsed `skrifa` views into a font file, borrowing from the file's [`Blob`].
 struct DependentFontData<'a> {
     skrifa: skrifa::FontRef<'a>,
+
+    #[cfg(feature = "color_fonts")]
+    index: u32,
+
+    /// Does the font have a `COLR`, `sbix`, `CBDT`, or `EBDT` table?
+    #[cfg(feature = "color_fonts")]
+    has_color_glyphs: bool,
+
     charmap: skrifa::charmap::Charmap<'a>,
     outline_glyphs: skrifa::outline::OutlineGlyphCollection<'a>,
     metrics: skrifa::metrics::Metrics,
@@ -78,10 +86,10 @@ impl FontCell {
         scale / units_per_em
     }
 
-    /// Render the outline of a glyph to a coverage bitmap.
+    /// Render a glyph to a bitmap: a color glyph if the font has one, else the outline as coverage.
     ///
-    /// Returns `None` if the glyph has no outline (e.g. a space).
-    fn rasterize_outline(
+    /// Returns `None` if the glyph has neither (e.g. a space).
+    fn rasterize_glyph(
         &mut self,
         metrics: &StyledMetrics,
         glyph_id: GlyphId,
@@ -94,6 +102,19 @@ impl FontCell {
         );
 
         let location: skrifa::instance::LocationRef<'_> = (&metrics.location).into();
+
+        // Color emoji fonts often have empty outlines next to their bitmap or `COLR` glyphs,
+        // so try those first:
+        core::cfg_select! {
+            feature = "color_fonts" => {
+                if self.borrow_dependent().has_color_glyphs
+                    && let Some(bitmap) = self.rasterize_color_glyph(metrics, glyph_id, bin, location)
+                {
+                    return Some(bitmap);
+                }
+            }
+            _ => {}
+        }
 
         let mut path = kurbo::BezPath::new();
         let mut pen = VelloPen {
@@ -152,6 +173,107 @@ impl FontCell {
         Some(GlyphBitmap {
             image,
             offset_px: vec2(bounds.x0 as f32, bounds.y0 as f32),
+            is_color: false,
+        })
+    }
+
+    /// Rasterize a bitmap (`sbix`, `CBDT`) or `COLR` glyph, e.g. a color emoji.
+    ///
+    /// Returns `None` if the glyph has neither.
+    #[cfg(feature = "color_fonts")]
+    fn rasterize_color_glyph(
+        &self,
+        metrics: &StyledMetrics,
+        glyph_id: GlyphId,
+        bin: SubpixelBin,
+        location: skrifa::instance::LocationRef<'_>,
+    ) -> Option<GlyphBitmap> {
+        use vello_cpu::peniko;
+
+        let font_data = self.borrow_dependent();
+        let font_size_px = metrics.scale;
+        let size = skrifa::instance::Size::new(font_size_px);
+
+        let has_color_glyph = font_data.skrifa.color_glyphs().get(glyph_id).is_some()
+            || font_data
+                .skrifa
+                .bitmap_strikes()
+                .glyph_for_size(size, glyph_id)
+                .is_some();
+        if !(has_color_glyph && 0.0 < font_size_px && font_size_px.is_finite()) {
+            return None;
+        }
+
+        // We don't know the bounds of the glyph up front, so we render it onto a
+        // canvas with room for one em on each side of the em box, then crop.
+        let canvas_size = (3.0 * font_size_px)
+            .ceil()
+            .clamp(1.0, crate::text::MAX_GLYPH_SIZE as f32) as u16;
+        let origin_x = font_size_px as f64 + bin.as_float() as f64;
+        let origin_y = 2.0 * font_size_px as f64;
+
+        let font = peniko::FontData::new(
+            peniko::Blob::new(std::sync::Arc::clone(self.borrow_owner())),
+            font_data.index,
+        );
+        let coords: Vec<i16> = location.coords().iter().map(|c| c.to_bits()).collect();
+
+        let mut ctx = vello_cpu::RenderContext::new(canvas_size, canvas_size);
+        let mut resources = vello_cpu::Resources::new();
+        ctx.set_paint(color::OpaqueColor::<color::Srgb>::WHITE);
+        ctx.glyph_run(&mut resources, &font)
+            .font_size(font_size_px)
+            .hint(false)
+            .normalized_coords(&coords)
+            .fill_glyphs(core::iter::once(vello_cpu::Glyph {
+                id: glyph_id.to_u32(),
+                x: origin_x as f32,
+                y: origin_y as f32,
+            }));
+        let mut pixmap = vello_cpu::Pixmap::new(canvas_size, canvas_size);
+        ctx.render(&mut pixmap, &mut resources);
+
+        let canvas_size = canvas_size as usize;
+        let pixels = pixmap.data_as_u8_slice();
+        let alpha_at = |x: usize, y: usize| pixels[4 * (y * canvas_size + x) + 3];
+
+        // Crop to the painted pixels:
+        let mut min = [canvas_size, canvas_size];
+        let mut max = [0, 0];
+        for y in 0..canvas_size {
+            for x in 0..canvas_size {
+                if alpha_at(x, y) != 0 {
+                    min = [min[0].min(x), min[1].min(y)];
+                    max = [max[0].max(x + 1), max[1].max(y + 1)];
+                }
+            }
+        }
+        if max[0] <= min[0] || max[1] <= min[1] {
+            return None; // Nothing painted
+        }
+        let width = max[0] - min[0];
+        let height = max[1] - min[1];
+
+        let cropped: Vec<Color32> = (min[1]..max[1])
+            .flat_map(|y| (min[0]..max[0]).map(move |x| (x, y)))
+            .map(|(x, y)| {
+                let i = 4 * (y * canvas_size + x);
+                Color32::from_rgba_premultiplied(
+                    pixels[i],
+                    pixels[i + 1],
+                    pixels[i + 2],
+                    pixels[i + 3],
+                )
+            })
+            .collect();
+
+        Some(GlyphBitmap {
+            image: ColorImage::new([width, height], cropped),
+            offset_px: vec2(
+                min[0] as f32 - origin_x as f32,
+                min[1] as f32 - origin_y as f32,
+            ),
+            is_color: true,
         })
     }
 }
@@ -255,8 +377,21 @@ impl FontFace {
                 })
                 .flatten();
 
+            #[cfg(feature = "color_fonts")]
+            let has_color_glyphs = {
+                use skrifa::raw::TableProvider as _;
+                skrifa_font.colr().is_ok()
+                    || skrifa_font.sbix().is_ok()
+                    || skrifa_font.cbdt().is_ok()
+                    || skrifa_font.ebdt().is_ok()
+            };
+
             Ok::<DependentFontData<'_>, Box<dyn core::error::Error>>(DependentFontData {
                 skrifa: skrifa_font,
+                #[cfg(feature = "color_fonts")]
+                index,
+                #[cfg(feature = "color_fonts")]
+                has_color_glyphs,
                 charmap,
                 outline_glyphs: glyphs,
                 metrics,
@@ -460,10 +595,10 @@ impl FontFace {
         self.subpixel_binning
     }
 
-    /// Render the outline of a glyph to a coverage bitmap.
+    /// Render a glyph to a bitmap: a color glyph if the font has one, else the outline as coverage.
     ///
     /// Not cached: see [`crate::text::glyph_atlas::GlyphAtlas::allocate_outline`].
-    pub(crate) fn rasterize_outline(
+    pub(crate) fn rasterize_glyph(
         &mut self,
         metrics: &StyledMetrics,
         glyph_id: GlyphId,
@@ -471,7 +606,7 @@ impl FontFace {
     ) -> Option<GlyphBitmap> {
         let hinting_target = self.tweak.hinting_target.into();
         self.font
-            .rasterize_outline(metrics, glyph_id, bin, hinting_target)
+            .rasterize_glyph(metrics, glyph_id, bin, hinting_target)
     }
 }
 

--- a/crates/epaint/src/text/font_face.rs
+++ b/crates/epaint/src/text/font_face.rs
@@ -10,9 +10,9 @@ use vello_cpu::{color, kurbo};
 use crate::{
     ColorImage, TextOptions,
     text::{
-        FontTweak, VariationCoords,
+        FontTweak, GlyphBitmap, VariationCoords,
         font_data::Blob,
-        glyph_atlas::{GlyphBitmap, SubpixelBin},
+        glyph_atlas::SubpixelBin,
         styled_metrics::{LocationHash, StyledMetrics},
         unicode::invisible_char,
     },

--- a/crates/epaint/src/text/font_provider.rs
+++ b/crates/epaint/src/text/font_provider.rs
@@ -175,8 +175,8 @@ mod tests {
         Color32, ColorImage,
         mutex::Mutex,
         text::{
-            FontData, FontDefinitions, FontId, Fonts, GlyphRasterizer, GlyphRasterizerRequest,
-            GlyphSource, RasterizedGlyph, TextOptions,
+            FontData, FontDefinitions, FontId, Fonts, GlyphBitmap, GlyphRasterizer,
+            GlyphRasterizerRequest, GlyphSource, RasterizedGlyph, TextOptions,
         },
     };
 
@@ -225,10 +225,12 @@ mod tests {
     fn color_rasterizer() -> GlyphRasterizer {
         GlyphRasterizer::new(|_: &GlyphRasterizerRequest<'_>| {
             Some(RasterizedGlyph {
-                image: ColorImage::new([1, 1], vec![Color32::RED]),
-                offset_px: emath::Vec2::ZERO,
+                bitmap: GlyphBitmap {
+                    image: ColorImage::new([1, 1], vec![Color32::RED]),
+                    offset_px: emath::Vec2::ZERO,
+                    is_color: true,
+                },
                 advance_px: 10.0,
-                is_color: true,
             })
         })
     }

--- a/crates/epaint/src/text/font_provider.rs
+++ b/crates/epaint/src/text/font_provider.rs
@@ -168,7 +168,7 @@ impl FontProviders {
 mod tests {
     use std::sync::Arc;
 
-    use epaint_default_fonts::{HACK_REGULAR, NOTO_EMOJI_REGULAR};
+    use epaint_default_fonts::{EMOJI_ICON, HACK_REGULAR, NOTO_EMOJI_REGULAR};
 
     use super::*;
     use crate::{
@@ -347,6 +347,61 @@ mod tests {
 
         let glyph = first_glyph(&mut fonts, EMOJI);
         assert!(!glyph.is_color, "Should come from the discovered font");
+        assert_eq!(requests.lock().len(), 1);
+    }
+
+    #[test]
+    fn emoji_presentation_prefers_discovered_fonts_over_configured() {
+        // Hack and NotoEmoji from the definitions, emoji-icon-font from the provider.
+        // Both emoji fonts have 🚀.
+        let mut definitions = hack_only();
+        definitions.font_data.insert(
+            "NotoEmoji-Regular".to_owned(),
+            Arc::new(FontData::from_static(NOTO_EMOJI_REGULAR)),
+        );
+        definitions.families.insert(
+            FontFamily::Proportional,
+            vec!["Hack".to_owned(), "NotoEmoji-Regular".to_owned()],
+        );
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let provider = {
+            let requests = Arc::clone(&requests);
+            Arc::new(move |request: &FallbackRequest<'_>| {
+                requests.lock().push(request.cluster.to_owned());
+                Some(FontInsert::new(
+                    "discovered:emoji-icon-font",
+                    FontData::from_static(EMOJI_ICON),
+                    vec![],
+                ))
+            })
+        };
+        let mut fonts =
+            Fonts::new(TextOptions::default(), definitions).with_font_providers(vec![provider]);
+        let font_id = FontId::proportional(14.0);
+        let mut layout = |text: &str| {
+            let galley = fonts.with_pixels_per_point(1.0).layout_no_wrap(
+                text.to_owned(),
+                font_id.clone(),
+                Color32::WHITE,
+            );
+            galley.rows[0].row.glyphs[0].uv_rect
+        };
+
+        // Text presentation: NotoEmoji from the definitions wins, and the provider is not asked.
+        let text_presentation = layout("🚀\u{FE0E}");
+        assert!(requests.lock().is_empty());
+
+        // Emoji presentation: the provider is asked first, even though NotoEmoji has the glyph.
+        let emoji_presentation = layout("🚀");
+        assert_eq!(*requests.lock(), ["🚀"]);
+        assert_ne!(
+            emoji_presentation.min, text_presentation.min,
+            "Should be different glyphs, from different fonts"
+        );
+
+        // Both are cached:
+        layout("🚀\u{FE0E}");
+        layout("🚀");
         assert_eq!(requests.lock().len(), 1);
     }
 

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -493,10 +493,23 @@ impl FontsImpl {
     }
 
     /// Like [`Self::resolve_face`] for the first char of `cluster`,
-    /// but lets the [`FontProvider`]s see the whole grapheme cluster.
+    /// but lets the [`FontProvider`]s see the whole grapheme cluster,
+    /// and lets the caller pick where to look first.
+    ///
+    /// See [`Family::resolve_cluster`].
     #[inline]
-    pub fn resolve_cluster_face(&mut self, family: FamilyKey, cluster: &str) -> FontFaceKey {
-        self.families[family.0].resolve_cluster(&mut self.faces, &mut self.font_providers, cluster)
+    pub fn resolve_cluster_face(
+        &mut self,
+        family: FamilyKey,
+        cluster: &str,
+        source: GlyphSource,
+    ) -> FontFaceKey {
+        self.families[family.0].resolve_cluster(
+            &mut self.faces,
+            &mut self.font_providers,
+            cluster,
+            source,
+        )
     }
 
     /// Resolve `c` to its (face, [`GlyphInfo`]) at the given face's location.

--- a/crates/epaint/src/text/glyph_atlas.rs
+++ b/crates/epaint/src/text/glyph_atlas.rs
@@ -281,11 +281,14 @@ impl GlyphAtlas {
             };
         }
 
-        let (x_px, bin) = if face.subpixel_binning() && !is_cjk {
+        let subpixel_binning =
+            face.subpixel_binning() && !is_cjk && !face.is_color_glyph(metrics, glyph_id);
+        let (x_px, bin) = if subpixel_binning {
             SubpixelBin::new(h_pos)
         } else {
             // CJK scripts contain a lot of characters and could hog the glyph atlas
             // if we stored 4 subpixel offsets per glyph.
+            // Color glyphs (emoji) are big, and gain nothing from subpixel positioning.
             (h_pos.round() as i32, SubpixelBin::Zero)
         };
 

--- a/crates/epaint/src/text/glyph_atlas.rs
+++ b/crates/epaint/src/text/glyph_atlas.rs
@@ -43,6 +43,10 @@ impl UvRect {
 pub struct GlyphAllocation {
     /// UV rectangle for drawing.
     pub uv_rect: UvRect,
+
+    /// A color glyph (e.g. emoji), stored with its own colors in the atlas.
+    /// Do not tint it with the text color.
+    pub is_color: bool,
 }
 
 /// An outline glyph in the atlas, positioned for one [`ShapedGlyph`].
@@ -63,7 +67,6 @@ pub(crate) struct OutlineGlyph {
 pub(crate) struct RasterGlyphAllocation {
     pub allocation: GlyphAllocation,
     pub advance_px: f32,
-    pub is_color: bool,
 }
 
 /// A glyph bitmap, ready to be copied into the atlas.
@@ -73,6 +76,9 @@ pub(crate) struct GlyphBitmap {
 
     /// Offset from the glyph origin to the top-left of the image, in physical pixels.
     pub offset_px: Vec2,
+
+    /// A color glyph (e.g. emoji) that must not be tinted with the text color.
+    pub is_color: bool,
 }
 
 // ----------------------------------------------------------------------------
@@ -302,14 +308,16 @@ impl GlyphAtlas {
             ..
         } = self;
         let allocation = *outline_glyphs.entry(key).or_insert_with(|| {
-            face.rasterize_outline(metrics, glyph_id, bin)
+            face.rasterize_glyph(metrics, glyph_id, bin)
                 .and_then(|bitmap| {
-                    let transfer = atlas.options().color_transfer_function;
-                    Self::allocate_bitmap(atlas, &bitmap, metrics.pixels_per_point, transfer)
-                })
-                .map(|mut uv_rect| {
+                    let transfer = Self::transfer_function(atlas, bitmap.is_color);
+                    let mut uv_rect =
+                        Self::allocate_bitmap(atlas, &bitmap, metrics.pixels_per_point, transfer)?;
                     uv_rect.offset.y += metrics.y_offset_in_points;
-                    GlyphAllocation { uv_rect }
+                    Some(GlyphAllocation {
+                        uv_rect,
+                        is_color: bitmap.is_color,
+                    })
                 })
                 .unwrap_or_default()
         });
@@ -342,27 +350,34 @@ impl GlyphAtlas {
             subpixel_offset_px: 0.0,
         };
         let allocation = (rasterizer.rasterize)(&request).and_then(|glyph| {
-            // The transfer function assumes white coverage glyphs and discards color,
-            // so color glyphs (e.g. emoji) must skip it.
-            let transfer = if glyph.is_color {
-                FontColorTransferFunction::Off
-            } else {
-                self.atlas.options().color_transfer_function
-            };
+            let transfer = Self::transfer_function(&self.atlas, glyph.is_color);
             let bitmap = GlyphBitmap {
                 image: glyph.image,
                 offset_px: glyph.offset_px,
+                is_color: glyph.is_color,
             };
             let uv_rect =
                 Self::allocate_bitmap(&mut self.atlas, &bitmap, pixels_per_point, transfer)?;
             Some(RasterGlyphAllocation {
-                allocation: GlyphAllocation { uv_rect },
+                allocation: GlyphAllocation {
+                    uv_rect,
+                    is_color: glyph.is_color,
+                },
                 advance_px: glyph.advance_px,
-                is_color: glyph.is_color,
             })
         });
         self.raster_glyphs.insert(key, allocation);
         allocation
+    }
+
+    /// The transfer function assumes white coverage glyphs and discards color,
+    /// so color glyphs (e.g. emoji) must skip it.
+    fn transfer_function(atlas: &TextureAtlas, is_color: bool) -> FontColorTransferFunction {
+        if is_color {
+            FontColorTransferFunction::Off
+        } else {
+            atlas.options().color_transfer_function
+        }
     }
 
     /// Copy a bitmap into the atlas.

--- a/crates/epaint/src/text/glyph_atlas.rs
+++ b/crates/epaint/src/text/glyph_atlas.rs
@@ -3,9 +3,10 @@ use nohash_hasher::IntMap;
 use skrifa::GlyphId;
 
 use crate::{
-    ColorImage, FontColorTransferFunction, ImageDelta, TextOptions, TextureAtlas,
+    FontColorTransferFunction, ImageDelta, TextOptions, TextureAtlas,
     text::{
-        FontFamily, GlyphRasterizer, GlyphRasterizerRequest, MAX_GLYPH_SIZE,
+        FontFamily, GlyphBitmap, GlyphRasterizer, GlyphRasterizerRequest, MAX_GLYPH_SIZE,
+        RasterizedGlyph,
         face_store::FontFaceKey,
         font_face::{FontFace, ShapedGlyph},
         styled_metrics::StyledMetrics,
@@ -67,18 +68,6 @@ pub(crate) struct OutlineGlyph {
 pub(crate) struct RasterGlyphAllocation {
     pub allocation: GlyphAllocation,
     pub advance_px: f32,
-}
-
-/// A glyph bitmap, ready to be copied into the atlas.
-pub(crate) struct GlyphBitmap {
-    /// Physical pixels. Coverage glyphs are white with alpha; color glyphs keep their colors.
-    pub image: ColorImage,
-
-    /// Offset from the glyph origin to the top-left of the image, in physical pixels.
-    pub offset_px: Vec2,
-
-    /// A color glyph (e.g. emoji) that must not be tinted with the text color.
-    pub is_color: bool,
 }
 
 // ----------------------------------------------------------------------------
@@ -349,23 +338,17 @@ impl GlyphAtlas {
             font_size_px: font_size * pixels_per_point,
             subpixel_offset_px: 0.0,
         };
-        let allocation = (rasterizer.rasterize)(&request).and_then(|glyph| {
-            let transfer = Self::transfer_function(&self.atlas, glyph.is_color);
-            let bitmap = GlyphBitmap {
-                image: glyph.image,
-                offset_px: glyph.offset_px,
-                is_color: glyph.is_color,
-            };
-            let uv_rect =
-                Self::allocate_bitmap(&mut self.atlas, &bitmap, pixels_per_point, transfer)?;
-            Some(RasterGlyphAllocation {
-                allocation: GlyphAllocation {
-                    uv_rect,
-                    is_color: glyph.is_color,
-                },
-                advance_px: glyph.advance_px,
-            })
-        });
+        let allocation =
+            (rasterizer.rasterize)(&request).and_then(|RasterizedGlyph { bitmap, advance_px }| {
+                let is_color = bitmap.is_color;
+                let transfer = Self::transfer_function(&self.atlas, is_color);
+                let uv_rect =
+                    Self::allocate_bitmap(&mut self.atlas, &bitmap, pixels_per_point, transfer)?;
+                Some(RasterGlyphAllocation {
+                    allocation: GlyphAllocation { uv_rect, is_color },
+                    advance_px,
+                })
+            });
         self.raster_glyphs.insert(key, allocation);
         allocation
     }

--- a/crates/epaint/src/text/glyph_rasterizer.rs
+++ b/crates/epaint/src/text/glyph_rasterizer.rs
@@ -18,6 +18,7 @@ pub struct GlyphRasterizerRequest<'a> {
 }
 
 /// A glyph rasterized by a platform fallback.
+#[derive(Clone)]
 pub struct RasterizedGlyph {
     /// Pixels in physical pixels. Color glyphs retain their original colors.
     pub image: ColorImage,

--- a/crates/epaint/src/text/glyph_rasterizer.rs
+++ b/crates/epaint/src/text/glyph_rasterizer.rs
@@ -17,20 +17,27 @@ pub struct GlyphRasterizerRequest<'a> {
     pub subpixel_offset_px: f32,
 }
 
+/// A glyph bitmap, ready to be copied into the glyph atlas.
+#[derive(Clone)]
+pub struct GlyphBitmap {
+    /// Pixels in physical pixels. Coverage glyphs are white with alpha;
+    /// color glyphs retain their original colors.
+    pub image: ColorImage,
+
+    /// Offset from the glyph origin to the image top-left, in physical pixels.
+    pub offset_px: emath::Vec2,
+
+    /// A color glyph (e.g. emoji) that must not be tinted with the text color.
+    pub is_color: bool,
+}
+
 /// A glyph rasterized by a platform fallback.
 #[derive(Clone)]
 pub struct RasterizedGlyph {
-    /// Pixels in physical pixels. Color glyphs retain their original colors.
-    pub image: ColorImage,
-
-    /// Offset from the baseline to the image top-left, in physical pixels.
-    pub offset_px: emath::Vec2,
+    pub bitmap: GlyphBitmap,
 
     /// Horizontal advance, in physical pixels.
     pub advance_px: f32,
-
-    /// Do not tint this glyph with the text color.
-    pub is_color: bool,
 }
 
 /// The callback of a [`GlyphRasterizer`].

--- a/crates/epaint/src/text/mod.rs
+++ b/crates/epaint/src/text/mod.rs
@@ -27,7 +27,7 @@ pub use {
     font_tweak::{FontTweak, HintingTarget, SmoothHinting},
     fonts::{Fonts, FontsView, MAX_GLYPH_SIZE},
     glyph_rasterizer::{
-        GlyphRasterizer, GlyphRasterizerRequest, GlyphSource, GlyphSourcePreference,
+        GlyphBitmap, GlyphRasterizer, GlyphRasterizerRequest, GlyphSource, GlyphSourcePreference,
         RasterizedGlyph, default_glyph_source, has_emoji_presentation,
     },
     index::{ByteIndex, ByteRange, ByteRangeExt, CharIndex, CharRange, CharRangeExt},

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -1562,12 +1562,7 @@ mod tests {
     #[test]
     fn color_raster_glyph_is_not_tinted() {
         let rasterizer = GlyphRasterizer::new(|request: &GlyphRasterizerRequest<'_>| {
-            (request.cluster == "한").then(|| RasterizedGlyph {
-                image: ColorImage::new([1, 1], vec![Color32::RED]),
-                offset_px: Vec2::ZERO,
-                advance_px: 10.0,
-                is_color: true,
-            })
+            (request.cluster == "한").then(color_raster_glyph)
         });
         let mut fonts = FontsImpl::new(TextOptions::default(), FontDefinitions::default())
             .with_glyph_rasterizer(rasterizer);
@@ -1621,14 +1616,8 @@ mod tests {
 
     #[test]
     fn color_raster_glyph_keeps_color_in_atlas() {
-        let rasterizer = GlyphRasterizer::new(|_: &GlyphRasterizerRequest<'_>| {
-            Some(RasterizedGlyph {
-                image: ColorImage::new([1, 1], vec![Color32::RED]),
-                offset_px: Vec2::ZERO,
-                advance_px: 10.0,
-                is_color: true,
-            })
-        });
+        let rasterizer =
+            GlyphRasterizer::new(|_: &GlyphRasterizerRequest<'_>| Some(color_raster_glyph()));
         // The default transfer function discards color for regular (white) glyphs:
         let options = TextOptions {
             color_transfer_function: crate::FontColorTransferFunction::TwoCoverageMinusCoverageSq,
@@ -1662,17 +1651,22 @@ mod tests {
 
     fn white_raster_glyph() -> RasterizedGlyph {
         RasterizedGlyph {
-            image: ColorImage::new([1, 1], vec![Color32::WHITE]),
-            offset_px: Vec2::ZERO,
+            bitmap: GlyphBitmap {
+                image: ColorImage::new([1, 1], vec![Color32::WHITE]),
+                offset_px: Vec2::ZERO,
+                is_color: false,
+            },
             advance_px: 10.0,
-            is_color: false,
         }
     }
 
     fn color_raster_glyph() -> RasterizedGlyph {
         RasterizedGlyph {
-            image: ColorImage::new([1, 1], vec![Color32::RED]),
-            is_color: true,
+            bitmap: GlyphBitmap {
+                image: ColorImage::new([1, 1], vec![Color32::RED]),
+                is_color: true,
+                ..white_raster_glyph().bitmap
+            },
             ..white_raster_glyph()
         }
     }

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -1656,12 +1656,7 @@ mod tests {
             requests
                 .lock()
                 .push((request.cluster.to_owned(), request.family.clone()));
-            result.as_ref().map(|glyph| RasterizedGlyph {
-                image: glyph.image.clone(),
-                offset_px: glyph.offset_px,
-                advance_px: glyph.advance_px,
-                is_color: glyph.is_color,
-            })
+            result.clone()
         })
     }
 

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -12,7 +12,6 @@ use crate::{
         ByteIndex, ByteRange,
         face_store::FontFaceKey,
         fonts::FontsImpl,
-        glyph_atlas::UvRect,
         styled_metrics::StyledMetrics,
         unicode::{is_cjk, is_cjk_break_allowed, is_combining_mark},
     },
@@ -23,7 +22,7 @@ use super::{
     RowVisuals, VariationCoords,
     family::FamilyKey,
     font_face::{FontFace, ShapedGlyph},
-    glyph_atlas::{OutlineGlyph, RasterGlyphAllocation},
+    glyph_atlas::{GlyphAllocation, OutlineGlyph, RasterGlyphAllocation},
 };
 
 // ----------------------------------------------------------------------------
@@ -184,7 +183,7 @@ impl ShapingContext {
         physical_x: i32,
         advance_width_px: f32,
         face_metrics: &StyledMetrics,
-        uv_rect: UvRect,
+        alloc: GlyphAllocation,
     ) -> Glyph {
         Glyph {
             chr,
@@ -195,8 +194,8 @@ impl ShapingContext {
             font_face_ascent: face_metrics.ascent,
             font_height: self.font_metrics.row_height,
             font_ascent: self.font_metrics.ascent,
-            uv_rect,
-            is_color: false,
+            uv_rect: alloc.uv_rect,
+            is_color: alloc.is_color,
             section_index: self.section_index,
             first_vertex: 0,
         }
@@ -218,6 +217,7 @@ struct TextRun {
     ///
     /// [`GlyphSource::Platform`]: try the glyph rasterizer (if any) for each cluster,
     /// shaping with `font_key` only if that fails.
+    /// `font_key` is then a discovered font, if one has the glyph.
     source: GlyphSource,
 }
 
@@ -352,13 +352,7 @@ fn layout_shaped_run(
 
                 paragraph.cursor_x_px += advance_width_px;
 
-                ctx.glyph(
-                    chr,
-                    x_px,
-                    advance_width_px,
-                    &fallback_metrics,
-                    allocation.uv_rect,
-                )
+                ctx.glyph(chr, x_px, advance_width_px, &fallback_metrics, allocation)
             }
         } else {
             let OutlineGlyph {
@@ -380,13 +374,7 @@ fn layout_shaped_run(
 
             paragraph.cursor_x_px += advance_width_px;
 
-            ctx.glyph(
-                chr,
-                x_px,
-                advance_width_px,
-                face_metrics,
-                glyph_alloc.uv_rect,
-            )
+            ctx.glyph(chr, x_px, advance_width_px, face_metrics, glyph_alloc)
         };
         paragraph.glyphs.push(glyph);
         cluster_glyph_count += 1;
@@ -415,15 +403,13 @@ fn raster_glyph(
 ) -> Glyph {
     let physical_x = paragraph.cursor_x_px.round() as i32;
     paragraph.cursor_x_px += raster.advance_px;
-    let mut glyph = ctx.glyph(
+    ctx.glyph(
         chr,
         physical_x,
         raster.advance_px,
         face_metrics,
-        raster.allocation.uv_rect,
-    );
-    glyph.is_color = raster.is_color;
-    glyph
+        raster.allocation,
+    )
 }
 
 /// Lay out a run whose clusters prefer the glyph rasterizer over the font.
@@ -503,7 +489,7 @@ fn layout_raster_run(
 ///
 /// This preserves the invariant `glyphs.len() == char_count` that all cursor
 /// and text-selection code depends on. Continuation glyphs have
-/// [`UvRect::default()`] so [`tessellate_glyphs`] skips them entirely.
+/// [`GlyphAllocation::default()`] so [`tessellate_glyphs`] skips them entirely.
 fn emit_continuation_glyphs(
     ctx: &ShapingContext,
     paragraph: &mut Paragraph,
@@ -523,9 +509,13 @@ fn emit_continuation_glyphs(
     let physical_x = paragraph.cursor_x_px.round() as i32;
 
     for chr in cluster_text.chars().skip(cluster_glyph_count) {
-        paragraph
-            .glyphs
-            .push(ctx.glyph(chr, physical_x, 0.0, face_metrics, UvRect::default()));
+        paragraph.glyphs.push(ctx.glyph(
+            chr,
+            physical_x,
+            0.0,
+            face_metrics,
+            GlyphAllocation::default(),
+        ));
     }
 }
 
@@ -1495,8 +1485,8 @@ fn segment_into_runs(fonts: &mut FontsImpl, family: FamilyKey, text: &str, out: 
         let byte_offset = ByteIndex(byte_offset);
         let byte_end = byte_offset + grapheme_str.len();
 
-        let font_key = fonts.resolve_cluster_face(family, grapheme_str);
         let source = fonts.glyph_source(grapheme_str);
+        let font_key = fonts.resolve_cluster_face(family, grapheme_str, source);
 
         if let Some(last_run) = out.last_mut()
             && last_run.font_key == font_key

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -185,6 +185,7 @@ impl ShapingContext {
         face_metrics: &StyledMetrics,
         alloc: GlyphAllocation,
     ) -> Glyph {
+        let GlyphAllocation { uv_rect, is_color } = alloc;
         Glyph {
             chr,
             pos: pos2(physical_x as f32 / self.pixels_per_point, f32::NAN),
@@ -194,8 +195,8 @@ impl ShapingContext {
             font_face_ascent: face_metrics.ascent,
             font_height: self.font_metrics.row_height,
             font_ascent: self.font_metrics.ascent,
-            uv_rect: alloc.uv_rect,
-            is_color: alloc.is_color,
+            uv_rect,
+            is_color,
             section_index: self.section_index,
             first_vertex: 0,
         }

--- a/deny.toml
+++ b/deny.toml
@@ -58,6 +58,7 @@ skip = [
   { name = "jni-sys" }, # 0.3.1 depends on 0.4
   { name = "kurbo" }, # Old version because of resvg
   { name = "phf" }, # mime_guess2 -> 0.11, unicode_names2 -> 0.13
+  { name = "png" }, # glifo (vello_cpu's text feature, for bitmap emoji) depends on 0.18, image 0.25.6 on 0.17
   { name = "phf_generator" }, # same phf split as phf
   { name = "phf_shared" }, # same phf split as phf
   { name = "rand_core" }, # rand ecosystem is migrating 0.8 -> 0.10; phf_generator's rand 0.8 needs rand_core 0.6, getrandom 0.4/chacha20 need rand_core 0.10


### PR DESCRIPTION
* Closes <https://github.com/emilk/egui/issues/2551>
* Closes https://github.com/emilk/egui/issues/7325


System emoji fonts store their glyphs as `sbix`/`CBDT` bitmaps or `COLR` paint graphs, often next to *empty* outlines. epaint could only render outlines, so #8491 skipped them. This PR adds bitmap and `COLR` glyph rendering to `FontFace`, behind the new epaint feature `color_fonts`, using `vello_cpu`'s text support. Glyphs are marked `is_color`, so the tessellator leaves their colors alone.

`egui_system_fonts` enables the feature and now accepts system color fonts, so eframe native renders 🦀 🤖 🦾 in color from Apple Color Emoji (macOS), and should from Segoe UI Emoji and Noto Color Emoji too (untested). Web is unaffected: the feature adds a PNG decoder, and the browser already renders emoji there.

`GlyphSource::Rasterizer` is now `GlyphSource::Platform` (discovered fonts + font providers + glyph rasterizer), and the preference moved from `GlyphRasterizer::prefer` to `Context::set_glyph_source_preference` / `Fonts::with_glyph_source_preference`, so it also works on native. Emoji-presentation clusters resolve platform-first, so 🚀 and 📷 come from the system emoji font even though the bundled NotoEmoji has them, while text-presentation symbols like ⏮ still come from the bundled fonts.

Implemented by Claude.

PR chain, in order:
* #8490
* #8500
* #8501
* #8502
* #8503
* #8504
* #8491
* #8492
* #8493
* #8508
* #8509
* #8510
* #8511
