### PR TITLE
Move glyph bitmap caches out of `FontFace` into a new `GlyphAtlas`

### DIFF
--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -2,77 +2,23 @@
 
 use ahash::HashMap;
 use ecolor::Color32;
-use emath::{GuiRounding as _, OrderedFloat, Vec2, vec2};
+use emath::{GuiRounding as _, OrderedFloat, vec2};
 use self_cell::self_cell;
 use skrifa::{GlyphId, MetadataProvider as _};
 use std::collections::BTreeMap;
 use vello_cpu::{color, kurbo};
 
 use crate::{
-    TextOptions, TextureAtlas,
+    ColorImage, TextOptions,
     text::{
-        FontTweak, GlyphSourcePreference, MAX_GLYPH_SIZE, VariationCoords,
+        FontTweak, GlyphSourcePreference, VariationCoords,
         font_data::Blob,
         fonts::{CachedFamily, FontFaceKey},
+        glyph_atlas::{GlyphAtlas, GlyphBitmap, RasterGlyphAllocation, SubpixelBin},
         styled_metrics::{LocationHash, StyledMetrics},
         unicode::invisible_char,
     },
 };
-
-#[derive(Clone, Copy)]
-pub(crate) struct RasterGlyphAllocation {
-    pub allocation: GlyphAllocation,
-    pub advance_px: f32,
-    pub is_color: bool,
-}
-
-/// Hash of `(cluster, family, pixels_per_point, font_size)`,
-/// so that cache lookups do not allocate.
-#[derive(Hash, PartialEq, Eq)]
-pub(crate) struct RasterGlyphCacheKey(u64);
-
-impl nohash_hasher::IsEnabled for RasterGlyphCacheKey {}
-
-impl RasterGlyphCacheKey {
-    fn new(
-        cluster: &str,
-        family: &crate::text::FontFamily,
-        pixels_per_point: f32,
-        font_size: f32,
-    ) -> Self {
-        Self(crate::util::hash((
-            cluster,
-            family,
-            pixels_per_point.to_bits(),
-            font_size.to_bits(),
-        )))
-    }
-}
-
-// ----------------------------------------------------------------------------
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct UvRect {
-    /// X/Y offset for nice rendering (unit: points).
-    pub offset: Vec2,
-
-    /// Screen size (in points) of this glyph.
-    /// Note that the height is different from the font height.
-    pub size: Vec2,
-
-    /// Top left corner UV in texture.
-    pub min: [u16; 2],
-
-    /// Bottom right corner (exclusive).
-    pub max: [u16; 2],
-}
-
-impl UvRect {
-    pub fn is_nothing(&self) -> bool {
-        self.min == self.max
-    }
-}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct GlyphInfo {
@@ -106,104 +52,6 @@ pub(super) enum GlyphIdResolution {
     Invisible,
 }
 
-// Subpixel binning, taken from cosmic-text:
-// https://github.com/pop-os/cosmic-text/blob/974ddaed96b334f560b606ebe5d2ca2d2f9f23ef/src/glyph_cache.rs
-
-/// Bin for subpixel positioning of glyphs.
-///
-/// For accurate glyph positioning, we want to render each glyph at a subpixel coordinate. However, we also want to
-/// cache each glyph's bitmap. As a compromise, we bin each subpixel offset into one of four fractional values. This
-/// means one glyph can have up to four subpixel-positioned bitmaps in the cache.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub(super) enum SubpixelBin {
-    #[default]
-    Zero,
-    One,
-    Two,
-    Three,
-}
-
-impl SubpixelBin {
-    /// Bin the given position and return the new integral coordinate.
-    fn new(pos: f32) -> (i32, Self) {
-        let trunc = pos as i32;
-        let fract = pos - trunc as f32;
-
-        if pos.is_sign_negative() {
-            if fract > -0.125 {
-                (trunc, Self::Zero)
-            } else if fract > -0.375 {
-                (trunc - 1, Self::Three)
-            } else if fract > -0.625 {
-                (trunc - 1, Self::Two)
-            } else if fract > -0.875 {
-                (trunc - 1, Self::One)
-            } else {
-                (trunc - 1, Self::Zero)
-            }
-        } else {
-            if fract < 0.125 {
-                (trunc, Self::Zero)
-            } else if fract < 0.375 {
-                (trunc, Self::One)
-            } else if fract < 0.625 {
-                (trunc, Self::Two)
-            } else if fract < 0.875 {
-                (trunc, Self::Three)
-            } else {
-                (trunc + 1, Self::Zero)
-            }
-        }
-    }
-
-    pub fn as_float(&self) -> f32 {
-        match self {
-            Self::Zero => 0.0,
-            Self::One => 0.25,
-            Self::Two => 0.5,
-            Self::Three => 0.75,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct GlyphAllocation {
-    /// UV rectangle for drawing.
-    pub uv_rect: UvRect,
-}
-
-#[derive(Hash, PartialEq, Eq)]
-struct GlyphCacheKey(u64);
-
-impl nohash_hasher::IsEnabled for GlyphCacheKey {}
-
-impl GlyphCacheKey {
-    #[inline]
-    fn new(glyph_id: GlyphId, metrics: &StyledMetrics, bin: SubpixelBin) -> Self {
-        let StyledMetrics {
-            pixels_per_point,
-            px_scale_factor,
-            location_hash,
-            ..
-        } = *metrics;
-        debug_assert!(
-            0.0 < pixels_per_point && pixels_per_point.is_finite(),
-            "Bad pixels_per_point {pixels_per_point}"
-        );
-        debug_assert!(
-            0.0 < px_scale_factor && px_scale_factor.is_finite(),
-            "Bad px_scale_factor: {px_scale_factor}"
-        );
-        Self(crate::util::hash((
-            glyph_id,
-            pixels_per_point.to_bits(),
-            px_scale_factor.to_bits(),
-            bin,
-            location_hash,
-        )))
-    }
-}
-
 // ----------------------------------------------------------------------------
 
 struct DependentFontData<'a> {
@@ -229,19 +77,22 @@ impl FontCell {
         scale / units_per_em
     }
 
-    fn allocate_glyph_uncached(
+    /// Render the outline of a glyph to a coverage bitmap.
+    ///
+    /// Returns `None` if the glyph has no outline (e.g. a space).
+    fn rasterize_outline(
         &mut self,
-        atlas: &mut TextureAtlas,
         metrics: &StyledMetrics,
         glyph_id: GlyphId,
         bin: SubpixelBin,
-        location: skrifa::instance::LocationRef<'_>,
         hinting_target: skrifa::outline::Target,
-    ) -> Option<GlyphAllocation> {
+    ) -> Option<GlyphBitmap> {
         debug_assert!(
             glyph_id != skrifa::GlyphId::NOTDEF,
-            "Can't allocate glyph for id 0"
+            "Can't rasterize glyph id 0"
         );
+
+        let location: skrifa::instance::LocationRef<'_> = (&metrics.location).into();
 
         let mut path = kurbo::BezPath::new();
         let mut pen = VelloPen {
@@ -278,51 +129,29 @@ impl FontCell {
         let bounds = path.control_box().expand();
         let width = bounds.width() as u16;
         let height = bounds.height() as u16;
+        if width == 0 || height == 0 {
+            return None;
+        }
 
-        let uv_rect = if width == 0 || height == 0 {
-            UvRect::default()
-        } else {
-            let mut ctx = vello_cpu::RenderContext::new(width, height);
-            ctx.set_transform(kurbo::Affine::translate((-bounds.x0, -bounds.y0)));
-            ctx.set_paint(color::OpaqueColor::<color::Srgb>::WHITE);
-            ctx.fill_path(&path);
-            let mut dest = vello_cpu::Pixmap::new(width, height);
-            let mut resources = vello_cpu::Resources::new();
-            ctx.render(&mut dest, &mut resources);
+        let mut ctx = vello_cpu::RenderContext::new(width, height);
+        ctx.set_transform(kurbo::Affine::translate((-bounds.x0, -bounds.y0)));
+        ctx.set_paint(color::OpaqueColor::<color::Srgb>::WHITE);
+        ctx.fill_path(&path);
+        let mut dest = vello_cpu::Pixmap::new(width, height);
+        let mut resources = vello_cpu::Resources::new();
+        ctx.render(&mut dest, &mut resources);
 
-            let glyph_pos = {
-                let color_transfer_function = atlas.options().color_transfer_function;
-                let (glyph_pos, image) = atlas.allocate((width as usize, height as usize));
-                let pixels = dest.data_as_u8_slice();
-                for y in 0..height as usize {
-                    for x in 0..width as usize {
-                        let pixel_offset = 4 * ((y * width as usize) + x);
-                        image[(x + glyph_pos.0, y + glyph_pos.1)] = color_transfer_function
-                            .to_atlas_color(Color32::from_rgba_premultiplied(
-                                pixels[pixel_offset],
-                                pixels[pixel_offset + 1],
-                                pixels[pixel_offset + 2],
-                                pixels[pixel_offset + 3],
-                            ));
-                    }
-                }
-                glyph_pos
-            };
-            let offset_in_pixels = vec2(bounds.x0 as f32, bounds.y0 as f32);
-            let offset =
-                offset_in_pixels / metrics.pixels_per_point + metrics.y_offset_in_points * Vec2::Y;
-            UvRect {
-                offset,
-                size: vec2(width as f32, height as f32) / metrics.pixels_per_point,
-                min: [glyph_pos.0 as u16, glyph_pos.1 as u16],
-                max: [
-                    (glyph_pos.0 + width as usize) as u16,
-                    (glyph_pos.1 + height as usize) as u16,
-                ],
-            }
-        };
+        let pixels = dest
+            .data_as_u8_slice()
+            .chunks_exact(4)
+            .map(|px| Color32::from_rgba_premultiplied(px[0], px[1], px[2], px[3]))
+            .collect();
+        let image = ColorImage::new([width as usize, height as usize], pixels);
 
-        Some(GlyphAllocation { uv_rect })
+        Some(GlyphBitmap {
+            image,
+            offset_px: vec2(bounds.x0 as f32, bounds.y0 as f32),
+        })
     }
 }
 
@@ -383,8 +212,6 @@ pub struct FontFace {
     /// Variable fonts can vary advance widths per axis (HVAR table), so this
     /// must be re-keyed per resolved [`skrifa::instance::Location`].
     advance_width_cache: HashMap<(char, LocationHash), OrderedFloat<f32>>,
-
-    glyph_alloc_cache: HashMap<GlyphCacheKey, GlyphAllocation>,
 }
 
 impl FontFace {
@@ -447,7 +274,6 @@ impl FontFace {
             shaper_data,
             glyph_id_cache: Default::default(),
             advance_width_cache: Default::default(),
-            glyph_alloc_cache: Default::default(),
         })
     }
 
@@ -614,48 +440,24 @@ impl FontFace {
         &self.shaper_data
     }
 
-    pub fn allocate_glyph(
+    /// Whether to render this face at up to four sub-pixel offsets.
+    #[inline]
+    pub(crate) fn subpixel_binning(&self) -> bool {
+        self.subpixel_binning
+    }
+
+    /// Render the outline of a glyph to a coverage bitmap.
+    ///
+    /// Not cached: see [`GlyphAtlas::allocate_outline`].
+    pub(crate) fn rasterize_outline(
         &mut self,
-        atlas: &mut TextureAtlas,
         metrics: &StyledMetrics,
-        shaped: &ShapedGlyph,
-    ) -> (GlyphAllocation, i32) {
-        let ShapedGlyph {
-            glyph_id,
-            h_pos,
-            is_cjk,
-        } = *shaped;
-
-        if glyph_id == GlyphId::NOTDEF {
-            // invisible
-            return (GlyphAllocation::default(), h_pos.round() as i32);
-        }
-
-        let (h_pos_round, bin) = if self.subpixel_binning && !is_cjk {
-            SubpixelBin::new(h_pos)
-        } else {
-            // CJK scripts contain a lot of characters and could hog the glyph atlas
-            // if we stored 4 subpixel offsets per glyph.
-            (h_pos.round() as i32, SubpixelBin::Zero)
-        };
-
-        let cache_key = GlyphCacheKey::new(glyph_id, metrics, bin);
-
+        glyph_id: GlyphId,
+        bin: SubpixelBin,
+    ) -> Option<GlyphBitmap> {
         let hinting_target = self.tweak.hinting_target.into();
-        let alloc = *self.glyph_alloc_cache.entry(cache_key).or_insert_with(|| {
-            self.font
-                .allocate_glyph_uncached(
-                    atlas,
-                    metrics,
-                    glyph_id,
-                    bin,
-                    (&metrics.location).into(),
-                    hinting_target,
-                )
-                .unwrap_or_default()
-        });
-
-        (alloc, h_pos_round)
+        self.font
+            .rasterize_outline(metrics, glyph_id, bin, hinting_target)
     }
 }
 
@@ -676,22 +478,16 @@ pub(crate) struct ShapedGlyph {
 pub struct Font<'a> {
     pub(super) fonts_by_id: &'a mut nohash_hasher::IntMap<FontFaceKey, FontFace>,
     pub(super) cached_family: &'a mut CachedFamily,
-    pub(super) atlas: &'a mut TextureAtlas,
+    pub(super) glyphs: &'a mut GlyphAtlas,
     pub(super) family: crate::text::FontFamily,
     pub(super) glyph_rasterizer: Option<&'a crate::text::GlyphRasterizer>,
-
-    /// `None` means the rasterizer could not handle the cluster.
-    pub(super) raster_glyph_cache:
-        &'a mut nohash_hasher::IntMap<RasterGlyphCacheKey, Option<RasterGlyphAllocation>>,
-
     pub(super) glyph_source_preference: &'a GlyphSourcePreference,
 }
 
 impl Font<'_> {
-    /// Rasterize a glyph using our fallback provider.
+    /// Rasterize a grapheme cluster using the platform [`crate::text::GlyphRasterizer`].
     ///
-    /// Failures are cached too, so the (potentially slow) rasterizer
-    /// is asked at most once per cluster and size.
+    /// Returns `None` if there is no rasterizer, or it could not handle the cluster.
     pub(crate) fn rasterize_glyph(
         &mut self,
         cluster: &str,
@@ -699,57 +495,13 @@ impl Font<'_> {
         font_size: f32,
     ) -> Option<RasterGlyphAllocation> {
         let rasterizer = self.glyph_rasterizer?;
-        let key = RasterGlyphCacheKey::new(cluster, &self.family, pixels_per_point, font_size);
-        if let Some(allocation) = self.raster_glyph_cache.get(&key) {
-            return *allocation;
-        }
-        let request = crate::text::GlyphRasterizerRequest {
+        self.glyphs.allocate_raster(
+            rasterizer,
             cluster,
-            family: &self.family,
-            font_size_px: font_size * pixels_per_point,
-            subpixel_offset_px: 0.0,
-        };
-        let allocation = (rasterizer.rasterize)(&request)
-            .and_then(|glyph| Self::allocate_raster_glyph(self.atlas, &glyph, pixels_per_point));
-        self.raster_glyph_cache.insert(key, allocation);
-        allocation
-    }
-
-    fn allocate_raster_glyph(
-        atlas: &mut TextureAtlas,
-        glyph: &crate::text::RasterizedGlyph,
-        pixels_per_point: f32,
-    ) -> Option<RasterGlyphAllocation> {
-        let [width, height] = glyph.image.size;
-        if width == 0 || height == 0 || MAX_GLYPH_SIZE < width || MAX_GLYPH_SIZE < height {
-            return None;
-        }
-        // The transfer function assumes white coverage glyphs and discards color,
-        // so color glyphs (e.g. emoji) must skip it.
-        let transfer = if glyph.is_color {
-            crate::FontColorTransferFunction::Off
-        } else {
-            atlas.options().color_transfer_function
-        };
-        let (glyph_pos, image) = atlas.allocate((width, height));
-        for y in 0..height {
-            for x in 0..width {
-                image[(glyph_pos.0 + x, glyph_pos.1 + y)] =
-                    transfer.to_atlas_color(glyph.image[(x, y)]);
-            }
-        }
-        Some(RasterGlyphAllocation {
-            allocation: GlyphAllocation {
-                uv_rect: UvRect {
-                    offset: glyph.offset_px / pixels_per_point,
-                    size: vec2(width as f32, height as f32) / pixels_per_point,
-                    min: [glyph_pos.0 as u16, glyph_pos.1 as u16],
-                    max: [(glyph_pos.0 + width) as u16, (glyph_pos.1 + height) as u16],
-                },
-            },
-            advance_px: glyph.advance_px,
-            is_color: glyph.is_color,
-        })
+            &self.family,
+            pixels_per_point,
+            font_size,
+        )
     }
 
     pub fn preload_characters(&mut self, s: &str) {

--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -20,6 +20,7 @@ use crate::{
     },
 };
 
+/// A glyph id and its advance, as resolved from a `char` in one [`FontFace`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct GlyphInfo {
     /// Doesn't need to be unique.
@@ -54,6 +55,7 @@ pub(super) enum GlyphIdResolution {
 
 // ----------------------------------------------------------------------------
 
+/// The parsed `skrifa` views into a font file, borrowing from the file's [`Blob`].
 struct DependentFontData<'a> {
     skrifa: skrifa::FontRef<'a>,
     charmap: skrifa::charmap::Charmap<'a>,
@@ -63,6 +65,7 @@ struct DependentFontData<'a> {
 }
 
 self_cell! {
+    /// A font file together with the parsed [`DependentFontData`] that borrows from it.
     struct FontCell {
         owner: Blob,
 
@@ -155,6 +158,7 @@ impl FontCell {
     }
 }
 
+/// Collects a `skrifa` glyph outline into a `kurbo` path, flipping Y to point down.
 struct VelloPen<'a> {
     path: &'a mut kurbo::BezPath,
     x_offset: f64,

--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -3,6 +3,7 @@
 use ahash::HashMap;
 use ecolor::Color32;
 use emath::{GuiRounding as _, OrderedFloat, vec2};
+use nohash_hasher::IntMap;
 use self_cell::self_cell;
 use skrifa::{GlyphId, MetadataProvider as _};
 use std::collections::BTreeMap;
@@ -480,7 +481,7 @@ pub(crate) struct ShapedGlyph {
 // TODO(emilk): rename?
 /// Wrapper over multiple [`FontFace`] (e.g. a primary + fallbacks for emojis)
 pub struct Font<'a> {
-    pub(super) fonts_by_id: &'a mut nohash_hasher::IntMap<FontFaceKey, FontFace>,
+    pub(super) fonts_by_id: &'a mut IntMap<FontFaceKey, FontFace>,
     pub(super) cached_family: &'a mut CachedFamily,
     pub(super) glyphs: &'a mut GlyphAtlas,
     pub(super) family: crate::text::FontFamily,

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -1,6 +1,8 @@
 use core::sync::atomic::{AtomicUsize, Ordering};
 use std::{collections::BTreeMap, sync::Arc};
 
+use nohash_hasher::IntMap;
+
 use crate::{
     Color32, TextureAtlas,
     text::{
@@ -66,10 +68,7 @@ pub(super) struct CachedFamily {
 }
 
 impl CachedFamily {
-    fn new(
-        fonts: Vec<FontFaceKey>,
-        fonts_by_id: &mut nohash_hasher::IntMap<FontFaceKey, FontFace>,
-    ) -> Self {
+    fn new(fonts: Vec<FontFaceKey>, fonts_by_id: &mut IntMap<FontFaceKey, FontFace>) -> Self {
         const PRIMARY_REPLACEMENT_CHAR: char = '◻'; // white medium square
         const FALLBACK_REPLACEMENT_CHAR: char = '?'; // fallback for the fallback
 
@@ -117,7 +116,7 @@ impl CachedFamily {
     pub(crate) fn find_face_for_char(
         &self,
         c: char,
-        fonts_by_id: &mut nohash_hasher::IntMap<FontFaceKey, FontFace>,
+        fonts_by_id: &mut IntMap<FontFaceKey, FontFace>,
     ) -> Option<FontFaceKey> {
         for font_key in &self.fonts {
             let font_face = fonts_by_id.get_mut(font_key).expect("Nonexistent font ID");
@@ -436,7 +435,7 @@ impl FontsView<'_> {
 pub struct FontsImpl {
     definitions: FontDefinitions,
     glyphs: GlyphAtlas,
-    fonts_by_id: nohash_hasher::IntMap<FontFaceKey, FontFace>,
+    fonts_by_id: IntMap<FontFaceKey, FontFace>,
     fonts_by_name: ahash::HashMap<String, FontFaceKey>,
     family_cache: ahash::HashMap<FontFamily, CachedFamily>,
 
@@ -450,7 +449,7 @@ impl FontsImpl {
     /// Create a new [`FontsImpl`] for text layout.
     /// This call is expensive, so only create one [`FontsImpl`] and then reuse it.
     pub fn new(options: TextOptions, definitions: FontDefinitions) -> Self {
-        let mut fonts_by_id: nohash_hasher::IntMap<FontFaceKey, FontFace> = Default::default();
+        let mut fonts_by_id: IntMap<FontFaceKey, FontFace> = Default::default();
         let mut fonts_by_name: ahash::HashMap<String, FontFaceKey> = Default::default();
         for (name, font_data) in &definitions.font_data {
             let blob = blob_from_font_data(font_data);

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -1,16 +1,15 @@
 use core::sync::atomic::{AtomicUsize, Ordering};
 use std::{collections::BTreeMap, sync::Arc};
 
-use emath::NumExt as _;
-
 use crate::{
     Color32, TextureAtlas,
     text::{
         FontDefinitions, FontFamily, FontId, Galley, GlyphRasterizer, GlyphSource,
         GlyphSourcePreference, LayoutJob, TextOptions, VariationCoords,
-        font::{Font, FontFace, RasterGlyphAllocation, RasterGlyphCacheKey},
+        font::{Font, FontFace},
         font_data::blob_from_font_data,
         galley_cache::GalleyCache,
+        glyph_atlas::GlyphAtlas,
         glyph_rasterizer::default_glyph_source,
     },
 };
@@ -146,7 +145,6 @@ impl CachedFamily {
 pub struct Fonts {
     pub fonts: FontsImpl,
     galley_cache: GalleyCache,
-    glyph_rasterizer: Option<GlyphRasterizer>,
 }
 
 impl Fonts {
@@ -157,7 +155,6 @@ impl Fonts {
         Self {
             fonts: FontsImpl::new(options, definitions),
             galley_cache: Default::default(),
-            glyph_rasterizer: None,
         }
     }
 
@@ -176,7 +173,6 @@ impl Fonts {
     ///
     /// See [`GlyphRasterizer`].
     pub fn set_glyph_rasterizer(&mut self, glyph_rasterizer: Option<GlyphRasterizer>) {
-        self.glyph_rasterizer = glyph_rasterizer.clone();
         self.fonts.set_glyph_rasterizer(glyph_rasterizer);
         self.galley_cache = Default::default();
     }
@@ -200,23 +196,18 @@ impl Fonts {
     /// This function will react to changes in [`TextOptions`],
     /// as well as notice when the font atlas is getting full, and handle that.
     pub fn begin_pass(&mut self, options: TextOptions) {
-        let text_options_changed = self.fonts.options() != &options;
-        let font_atlas_almost_full = self.fonts.atlas.fill_ratio() > 0.8;
-        let needs_recreate = text_options_changed || font_atlas_almost_full;
-
-        if needs_recreate {
+        if self.fonts.options() != &options {
+            // Hinting and other options are baked into each parsed face, so start over:
             let definitions = self.fonts.definitions.clone();
-            let glyph_rasterizer = self.glyph_rasterizer.clone();
-
             let mut fonts = FontsImpl::new(options, definitions);
-            fonts.set_glyph_rasterizer(glyph_rasterizer.clone());
+            fonts.set_glyph_rasterizer(self.fonts.glyph_rasterizer.take());
             fonts.glyph_source_preference = Arc::clone(&self.fonts.glyph_source_preference);
-
-            *self = Self {
-                fonts,
-                galley_cache: Default::default(),
-                glyph_rasterizer,
-            };
+            self.fonts = fonts;
+            self.galley_cache = Default::default();
+        } else if 0.8 < self.fonts.glyphs.fill_ratio() {
+            // The parsed faces are still fine; only the bitmaps need to go.
+            self.fonts.glyphs.clear();
+            self.galley_cache = Default::default(); // Galleys point into the old atlas.
         }
 
         self.galley_cache.flush_cache();
@@ -224,7 +215,7 @@ impl Fonts {
 
     /// Call at the end of each frame (before painting) to get the change to the font texture since last call.
     pub fn font_image_delta(&mut self) -> Option<crate::ImageDelta> {
-        self.fonts.atlas.take_delta()
+        self.fonts.glyphs.take_delta()
     }
 
     #[inline]
@@ -240,19 +231,19 @@ impl Fonts {
     /// The font atlas.
     /// Pass this to [`crate::Tessellator`].
     pub fn texture_atlas(&self) -> &TextureAtlas {
-        &self.fonts.atlas
+        self.fonts.glyphs.atlas()
     }
 
     /// The full font atlas image.
     #[inline]
     pub fn image(&self) -> crate::ColorImage {
-        self.fonts.atlas.image().clone()
+        self.fonts.glyphs.atlas().image().clone()
     }
 
     /// Current size of the font image.
     /// Pass this to [`crate::Tessellator`].
     pub fn font_image_size(&self) -> [usize; 2] {
-        self.fonts.atlas.size()
+        self.fonts.glyphs.atlas().size()
     }
 
     /// Do the installed fonts have this glyph?
@@ -279,7 +270,7 @@ impl Fonts {
     /// This increases as new fonts and/or glyphs are used,
     /// but can also decrease in a call to [`Self::begin_pass`].
     pub fn font_atlas_fill_ratio(&self) -> f32 {
-        self.fonts.atlas.fill_ratio()
+        self.fonts.glyphs.fill_ratio()
     }
 
     /// Returns a [`FontsView`] with the given `pixels_per_point` that can be used to do text layout.
@@ -315,13 +306,13 @@ impl FontsView<'_> {
     /// The full font atlas image.
     #[inline]
     pub fn image(&self) -> crate::ColorImage {
-        self.fonts.atlas.image().clone()
+        self.fonts.glyphs.atlas().image().clone()
     }
 
     /// Current size of the font image.
     /// Pass this to [`crate::Tessellator`].
     pub fn font_image_size(&self) -> [usize; 2] {
-        self.fonts.atlas.size()
+        self.fonts.glyphs.atlas().size()
     }
 
     /// Width of this character in points.
@@ -396,7 +387,7 @@ impl FontsView<'_> {
     /// This increases as new fonts and/or glyphs are used,
     /// but can also decrease in a call to [`Fonts::begin_pass`].
     pub fn font_atlas_fill_ratio(&self) -> f32 {
-        self.fonts.atlas.fill_ratio()
+        self.fonts.glyphs.fill_ratio()
     }
 
     /// Will wrap text at the given width and line break at `\n`.
@@ -444,7 +435,7 @@ impl FontsView<'_> {
 /// Required in order to paint text.
 pub struct FontsImpl {
     definitions: FontDefinitions,
-    atlas: TextureAtlas,
+    glyphs: GlyphAtlas,
     fonts_by_id: nohash_hasher::IntMap<FontFaceKey, FontFace>,
     fonts_by_name: ahash::HashMap<String, FontFaceKey>,
     family_cache: ahash::HashMap<FontFamily, CachedFamily>,
@@ -452,7 +443,6 @@ pub struct FontsImpl {
     /// Recycled `harfrust` shaping buffer to avoid per-layout allocations.
     shape_buffer: Option<harfrust::UnicodeBuffer>,
     glyph_rasterizer: Option<GlyphRasterizer>,
-    raster_glyph_cache: nohash_hasher::IntMap<RasterGlyphCacheKey, Option<RasterGlyphAllocation>>,
     glyph_source_preference: GlyphSourcePreference,
 }
 
@@ -460,10 +450,6 @@ impl FontsImpl {
     /// Create a new [`FontsImpl`] for text layout.
     /// This call is expensive, so only create one [`FontsImpl`] and then reuse it.
     pub fn new(options: TextOptions, definitions: FontDefinitions) -> Self {
-        let texture_width = options.max_texture_side.at_most(16 * 1024);
-        let initial_height = 32; // Keep initial font atlas small, so it is fast to upload to GPU. This will expand as needed anyways.
-        let atlas = TextureAtlas::new([texture_width, initial_height], options);
-
         let mut fonts_by_id: nohash_hasher::IntMap<FontFaceKey, FontFace> = Default::default();
         let mut fonts_by_name: ahash::HashMap<String, FontFaceKey> = Default::default();
         for (name, font_data) in &definitions.font_data {
@@ -483,13 +469,12 @@ impl FontsImpl {
 
         Self {
             definitions,
-            atlas,
+            glyphs: GlyphAtlas::new(options),
             fonts_by_id,
             fonts_by_name,
             family_cache: Default::default(),
             shape_buffer: Some(harfrust::UnicodeBuffer::new()),
             glyph_rasterizer: None,
-            raster_glyph_cache: Default::default(),
             glyph_source_preference: Arc::new(default_glyph_source),
         }
     }
@@ -510,7 +495,7 @@ impl FontsImpl {
     /// See [`GlyphRasterizer`].
     pub fn set_glyph_rasterizer(&mut self, glyph_rasterizer: Option<GlyphRasterizer>) {
         self.glyph_rasterizer = glyph_rasterizer;
-        self.raster_glyph_cache = Default::default();
+        self.glyphs.clear_raster_glyphs();
     }
 
     /// Decide where to look first for the glyphs of each grapheme cluster.
@@ -524,7 +509,7 @@ impl FontsImpl {
     }
 
     pub fn options(&self) -> &TextOptions {
-        self.atlas.options()
+        self.glyphs.options()
     }
 
     /// Take the recycled shaping buffer (or create a new one if already taken).
@@ -559,10 +544,9 @@ impl FontsImpl {
         Font {
             fonts_by_id: &mut self.fonts_by_id,
             cached_family,
-            atlas: &mut self.atlas,
+            glyphs: &mut self.glyphs,
             family: family.clone(),
             glyph_rasterizer: self.glyph_rasterizer.as_ref(),
-            raster_glyph_cache: &mut self.raster_glyph_cache,
             glyph_source_preference: &self.glyph_source_preference,
         }
     }

--- a/crates/epaint/src/text/galley_cache.rs
+++ b/crates/epaint/src/text/galley_cache.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use emath::OrderedFloat;
+use nohash_hasher::IntMap;
 
 use crate::text::{ByteIndex, FontsImpl, Galley, LayoutJob, LayoutSection};
 
@@ -24,7 +25,7 @@ struct CachedGalley {
 pub(super) struct GalleyCache {
     /// Frame counter used to do garbage collection on the cache
     generation: u32,
-    cache: nohash_hasher::IntMap<u64, CachedGalley>,
+    cache: IntMap<u64, CachedGalley>,
 }
 
 impl GalleyCache {

--- a/crates/epaint/src/text/glyph_atlas.rs
+++ b/crates/epaint/src/text/glyph_atlas.rs
@@ -1,4 +1,5 @@
 use emath::{NumExt as _, Vec2, vec2};
+use nohash_hasher::IntMap;
 use skrifa::GlyphId;
 
 use crate::{
@@ -42,6 +43,19 @@ impl UvRect {
 pub struct GlyphAllocation {
     /// UV rectangle for drawing.
     pub uv_rect: UvRect,
+}
+
+/// An outline glyph in the atlas, positioned for one [`ShapedGlyph`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct OutlineGlyph {
+    pub allocation: GlyphAllocation,
+
+    /// Left edge of the glyph's pixel grid, in physical pixels.
+    ///
+    /// This is [`ShapedGlyph::h_pos`] rounded to the pixel (or sub-pixel bin)
+    /// the bitmap was rendered for. Draw the bitmap here, not at the
+    /// un-rounded `h_pos`, or it will be blurry.
+    pub x_px: i32,
 }
 
 /// A glyph from the [`GlyphRasterizer`], allocated in the atlas.
@@ -192,12 +206,12 @@ pub(crate) struct GlyphAtlas {
     atlas: TextureAtlas,
 
     /// Glyphs rendered from font outlines.
-    outline_glyphs: nohash_hasher::IntMap<OutlineGlyphKey, GlyphAllocation>,
+    outline_glyphs: IntMap<OutlineGlyphKey, GlyphAllocation>,
 
     /// Glyphs from the [`GlyphRasterizer`].
     ///
     /// `None` means the rasterizer could not handle the cluster.
-    raster_glyphs: nohash_hasher::IntMap<RasterGlyphKey, Option<RasterGlyphAllocation>>,
+    raster_glyphs: IntMap<RasterGlyphKey, Option<RasterGlyphAllocation>>,
 }
 
 impl GlyphAtlas {
@@ -246,14 +260,18 @@ impl GlyphAtlas {
 
     /// Get or render the glyph of `face` for `shaped`.
     ///
-    /// Returns the allocation and the rounded horizontal position (in physical pixels).
+    /// The bitmap is rendered at the sub-pixel bin of [`ShapedGlyph::h_pos`]
+    /// (if the face has sub-pixel binning on, and the glyph is not CJK),
+    /// so the same glyph can occupy up to four slots in the atlas.
+    ///
+    /// Never fails: see [`Self::allocate_bitmap`] for what happens when the atlas is full.
     pub fn allocate_outline(
         &mut self,
         face_key: FontFaceKey,
         face: &mut FontFace,
         metrics: &StyledMetrics,
         shaped: &ShapedGlyph,
-    ) -> (GlyphAllocation, i32) {
+    ) -> OutlineGlyph {
         let ShapedGlyph {
             glyph_id,
             h_pos,
@@ -262,10 +280,13 @@ impl GlyphAtlas {
 
         if glyph_id == GlyphId::NOTDEF {
             // invisible
-            return (GlyphAllocation::default(), h_pos.round() as i32);
+            return OutlineGlyph {
+                allocation: GlyphAllocation::default(),
+                x_px: h_pos.round() as i32,
+            };
         }
 
-        let (h_pos_round, bin) = if face.subpixel_binning() && !is_cjk {
+        let (x_px, bin) = if face.subpixel_binning() && !is_cjk {
             SubpixelBin::new(h_pos)
         } else {
             // CJK scripts contain a lot of characters and could hog the glyph atlas
@@ -280,7 +301,7 @@ impl GlyphAtlas {
             outline_glyphs,
             ..
         } = self;
-        let alloc = *outline_glyphs.entry(key).or_insert_with(|| {
+        let allocation = *outline_glyphs.entry(key).or_insert_with(|| {
             face.rasterize_outline(metrics, glyph_id, bin)
                 .and_then(|bitmap| {
                     let transfer = atlas.options().color_transfer_function;
@@ -293,13 +314,15 @@ impl GlyphAtlas {
                 .unwrap_or_default()
         });
 
-        (alloc, h_pos_round)
+        OutlineGlyph { allocation, x_px }
     }
 
     /// Get or rasterize `cluster` using the platform [`GlyphRasterizer`].
     ///
     /// Failures are cached too, so the (potentially slow) rasterizer
     /// is asked at most once per cluster and size.
+    ///
+    /// See [`Self::allocate_bitmap`] for what happens when the atlas is full.
     pub fn allocate_raster(
         &mut self,
         rasterizer: &GlyphRasterizer,
@@ -345,6 +368,11 @@ impl GlyphAtlas {
     /// Copy a bitmap into the atlas.
     ///
     /// Returns `None` for empty and oversized bitmaps.
+    ///
+    /// Never fails for lack of space: the [`TextureAtlas`] grows in height as needed,
+    /// and once it hits its maximum it logs a warning and starts overwriting old glyphs
+    /// (see [`TextureAtlas::allocate`]). We avoid getting there because `Fonts::begin_pass`
+    /// calls [`Self::clear`] as soon as [`Self::fill_ratio`] passes 80%.
     fn allocate_bitmap(
         atlas: &mut TextureAtlas,
         bitmap: &GlyphBitmap,

--- a/crates/epaint/src/text/glyph_atlas.rs
+++ b/crates/epaint/src/text/glyph_atlas.rs
@@ -1,0 +1,369 @@
+use emath::{NumExt as _, Vec2, vec2};
+use skrifa::GlyphId;
+
+use crate::{
+    ColorImage, FontColorTransferFunction, ImageDelta, TextOptions, TextureAtlas,
+    text::{
+        FontFamily, GlyphRasterizer, GlyphRasterizerRequest, MAX_GLYPH_SIZE,
+        font::{FontFace, ShapedGlyph},
+        fonts::FontFaceKey,
+        styled_metrics::StyledMetrics,
+    },
+};
+
+/// Where a glyph ended up in the font atlas, in UV coordinates.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct UvRect {
+    /// X/Y offset for nice rendering (unit: points).
+    pub offset: Vec2,
+
+    /// Screen size (in points) of this glyph.
+    /// Note that the height is different from the font height.
+    pub size: Vec2,
+
+    /// Top left corner UV in texture.
+    pub min: [u16; 2],
+
+    /// Bottom right corner (exclusive).
+    pub max: [u16; 2],
+}
+
+impl UvRect {
+    pub fn is_nothing(&self) -> bool {
+        self.min == self.max
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct GlyphAllocation {
+    /// UV rectangle for drawing.
+    pub uv_rect: UvRect,
+}
+
+/// A glyph from the [`GlyphRasterizer`], allocated in the atlas.
+#[derive(Clone, Copy)]
+pub(crate) struct RasterGlyphAllocation {
+    pub allocation: GlyphAllocation,
+    pub advance_px: f32,
+    pub is_color: bool,
+}
+
+/// A glyph bitmap, ready to be copied into the atlas.
+pub(crate) struct GlyphBitmap {
+    /// Physical pixels. Coverage glyphs are white with alpha; color glyphs keep their colors.
+    pub image: ColorImage,
+
+    /// Offset from the glyph origin to the top-left of the image, in physical pixels.
+    pub offset_px: Vec2,
+}
+
+// ----------------------------------------------------------------------------
+
+// Subpixel binning, taken from cosmic-text:
+// https://github.com/pop-os/cosmic-text/blob/974ddaed96b334f560b606ebe5d2ca2d2f9f23ef/src/glyph_cache.rs
+
+/// Bin for subpixel positioning of glyphs.
+///
+/// For accurate glyph positioning, we want to render each glyph at a subpixel coordinate. However, we also want to
+/// cache each glyph's bitmap. As a compromise, we bin each subpixel offset into one of four fractional values. This
+/// means one glyph can have up to four subpixel-positioned bitmaps in the cache.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub(super) enum SubpixelBin {
+    #[default]
+    Zero,
+    One,
+    Two,
+    Three,
+}
+
+impl SubpixelBin {
+    /// Bin the given position and return the new integral coordinate.
+    fn new(pos: f32) -> (i32, Self) {
+        let trunc = pos as i32;
+        let fract = pos - trunc as f32;
+
+        if pos.is_sign_negative() {
+            if fract > -0.125 {
+                (trunc, Self::Zero)
+            } else if fract > -0.375 {
+                (trunc - 1, Self::Three)
+            } else if fract > -0.625 {
+                (trunc - 1, Self::Two)
+            } else if fract > -0.875 {
+                (trunc - 1, Self::One)
+            } else {
+                (trunc - 1, Self::Zero)
+            }
+        } else {
+            if fract < 0.125 {
+                (trunc, Self::Zero)
+            } else if fract < 0.375 {
+                (trunc, Self::One)
+            } else if fract < 0.625 {
+                (trunc, Self::Two)
+            } else if fract < 0.875 {
+                (trunc, Self::Three)
+            } else {
+                (trunc + 1, Self::Zero)
+            }
+        }
+    }
+
+    pub fn as_float(&self) -> f32 {
+        match self {
+            Self::Zero => 0.0,
+            Self::One => 0.25,
+            Self::Two => 0.5,
+            Self::Three => 0.75,
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+/// Hash of everything that decides what an outline glyph looks like in the atlas.
+#[derive(Hash, PartialEq, Eq)]
+struct OutlineGlyphKey(u64);
+
+impl nohash_hasher::IsEnabled for OutlineGlyphKey {}
+
+impl OutlineGlyphKey {
+    #[inline]
+    fn new(
+        face_key: FontFaceKey,
+        glyph_id: GlyphId,
+        metrics: &StyledMetrics,
+        bin: SubpixelBin,
+    ) -> Self {
+        let StyledMetrics {
+            pixels_per_point,
+            px_scale_factor,
+            location_hash,
+            ..
+        } = *metrics;
+        debug_assert!(
+            0.0 < pixels_per_point && pixels_per_point.is_finite(),
+            "Bad pixels_per_point {pixels_per_point}"
+        );
+        debug_assert!(
+            0.0 < px_scale_factor && px_scale_factor.is_finite(),
+            "Bad px_scale_factor: {px_scale_factor}"
+        );
+        Self(crate::util::hash((
+            face_key,
+            glyph_id,
+            pixels_per_point.to_bits(),
+            px_scale_factor.to_bits(),
+            bin,
+            location_hash,
+        )))
+    }
+}
+
+/// Hash of `(cluster, family, pixels_per_point, font_size)`,
+/// so that cache lookups do not allocate.
+#[derive(Hash, PartialEq, Eq)]
+struct RasterGlyphKey(u64);
+
+impl nohash_hasher::IsEnabled for RasterGlyphKey {}
+
+impl RasterGlyphKey {
+    fn new(cluster: &str, family: &FontFamily, pixels_per_point: f32, font_size: f32) -> Self {
+        Self(crate::util::hash((
+            cluster,
+            family,
+            pixels_per_point.to_bits(),
+            font_size.to_bits(),
+        )))
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+/// The font atlas, plus every cache that points into it.
+///
+/// Cleared as a unit when the atlas is getting full.
+/// Knows nothing about families or fallback chains.
+pub(crate) struct GlyphAtlas {
+    atlas: TextureAtlas,
+
+    /// Glyphs rendered from font outlines.
+    outline_glyphs: nohash_hasher::IntMap<OutlineGlyphKey, GlyphAllocation>,
+
+    /// Glyphs from the [`GlyphRasterizer`].
+    ///
+    /// `None` means the rasterizer could not handle the cluster.
+    raster_glyphs: nohash_hasher::IntMap<RasterGlyphKey, Option<RasterGlyphAllocation>>,
+}
+
+impl GlyphAtlas {
+    pub fn new(options: TextOptions) -> Self {
+        let texture_width = options.max_texture_side.at_most(16 * 1024);
+        let initial_height = 32; // Keep initial font atlas small, so it is fast to upload to GPU. This will expand as needed anyways.
+        Self {
+            atlas: TextureAtlas::new([texture_width, initial_height], options),
+            outline_glyphs: Default::default(),
+            raster_glyphs: Default::default(),
+        }
+    }
+
+    #[inline]
+    pub fn options(&self) -> &TextOptions {
+        self.atlas.options()
+    }
+
+    #[inline]
+    pub fn atlas(&self) -> &TextureAtlas {
+        &self.atlas
+    }
+
+    #[inline]
+    pub fn take_delta(&mut self) -> Option<ImageDelta> {
+        self.atlas.take_delta()
+    }
+
+    /// How full is the atlas?
+    #[inline]
+    pub fn fill_ratio(&self) -> f32 {
+        self.atlas.fill_ratio()
+    }
+
+    /// Forget every glyph and start over with an empty atlas.
+    ///
+    /// Anything holding a [`UvRect`] into the old atlas (e.g. a cached galley) is now stale.
+    pub fn clear(&mut self) {
+        *self = Self::new(*self.atlas.options());
+    }
+
+    /// Forget what the [`GlyphRasterizer`] produced, e.g. because it was replaced.
+    pub fn clear_raster_glyphs(&mut self) {
+        self.raster_glyphs.clear();
+    }
+
+    /// Get or render the glyph of `face` for `shaped`.
+    ///
+    /// Returns the allocation and the rounded horizontal position (in physical pixels).
+    pub fn allocate_outline(
+        &mut self,
+        face_key: FontFaceKey,
+        face: &mut FontFace,
+        metrics: &StyledMetrics,
+        shaped: &ShapedGlyph,
+    ) -> (GlyphAllocation, i32) {
+        let ShapedGlyph {
+            glyph_id,
+            h_pos,
+            is_cjk,
+        } = *shaped;
+
+        if glyph_id == GlyphId::NOTDEF {
+            // invisible
+            return (GlyphAllocation::default(), h_pos.round() as i32);
+        }
+
+        let (h_pos_round, bin) = if face.subpixel_binning() && !is_cjk {
+            SubpixelBin::new(h_pos)
+        } else {
+            // CJK scripts contain a lot of characters and could hog the glyph atlas
+            // if we stored 4 subpixel offsets per glyph.
+            (h_pos.round() as i32, SubpixelBin::Zero)
+        };
+
+        let key = OutlineGlyphKey::new(face_key, glyph_id, metrics, bin);
+
+        let Self {
+            atlas,
+            outline_glyphs,
+            ..
+        } = self;
+        let alloc = *outline_glyphs.entry(key).or_insert_with(|| {
+            face.rasterize_outline(metrics, glyph_id, bin)
+                .and_then(|bitmap| {
+                    let transfer = atlas.options().color_transfer_function;
+                    Self::allocate_bitmap(atlas, &bitmap, metrics.pixels_per_point, transfer)
+                })
+                .map(|mut uv_rect| {
+                    uv_rect.offset.y += metrics.y_offset_in_points;
+                    GlyphAllocation { uv_rect }
+                })
+                .unwrap_or_default()
+        });
+
+        (alloc, h_pos_round)
+    }
+
+    /// Get or rasterize `cluster` using the platform [`GlyphRasterizer`].
+    ///
+    /// Failures are cached too, so the (potentially slow) rasterizer
+    /// is asked at most once per cluster and size.
+    pub fn allocate_raster(
+        &mut self,
+        rasterizer: &GlyphRasterizer,
+        cluster: &str,
+        family: &FontFamily,
+        pixels_per_point: f32,
+        font_size: f32,
+    ) -> Option<RasterGlyphAllocation> {
+        let key = RasterGlyphKey::new(cluster, family, pixels_per_point, font_size);
+        if let Some(allocation) = self.raster_glyphs.get(&key) {
+            return *allocation;
+        }
+        let request = GlyphRasterizerRequest {
+            cluster,
+            family,
+            font_size_px: font_size * pixels_per_point,
+            subpixel_offset_px: 0.0,
+        };
+        let allocation = (rasterizer.rasterize)(&request).and_then(|glyph| {
+            // The transfer function assumes white coverage glyphs and discards color,
+            // so color glyphs (e.g. emoji) must skip it.
+            let transfer = if glyph.is_color {
+                FontColorTransferFunction::Off
+            } else {
+                self.atlas.options().color_transfer_function
+            };
+            let bitmap = GlyphBitmap {
+                image: glyph.image,
+                offset_px: glyph.offset_px,
+            };
+            let uv_rect =
+                Self::allocate_bitmap(&mut self.atlas, &bitmap, pixels_per_point, transfer)?;
+            Some(RasterGlyphAllocation {
+                allocation: GlyphAllocation { uv_rect },
+                advance_px: glyph.advance_px,
+                is_color: glyph.is_color,
+            })
+        });
+        self.raster_glyphs.insert(key, allocation);
+        allocation
+    }
+
+    /// Copy a bitmap into the atlas.
+    ///
+    /// Returns `None` for empty and oversized bitmaps.
+    fn allocate_bitmap(
+        atlas: &mut TextureAtlas,
+        bitmap: &GlyphBitmap,
+        pixels_per_point: f32,
+        transfer: FontColorTransferFunction,
+    ) -> Option<UvRect> {
+        let [width, height] = bitmap.image.size;
+        if width == 0 || height == 0 || MAX_GLYPH_SIZE < width || MAX_GLYPH_SIZE < height {
+            return None;
+        }
+        let (glyph_pos, image) = atlas.allocate((width, height));
+        for y in 0..height {
+            for x in 0..width {
+                image[(glyph_pos.0 + x, glyph_pos.1 + y)] =
+                    transfer.to_atlas_color(bitmap.image[(x, y)]);
+            }
+        }
+        Some(UvRect {
+            offset: bitmap.offset_px / pixels_per_point,
+            size: vec2(width as f32, height as f32) / pixels_per_point,
+            min: [glyph_pos.0 as u16, glyph_pos.1 as u16],
+            max: [(glyph_pos.0 + width) as u16, (glyph_pos.1 + height) as u16],
+        })
+    }
+}

--- a/crates/epaint/src/text/glyph_atlas.rs
+++ b/crates/epaint/src/text/glyph_atlas.rs
@@ -35,6 +35,9 @@ impl UvRect {
     }
 }
 
+/// Where a glyph is in the font atlas.
+///
+/// The default value is the invisible, zero-size glyph.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct GlyphAllocation {
     /// UV rectangle for drawing.

--- a/crates/epaint/src/text/mod.rs
+++ b/crates/epaint/src/text/mod.rs
@@ -8,6 +8,7 @@ mod font_id;
 mod font_tweak;
 mod fonts;
 mod galley_cache;
+mod glyph_atlas;
 mod glyph_rasterizer;
 mod index;
 mod styled_metrics;

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -21,7 +21,7 @@ use super::{
     ByteRangeExt as _, FontsImpl, Galley, Glyph, GlyphSource, LayoutJob, LayoutSection, PlacedRow,
     Row, RowVisuals, VariationCoords,
     font::{Font, FontFace, ShapedGlyph},
-    glyph_atlas::RasterGlyphAllocation,
+    glyph_atlas::{OutlineGlyph, RasterGlyphAllocation},
 };
 
 // ----------------------------------------------------------------------------
@@ -274,7 +274,7 @@ fn layout_shaped_run(
         // Tab is a layout concept, not a glyph — the shaper doesn't know about tab stops.
         // Override the advance width using the font's configured tab size.
         if chr == '\t' {
-            let tweak = font.fonts_by_id.get(&run.font_key).map(|ff| ff.tweak());
+            let tweak = font.fonts_by_id.get(&run.font_key).map(|face| face.tweak());
             let tab_size = tweak.map_or(4.0, |t| t.tab_size);
             let (_, space_info) = font.glyph_info(' ', face_metrics);
             let space_width_px = space_info.advance_width_unscaled.0 * px_scale;
@@ -284,7 +284,7 @@ fn layout_shaped_run(
         // Thin space (U+2009) and narrow no-break space (U+202F):
         // override the shaper's advance width with the configured fraction of a space.
         if chr == '\u{2009}' || chr == '\u{202F}' {
-            let tweak = font.fonts_by_id.get(&run.font_key).map(|ff| ff.tweak());
+            let tweak = font.fonts_by_id.get(&run.font_key).map(|face| face.tweak());
             let thin_space_width = tweak.map_or(0.5, |t| t.thin_space_width);
             let (_, space_info) = font.glyph_info(' ', face_metrics);
             let space_width_px = space_info.advance_width_unscaled.0 * px_scale;
@@ -339,18 +339,22 @@ fn layout_shaped_run(
                 let fallback_metrics = font
                     .fonts_by_id
                     .get(&fallback_key)
-                    .map(|ff| {
-                        ff.styled_metrics(ctx.pixels_per_point, ctx.font_size, &Default::default())
+                    .map(|face| {
+                        face.styled_metrics(
+                            ctx.pixels_per_point,
+                            ctx.font_size,
+                            &Default::default(),
+                        )
                     })
                     .unwrap_or_default();
                 let (_, glyph_info) = font.glyph_info(chr, &fallback_metrics);
                 let advance_width_px =
                     glyph_info.advance_width_unscaled.0 * fallback_metrics.px_scale_factor;
-                let (glyph_alloc, physical_x) =
-                    if let Some(ff) = font.fonts_by_id.get_mut(&fallback_key) {
+                let OutlineGlyph { allocation, x_px } =
+                    if let Some(face) = font.fonts_by_id.get_mut(&fallback_key) {
                         font.glyphs.allocate_outline(
                             fallback_key,
-                            ff,
+                            face,
                             &fallback_metrics,
                             &ShapedGlyph {
                                 glyph_id: glyph_info.id.unwrap_or(skrifa::GlyphId::NOTDEF),
@@ -366,28 +370,30 @@ fn layout_shaped_run(
 
                 ctx.glyph(
                     chr,
-                    physical_x,
+                    x_px,
                     advance_width_px,
                     &fallback_metrics,
-                    glyph_alloc.uv_rect,
+                    allocation.uv_rect,
                 )
             }
         } else {
-            let (mut glyph_alloc, physical_x) =
-                if let Some(ff) = font.fonts_by_id.get_mut(&run.font_key) {
-                    font.glyphs.allocate_outline(
-                        run.font_key,
-                        ff,
-                        face_metrics,
-                        &ShapedGlyph {
-                            glyph_id,
-                            h_pos: paragraph.cursor_x_px + x_offset_px,
-                            is_cjk: is_cjk(chr),
-                        },
-                    )
-                } else {
-                    Default::default()
-                };
+            let OutlineGlyph {
+                allocation: mut glyph_alloc,
+                x_px,
+            } = if let Some(face) = font.fonts_by_id.get_mut(&run.font_key) {
+                font.glyphs.allocate_outline(
+                    run.font_key,
+                    face,
+                    face_metrics,
+                    &ShapedGlyph {
+                        glyph_id,
+                        h_pos: paragraph.cursor_x_px + x_offset_px,
+                        is_cjk: is_cjk(chr),
+                    },
+                )
+            } else {
+                Default::default()
+            };
 
             // Apply shaper y_offset — this varies per glyph instance so it
             // is not part of the cached ShapedGlyph / GlyphAllocation.
@@ -397,7 +403,7 @@ fn layout_shaped_run(
 
             ctx.glyph(
                 chr,
-                physical_x,
+                x_px,
                 advance_width_px,
                 face_metrics,
                 glyph_alloc.uv_rect,
@@ -913,7 +919,7 @@ fn replace_last_glyph_with_overflow_character(
         let font_face_metrics = font
             .fonts_by_id
             .get(&font_id)
-            .map(|f| f.styled_metrics(pixels_per_point, font_size, &section.format.coords))
+            .map(|face| face.styled_metrics(pixels_per_point, font_size, &section.format.coords))
             .unwrap_or_default();
         let (_, glyph_info) = font.glyph_info(overflow_character, &font_face_metrics);
         let mut font_face = font.fonts_by_id.get_mut(&font_id);
@@ -934,12 +940,15 @@ fn replace_last_glyph_with_overflow_character(
         {
             // we are done
 
-            let (replacement_glyph_alloc, physical_x) = font_face
+            let OutlineGlyph {
+                allocation: replacement_glyph_alloc,
+                x_px,
+            } = font_face
                 .as_mut()
-                .map(|f| {
+                .map(|face| {
                     font.glyphs.allocate_outline(
                         font_id,
-                        f,
+                        face,
                         &font_face_metrics,
                         &ShapedGlyph {
                             glyph_id: glyph_info.id.unwrap_or(skrifa::GlyphId::NOTDEF),
@@ -959,7 +968,7 @@ fn replace_last_glyph_with_overflow_character(
 
             row.glyphs.push(Glyph {
                 chr: overflow_character,
-                pos: pos2(physical_x as f32 / pixels_per_point, f32::NAN),
+                pos: pos2(x_px as f32 / pixels_per_point, f32::NAN),
                 advance_width: advance_width_px / pixels_per_point,
                 line_height,
                 font_face_height: font_face_metrics.row_height,

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -10,8 +10,8 @@ use crate::{
     stroke::PathStroke,
     text::{
         ByteIndex, ByteRange,
-        font::UvRect,
         fonts::FontFaceKey,
+        glyph_atlas::UvRect,
         styled_metrics::StyledMetrics,
         unicode::{is_cjk, is_cjk_break_allowed},
     },
@@ -20,7 +20,8 @@ use crate::{
 use super::{
     ByteRangeExt as _, FontsImpl, Galley, Glyph, GlyphSource, LayoutJob, LayoutSection, PlacedRow,
     Row, RowVisuals, VariationCoords,
-    font::{Font, FontFace, RasterGlyphAllocation, ShapedGlyph},
+    font::{Font, FontFace, ShapedGlyph},
+    glyph_atlas::RasterGlyphAllocation,
 };
 
 // ----------------------------------------------------------------------------
@@ -347,8 +348,9 @@ fn layout_shaped_run(
                     glyph_info.advance_width_unscaled.0 * fallback_metrics.px_scale_factor;
                 let (glyph_alloc, physical_x) =
                     if let Some(ff) = font.fonts_by_id.get_mut(&fallback_key) {
-                        ff.allocate_glyph(
-                            font.atlas,
+                        font.glyphs.allocate_outline(
+                            fallback_key,
+                            ff,
                             &fallback_metrics,
                             &ShapedGlyph {
                                 glyph_id: glyph_info.id.unwrap_or(skrifa::GlyphId::NOTDEF),
@@ -373,8 +375,9 @@ fn layout_shaped_run(
         } else {
             let (mut glyph_alloc, physical_x) =
                 if let Some(ff) = font.fonts_by_id.get_mut(&run.font_key) {
-                    ff.allocate_glyph(
-                        font.atlas,
+                    font.glyphs.allocate_outline(
+                        run.font_key,
+                        ff,
                         face_metrics,
                         &ShapedGlyph {
                             glyph_id,
@@ -934,8 +937,9 @@ fn replace_last_glyph_with_overflow_character(
             let (replacement_glyph_alloc, physical_x) = font_face
                 .as_mut()
                 .map(|f| {
-                    f.allocate_glyph(
-                        font.atlas,
+                    font.glyphs.allocate_outline(
+                        font_id,
+                        f,
                         &font_face_metrics,
                         &ShapedGlyph {
                             glyph_id: glyph_info.id.unwrap_or(skrifa::GlyphId::NOTDEF),

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use super::{
     cursor::{CCursor, LayoutCursor},
-    font::UvRect,
+    glyph_atlas::UvRect,
     index::{ByteIndex, ByteRange, ByteRangeExt as _, CharIndex},
 };
 use crate::{Color32, FontId, Mesh, Stroke, text::FontsView};


### PR DESCRIPTION
`GlyphAtlas` owns the `TextureAtlas` plus every cache that points into it (outline glyphs keyed by face, and platform-rasterized glyphs). `FontFace` no longer knows about the atlas: it just renders an outline to a bitmap.

When the atlas gets full, `Fonts::begin_pass` now clears the bitmaps instead of reparsing and re-hinting every font face. That also removes the duplicated `glyph_rasterizer` field on `Fonts`, which only existed to survive the rebuild. Fonts found by font providers (#8491) will survive an atlas clear the same way.

* [x] I have followed the instructions in the PR template

PR chain, in order:
* #8490
* #8500
* #8501
* #8502
* #8503
* #8504
* #8491
* #8492
* #8493
* #8508