### PR TITLE
Bump accesskit{,_consumer,_winit} to latest versions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "accesskit"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
+checksum = "438a7081a65b95c668db56591a4fef9bc5dad275f448bd6223fc6949d823db38"
 dependencies = [
  "enumn",
  "serde",
@@ -31,37 +31,51 @@ dependencies = [
 
 [[package]]
 name = "accesskit_atspi_common"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842fd8203e6dfcf531d24f5bac792088edfba7d6b35844fead191603fb32a260"
+checksum = "c9d47ad644916f6cb7e432a5ca0dbd7cc78281a9772881057bb72d4aadb93257"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
  "atspi-common",
- "phf 0.13.1",
+ "phf 0.14.0",
  "serde",
  "zvariant",
 ]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.35.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
+checksum = "cc882fa0c9c24c53649e256311b51046cf36eca9a8f7e54ff4ef682160b0cb27"
 dependencies = [
  "accesskit",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "accesskit_ios"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5e9b29c6ba5f4d2e0662e9c562484f061ffc58f658479c538ecca8299ada1e9"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.17.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit 0.2.2",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534bc3fdc89a64a1db3c46b33c198fde2b7c3c7d094e5809c8c8bf2970c18243"
+checksum = "a3f278988416e5fb600f24d0cfffe31a249ebbff980fb9c5a3b5fbed2c579f73"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -69,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_unix"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e549dd7c6562b6a2ea807b44726e6241707db054a817dc4c7e2b8d3b39bfac"
+checksum = "665c9079b7325a8168a6793437a172dda44b19a05af8ed52d7e32abaada996fe"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
@@ -87,13 +101,13 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.32.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff7009f1a532e917d66970a1e80c965140c6cfbbabbdde3d64e5431e6c78e21"
+checksum = "a59e8d7160cbac991c1345c99153783ab96423644ccb1f20617cf80c97596aa1"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "static_assertions",
  "windows",
  "windows-core",
@@ -101,11 +115,12 @@ dependencies = [
 
 [[package]]
 name = "accesskit_winit"
-version = "0.32.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe9a94394896352cc4660ca2288bd4ef883d83238853c038b44070c8f134313"
+checksum = "1eb960a51582305f94b3884a7ff54b3462abe38f0de95a9e7e04dd7ab7b757da"
 dependencies = [
  "accesskit",
+ "accesskit_ios",
  "accesskit_macos",
  "accesskit_unix",
  "accesskit_windows",
@@ -2585,8 +2600,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 [[package]]
 name = "kittest"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ceaa75eb0036a32b6b9833962eb18137449e9817e2e586006471925b727fd5"
+source = "git+https://github.com/rerun-io/kittest.git?rev=46eb59019fa8b45871a7b83b8219b4c627c3db2f#46eb59019fa8b45871a7b83b8219b4c627c3db2f"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -3381,12 +3395,12 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
+ "phf_macros 0.14.0",
+ "phf_shared 0.14.0",
  "serde",
 ]
 
@@ -3412,12 +3426,12 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
- "phf_shared 0.13.1",
+ "phf_shared 0.14.0",
 ]
 
 [[package]]
@@ -3436,12 +3450,12 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator 0.14.0",
+ "phf_shared 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3459,9 +3473,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,9 +70,9 @@ egui_inspection = { version = "0.36.1", path = "crates/egui_inspection", default
 egui_kittest = { version = "0.36.1", path = "crates/egui_kittest", default-features = false }
 eframe = { version = "0.36.1", path = "crates/eframe", default-features = false }
 
-accesskit = "0.24.1"
-accesskit_consumer = "0.35.0" # Can't update to 0.36+: kittest 0.4 pins accesskit_consumer 0.35, so bumping splits it into two versions
-accesskit_winit = "0.32.0" # Can't update to 0.33: it needs accesskit_macos 0.26.2, which pulls accesskit_consumer 0.37, duplicating the 0.35 that kittest 0.4 needs. For the same reason, `accesskit_macos` is held at 0.26.0 in `Cargo.lock`.
+accesskit = "0.25.0"
+accesskit_consumer = "0.39.0"
+accesskit_winit = "0.34.0"
 ahash = { version = "0.8.12", default-features = false, features = [
   "no-rng", # we don't need DOS-protection, so we let users opt-in to it instead
   "std",
@@ -301,3 +301,7 @@ let_underscore_must_use = "allow"
 let_underscore_untyped = "allow"
 self_named_module_files = "allow" # Disabled waiting on https://github.com/rust-lang/rust-clippy/issues/9602
 significant_drop_tightening = "allow" # Too many false positives
+
+[patch.crates-io]
+# TODO: remove whenever kittest releases their next version
+kittest = { git = "https://github.com/rerun-io/kittest.git", rev = "46eb59019fa8b45871a7b83b8219b4c627c3db2f" }

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2822,7 +2822,7 @@ impl ContextImpl {
                     .map_or(root_id, |id| id.accesskit_id());
                 platform_output.accesskit_update = Some(accesskit::TreeUpdate {
                     nodes,
-                    tree: Some(accesskit::Tree::new(root_id)),
+                    tree: Some(accesskit::TreeInfo::new(root_id)),
                     tree_id: accesskit::TreeId::ROOT,
                     focus: focus_id,
                 });

--- a/crates/egui_demo_app/src/accessibility_inspector.rs
+++ b/crates/egui_demo_app/src/accessibility_inspector.rs
@@ -1,7 +1,7 @@
 use core::mem;
 
 use accesskit::{Action, ActionRequest};
-use accesskit_consumer::{FilterResult, Node, NodeId, Tree, TreeChangeHandler};
+use accesskit_consumer::{FilterResult, FullNodeId, NodeRef, Tree, TreeChangeHandler};
 
 use eframe::epaint::text::TextWrapMode;
 use egui::{
@@ -24,21 +24,21 @@ use egui::{
 #[derive(Default, Debug)]
 pub struct AccessibilityInspectorPlugin {
     pub open: bool,
-    tree: Option<accesskit_consumer::Tree>,
-    selected_node: Option<NodeId>,
+    tree: Option<Tree>,
+    selected_node: Option<FullNodeId>,
     queued_action: Option<ActionRequest>,
 }
 
 struct ChangeHandler;
 
 impl TreeChangeHandler for ChangeHandler {
-    fn node_added(&mut self, _node: &Node<'_>) {}
+    fn node_added(&mut self, _node: &NodeRef<'_>) {}
 
-    fn node_updated(&mut self, _old_node: &Node<'_>, _new_node: &Node<'_>) {}
+    fn node_updated(&mut self, _old_node: &NodeRef<'_>, _new_node: &NodeRef<'_>) {}
 
-    fn focus_moved(&mut self, _old_node: Option<&Node<'_>>, _new_node: Option<&Node<'_>>) {}
+    fn focus_moved(&mut self, _old_node: Option<&NodeRef<'_>>, _new_node: Option<&NodeRef<'_>>) {}
 
-    fn node_removed(&mut self, _node: &Node<'_>) {}
+    fn node_removed(&mut self, _node: &NodeRef<'_>) {}
 }
 
 impl egui::Plugin for AccessibilityInspectorPlugin {
@@ -113,7 +113,7 @@ impl AccessibilityInspectorPlugin {
         Id::new("Accessibility Inspector")
     }
 
-    fn selection_ui(&mut self, ui: &mut Ui, selected_node: NodeId) {
+    fn selection_ui(&mut self, ui: &mut Ui, selected_node: FullNodeId) {
         ui.separator();
 
         if let Some(tree) = &self.tree
@@ -194,7 +194,7 @@ impl AccessibilityInspectorPlugin {
         }
     }
 
-    fn node_ui(ui: &mut Ui, node: &Node<'_>, selected_node: &mut Option<NodeId>) {
+    fn node_ui(ui: &mut Ui, node: &NodeRef<'_>, selected_node: &mut Option<FullNodeId>) {
         if node.locate() == (Self::id().value().into(), accesskit::TreeId::ROOT)
             || node
                 .value()


### PR DESCRIPTION
Also make some minor code changes because some structs have been renamed in `accesskit` and `accesskit_consumer`.

As of today, this requires patching kittest, which has a commit bumping its version of accesskit_consumer that isn't in a release yet.

I don't mind holding off on landing this for a little bit to see whether they'll release a new version soon, if you prefer.

* (No issue, since this seems pretty small, but happy to file one if you like)
* [x] I have followed the instructions in the PR template
