### PR TITLE
Add `FaceStore`: one place that parses and stores font faces

### DIFF
--- a/crates/epaint/src/text/face_store.rs
+++ b/crates/epaint/src/text/face_store.rs
@@ -1,0 +1,90 @@
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use nohash_hasher::IntMap;
+
+use crate::text::{FontData, FontDefinitions, TextOptions, font::FontFace};
+
+/// Unique ID for looking up a single font face/file.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct FontFaceKey(u64);
+
+impl FontFaceKey {
+    pub const INVALID: Self = Self(0);
+
+    fn new() -> Self {
+        static KEY_COUNTER: AtomicUsize = AtomicUsize::new(1);
+        Self(crate::util::hash(
+            KEY_COUNTER.fetch_add(1, Ordering::Relaxed),
+        ))
+    }
+}
+
+// Safe, because we hash the value in the constructor.
+impl nohash_hasher::IsEnabled for FontFaceKey {}
+
+// ----------------------------------------------------------------------------
+
+/// Every parsed [`FontFace`], by key and by name.
+///
+/// This is the one place fonts get parsed, whether they come from
+/// [`FontDefinitions`] or are found later (e.g. by a font provider).
+pub(crate) struct FaceStore {
+    options: TextOptions,
+    by_key: IntMap<FontFaceKey, FontFace>,
+    by_name: ahash::HashMap<String, FontFaceKey>,
+}
+
+impl FaceStore {
+    /// Parse every font in the definitions.
+    ///
+    /// Panics if a font fails to parse.
+    pub fn new(options: TextOptions, definitions: &FontDefinitions) -> Self {
+        let mut slf = Self {
+            options,
+            by_key: Default::default(),
+            by_name: Default::default(),
+        };
+        for (name, font_data) in &definitions.font_data {
+            slf.install(name, font_data)
+                .unwrap_or_else(|err| panic!("Error parsing {name:?} TTF/OTF font file: {err}"));
+        }
+        slf
+    }
+
+    /// Parse a font and add it, unless a font with the same name is already installed.
+    pub fn install(
+        &mut self,
+        name: &str,
+        font_data: &FontData,
+    ) -> Result<FontFaceKey, Box<dyn core::error::Error>> {
+        if let Some(key) = self.by_name.get(name) {
+            return Ok(*key);
+        }
+        let font_face = FontFace::new(
+            self.options,
+            name.to_owned(),
+            font_data.blob(),
+            font_data.index,
+            font_data.tweak.clone(),
+        )?;
+        let key = FontFaceKey::new();
+        self.by_key.insert(key, font_face);
+        self.by_name.insert(name.to_owned(), key);
+        Ok(key)
+    }
+
+    #[inline]
+    pub fn key_by_name(&self, name: &str) -> Option<FontFaceKey> {
+        self.by_name.get(name).copied()
+    }
+
+    #[inline]
+    pub fn get(&self, key: FontFaceKey) -> Option<&FontFace> {
+        self.by_key.get(&key)
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self, key: FontFaceKey) -> Option<&mut FontFace> {
+        self.by_key.get_mut(&key)
+    }
+}

--- a/crates/epaint/src/text/face_store.rs
+++ b/crates/epaint/src/text/face_store.rs
@@ -87,4 +87,9 @@ impl FaceStore {
     pub fn get_mut(&mut self, key: FontFaceKey) -> Option<&mut FontFace> {
         self.by_key.get_mut(&key)
     }
+
+    /// All installed faces, in no particular order.
+    pub fn iter(&self) -> impl Iterator<Item = (FontFaceKey, &FontFace)> {
+        self.by_key.iter().map(|(key, face)| (*key, face))
+    }
 }

--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -302,6 +302,11 @@ impl FontFace {
         )
     }
 
+    #[inline]
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
     /// An un-ordered iterator over all supported characters.
     fn characters(&self) -> impl Iterator<Item = char> + '_ {
         self.font

--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -3,7 +3,6 @@
 use ahash::HashMap;
 use ecolor::Color32;
 use emath::{GuiRounding as _, OrderedFloat, vec2};
-use nohash_hasher::IntMap;
 use self_cell::self_cell;
 use skrifa::{GlyphId, MetadataProvider as _};
 use std::collections::BTreeMap;
@@ -13,8 +12,9 @@ use crate::{
     ColorImage, TextOptions,
     text::{
         FontTweak, GlyphSourcePreference, VariationCoords,
+        face_store::{FaceStore, FontFaceKey},
         font_data::Blob,
-        fonts::{CachedFamily, FontFaceKey},
+        fonts::CachedFamily,
         glyph_atlas::{GlyphAtlas, GlyphBitmap, RasterGlyphAllocation, SubpixelBin},
         styled_metrics::{LocationHash, StyledMetrics},
         unicode::invisible_char,
@@ -481,7 +481,7 @@ pub(crate) struct ShapedGlyph {
 // TODO(emilk): rename?
 /// Wrapper over multiple [`FontFace`] (e.g. a primary + fallbacks for emojis)
 pub struct Font<'a> {
-    pub(super) fonts_by_id: &'a mut IntMap<FontFaceKey, FontFace>,
+    pub(super) faces: &'a mut FaceStore,
     pub(super) cached_family: &'a mut CachedFamily,
     pub(super) glyphs: &'a mut GlyphAtlas,
     pub(super) family: crate::text::FontFamily,
@@ -520,7 +520,7 @@ impl Font<'_> {
         self.cached_family.characters.get_or_insert_with(|| {
             let mut characters: BTreeMap<char, Vec<String>> = Default::default();
             for font_id in &self.cached_family.fonts {
-                let font = self.fonts_by_id.get(font_id).expect("Nonexistent font ID");
+                let font = self.faces.get(*font_id).expect("Nonexistent font ID");
                 for chr in font.characters() {
                     characters.entry(chr).or_default().push(font.name.clone());
                 }
@@ -538,7 +538,7 @@ impl Font<'_> {
         self.cached_family
             .fonts
             .first()
-            .and_then(|key| self.fonts_by_id.get(key))
+            .and_then(|key| self.faces.get(*key))
             .map(|font_face| font_face.styled_metrics(pixels_per_point, font_size, coords))
             .unwrap_or_default()
     }
@@ -546,7 +546,7 @@ impl Font<'_> {
     /// Width of this character in points, at the font's default variation location.
     pub fn glyph_width(&mut self, c: char, font_size: f32) -> f32 {
         let face_key = self.resolve_face(c);
-        let Some(font_face) = self.fonts_by_id.get_mut(&face_key) else {
+        let Some(font_face) = self.faces.get_mut(face_key) else {
             return 0.0;
         };
         let metrics = font_face.styled_metrics(1.0, font_size, &VariationCoords::default());
@@ -588,7 +588,7 @@ impl Font<'_> {
     fn resolve_face_slow(&mut self, c: char) -> FontFaceKey {
         let font_key = self
             .cached_family
-            .find_face_for_char(c, self.fonts_by_id)
+            .find_face_for_char(c, self.faces)
             .unwrap_or(self.cached_family.replacement_face_key);
         self.cached_family.face_cache.insert(c, font_key);
         font_key
@@ -609,7 +609,7 @@ impl Font<'_> {
         metrics: &StyledMetrics,
     ) -> (FontFaceKey, GlyphInfo) {
         let face_key = self.resolve_face(c);
-        let Some(face) = self.fonts_by_id.get_mut(&face_key) else {
+        let Some(face) = self.faces.get_mut(face_key) else {
             return (face_key, GlyphInfo::INVISIBLE);
         };
         let glyph_info = face.glyph_info(c, metrics).unwrap_or_else(|| {

--- a/crates/epaint/src/text/font_data.rs
+++ b/crates/epaint/src/text/font_data.rs
@@ -103,9 +103,12 @@ impl AsRef<[u8]> for FontData {
 /// Shared, immutable bytes of a font file.
 pub type Blob = Arc<dyn AsRef<[u8]> + Send + Sync>;
 
-pub(super) fn blob_from_font_data(data: &FontData) -> Blob {
-    match data.clone().font {
-        Cow::Borrowed(bytes) => Arc::new(bytes) as Blob,
-        Cow::Owned(bytes) => Arc::new(bytes) as Blob,
+impl FontData {
+    /// The font file bytes as a shared blob.
+    pub(crate) fn blob(&self) -> Blob {
+        match self.font.clone() {
+            Cow::Borrowed(bytes) => Arc::new(bytes) as Blob,
+            Cow::Owned(bytes) => Arc::new(bytes) as Blob,
+        }
     }
 }

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -1,15 +1,12 @@
-use core::sync::atomic::{AtomicUsize, Ordering};
 use std::{collections::BTreeMap, sync::Arc};
-
-use nohash_hasher::IntMap;
 
 use crate::{
     Color32, TextureAtlas,
     text::{
         FontDefinitions, FontFamily, FontId, Galley, GlyphRasterizer, GlyphSource,
         GlyphSourcePreference, LayoutJob, TextOptions, VariationCoords,
-        font::{Font, FontFace},
-        font_data::blob_from_font_data,
+        face_store::{FaceStore, FontFaceKey},
+        font::Font,
         galley_cache::GalleyCache,
         glyph_atlas::GlyphAtlas,
         glyph_rasterizer::default_glyph_source,
@@ -24,24 +21,6 @@ use crate::{
 pub const MAX_GLYPH_SIZE: usize = 1024;
 
 // ----------------------------------------------------------------------------
-
-/// Unique ID for looking up a single font face/file.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub(crate) struct FontFaceKey(u64);
-
-impl FontFaceKey {
-    pub const INVALID: Self = Self(0);
-
-    fn new() -> Self {
-        static KEY_COUNTER: AtomicUsize = AtomicUsize::new(1);
-        Self(crate::util::hash(
-            KEY_COUNTER.fetch_add(1, Ordering::Relaxed),
-        ))
-    }
-}
-
-// Safe, because we hash the value in the constructor.
-impl nohash_hasher::IsEnabled for FontFaceKey {}
 
 /// Cached data for working with a font family (e.g. doing character lookups).
 #[derive(Debug)]
@@ -68,7 +47,7 @@ pub(super) struct CachedFamily {
 }
 
 impl CachedFamily {
-    fn new(fonts: Vec<FontFaceKey>, fonts_by_id: &mut IntMap<FontFaceKey, FontFace>) -> Self {
+    fn new(fonts: Vec<FontFaceKey>, faces: &mut FaceStore) -> Self {
         const PRIMARY_REPLACEMENT_CHAR: char = '◻'; // white medium square
         const FALLBACK_REPLACEMENT_CHAR: char = '?'; // fallback for the fallback
 
@@ -91,10 +70,10 @@ impl CachedFamily {
         };
 
         let (replacement_face_key, replacement_char) = slf
-            .find_face_for_char(PRIMARY_REPLACEMENT_CHAR, fonts_by_id)
+            .find_face_for_char(PRIMARY_REPLACEMENT_CHAR, faces)
             .map(|key| (key, PRIMARY_REPLACEMENT_CHAR))
             .or_else(|| {
-                slf.find_face_for_char(FALLBACK_REPLACEMENT_CHAR, fonts_by_id)
+                slf.find_face_for_char(FALLBACK_REPLACEMENT_CHAR, faces)
                     .map(|key| (key, FALLBACK_REPLACEMENT_CHAR))
             })
             .unwrap_or_else(|| {
@@ -113,13 +92,9 @@ impl CachedFamily {
     ///
     /// Pure — does not touch any cache. Callers that want memoisation should
     /// insert into [`Self::face_cache`] themselves.
-    pub(crate) fn find_face_for_char(
-        &self,
-        c: char,
-        fonts_by_id: &mut IntMap<FontFaceKey, FontFace>,
-    ) -> Option<FontFaceKey> {
+    pub(crate) fn find_face_for_char(&self, c: char, faces: &mut FaceStore) -> Option<FontFaceKey> {
         for font_key in &self.fonts {
-            let font_face = fonts_by_id.get_mut(font_key).expect("Nonexistent font ID");
+            let font_face = faces.get_mut(*font_key).expect("Nonexistent font ID");
             if font_face.glyph_id_resolution(c).is_some() {
                 return Some(*font_key);
             }
@@ -435,8 +410,7 @@ impl FontsView<'_> {
 pub struct FontsImpl {
     definitions: FontDefinitions,
     glyphs: GlyphAtlas,
-    fonts_by_id: IntMap<FontFaceKey, FontFace>,
-    fonts_by_name: ahash::HashMap<String, FontFaceKey>,
+    faces: FaceStore,
     family_cache: ahash::HashMap<FontFamily, CachedFamily>,
 
     /// Recycled `harfrust` shaping buffer to avoid per-layout allocations.
@@ -449,28 +423,12 @@ impl FontsImpl {
     /// Create a new [`FontsImpl`] for text layout.
     /// This call is expensive, so only create one [`FontsImpl`] and then reuse it.
     pub fn new(options: TextOptions, definitions: FontDefinitions) -> Self {
-        let mut fonts_by_id: IntMap<FontFaceKey, FontFace> = Default::default();
-        let mut fonts_by_name: ahash::HashMap<String, FontFaceKey> = Default::default();
-        for (name, font_data) in &definitions.font_data {
-            let blob = blob_from_font_data(font_data);
-            let font_face = FontFace::new(
-                options,
-                name.clone(),
-                blob,
-                font_data.index,
-                font_data.tweak.clone(),
-            )
-            .unwrap_or_else(|err| panic!("Error parsing {name:?} TTF/OTF font file: {err}"));
-            let key = FontFaceKey::new();
-            fonts_by_id.insert(key, font_face);
-            fonts_by_name.insert(name.clone(), key);
-        }
+        let faces = FaceStore::new(options, &definitions);
 
         Self {
             definitions,
             glyphs: GlyphAtlas::new(options),
-            fonts_by_id,
-            fonts_by_name,
+            faces,
             family_cache: Default::default(),
             shape_buffer: Some(harfrust::UnicodeBuffer::new()),
             glyph_rasterizer: None,
@@ -531,17 +489,16 @@ impl FontsImpl {
             let fonts: Vec<FontFaceKey> = fonts
                 .iter()
                 .map(|font_name| {
-                    *self
-                        .fonts_by_name
-                        .get(font_name)
+                    self.faces
+                        .key_by_name(font_name)
                         .unwrap_or_else(|| panic!("No font data found for {font_name:?}"))
                 })
                 .collect();
 
-            CachedFamily::new(fonts, &mut self.fonts_by_id)
+            CachedFamily::new(fonts, &mut self.faces)
         });
         Font {
-            fonts_by_id: &mut self.fonts_by_id,
+            faces: &mut self.faces,
             cached_family,
             glyphs: &mut self.glyphs,
             family: family.clone(),

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -489,9 +489,13 @@ impl FontsImpl {
             let fonts: Vec<FontFaceKey> = fonts
                 .iter()
                 .map(|font_name| {
-                    self.faces
-                        .key_by_name(font_name)
-                        .unwrap_or_else(|| panic!("No font data found for {font_name:?}"))
+                    self.faces.key_by_name(font_name).unwrap_or_else(|| {
+                        let available: Vec<&str> =
+                            self.faces.iter().map(|(_, face)| face.name()).collect();
+                        panic!(
+                            "No font data found for {font_name:?}. Installed fonts: {available:?}"
+                        )
+                    })
                 })
                 .collect();
 

--- a/crates/epaint/src/text/glyph_atlas.rs
+++ b/crates/epaint/src/text/glyph_atlas.rs
@@ -6,8 +6,8 @@ use crate::{
     ColorImage, FontColorTransferFunction, ImageDelta, TextOptions, TextureAtlas,
     text::{
         FontFamily, GlyphRasterizer, GlyphRasterizerRequest, MAX_GLYPH_SIZE,
+        face_store::FontFaceKey,
         font::{FontFace, ShapedGlyph},
-        fonts::FontFaceKey,
         styled_metrics::StyledMetrics,
     },
 };

--- a/crates/epaint/src/text/mod.rs
+++ b/crates/epaint/src/text/mod.rs
@@ -1,6 +1,7 @@
 //! Everything related to text, fonts, text layout, cursors etc.
 
 pub mod cursor;
+mod face_store;
 mod font;
 mod font_data;
 mod font_definitions;

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -10,7 +10,7 @@ use crate::{
     stroke::PathStroke,
     text::{
         ByteIndex, ByteRange,
-        fonts::FontFaceKey,
+        face_store::FontFaceKey,
         glyph_atlas::UvRect,
         styled_metrics::StyledMetrics,
         unicode::{is_cjk, is_cjk_break_allowed},
@@ -274,7 +274,7 @@ fn layout_shaped_run(
         // Tab is a layout concept, not a glyph — the shaper doesn't know about tab stops.
         // Override the advance width using the font's configured tab size.
         if chr == '\t' {
-            let tweak = font.fonts_by_id.get(&run.font_key).map(|face| face.tweak());
+            let tweak = font.faces.get(run.font_key).map(|face| face.tweak());
             let tab_size = tweak.map_or(4.0, |t| t.tab_size);
             let (_, space_info) = font.glyph_info(' ', face_metrics);
             let space_width_px = space_info.advance_width_unscaled.0 * px_scale;
@@ -284,7 +284,7 @@ fn layout_shaped_run(
         // Thin space (U+2009) and narrow no-break space (U+202F):
         // override the shaper's advance width with the configured fraction of a space.
         if chr == '\u{2009}' || chr == '\u{202F}' {
-            let tweak = font.fonts_by_id.get(&run.font_key).map(|face| face.tweak());
+            let tweak = font.faces.get(run.font_key).map(|face| face.tweak());
             let thin_space_width = tweak.map_or(0.5, |t| t.thin_space_width);
             let (_, space_info) = font.glyph_info(' ', face_metrics);
             let space_width_px = space_info.advance_width_unscaled.0 * px_scale;
@@ -337,8 +337,8 @@ fn layout_shaped_run(
                 // Use the fallback font face (not run.font_key which returned NOTDEF).
                 let fallback_key = font.resolve_face(chr);
                 let fallback_metrics = font
-                    .fonts_by_id
-                    .get(&fallback_key)
+                    .faces
+                    .get(fallback_key)
                     .map(|face| {
                         face.styled_metrics(
                             ctx.pixels_per_point,
@@ -351,7 +351,7 @@ fn layout_shaped_run(
                 let advance_width_px =
                     glyph_info.advance_width_unscaled.0 * fallback_metrics.px_scale_factor;
                 let OutlineGlyph { allocation, x_px } =
-                    if let Some(face) = font.fonts_by_id.get_mut(&fallback_key) {
+                    if let Some(face) = font.faces.get_mut(fallback_key) {
                         font.glyphs.allocate_outline(
                             fallback_key,
                             face,
@@ -380,7 +380,7 @@ fn layout_shaped_run(
             let OutlineGlyph {
                 allocation: mut glyph_alloc,
                 x_px,
-            } = if let Some(face) = font.fonts_by_id.get_mut(&run.font_key) {
+            } = if let Some(face) = font.faces.get_mut(run.font_key) {
                 font.glyphs.allocate_outline(
                     run.font_key,
                     face,
@@ -462,7 +462,7 @@ fn layout_raster_run(
 ) -> harfrust::UnicodeBuffer {
     use unicode_segmentation::UnicodeSegmentation as _;
 
-    let Some(font_face) = font.fonts_by_id.get(&run.font_key) else {
+    let Some(font_face) = font.faces.get(run.font_key) else {
         return shape_buffer;
     };
     let face_metrics = &font_face.styled_metrics(ctx.pixels_per_point, ctx.font_size, coords);
@@ -475,7 +475,7 @@ fn layout_raster_run(
         let Some(raster) = font.rasterize_glyph(cluster, ctx.pixels_per_point, ctx.font_size)
         else {
             // Shape this one cluster with the font instead.
-            let Some(font_face) = font.fonts_by_id.get(&run.font_key) else {
+            let Some(font_face) = font.faces.get(run.font_key) else {
                 continue;
             };
             let glyph_buffer = shape_text(
@@ -610,7 +610,7 @@ fn layout_section(
         let num_runs = runs.len();
         for (run_idx, run) in runs.iter().enumerate() {
             let run_text = &segment[run.byte_range.as_usize()];
-            let Some(font_face) = font.fonts_by_id.get(&run.font_key) else {
+            let Some(font_face) = font.faces.get(run.font_key) else {
                 continue;
             };
 
@@ -917,12 +917,12 @@ fn replace_last_glyph_with_overflow_character(
 
         let font_id = font.resolve_face(overflow_character);
         let font_face_metrics = font
-            .fonts_by_id
-            .get(&font_id)
+            .faces
+            .get(font_id)
             .map(|face| face.styled_metrics(pixels_per_point, font_size, &section.format.coords))
             .unwrap_or_default();
         let (_, glyph_info) = font.glyph_info(overflow_character, &font_face_metrics);
-        let mut font_face = font.fonts_by_id.get_mut(&font_id);
+        let mut font_face = font.faces.get_mut(font_id);
 
         let overflow_glyph_x = if let Some(prev_glyph) = row.glyphs.last() {
             prev_glyph.max_x() + extra_letter_spacing


### PR DESCRIPTION
`FaceStore` wraps the old `fonts_by_id` and `fonts_by_name` maps and owns `FontFaceKey`. It has a single `install(name, &FontData)` so fonts from `FontDefinitions` and fonts found later by a font provider (#8491) go through the same code.

* [x] I have followed the instructions in the PR template

PR chain, in order:
* #8490
* #8500
* #8501
* #8502
* #8503
* #8504
* #8491
* #8492
* #8493
* #8508