### PR TITLE
Remove the `Font` borrow-bag; put its methods on `FontsImpl`

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1754,11 +1754,9 @@ impl Context {
 
         let font_id = TextStyle::Body.resolve(&self.global_style());
         self.fonts_mut(|f| {
-            let mut font = f.fonts.font(&font_id.family);
-            font.has_glyphs(alt)
-                && font.has_glyphs(ctrl)
-                && font.has_glyphs(shift)
-                && font.has_glyphs(mac_cmd)
+            [alt, ctrl, shift, mac_cmd]
+                .iter()
+                .all(|symbols| f.has_glyphs(&font_id, symbols))
         })
     }
 

--- a/crates/egui_demo_lib/benches/benchmark.rs
+++ b/crates/egui_demo_lib/benches/benchmark.rs
@@ -176,7 +176,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         {
             c.bench_function("text_layout_uncached", |b| {
                 b.iter(|| {
-                    use egui::epaint::text::{LayoutJob, layout};
+                    use egui::epaint::text::LayoutJob;
 
                     let job = LayoutJob::simple(
                         LOREM_IPSUM_LONG.to_owned(),
@@ -184,7 +184,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                         text_color,
                         wrap_width,
                     );
-                    layout(&mut fonts.fonts, pixels_per_point, job.into())
+                    fonts.layout_uncached(pixels_per_point, job.into())
                 });
             });
         }

--- a/crates/egui_demo_lib/src/demo/font_book.rs
+++ b/crates/egui_demo_lib/src/demo/font_book.rs
@@ -145,9 +145,7 @@ fn char_info_ui(ui: &mut egui::Ui, chr: char, glyph_info: &GlyphInfo, font_id: e
 
 fn available_characters(ui: &egui::Ui, family: &egui::FontFamily) -> BTreeMap<char, GlyphInfo> {
     ui.fonts_mut(|f| {
-        f.fonts
-            .font(family)
-            .characters()
+        f.characters(family)
             .iter()
             .filter(|(chr, _fonts)| !chr.is_whitespace() && !chr.is_ascii_control())
             .map(|(chr, fonts)| {

--- a/crates/epaint/src/text/face_store.rs
+++ b/crates/epaint/src/text/face_store.rs
@@ -2,7 +2,7 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 
 use nohash_hasher::IntMap;
 
-use crate::text::{FontData, FontDefinitions, TextOptions, font::FontFace};
+use crate::text::{FontData, FontDefinitions, TextOptions, font_face::FontFace};
 
 /// Unique ID for looking up a single font face/file.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/crates/epaint/src/text/family.rs
+++ b/crates/epaint/src/text/family.rs
@@ -5,6 +5,12 @@ use crate::text::{
     face_store::{FaceStore, FontFaceKey},
 };
 
+/// Index of a [`Family`] in `FontsImpl`.
+///
+/// Cheaper to pass around and look up than a [`FontFamily`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct FamilyKey(pub(crate) usize);
+
 /// The fallback chain of one [`FontFamily`], and the caches for resolving chars against it.
 ///
 /// This is the only place that decides which face renders a given char.

--- a/crates/epaint/src/text/font_face.rs
+++ b/crates/epaint/src/text/font_face.rs
@@ -462,7 +462,7 @@ impl FontFace {
 
     /// Render the outline of a glyph to a coverage bitmap.
     ///
-    /// Not cached: see [`GlyphAtlas::allocate_outline`].
+    /// Not cached: see [`crate::text::glyph_atlas::GlyphAtlas::allocate_outline`].
     pub(crate) fn rasterize_outline(
         &mut self,
         metrics: &StyledMetrics,

--- a/crates/epaint/src/text/font_face.rs
+++ b/crates/epaint/src/text/font_face.rs
@@ -5,17 +5,14 @@ use ecolor::Color32;
 use emath::{GuiRounding as _, OrderedFloat, vec2};
 use self_cell::self_cell;
 use skrifa::{GlyphId, MetadataProvider as _};
-use std::collections::BTreeMap;
 use vello_cpu::{color, kurbo};
 
 use crate::{
     ColorImage, TextOptions,
     text::{
-        FontTweak, GlyphSourcePreference, VariationCoords,
-        face_store::{FaceStore, FontFaceKey},
-        family::Family,
+        FontTweak, VariationCoords,
         font_data::Blob,
-        glyph_atlas::{GlyphAtlas, GlyphBitmap, RasterGlyphAllocation, SubpixelBin},
+        glyph_atlas::{GlyphBitmap, SubpixelBin},
         styled_metrics::{LocationHash, StyledMetrics},
         unicode::invisible_char,
     },
@@ -308,6 +305,12 @@ impl FontFace {
         &self.name
     }
 
+    /// Scale factor from the font's unscaled units to `scale` (points or pixels).
+    #[inline]
+    pub(crate) fn px_scale_factor(&self, scale: f32) -> f32 {
+        self.font.px_scale_factor(scale)
+    }
+
     /// An un-ordered iterator over all supported characters.
     pub fn characters(&self) -> impl Iterator<Item = char> + '_ {
         self.font
@@ -482,122 +485,4 @@ pub(crate) struct ShapedGlyph {
 
     /// CJK glyphs skip subpixel positioning to save atlas space.
     pub is_cjk: bool,
-}
-
-// TODO(emilk): rename?
-/// Wrapper over multiple [`FontFace`] (e.g. a primary + fallbacks for emojis)
-pub struct Font<'a> {
-    pub(super) faces: &'a mut FaceStore,
-    pub(super) family: &'a mut Family,
-    pub(super) glyphs: &'a mut GlyphAtlas,
-    pub(super) glyph_rasterizer: Option<&'a crate::text::GlyphRasterizer>,
-    pub(super) glyph_source_preference: &'a GlyphSourcePreference,
-}
-
-impl Font<'_> {
-    /// Rasterize a grapheme cluster using the platform [`crate::text::GlyphRasterizer`].
-    ///
-    /// Returns `None` if there is no rasterizer, or it could not handle the cluster.
-    pub(crate) fn rasterize_glyph(
-        &mut self,
-        cluster: &str,
-        pixels_per_point: f32,
-        font_size: f32,
-    ) -> Option<RasterGlyphAllocation> {
-        let rasterizer = self.glyph_rasterizer?;
-        self.glyphs.allocate_raster(
-            rasterizer,
-            cluster,
-            self.family.name(),
-            pixels_per_point,
-            font_size,
-        )
-    }
-
-    pub fn preload_characters(&mut self, s: &str) {
-        for c in s.chars() {
-            self.resolve_face(c);
-        }
-    }
-
-    /// All supported characters, and in which font they are available in.
-    pub fn characters(&mut self) -> &BTreeMap<char, Vec<String>> {
-        self.family.characters(self.faces)
-    }
-
-    pub fn styled_metrics(
-        &self,
-        pixels_per_point: f32,
-        font_size: f32,
-        coords: &VariationCoords,
-    ) -> StyledMetrics {
-        self.family
-            .primary()
-            .and_then(|key| self.faces.get(key))
-            .map(|font_face| font_face.styled_metrics(pixels_per_point, font_size, coords))
-            .unwrap_or_default()
-    }
-
-    /// Width of this character in points, at the font's default variation location.
-    pub fn glyph_width(&mut self, c: char, font_size: f32) -> f32 {
-        let face_key = self.resolve_face(c);
-        let Some(font_face) = self.faces.get_mut(face_key) else {
-            return 0.0;
-        };
-        let metrics = font_face.styled_metrics(1.0, font_size, &VariationCoords::default());
-        let Some(glyph_info) = font_face.glyph_info(c, &metrics) else {
-            return 0.0;
-        };
-        glyph_info.advance_width_unscaled.0 * font_face.font.px_scale_factor(font_size)
-    }
-
-    /// Do the installed fonts have this glyph?
-    ///
-    /// This does not consult the [`crate::text::GlyphRasterizer`], so it can return `false`
-    /// for a character that would still render via the rasterizer (e.g. the browser on web).
-    pub fn has_glyph(&mut self, c: char) -> bool {
-        // TODO(emilk): this is a false negative if the user asks about the replacement character itself 🤦‍♂️
-        self.resolve_face(c) != self.family.replacement_face_key()
-    }
-
-    /// Do the installed fonts have all the glyphs in this text?
-    ///
-    /// See [`Self::has_glyph`] for the caveat about the glyph rasterizer.
-    pub fn has_glyphs(&mut self, s: &str) -> bool {
-        s.chars().all(|c| self.has_glyph(c))
-    }
-
-    /// Find which face in the fallback chain owns `c`.
-    ///
-    /// See [`Family::resolve`].
-    #[inline]
-    pub(crate) fn resolve_face(&mut self, c: char) -> FontFaceKey {
-        self.family.resolve(self.faces, c)
-    }
-
-    /// Resolve `c` to its (face, [`GlyphInfo`]) at the given face's location.
-    ///
-    /// `\n` will (intentionally) show up as the replacement character.
-    ///
-    /// `metrics` must be the resolved [`StyledMetrics`] for the face that ends
-    /// up owning `c`. Most callers pass the metrics of their text run's primary
-    /// face — that is correct as long as `c` is in that face. For correct
-    /// fallback-face advances, resolve the face first with [`Self::resolve_face`]
-    /// and build metrics for that face.
-    pub(crate) fn glyph_info(
-        &mut self,
-        c: char,
-        metrics: &StyledMetrics,
-    ) -> (FontFaceKey, GlyphInfo) {
-        let face_key = self.resolve_face(c);
-        let Some(face) = self.faces.get_mut(face_key) else {
-            return (face_key, GlyphInfo::INVISIBLE);
-        };
-        let glyph_info = face.glyph_info(c, metrics).unwrap_or_else(|| {
-            // `c` is in no face — render the replacement character instead.
-            face.glyph_info(self.family.replacement_char(), metrics)
-                .unwrap_or(GlyphInfo::INVISIBLE)
-        });
-        (face_key, glyph_info)
-    }
 }

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -374,6 +374,7 @@ impl FontsImpl {
 
     /// Use this platform glyph rasterizer, e.g. the browser on web.
     #[cfg(test)]
+    #[inline]
     pub fn with_glyph_rasterizer(mut self, glyph_rasterizer: GlyphRasterizer) -> Self {
         self.set_glyph_rasterizer(Some(glyph_rasterizer));
         self

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -357,7 +357,7 @@ pub(crate) struct FontsImpl {
 impl FontsImpl {
     /// Create a new [`FontsImpl`] for text layout.
     /// This call is expensive, so only create one [`FontsImpl`] and then reuse it.
-    pub(crate) fn new(options: TextOptions, definitions: FontDefinitions) -> Self {
+    pub fn new(options: TextOptions, definitions: FontDefinitions) -> Self {
         let faces = FaceStore::new(options, &definitions);
 
         Self {
@@ -374,7 +374,7 @@ impl FontsImpl {
 
     /// Use this platform glyph rasterizer, e.g. the browser on web.
     #[cfg(test)]
-    pub(crate) fn with_glyph_rasterizer(mut self, glyph_rasterizer: GlyphRasterizer) -> Self {
+    pub fn with_glyph_rasterizer(mut self, glyph_rasterizer: GlyphRasterizer) -> Self {
         self.set_glyph_rasterizer(Some(glyph_rasterizer));
         self
     }
@@ -384,7 +384,7 @@ impl FontsImpl {
     /// Pass `None` to only use the installed fonts.
     ///
     /// See [`GlyphRasterizer`].
-    pub(crate) fn set_glyph_rasterizer(&mut self, glyph_rasterizer: Option<GlyphRasterizer>) {
+    pub fn set_glyph_rasterizer(&mut self, glyph_rasterizer: Option<GlyphRasterizer>) {
         self.glyph_rasterizer = glyph_rasterizer;
         self.glyphs.clear_raster_glyphs();
     }
@@ -392,24 +392,24 @@ impl FontsImpl {
     /// Decide where to look first for the glyphs of each grapheme cluster.
     ///
     /// See [`GlyphSourcePreference`].
-    pub(crate) fn set_glyph_source_preference(
+    pub fn set_glyph_source_preference(
         &mut self,
         prefer: impl Fn(&str) -> GlyphSource + Send + Sync + 'static,
     ) {
         self.glyph_source_preference = Arc::new(prefer);
     }
 
-    pub(crate) fn options(&self) -> &TextOptions {
+    pub fn options(&self) -> &TextOptions {
         self.glyphs.options()
     }
 
     /// Take the recycled shaping buffer (or create a new one if already taken).
-    pub(crate) fn take_shape_buffer(&mut self) -> harfrust::UnicodeBuffer {
+    pub fn take_shape_buffer(&mut self) -> harfrust::UnicodeBuffer {
         self.shape_buffer.take().unwrap_or_default()
     }
 
     /// Return a shaping buffer for reuse.
-    pub(crate) fn return_shape_buffer(&mut self, buffer: harfrust::UnicodeBuffer) {
+    pub fn return_shape_buffer(&mut self, buffer: harfrust::UnicodeBuffer) {
         self.shape_buffer = Some(buffer);
     }
 
@@ -419,7 +419,7 @@ impl FontsImpl {
     /// Look up (or build) the fallback chain of a family.
     ///
     /// Panics if the family is not in the [`FontDefinitions`].
-    pub(crate) fn family_key(&mut self, family: &FontFamily) -> FamilyKey {
+    pub fn family_key(&mut self, family: &FontFamily) -> FamilyKey {
         if let Some(key) = self.family_keys.get(family) {
             return *key;
         }
@@ -439,7 +439,7 @@ impl FontsImpl {
     ///
     /// See [`Family::resolve`].
     #[inline]
-    pub(crate) fn resolve_face(&mut self, family: FamilyKey, c: char) -> FontFaceKey {
+    pub fn resolve_face(&mut self, family: FamilyKey, c: char) -> FontFaceKey {
         self.families[family.0].resolve(&mut self.faces, c)
     }
 
@@ -452,7 +452,7 @@ impl FontsImpl {
     /// face, which is correct as long as `c` is in that face. For correct
     /// fallback-face advances, resolve the face first with [`Self::resolve_face`]
     /// and build metrics for that face.
-    pub(crate) fn glyph_info(
+    pub fn glyph_info(
         &mut self,
         family: FamilyKey,
         c: char,
@@ -472,7 +472,7 @@ impl FontsImpl {
     }
 
     /// Metrics of the primary face of the family.
-    pub(crate) fn family_metrics(
+    pub fn family_metrics(
         &self,
         family: FamilyKey,
         pixels_per_point: f32,
@@ -488,14 +488,14 @@ impl FontsImpl {
 
     /// Where to look first for the glyphs of this grapheme cluster.
     #[inline]
-    pub(crate) fn glyph_source(&self, cluster: &str) -> GlyphSource {
+    pub fn glyph_source(&self, cluster: &str) -> GlyphSource {
         (self.glyph_source_preference)(cluster)
     }
 
     /// Width of this character in points, at the font's default variation location.
     ///
     /// Returns `0.0` if no font has the character.
-    pub(crate) fn glyph_width(&mut self, family: &FontFamily, c: char, font_size: f32) -> f32 {
+    pub fn glyph_width(&mut self, family: &FontFamily, c: char, font_size: f32) -> f32 {
         let family = self.family_key(family);
         let face_key = self.resolve_face(family, c);
         let Some(face) = self.faces.get_mut(face_key) else {
@@ -512,7 +512,7 @@ impl FontsImpl {
     ///
     /// This does not consult the [`GlyphRasterizer`], so it can return `false`
     /// for a character that would still render via the rasterizer (e.g. the browser on web).
-    pub(crate) fn has_glyph(&mut self, family: &FontFamily, c: char) -> bool {
+    pub fn has_glyph(&mut self, family: &FontFamily, c: char) -> bool {
         let family = self.family_key(family);
         // TODO(emilk): this is a false negative if the user asks about the replacement character itself 🤦‍♂️
         self.resolve_face(family, c) != self.family(family).replacement_face_key()
@@ -521,12 +521,12 @@ impl FontsImpl {
     /// Do the installed fonts have all the glyphs in this text?
     ///
     /// See [`Self::has_glyph`] for the caveat about the glyph rasterizer.
-    pub(crate) fn has_glyphs(&mut self, family: &FontFamily, s: &str) -> bool {
+    pub fn has_glyphs(&mut self, family: &FontFamily, s: &str) -> bool {
         s.chars().all(|c| self.has_glyph(family, c))
     }
 
     /// All characters the fonts of this family support, and the names of the fonts that have each.
-    pub(crate) fn characters(&mut self, family: &FontFamily) -> &BTreeMap<char, Vec<String>> {
+    pub fn characters(&mut self, family: &FontFamily) -> &BTreeMap<char, Vec<String>> {
         let family = self.family_key(family);
         self.families[family.0].characters(&self.faces)
     }
@@ -535,14 +535,14 @@ impl FontsImpl {
     // Faces and glyphs
 
     #[inline]
-    pub(crate) fn face(&self, key: FontFaceKey) -> Option<&FontFace> {
+    pub fn face(&self, key: FontFaceKey) -> Option<&FontFace> {
         self.faces.get(key)
     }
 
     /// Get or render the glyph of a face, and put it in the atlas.
     ///
     /// See [`GlyphAtlas::allocate_outline`].
-    pub(crate) fn allocate_glyph(
+    pub fn allocate_glyph(
         &mut self,
         face_key: FontFaceKey,
         metrics: &StyledMetrics,
@@ -556,14 +556,14 @@ impl FontsImpl {
     }
 
     #[inline]
-    pub(crate) fn has_glyph_rasterizer(&self) -> bool {
+    pub fn has_glyph_rasterizer(&self) -> bool {
         self.glyph_rasterizer.is_some()
     }
 
     /// Rasterize a grapheme cluster using the platform [`GlyphRasterizer`].
     ///
     /// Returns `None` if there is no rasterizer, or it could not handle the cluster.
-    pub(crate) fn rasterize_cluster(
+    pub fn rasterize_cluster(
         &mut self,
         family: FamilyKey,
         cluster: &str,

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -459,15 +459,20 @@ impl FontsImpl {
         metrics: &StyledMetrics,
     ) -> (FontFaceKey, GlyphInfo) {
         let face_key = self.resolve_face(family, c);
-        let replacement_char = self.family(family).replacement_char();
         let Some(face) = self.faces.get_mut(face_key) else {
             return (face_key, GlyphInfo::INVISIBLE);
         };
-        let glyph_info = face.glyph_info(c, metrics).unwrap_or_else(|| {
-            // `c` is in no face: render the replacement character instead.
-            face.glyph_info(replacement_char, metrics)
-                .unwrap_or(GlyphInfo::INVISIBLE)
-        });
+        if let Some(glyph_info) = face.glyph_info(c, metrics) {
+            return (face_key, glyph_info);
+        }
+
+        // `c` is in no face: render the replacement character instead.
+        let replacement_char = self.family(family).replacement_char();
+        let glyph_info = self
+            .faces
+            .get_mut(face_key)
+            .and_then(|face| face.glyph_info(replacement_char, metrics))
+            .unwrap_or(GlyphInfo::INVISIBLE);
         (face_key, glyph_info)
     }
 

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -12,6 +12,7 @@ use crate::{
         glyph_atlas::{GlyphAtlas, OutlineGlyph, RasterGlyphAllocation},
         glyph_rasterizer::default_glyph_source,
         styled_metrics::StyledMetrics,
+        text_layout::layout,
     },
 };
 
@@ -34,7 +35,7 @@ pub const MAX_GLYPH_SIZE: usize = 1024;
 ///
 /// You need to call [`Self::begin_pass`] and [`Self::font_image_delta`] once every frame.
 pub struct Fonts {
-    pub fonts: FontsImpl,
+    fonts: FontsImpl,
     galley_cache: GalleyCache,
 }
 
@@ -164,6 +165,14 @@ impl Fonts {
         self.fonts.glyphs.fill_ratio()
     }
 
+    /// Lay out some text, bypassing the galley cache.
+    ///
+    /// Prefer [`FontsView::layout_job`], which memoizes.
+    /// This is mostly useful for benchmarking the layout code.
+    pub fn layout_uncached(&mut self, pixels_per_point: f32, job: Arc<LayoutJob>) -> Galley {
+        layout(&mut self.fonts, pixels_per_point, job)
+    }
+
     /// Returns a [`FontsView`] with the given `pixels_per_point` that can be used to do text layout.
     pub fn with_pixels_per_point(&mut self, pixels_per_point: f32) -> FontsView<'_> {
         FontsView {
@@ -178,7 +187,7 @@ impl Fonts {
 
 /// The context's collection of fonts, with this context's `pixels_per_point`. This is what you use to do text layout.
 pub struct FontsView<'a> {
-    pub fonts: &'a mut FontsImpl,
+    fonts: &'a mut FontsImpl,
     galley_cache: &'a mut GalleyCache,
     pixels_per_point: f32,
 }
@@ -330,7 +339,7 @@ impl FontsView<'_> {
 /// The collection of fonts used by `epaint`.
 ///
 /// Required in order to paint text.
-pub struct FontsImpl {
+pub(crate) struct FontsImpl {
     definitions: FontDefinitions,
     glyphs: GlyphAtlas,
     faces: FaceStore,
@@ -348,7 +357,7 @@ pub struct FontsImpl {
 impl FontsImpl {
     /// Create a new [`FontsImpl`] for text layout.
     /// This call is expensive, so only create one [`FontsImpl`] and then reuse it.
-    pub fn new(options: TextOptions, definitions: FontDefinitions) -> Self {
+    pub(crate) fn new(options: TextOptions, definitions: FontDefinitions) -> Self {
         let faces = FaceStore::new(options, &definitions);
 
         Self {
@@ -364,10 +373,8 @@ impl FontsImpl {
     }
 
     /// Use this platform glyph rasterizer, e.g. the browser on web.
-    ///
-    /// See [`GlyphRasterizer`].
-    #[inline]
-    pub fn with_glyph_rasterizer(mut self, glyph_rasterizer: GlyphRasterizer) -> Self {
+    #[cfg(test)]
+    pub(crate) fn with_glyph_rasterizer(mut self, glyph_rasterizer: GlyphRasterizer) -> Self {
         self.set_glyph_rasterizer(Some(glyph_rasterizer));
         self
     }
@@ -377,7 +384,7 @@ impl FontsImpl {
     /// Pass `None` to only use the installed fonts.
     ///
     /// See [`GlyphRasterizer`].
-    pub fn set_glyph_rasterizer(&mut self, glyph_rasterizer: Option<GlyphRasterizer>) {
+    pub(crate) fn set_glyph_rasterizer(&mut self, glyph_rasterizer: Option<GlyphRasterizer>) {
         self.glyph_rasterizer = glyph_rasterizer;
         self.glyphs.clear_raster_glyphs();
     }
@@ -385,24 +392,24 @@ impl FontsImpl {
     /// Decide where to look first for the glyphs of each grapheme cluster.
     ///
     /// See [`GlyphSourcePreference`].
-    pub fn set_glyph_source_preference(
+    pub(crate) fn set_glyph_source_preference(
         &mut self,
         prefer: impl Fn(&str) -> GlyphSource + Send + Sync + 'static,
     ) {
         self.glyph_source_preference = Arc::new(prefer);
     }
 
-    pub fn options(&self) -> &TextOptions {
+    pub(crate) fn options(&self) -> &TextOptions {
         self.glyphs.options()
     }
 
     /// Take the recycled shaping buffer (or create a new one if already taken).
-    pub fn take_shape_buffer(&mut self) -> harfrust::UnicodeBuffer {
+    pub(crate) fn take_shape_buffer(&mut self) -> harfrust::UnicodeBuffer {
         self.shape_buffer.take().unwrap_or_default()
     }
 
     /// Return a shaping buffer for reuse.
-    pub fn return_shape_buffer(&mut self, buffer: harfrust::UnicodeBuffer) {
+    pub(crate) fn return_shape_buffer(&mut self, buffer: harfrust::UnicodeBuffer) {
         self.shape_buffer = Some(buffer);
     }
 
@@ -488,7 +495,7 @@ impl FontsImpl {
     /// Width of this character in points, at the font's default variation location.
     ///
     /// Returns `0.0` if no font has the character.
-    pub fn glyph_width(&mut self, family: &FontFamily, c: char, font_size: f32) -> f32 {
+    pub(crate) fn glyph_width(&mut self, family: &FontFamily, c: char, font_size: f32) -> f32 {
         let family = self.family_key(family);
         let face_key = self.resolve_face(family, c);
         let Some(face) = self.faces.get_mut(face_key) else {
@@ -505,7 +512,7 @@ impl FontsImpl {
     ///
     /// This does not consult the [`GlyphRasterizer`], so it can return `false`
     /// for a character that would still render via the rasterizer (e.g. the browser on web).
-    pub fn has_glyph(&mut self, family: &FontFamily, c: char) -> bool {
+    pub(crate) fn has_glyph(&mut self, family: &FontFamily, c: char) -> bool {
         let family = self.family_key(family);
         // TODO(emilk): this is a false negative if the user asks about the replacement character itself 🤦‍♂️
         self.resolve_face(family, c) != self.family(family).replacement_face_key()
@@ -514,12 +521,12 @@ impl FontsImpl {
     /// Do the installed fonts have all the glyphs in this text?
     ///
     /// See [`Self::has_glyph`] for the caveat about the glyph rasterizer.
-    pub fn has_glyphs(&mut self, family: &FontFamily, s: &str) -> bool {
+    pub(crate) fn has_glyphs(&mut self, family: &FontFamily, s: &str) -> bool {
         s.chars().all(|c| self.has_glyph(family, c))
     }
 
     /// All characters the fonts of this family support, and the names of the fonts that have each.
-    pub fn characters(&mut self, family: &FontFamily) -> &BTreeMap<char, Vec<String>> {
+    pub(crate) fn characters(&mut self, family: &FontFamily) -> &BTreeMap<char, Vec<String>> {
         let family = self.family_key(family);
         self.families[family.0].characters(&self.faces)
     }

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -1,12 +1,17 @@
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use crate::{
     Color32, TextureAtlas,
     text::{
         FontDefinitions, FontFamily, FontId, Galley, GlyphRasterizer, GlyphSource,
-        GlyphSourcePreference, LayoutJob, TextOptions, VariationCoords, face_store::FaceStore,
-        family::Family, font::Font, galley_cache::GalleyCache, glyph_atlas::GlyphAtlas,
+        GlyphSourcePreference, LayoutJob, TextOptions, VariationCoords,
+        face_store::{FaceStore, FontFaceKey},
+        family::{Family, FamilyKey},
+        font_face::{FontFace, GlyphInfo, ShapedGlyph},
+        galley_cache::GalleyCache,
+        glyph_atlas::{GlyphAtlas, OutlineGlyph, RasterGlyphAllocation},
         glyph_rasterizer::default_glyph_source,
+        styled_metrics::StyledMetrics,
     },
 };
 
@@ -137,14 +142,14 @@ impl Fonts {
     /// This does not consult the [`GlyphRasterizer`], so it can return `false`
     /// for a character that would still render via the rasterizer (e.g. the browser on web).
     pub fn has_glyph(&mut self, font_id: &FontId, c: char) -> bool {
-        self.fonts.font(&font_id.family).has_glyph(c)
+        self.fonts.has_glyph(&font_id.family, c)
     }
 
     /// Do the installed fonts have all the glyphs in this text?
     ///
     /// See [`Self::has_glyph`] for the caveat about the [`GlyphRasterizer`].
     pub fn has_glyphs(&mut self, font_id: &FontId, s: &str) -> bool {
-        self.fonts.font(&font_id.family).has_glyphs(s)
+        self.fonts.has_glyphs(&font_id.family, s)
     }
 
     pub fn num_galleys_in_cache(&self) -> usize {
@@ -205,9 +210,7 @@ impl FontsView<'_> {
     ///
     /// If the font doesn't exist, this will return `0.0`.
     pub fn glyph_width(&mut self, font_id: &FontId, c: char) -> f32 {
-        self.fonts
-            .font(&font_id.family)
-            .glyph_width(c, font_id.size)
+        self.fonts.glyph_width(&font_id.family, c, font_id.size)
     }
 
     /// Do the installed fonts have this glyph?
@@ -215,14 +218,21 @@ impl FontsView<'_> {
     /// This does not consult the [`GlyphRasterizer`], so it can return `false`
     /// for a character that would still render via the rasterizer (e.g. the browser on web).
     pub fn has_glyph(&mut self, font_id: &FontId, c: char) -> bool {
-        self.fonts.font(&font_id.family).has_glyph(c)
+        self.fonts.has_glyph(&font_id.family, c)
     }
 
     /// Do the installed fonts have all the glyphs in this text?
     ///
     /// See [`Self::has_glyph`] for the caveat about the [`GlyphRasterizer`].
     pub fn has_glyphs(&mut self, font_id: &FontId, s: &str) -> bool {
-        self.fonts.font(&font_id.family).has_glyphs(s)
+        self.fonts.has_glyphs(&font_id.family, s)
+    }
+
+    /// All characters the fonts of this family support, and the names of the fonts that have each.
+    ///
+    /// This does not consult the [`GlyphRasterizer`].
+    pub fn characters(&mut self, family: &FontFamily) -> &BTreeMap<char, Vec<String>> {
+        self.fonts.characters(family)
     }
 
     /// Height of one row of text in points.
@@ -230,9 +240,10 @@ impl FontsView<'_> {
     /// Returns a value rounded to [`emath::GUI_ROUNDING`].
     #[inline]
     pub fn row_height(&mut self, font_id: &FontId) -> f32 {
+        let family = self.fonts.family_key(&font_id.family);
         self.fonts
-            .font(&font_id.family)
-            .styled_metrics(
+            .family_metrics(
+                family,
                 self.pixels_per_point,
                 font_id.size,
                 // TODO(valadaptive): use font variation coords when calculating row height
@@ -323,7 +334,10 @@ pub struct FontsImpl {
     definitions: FontDefinitions,
     glyphs: GlyphAtlas,
     faces: FaceStore,
-    families: ahash::HashMap<FontFamily, Family>,
+
+    /// Indexed by [`FamilyKey`].
+    families: Vec<Family>,
+    family_keys: ahash::HashMap<FontFamily, FamilyKey>,
 
     /// Recycled `harfrust` shaping buffer to avoid per-layout allocations.
     shape_buffer: Option<harfrust::UnicodeBuffer>,
@@ -342,6 +356,7 @@ impl FontsImpl {
             glyphs: GlyphAtlas::new(options),
             faces,
             families: Default::default(),
+            family_keys: Default::default(),
             shape_buffer: Some(harfrust::UnicodeBuffer::new()),
             glyph_rasterizer: None,
             glyph_source_preference: Arc::new(default_glyph_source),
@@ -391,19 +406,172 @@ impl FontsImpl {
         self.shape_buffer = Some(buffer);
     }
 
-    /// Get the right font implementation from [`FontFamily`].
-    pub fn font(&mut self, family: &FontFamily) -> Font<'_> {
-        let family = self
-            .families
-            .entry(family.clone())
-            .or_insert_with(|| Family::new(family, &self.definitions, &mut self.faces));
-        Font {
-            faces: &mut self.faces,
-            family,
-            glyphs: &mut self.glyphs,
-            glyph_rasterizer: self.glyph_rasterizer.as_ref(),
-            glyph_source_preference: &self.glyph_source_preference,
+    // ------------------------------------------------------------------------
+    // Families
+
+    /// Look up (or build) the fallback chain of a family.
+    ///
+    /// Panics if the family is not in the [`FontDefinitions`].
+    pub(crate) fn family_key(&mut self, family: &FontFamily) -> FamilyKey {
+        if let Some(key) = self.family_keys.get(family) {
+            return *key;
         }
+        let key = FamilyKey(self.families.len());
+        self.families
+            .push(Family::new(family, &self.definitions, &mut self.faces));
+        self.family_keys.insert(family.clone(), key);
+        key
+    }
+
+    #[inline]
+    fn family(&self, key: FamilyKey) -> &Family {
+        &self.families[key.0]
+    }
+
+    /// Find which face in the fallback chain owns `c`.
+    ///
+    /// See [`Family::resolve`].
+    #[inline]
+    pub(crate) fn resolve_face(&mut self, family: FamilyKey, c: char) -> FontFaceKey {
+        self.families[family.0].resolve(&mut self.faces, c)
+    }
+
+    /// Resolve `c` to its (face, [`GlyphInfo`]) at the given face's location.
+    ///
+    /// `\n` will (intentionally) show up as the replacement character.
+    ///
+    /// `metrics` must be the resolved [`StyledMetrics`] for the face that ends
+    /// up owning `c`. Most callers pass the metrics of their text run's primary
+    /// face, which is correct as long as `c` is in that face. For correct
+    /// fallback-face advances, resolve the face first with [`Self::resolve_face`]
+    /// and build metrics for that face.
+    pub(crate) fn glyph_info(
+        &mut self,
+        family: FamilyKey,
+        c: char,
+        metrics: &StyledMetrics,
+    ) -> (FontFaceKey, GlyphInfo) {
+        let face_key = self.resolve_face(family, c);
+        let replacement_char = self.family(family).replacement_char();
+        let Some(face) = self.faces.get_mut(face_key) else {
+            return (face_key, GlyphInfo::INVISIBLE);
+        };
+        let glyph_info = face.glyph_info(c, metrics).unwrap_or_else(|| {
+            // `c` is in no face: render the replacement character instead.
+            face.glyph_info(replacement_char, metrics)
+                .unwrap_or(GlyphInfo::INVISIBLE)
+        });
+        (face_key, glyph_info)
+    }
+
+    /// Metrics of the primary face of the family.
+    pub(crate) fn family_metrics(
+        &self,
+        family: FamilyKey,
+        pixels_per_point: f32,
+        font_size: f32,
+        coords: &VariationCoords,
+    ) -> StyledMetrics {
+        self.family(family)
+            .primary()
+            .and_then(|key| self.faces.get(key))
+            .map(|face| face.styled_metrics(pixels_per_point, font_size, coords))
+            .unwrap_or_default()
+    }
+
+    /// Where to look first for the glyphs of this grapheme cluster.
+    #[inline]
+    pub(crate) fn glyph_source(&self, cluster: &str) -> GlyphSource {
+        (self.glyph_source_preference)(cluster)
+    }
+
+    /// Width of this character in points, at the font's default variation location.
+    ///
+    /// Returns `0.0` if no font has the character.
+    pub fn glyph_width(&mut self, family: &FontFamily, c: char, font_size: f32) -> f32 {
+        let family = self.family_key(family);
+        let face_key = self.resolve_face(family, c);
+        let Some(face) = self.faces.get_mut(face_key) else {
+            return 0.0;
+        };
+        let metrics = face.styled_metrics(1.0, font_size, &VariationCoords::default());
+        let Some(glyph_info) = face.glyph_info(c, &metrics) else {
+            return 0.0;
+        };
+        glyph_info.advance_width_unscaled.0 * face.px_scale_factor(font_size)
+    }
+
+    /// Do the installed fonts have this glyph?
+    ///
+    /// This does not consult the [`GlyphRasterizer`], so it can return `false`
+    /// for a character that would still render via the rasterizer (e.g. the browser on web).
+    pub fn has_glyph(&mut self, family: &FontFamily, c: char) -> bool {
+        let family = self.family_key(family);
+        // TODO(emilk): this is a false negative if the user asks about the replacement character itself 🤦‍♂️
+        self.resolve_face(family, c) != self.family(family).replacement_face_key()
+    }
+
+    /// Do the installed fonts have all the glyphs in this text?
+    ///
+    /// See [`Self::has_glyph`] for the caveat about the glyph rasterizer.
+    pub fn has_glyphs(&mut self, family: &FontFamily, s: &str) -> bool {
+        s.chars().all(|c| self.has_glyph(family, c))
+    }
+
+    /// All characters the fonts of this family support, and the names of the fonts that have each.
+    pub fn characters(&mut self, family: &FontFamily) -> &BTreeMap<char, Vec<String>> {
+        let family = self.family_key(family);
+        self.families[family.0].characters(&self.faces)
+    }
+
+    // ------------------------------------------------------------------------
+    // Faces and glyphs
+
+    #[inline]
+    pub(crate) fn face(&self, key: FontFaceKey) -> Option<&FontFace> {
+        self.faces.get(key)
+    }
+
+    /// Get or render the glyph of a face, and put it in the atlas.
+    ///
+    /// See [`GlyphAtlas::allocate_outline`].
+    pub(crate) fn allocate_glyph(
+        &mut self,
+        face_key: FontFaceKey,
+        metrics: &StyledMetrics,
+        shaped: &ShapedGlyph,
+    ) -> OutlineGlyph {
+        let Some(face) = self.faces.get_mut(face_key) else {
+            return Default::default();
+        };
+        self.glyphs
+            .allocate_outline(face_key, face, metrics, shaped)
+    }
+
+    #[inline]
+    pub(crate) fn has_glyph_rasterizer(&self) -> bool {
+        self.glyph_rasterizer.is_some()
+    }
+
+    /// Rasterize a grapheme cluster using the platform [`GlyphRasterizer`].
+    ///
+    /// Returns `None` if there is no rasterizer, or it could not handle the cluster.
+    pub(crate) fn rasterize_cluster(
+        &mut self,
+        family: FamilyKey,
+        cluster: &str,
+        pixels_per_point: f32,
+        font_size: f32,
+    ) -> Option<RasterGlyphAllocation> {
+        let rasterizer = self.glyph_rasterizer.as_ref()?;
+        let family_name = self.families[family.0].name();
+        self.glyphs.allocate_raster(
+            rasterizer,
+            cluster,
+            family_name,
+            pixels_per_point,
+            font_size,
+        )
     }
 }
 

--- a/crates/epaint/src/text/galley_cache.rs
+++ b/crates/epaint/src/text/galley_cache.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use emath::OrderedFloat;
 use nohash_hasher::IntMap;
 
-use crate::text::{ByteIndex, FontsImpl, Galley, LayoutJob, LayoutSection};
+use crate::text::{
+    ByteIndex, Galley, LayoutJob, LayoutSection, fonts::FontsImpl, text_layout::layout,
+};
 
 /// A laid-out [`Galley`], and what we need to know to evict it.
 struct CachedGalley {
@@ -107,7 +109,7 @@ impl GalleyCache {
                     );
                     galley
                 } else {
-                    let galley = super::layout(fonts, pixels_per_point, job);
+                    let galley = layout(fonts, pixels_per_point, job);
                     let galley = Arc::new(galley);
                     entry.insert(CachedGalley {
                         last_used: self.generation,
@@ -270,7 +272,7 @@ mod tests {
     use core::f32;
 
     use super::*;
-    use crate::text::{FontDefinitions, FontFamily, FontId, TextOptions, TextWrapping, layout};
+    use crate::text::{FontDefinitions, FontFamily, FontId, TextOptions, TextWrapping};
     use crate::{Stroke, text::TextFormat};
     use ecolor::Color32;
     use emath::Align;

--- a/crates/epaint/src/text/glyph_atlas.rs
+++ b/crates/epaint/src/text/glyph_atlas.rs
@@ -7,7 +7,7 @@ use crate::{
     text::{
         FontFamily, GlyphRasterizer, GlyphRasterizerRequest, MAX_GLYPH_SIZE,
         face_store::FontFaceKey,
-        font::{FontFace, ShapedGlyph},
+        font_face::{FontFace, ShapedGlyph},
         styled_metrics::StyledMetrics,
     },
 };
@@ -86,7 +86,7 @@ pub(crate) struct GlyphBitmap {
 /// cache each glyph's bitmap. As a compromise, we bin each subpixel offset into one of four fractional values. This
 /// means one glyph can have up to four subpixel-positioned bitmaps in the cache.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub(super) enum SubpixelBin {
+pub(crate) enum SubpixelBin {
     #[default]
     Zero,
     One,

--- a/crates/epaint/src/text/mod.rs
+++ b/crates/epaint/src/text/mod.rs
@@ -3,9 +3,9 @@
 pub mod cursor;
 mod face_store;
 mod family;
-mod font;
 mod font_data;
 mod font_definitions;
+mod font_face;
 mod font_id;
 mod font_tweak;
 mod fonts;

--- a/crates/epaint/src/text/mod.rs
+++ b/crates/epaint/src/text/mod.rs
@@ -23,13 +23,12 @@ pub use {
     font_definitions::{FontDefinitions, FontInsert, FontPriority, InsertFontFamily},
     font_id::{FontFamily, FontId},
     font_tweak::{FontTweak, HintingTarget, SmoothHinting},
-    fonts::{Fonts, FontsImpl, FontsView, MAX_GLYPH_SIZE},
+    fonts::{Fonts, FontsView, MAX_GLYPH_SIZE},
     glyph_rasterizer::{
         GlyphRasterizer, GlyphRasterizerRequest, GlyphSource, GlyphSourcePreference,
         RasterizedGlyph, default_glyph_source, has_emoji_presentation,
     },
     index::{ByteIndex, ByteRange, ByteRangeExt, CharIndex, CharRange, CharRangeExt},
-    text_layout::*,
     text_layout_types::*,
 };
 

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -20,7 +20,8 @@ use crate::{
 use super::{
     ByteRangeExt as _, FontsImpl, Galley, Glyph, GlyphSource, LayoutJob, LayoutSection, PlacedRow,
     Row, RowVisuals, VariationCoords,
-    font::{Font, FontFace, ShapedGlyph},
+    family::FamilyKey,
+    font_face::{FontFace, ShapedGlyph},
     glyph_atlas::{OutlineGlyph, RasterGlyphAllocation},
 };
 
@@ -127,9 +128,8 @@ pub fn layout(fonts: &mut FontsImpl, pixels_per_point: f32, job: Arc<LayoutJob>)
     {
         let mut shape_buffer = fonts.take_shape_buffer();
         for (section_index, section) in job.sections.iter().enumerate() {
-            let mut font = fonts.font(&section.format.font_id.family);
             shape_buffer = layout_section(
-                &mut font,
+                fonts,
                 shape_buffer,
                 pixels_per_point,
                 &job,
@@ -179,6 +179,8 @@ pub fn layout(fonts: &mut FontsImpl, pixels_per_point: f32, job: Arc<LayoutJob>)
 
 /// Shared context for emitting shaped glyphs into a [`Paragraph`].
 struct ShapingContext {
+    /// The family of the section being shaped.
+    family: FamilyKey,
     pixels_per_point: f32,
     font_size: f32,
     line_height: f32,
@@ -240,7 +242,7 @@ struct TextRun {
 /// characters so that `glyphs.len() == char_count` — an invariant that all
 /// cursor and selection code relies on.
 fn layout_shaped_run(
-    font: &mut Font<'_>,
+    fonts: &mut FontsImpl,
     run: &TextRun,
     run_text: &str,
     glyph_buffer: &harfrust::GlyphBuffer,
@@ -274,9 +276,9 @@ fn layout_shaped_run(
         // Tab is a layout concept, not a glyph — the shaper doesn't know about tab stops.
         // Override the advance width using the font's configured tab size.
         if chr == '\t' {
-            let tweak = font.faces.get(run.font_key).map(|face| face.tweak());
+            let tweak = fonts.face(run.font_key).map(|face| face.tweak());
             let tab_size = tweak.map_or(4.0, |t| t.tab_size);
-            let (_, space_info) = font.glyph_info(' ', face_metrics);
+            let (_, space_info) = fonts.glyph_info(ctx.family, ' ', face_metrics);
             let space_width_px = space_info.advance_width_unscaled.0 * px_scale;
             advance_width_px = tab_size * space_width_px;
         }
@@ -284,9 +286,9 @@ fn layout_shaped_run(
         // Thin space (U+2009) and narrow no-break space (U+202F):
         // override the shaper's advance width with the configured fraction of a space.
         if chr == '\u{2009}' || chr == '\u{202F}' {
-            let tweak = font.faces.get(run.font_key).map(|face| face.tweak());
+            let tweak = fonts.face(run.font_key).map(|face| face.tweak());
             let thin_space_width = tweak.map_or(0.5, |t| t.thin_space_width);
-            let (_, space_info) = font.glyph_info(' ', face_metrics);
+            let (_, space_info) = fonts.glyph_info(ctx.family, ' ', face_metrics);
             let space_width_px = space_info.advance_width_unscaled.0 * px_scale;
             advance_width_px = thin_space_width * space_width_px;
         }
@@ -329,16 +331,18 @@ fn layout_shaped_run(
                 })
                 .unwrap_or_default();
 
-            if let Some(raster) =
-                font.rasterize_glyph(cluster_text, ctx.pixels_per_point, ctx.font_size)
-            {
+            if let Some(raster) = fonts.rasterize_cluster(
+                ctx.family,
+                cluster_text,
+                ctx.pixels_per_point,
+                ctx.font_size,
+            ) {
                 raster_glyph(ctx, paragraph, chr, &raster, face_metrics)
             } else {
                 // Use the fallback font face (not run.font_key which returned NOTDEF).
-                let fallback_key = font.resolve_face(chr);
-                let fallback_metrics = font
-                    .faces
-                    .get(fallback_key)
+                let fallback_key = fonts.resolve_face(ctx.family, chr);
+                let fallback_metrics = fonts
+                    .face(fallback_key)
                     .map(|face| {
                         face.styled_metrics(
                             ctx.pixels_per_point,
@@ -347,24 +351,18 @@ fn layout_shaped_run(
                         )
                     })
                     .unwrap_or_default();
-                let (_, glyph_info) = font.glyph_info(chr, &fallback_metrics);
+                let (_, glyph_info) = fonts.glyph_info(ctx.family, chr, &fallback_metrics);
                 let advance_width_px =
                     glyph_info.advance_width_unscaled.0 * fallback_metrics.px_scale_factor;
-                let OutlineGlyph { allocation, x_px } =
-                    if let Some(face) = font.faces.get_mut(fallback_key) {
-                        font.glyphs.allocate_outline(
-                            fallback_key,
-                            face,
-                            &fallback_metrics,
-                            &ShapedGlyph {
-                                glyph_id: glyph_info.id.unwrap_or(skrifa::GlyphId::NOTDEF),
-                                h_pos: paragraph.cursor_x_px,
-                                is_cjk: is_cjk(chr),
-                            },
-                        )
-                    } else {
-                        Default::default()
-                    };
+                let OutlineGlyph { allocation, x_px } = fonts.allocate_glyph(
+                    fallback_key,
+                    &fallback_metrics,
+                    &ShapedGlyph {
+                        glyph_id: glyph_info.id.unwrap_or(skrifa::GlyphId::NOTDEF),
+                        h_pos: paragraph.cursor_x_px,
+                        is_cjk: is_cjk(chr),
+                    },
+                );
 
                 paragraph.cursor_x_px += advance_width_px;
 
@@ -380,20 +378,15 @@ fn layout_shaped_run(
             let OutlineGlyph {
                 allocation: mut glyph_alloc,
                 x_px,
-            } = if let Some(face) = font.faces.get_mut(run.font_key) {
-                font.glyphs.allocate_outline(
-                    run.font_key,
-                    face,
-                    face_metrics,
-                    &ShapedGlyph {
-                        glyph_id,
-                        h_pos: paragraph.cursor_x_px + x_offset_px,
-                        is_cjk: is_cjk(chr),
-                    },
-                )
-            } else {
-                Default::default()
-            };
+            } = fonts.allocate_glyph(
+                run.font_key,
+                face_metrics,
+                &ShapedGlyph {
+                    glyph_id,
+                    h_pos: paragraph.cursor_x_px + x_offset_px,
+                    is_cjk: is_cjk(chr),
+                },
+            );
 
             // Apply shaper y_offset — this varies per glyph instance so it
             // is not part of the cached ShapedGlyph / GlyphAllocation.
@@ -452,7 +445,7 @@ fn raster_glyph(
 /// Clusters the rasterizer cannot handle are shaped with the run's font face instead.
 #[must_use]
 fn layout_raster_run(
-    font: &mut Font<'_>,
+    fonts: &mut FontsImpl,
     run: &TextRun,
     run_text: &str,
     coords: &VariationCoords,
@@ -462,7 +455,7 @@ fn layout_raster_run(
 ) -> harfrust::UnicodeBuffer {
     use unicode_segmentation::UnicodeSegmentation as _;
 
-    let Some(font_face) = font.faces.get(run.font_key) else {
+    let Some(font_face) = fonts.face(run.font_key) else {
         return shape_buffer;
     };
     let face_metrics = &font_face.styled_metrics(ctx.pixels_per_point, ctx.font_size, coords);
@@ -472,10 +465,11 @@ fn layout_raster_run(
             continue;
         };
 
-        let Some(raster) = font.rasterize_glyph(cluster, ctx.pixels_per_point, ctx.font_size)
+        let Some(raster) =
+            fonts.rasterize_cluster(ctx.family, cluster, ctx.pixels_per_point, ctx.font_size)
         else {
             // Shape this one cluster with the font instead.
-            let Some(font_face) = font.faces.get(run.font_key) else {
+            let Some(font_face) = fonts.face(run.font_key) else {
                 continue;
             };
             let glyph_buffer = shape_text(
@@ -492,7 +486,7 @@ fn layout_raster_run(
                 source: GlyphSource::Fonts,
             };
             layout_shaped_run(
-                font,
+                fonts,
                 &cluster_run,
                 cluster,
                 &glyph_buffer,
@@ -552,7 +546,7 @@ fn emit_continuation_glyphs(
 // Ignores the Y coordinate.
 #[must_use]
 fn layout_section(
-    font: &mut Font<'_>,
+    fonts: &mut FontsImpl,
     mut shape_buffer: harfrust::UnicodeBuffer,
     pixels_per_point: f32,
     job: &LayoutJob,
@@ -566,8 +560,9 @@ fn layout_section(
         format,
     } = section;
 
+    let family = fonts.family_key(&format.font_id.family);
     let font_size = format.font_id.size;
-    let font_metrics = font.styled_metrics(pixels_per_point, font_size, &format.coords);
+    let font_metrics = fonts.family_metrics(family, pixels_per_point, font_size, &format.coords);
     let line_height = section
         .format
         .line_height
@@ -582,6 +577,7 @@ fn layout_section(
 
     let section_text = &job.text[byte_range.as_usize()];
     let mut ctx = ShapingContext {
+        family,
         pixels_per_point,
         font_size,
         line_height,
@@ -605,21 +601,21 @@ fn layout_section(
             continue;
         }
 
-        segment_into_runs(font, segment, &mut runs);
+        segment_into_runs(fonts, family, segment, &mut runs);
 
         let num_runs = runs.len();
         for (run_idx, run) in runs.iter().enumerate() {
             let run_text = &segment[run.byte_range.as_usize()];
-            let Some(font_face) = font.faces.get(run.font_key) else {
+            let Some(font_face) = fonts.face(run.font_key) else {
                 continue;
             };
 
             let face_metrics =
                 font_face.styled_metrics(pixels_per_point, font_size, &format.coords);
 
-            if run.source == GlyphSource::Platform && font.glyph_rasterizer.is_some() {
+            if run.source == GlyphSource::Platform && fonts.has_glyph_rasterizer() {
                 shape_buffer = layout_raster_run(
-                    font,
+                    fonts,
                     run,
                     run_text,
                     &format.coords,
@@ -641,7 +637,7 @@ fn layout_section(
                     shape_text(font_face, run_text, &format.coords, shape_buffer, flags);
 
                 layout_shaped_run(
-                    font,
+                    fonts,
                     run,
                     run_text,
                     &glyph_buffer,
@@ -912,17 +908,15 @@ fn replace_last_glyph_with_overflow_character(
     loop {
         let section = &job.sections[section_index as usize];
         let extra_letter_spacing = section.format.extra_letter_spacing;
-        let mut font = fonts.font(&section.format.font_id.family);
+        let family = fonts.family_key(&section.format.font_id.family);
         let font_size = section.format.font_id.size;
 
-        let font_id = font.resolve_face(overflow_character);
-        let font_face_metrics = font
-            .faces
-            .get(font_id)
+        let face_key = fonts.resolve_face(family, overflow_character);
+        let font_face_metrics = fonts
+            .face(face_key)
             .map(|face| face.styled_metrics(pixels_per_point, font_size, &section.format.coords))
             .unwrap_or_default();
-        let (_, glyph_info) = font.glyph_info(overflow_character, &font_face_metrics);
-        let mut font_face = font.faces.get_mut(font_id);
+        let (_, glyph_info) = fonts.glyph_info(family, overflow_character, &font_face_metrics);
 
         let overflow_glyph_x = if let Some(prev_glyph) = row.glyphs.last() {
             prev_glyph.max_x() + extra_letter_spacing
@@ -943,24 +937,18 @@ fn replace_last_glyph_with_overflow_character(
             let OutlineGlyph {
                 allocation: replacement_glyph_alloc,
                 x_px,
-            } = font_face
-                .as_mut()
-                .map(|face| {
-                    font.glyphs.allocate_outline(
-                        font_id,
-                        face,
-                        &font_face_metrics,
-                        &ShapedGlyph {
-                            glyph_id: glyph_info.id.unwrap_or(skrifa::GlyphId::NOTDEF),
-                            h_pos: overflow_glyph_x * pixels_per_point,
-                            is_cjk: is_cjk(overflow_character),
-                        },
-                    )
-                })
-                .unwrap_or_default();
+            } = fonts.allocate_glyph(
+                face_key,
+                &font_face_metrics,
+                &ShapedGlyph {
+                    glyph_id: glyph_info.id.unwrap_or(skrifa::GlyphId::NOTDEF),
+                    h_pos: overflow_glyph_x * pixels_per_point,
+                    is_cjk: is_cjk(overflow_character),
+                },
+            );
 
             let font_metrics =
-                font.styled_metrics(pixels_per_point, font_size, &section.format.coords);
+                fonts.family_metrics(family, pixels_per_point, font_size, &section.format.coords);
             let line_height = section
                 .format
                 .line_height
@@ -1512,7 +1500,7 @@ impl RowBreakCandidates {
 ///
 /// Results are appended to `out` (which is cleared first) to allow
 /// the caller to reuse the allocation across calls.
-fn segment_into_runs(font: &mut Font<'_>, text: &str, out: &mut Vec<TextRun>) {
+fn segment_into_runs(fonts: &mut FontsImpl, family: FamilyKey, text: &str, out: &mut Vec<TextRun>) {
     use unicode_segmentation::UnicodeSegmentation as _;
 
     out.clear();
@@ -1522,8 +1510,8 @@ fn segment_into_runs(font: &mut Font<'_>, text: &str, out: &mut Vec<TextRun>) {
         let byte_end = byte_offset + grapheme_str.len();
 
         let base_char = grapheme_str.chars().next().unwrap_or(' ');
-        let font_key = font.resolve_face(base_char);
-        let source = (font.glyph_source_preference)(grapheme_str);
+        let font_key = fonts.resolve_face(family, base_char);
+        let source = fonts.glyph_source(grapheme_str);
 
         if let Some(last_run) = out.last_mut()
             && last_run.font_key == font_key
@@ -2038,9 +2026,14 @@ mod tests {
         let mut fonts = test_fonts();
 
         let font_id = FontId::default();
+        let family = fonts.family_key(&font_id.family);
         let font_height = fonts
-            .font(&font_id.family)
-            .styled_metrics(pixels_per_point, font_id.size, &VariationCoords::default())
+            .family_metrics(
+                family,
+                pixels_per_point,
+                font_id.size,
+                &VariationCoords::default(),
+            )
             .row_height;
 
         let job = LayoutJob::simple(String::new(), font_id, Color32::WHITE, f32::INFINITY);
@@ -2071,9 +2064,14 @@ mod tests {
         let mut fonts = test_fonts();
 
         let font_id = FontId::default();
+        let family = fonts.family_key(&font_id.family);
         let font_height = fonts
-            .font(&font_id.family)
-            .styled_metrics(pixels_per_point, font_id.size, &VariationCoords::default())
+            .family_metrics(
+                family,
+                pixels_per_point,
+                font_id.size,
+                &VariationCoords::default(),
+            )
             .row_height;
 
         let job = LayoutJob::simple("Hi!\n".to_owned(), font_id, Color32::WHITE, f32::INFINITY);

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -11,6 +11,7 @@ use crate::{
     text::{
         ByteIndex, ByteRange,
         face_store::FontFaceKey,
+        fonts::FontsImpl,
         glyph_atlas::UvRect,
         styled_metrics::StyledMetrics,
         unicode::{is_cjk, is_cjk_break_allowed},
@@ -18,8 +19,8 @@ use crate::{
 };
 
 use super::{
-    ByteRangeExt as _, FontsImpl, Galley, Glyph, GlyphSource, LayoutJob, LayoutSection, PlacedRow,
-    Row, RowVisuals, VariationCoords,
+    ByteRangeExt as _, Galley, Glyph, GlyphSource, LayoutJob, LayoutSection, PlacedRow, Row,
+    RowVisuals, VariationCoords,
     family::FamilyKey,
     font_face::{FontFace, ShapedGlyph},
     glyph_atlas::{OutlineGlyph, RasterGlyphAllocation},
@@ -102,7 +103,7 @@ impl Paragraph {
 ///
 /// In most cases you should use [`crate::FontsView::layout_job`] instead
 /// since that memoizes the input, making subsequent layouting of the same text much faster.
-pub fn layout(fonts: &mut FontsImpl, pixels_per_point: f32, job: Arc<LayoutJob>) -> Galley {
+pub(crate) fn layout(fonts: &mut FontsImpl, pixels_per_point: f32, job: Arc<LayoutJob>) -> Galley {
     profiling::function_scope!();
 
     job.debug_sanity_check();

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -15,7 +15,7 @@ use smallvec::SmallVec;
 ///
 /// This supports mixing different fonts, color and formats (underline etc).
 ///
-/// Pass this to [`crate::FontsView::layout_job`] or [`crate::text::layout`].
+/// Pass this to [`crate::FontsView::layout_job`].
 ///
 /// ## Example:
 /// ```


### PR DESCRIPTION
`Font<'a>` was a hand-rolled split borrow of every field of `FontsImpl`, and it grew a new `&'a mut` for each new feature. `text_layout` now calls `FontsImpl` directly (`resolve_face`, `glyph_info`, `allocate_glyph`, `rasterize_cluster`, …) with a cheap `FamilyKey` index instead of re-hashing the `FontFamily` per glyph.

`font.rs` is renamed to `font_face.rs`, since only `FontFace` is left in it. `FontsView::characters` replaces `f.fonts.font(family).characters()` in the font book demo.

`FontsImpl` and `epaint::text::layout` are now crate-private: nothing outside `epaint` used them, and `Fonts` / `FontsView` cover the public API. The `fonts` fields of `Fonts` and `FontsView` are private too. The benchmark that used `layout` directly now calls the new `Fonts::layout_uncached`.

* [x] I have followed the instructions in the PR template

PR chain, in order:
* #8490
* #8500
* #8501
* #8502
* #8503
* #8504
* #8491
* #8492
* #8493
* #8508