### PR TITLE
Center macOS traffic lights in custom title bars

### DIFF
--- a/crates/eframe/src/native/macos.rs
+++ b/crates/eframe/src/native/macos.rs
@@ -22,13 +22,15 @@ impl WindowChromeMetrics {
         window_chrome_metrics(window_handle)
     }
 
-    /// Vertically center the traffic lights in a title bar of the given height.
+    /// Position the traffic lights in a title bar of the given height.
     ///
-    /// The height uses the same native scale as [`Self::traffic_lights_size`].
+    /// The buttons are centered vertically and inset by `left_margin`.
+    /// Both arguments use the same native scale as [`Self::traffic_lights_size`].
     /// Returns the updated window chrome metrics.
-    pub fn center_traffic_lights(
+    pub fn position_traffic_lights(
         window_handle: &RawWindowHandle,
         title_bar_height: f32,
+        left_margin: f32,
     ) -> Option<Self> {
         let RawWindowHandle::AppKit(appkit_handle) = window_handle else {
             return None;
@@ -36,7 +38,7 @@ impl WindowChromeMetrics {
 
         let ns_view = ns_view_from_handle(appkit_handle)?;
         let ns_window = ns_view.window()?;
-        center_traffic_lights_in_title_bar(&ns_window, title_bar_height)?;
+        position_traffic_lights_in_title_bar(&ns_window, title_bar_height, left_margin)?;
 
         Some(Self {
             traffic_lights_size: traffic_lights_metrics(&ns_window)?,
@@ -77,7 +79,18 @@ fn traffic_lights_metrics(ns_window: &NSWindow) -> Option<Vec2> {
     Some(Vec2::new(total_width as f32, total_height as f32))
 }
 
-fn center_traffic_lights_in_title_bar(ns_window: &NSWindow, title_bar_height: f32) -> Option<()> {
+fn position_traffic_lights_in_title_bar(
+    ns_window: &NSWindow,
+    title_bar_height: f32,
+    left_margin: f32,
+) -> Option<()> {
+    let close_button_x = ns_window
+        .standardWindowButton(NSWindowButton::CloseButton)?
+        .frame()
+        .origin
+        .x;
+    let x_offset = left_margin as f64 - close_button_x;
+
     for button_kind in [
         NSWindowButton::CloseButton,
         NSWindowButton::MiniaturizeButton,
@@ -92,6 +105,7 @@ fn center_traffic_lights_in_title_bar(ns_window: &NSWindow, title_bar_height: f3
         let bounds = superview.bounds();
         let top_margin = ((title_bar_height as f64 - frame.size.height) / 2.0).max(0.0);
         let mut origin = frame.origin;
+        origin.x += x_offset;
         origin.y = if superview.isFlipped() {
             bounds.origin.y + top_margin
         } else {

--- a/crates/eframe/src/native/macos.rs
+++ b/crates/eframe/src/native/macos.rs
@@ -21,6 +21,27 @@ impl WindowChromeMetrics {
     pub fn from_window_handle(window_handle: &RawWindowHandle) -> Option<Self> {
         window_chrome_metrics(window_handle)
     }
+
+    /// Vertically center the traffic lights in a title bar of the given height.
+    ///
+    /// The height uses the same native scale as [`Self::traffic_lights_size`].
+    /// Returns the updated window chrome metrics.
+    pub fn center_traffic_lights(
+        window_handle: &RawWindowHandle,
+        title_bar_height: f32,
+    ) -> Option<Self> {
+        let RawWindowHandle::AppKit(appkit_handle) = window_handle else {
+            return None;
+        };
+
+        let ns_view = ns_view_from_handle(appkit_handle)?;
+        let ns_window = ns_view.window()?;
+        center_traffic_lights_in_title_bar(&ns_window, title_bar_height)?;
+
+        Some(Self {
+            traffic_lights_size: traffic_lights_metrics(&ns_window)?,
+        })
+    }
 }
 
 fn window_chrome_metrics(window_handle: &RawWindowHandle) -> Option<WindowChromeMetrics> {
@@ -55,6 +76,22 @@ fn traffic_lights_metrics(ns_window: &NSWindow) -> Option<Vec2> {
     let total_height = top_margin + close_button.size.height + bottom_margin;
 
     Some(Vec2::new(total_width as f32, total_height as f32))
+}
+
+fn center_traffic_lights_in_title_bar(ns_window: &NSWindow, title_bar_height: f32) -> Option<()> {
+    for button_kind in [
+        NSWindowButton::CloseButton,
+        NSWindowButton::MiniaturizeButton,
+        NSWindowButton::ZoomButton,
+    ] {
+        let button = ns_window.standardWindowButton(button_kind)?;
+        let frame = button.frame();
+        let mut origin = frame.origin;
+        origin.y = ((title_bar_height as f64 - frame.size.height) / 2.0).max(0.0);
+        button.setFrameOrigin(origin);
+    }
+
+    Some(())
 }
 
 fn ns_view_from_handle(handle: &AppKitWindowHandle) -> Option<&NSView> {

--- a/crates/eframe/src/native/macos.rs
+++ b/crates/eframe/src/native/macos.rs
@@ -59,21 +59,20 @@ fn window_chrome_metrics(window_handle: &RawWindowHandle) -> Option<WindowChrome
 
 fn traffic_lights_metrics(ns_window: &NSWindow) -> Option<Vec2> {
     // Button order is CloseButton, MiniaturizeButton, ZoomButton:
-    let close_button = ns_window
-        .standardWindowButton(NSWindowButton::CloseButton)?
-        .frame();
+    let close_button = ns_window.standardWindowButton(NSWindowButton::CloseButton)?;
+    let close_button_frame = close_button.frame();
     let zoom_button = ns_window
         .standardWindowButton(NSWindowButton::ZoomButton)?
         .frame();
 
-    let left_margin = close_button.origin.x;
+    let left_margin = close_button_frame.origin.x;
     let right_margin = left_margin; // for symmetry
 
     let total_width = zoom_button.origin.x + zoom_button.size.width + right_margin;
 
-    let top_margin = close_button.origin.y;
+    let top_margin = distance_from_top(&close_button)?;
     let bottom_margin = top_margin; // Usually symmetric
-    let total_height = top_margin + close_button.size.height + bottom_margin;
+    let total_height = top_margin + close_button_frame.size.height + bottom_margin;
 
     Some(Vec2::new(total_width as f32, total_height as f32))
 }
@@ -86,12 +85,37 @@ fn center_traffic_lights_in_title_bar(ns_window: &NSWindow, title_bar_height: f3
     ] {
         let button = ns_window.standardWindowButton(button_kind)?;
         let frame = button.frame();
+        // SAFETY: native eframe window updates run on the main thread, and `button` stays retained
+        // while its superview is accessed.
+        #[expect(unsafe_code)]
+        let superview = unsafe { button.superview()? };
+        let bounds = superview.bounds();
+        let top_margin = ((title_bar_height as f64 - frame.size.height) / 2.0).max(0.0);
         let mut origin = frame.origin;
-        origin.y = ((title_bar_height as f64 - frame.size.height) / 2.0).max(0.0);
+        origin.y = if superview.isFlipped() {
+            bounds.origin.y + top_margin
+        } else {
+            bounds.origin.y + bounds.size.height - top_margin - frame.size.height
+        };
         button.setFrameOrigin(origin);
     }
 
     Some(())
+}
+
+fn distance_from_top(view: &NSView) -> Option<f64> {
+    let frame = view.frame();
+    // SAFETY: native eframe window updates run on the main thread, and the caller retains `view`
+    // while its superview is accessed.
+    #[expect(unsafe_code)]
+    let superview = unsafe { view.superview()? };
+    let bounds = superview.bounds();
+
+    if superview.isFlipped() {
+        Some(frame.origin.y - bounds.origin.y)
+    } else {
+        Some(bounds.origin.y + bounds.size.height - frame.origin.y - frame.size.height)
+    }
 }
 
 fn ns_view_from_handle(handle: &AppKitWindowHandle) -> Option<&NSView> {


### PR DESCRIPTION
Adds an eframe API for positioning the native macOS traffic lights within a caller-defined title-bar height and left inset. It centers the buttons vertically while preserving AppKit’s native inter-button spacing. This lets full-size content views align native controls with taller custom title bars without importing AppKit directly.

Tested with `cargo fmt --all --check`, `cargo clippy -p eframe --lib --all-features -- -D warnings`, and `cargo test -p eframe --lib --all-features`.

* [x] I have followed the instructions in the PR template

🤖 This PR was written with Codex; Marten remains responsible for the change.