### PR TITLE
Run all tests in CI even when a snapshot test fails

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -233,11 +233,16 @@ jobs:
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
 
+      # `--no-fail-fast` so that a failing snapshot test in one crate doesn't
+      # stop the tests of the other crates from running.
+      # That way a single CI run reports _all_ failing snapshots,
+      # and all the new snapshots end up in the uploaded artifact.
       - name: Run tests
-        run: cargo test --all-features
+        run: cargo test --all-features --no-fail-fast
 
       - name: Run doc-tests
-        run: cargo test --all-features --doc
+        if: always()
+        run: cargo test --all-features --doc --no-fail-fast
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -29,7 +29,7 @@ cargo check --quiet  --all-targets
 cargo check --quiet  --all-targets --all-features
 cargo check --quiet  -p egui_demo_app --lib --target wasm32-unknown-unknown
 cargo check --quiet  -p egui_demo_app --lib --target wasm32-unknown-unknown --all-features
-cargo test  --quiet --all-targets --all-features
+cargo test  --quiet --all-targets --all-features --no-fail-fast # `--no-fail-fast` so that all failing snapshots are reported at once
 cargo test  --quiet --doc # slow - checks all doc-tests
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then


### PR DESCRIPTION
Run the tests with `--no-fail-fast`, in CI and in `scripts/check.sh`.

`cargo test` stops after the first failing test target, so one failing snapshot test in `egui_demo_app` hid the failing snapshots of every later crate, and it took several CI rounds to collect all the new snapshots. Now one run reports them all and uploads all `.new.png` files, so one kitdiff pass is enough.

`egui_kittest` already collects all snapshot errors of a test in one `SnapshotResults` and only panics when it is dropped, so no change is needed there.

* [x] I have followed the instructions in the PR template