### PR TITLE
CI: run once per PR, and stop PR caches from evicting the `main` cache

### DIFF
--- a/.github/workflows/cache_cleanup.yml
+++ b/.github/workflows/cache_cleanup.yml
@@ -1,0 +1,33 @@
+# Delete the GitHub Actions caches of a pull request once it is closed.
+#
+# A repository can only hold 10 GB of caches, and the oldest ones are evicted when it is full.
+# Without this the caches of merged pull requests would push out the `main` cache
+# that every new pull request starts from.
+
+name: Cache Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  actions: write
+
+jobs:
+  cleanup:
+    name: Delete the caches of the closed PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Delete caches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+          BRANCH_REF: refs/heads/${{ github.event.pull_request.head.ref }}
+        run: |
+          for ref in "$PR_REF" "$BRANCH_REF"; do
+            echo "Deleting the caches of $ref"
+            gh cache list --ref "$ref" --limit 100 --json id --jq '.[].id' \
+              | xargs -r -I {} gh cache delete {}
+          done

--- a/.github/workflows/png_only_on_lfs.yml
+++ b/.github/workflows/png_only_on_lfs.yml
@@ -1,6 +1,11 @@
 name: All; .png on git LFS
 
-on: [push, pull_request]
+on:
+  # Only on `main`, so that a PR from a branch in this repo
+  # doesn't run the whole workflow twice (once for the push, once for the PR):
+  push:
+    branches: ["main"]
+  pull_request:
 
 jobs:
   check-binary-files:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,9 @@
-on: [push, pull_request]
+on:
+  # Only on `main`, so that a PR from a branch in this repo
+  # doesn't run the whole workflow twice (once for the push, once for the PR):
+  push:
+    branches: ["main"]
+  pull_request:
 
 name: Rust
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,9 @@ jobs:
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
+        with:
+          # Only `main` writes to the cache, so PR caches can't evict it (10 GB repository limit).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Rustfmt
         run: cargo fmt --all -- --check
@@ -86,6 +89,9 @@ jobs:
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
+        with:
+          # Only `main` writes to the cache, so PR caches can't evict it (10 GB repository limit).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: clippy wasm32 egui_demo_app
         run: cargo clippy -p egui_demo_app --lib --target wasm32-unknown-unknown
@@ -117,6 +123,9 @@ jobs:
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
+        with:
+          # Only `main` writes to the cache, so PR caches can't evict it (10 GB repository limit).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{env.NIGHTLY_VERSION}}
@@ -174,6 +183,9 @@ jobs:
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
+        with:
+          # Only `main` writes to the cache, so PR caches can't evict it (10 GB repository limit).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
         # Default features disabled to turn off accesskit, which does not work
         # with NativeActivity.
@@ -196,6 +208,9 @@ jobs:
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
+        with:
+          # Only `main` writes to the cache, so PR caches can't evict it (10 GB repository limit).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
         # Default features are disabled because glutin doesn't compile for ios.
       - run: cargo check --features wgpu --target aarch64-apple-ios --no-default-features
@@ -215,6 +230,9 @@ jobs:
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
+        with:
+          # Only `main` writes to the cache, so PR caches can't evict it (10 GB repository limit).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - run: cargo clippy --all-targets --all-features
 
@@ -237,6 +255,9 @@ jobs:
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
+        with:
+          # Only `main` writes to the cache, so PR caches can't evict it (10 GB repository limit).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run tests
         run: cargo test --all-features


### PR DESCRIPTION
The `Run tests` job takes 9-12 minutes because it finds no cargo cache and rebuilds all 390 crates; the last run that hit the cache took 4m20s for the whole job. The repository holds 30 caches totalling 10.6 GB, over the 10 GB limit, so entries are evicted constantly. Each PR saves its own ~2.5 GB copy of every job cache, which pushes out the `main` cache that every new PR starts from.

* `on: [push, pull_request]` ran the whole workflow twice for a PR from a branch in this repo, doubling both runner time and cache writes. The push half now only runs for `main`.
* Only `main` writes to the cargo cache (`save-if`). PRs still read it.
* New workflow deletes the caches of a PR when it is closed.

* [x] I have followed the instructions in the PR template