### PR TITLE
Add emoji presentation selectors to the emoji used in the UI

### DIFF
--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -3563,13 +3563,13 @@ impl Context {
                 paint_stats.ui(ui);
             });
 
-        CollapsingHeader::new("🖼 Textures")
+        CollapsingHeader::new("🖼️ Textures")
             .default_open(false)
             .show(ui, |ui| {
                 self.texture_ui(ui);
             });
 
-        CollapsingHeader::new("🖼 Image loaders")
+        CollapsingHeader::new("🖼️ Image loaders")
             .default_open(false)
             .show(ui, |ui| {
                 self.loaders_ui(ui);

--- a/crates/egui/src/input_state/mod.rs
+++ b/crates/egui/src/input_state/mod.rs
@@ -1603,7 +1603,7 @@ impl InputState {
 
         ui.collapsing("Raw Input", |ui| raw.ui(ui));
 
-        crate::containers::CollapsingHeader::new("🖱 Pointer")
+        crate::containers::CollapsingHeader::new("🖱️ Pointer")
             .default_open(false)
             .show(ui, |ui| {
                 pointer.ui(ui);

--- a/crates/egui/src/input_state/mod.rs
+++ b/crates/egui/src/input_state/mod.rs
@@ -1615,7 +1615,7 @@ impl InputState {
             });
         }
 
-        crate::containers::CollapsingHeader::new("⬍ Scroll")
+        crate::containers::CollapsingHeader::new("↕️ Scroll")
             .default_open(false)
             .show(ui, |ui| {
                 wheel.ui(ui);

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -511,7 +511,7 @@ pub use self::{
 pub fn warn_if_debug_build(ui: &mut crate::Ui) {
     if cfg!(debug_assertions) {
         ui.label(
-            RichText::new("⚠ Debug build ⚠")
+            RichText::new("⚠️ Debug build ⚠️")
                 .small()
                 .color(ui.visuals().warn_fg_color),
         )

--- a/crates/egui/src/memory/mod.rs
+++ b/crates/egui/src/memory/mod.rs
@@ -410,7 +410,7 @@ impl Options {
         use crate::Widget as _;
         use crate::containers::CollapsingHeader;
 
-        CollapsingHeader::new("⚙ Options")
+        CollapsingHeader::new("⚙️ Options")
             .default_open(false)
             .show(ui, |ui| {
                 ui.horizontal(|ui| {
@@ -452,7 +452,7 @@ impl Options {
                 style.ui(ui);
             });
 
-        CollapsingHeader::new("✒ Painting")
+        CollapsingHeader::new("✒️ Painting")
             .default_open(false)
             .show(ui, |ui| {
                 tessellation_options.ui(ui);
@@ -461,7 +461,7 @@ impl Options {
                 });
             });
 
-        CollapsingHeader::new("🖱 Input")
+        CollapsingHeader::new("🖱️ Input")
             .default_open(false)
             .show(ui, |ui| {
                 input_options.ui(ui);

--- a/crates/egui/src/memory/theme.rs
+++ b/crates/egui/src/memory/theme.rs
@@ -42,7 +42,7 @@ impl Theme {
         #![expect(clippy::collapsible_else_if)]
         if self == Self::Dark {
             if ui
-                .add(Button::new("☀").frame(false))
+                .add(Button::new("☀️").frame(false))
                 .on_hover_text("Switch to light mode")
                 .clicked()
             {
@@ -90,7 +90,7 @@ impl ThemePreference {
     pub fn icon(self) -> &'static str {
         match self {
             Self::Dark => "🌙",
-            Self::Light => "☀",
+            Self::Light => "☀️",
             Self::System => "💻",
         }
     }

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -1901,7 +1901,7 @@ impl Style {
 
         ui.collapsing("🔠 Text styles", |ui| text_styles_ui(ui, text_styles));
         ui.collapsing("📏 Spacing", |ui| spacing.ui(ui));
-        ui.collapsing("☝ Interaction", |ui| interaction.ui(ui));
+        ui.collapsing("☝️ Interaction", |ui| interaction.ui(ui));
         ui.collapsing("🎨 Visuals", |ui| visuals.ui(ui));
         ui.collapsing("🔄 Scroll animation", |ui| scroll_animation.ui(ui));
 

--- a/crates/egui/src/widgets/image.rs
+++ b/crates/egui/src/widgets/image.rs
@@ -683,7 +683,7 @@ pub fn paint_texture_load_result(
                 ..Default::default()
             };
             job.append(
-                "⚠",
+                "⚠️",
                 0.0,
                 TextFormat::simple(font_id.clone(), ui.visuals().error_fg_color),
             );

--- a/crates/egui_demo_app/src/apps/image_viewer.rs
+++ b/crates/egui_demo_app/src/apps/image_viewer.rs
@@ -55,7 +55,7 @@ impl crate::DemoApp for ImageViewer {
                 let label = ui.label("URI:");
                 ui.text_edit_singleline(&mut self.uri_edit_text)
                     .labelled_by(label.id);
-                if ui.small_button("✔").clicked() {
+                if ui.small_button("✔️").clicked() {
                     ui.ctx().forget_image(&self.current_uri);
                     self.uri_edit_text = self.uri_edit_text.trim().to_owned();
                     self.current_uri = self.uri_edit_text.clone();

--- a/crates/egui_demo_app/src/backend_panel.rs
+++ b/crates/egui_demo_app/src/backend_panel.rs
@@ -328,7 +328,7 @@ fn integration_ui(ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
             {
                 let mut fullscreen = ui.input(|i| i.viewport().fullscreen.unwrap_or(false));
                 if ui
-                    .checkbox(&mut fullscreen, "🗖 Fullscreen (F11)")
+                    .checkbox(&mut fullscreen, "🔳 Fullscreen (F11)")
                     .on_hover_text("Fullscreen the window")
                     .changed()
                 {

--- a/crates/egui_demo_app/src/backend_panel.rs
+++ b/crates/egui_demo_app/src/backend_panel.rs
@@ -349,12 +349,12 @@ fn integration_ui(ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
                     ui.selectable_value(
                         &mut size,
                         Some(egui::vec2(1280.0, 720.0)),
-                        "🖥 Desktop 720p",
+                        "🖥️ Desktop 720p",
                     );
                     ui.selectable_value(
                         &mut size,
                         Some(egui::vec2(1920.0, 1080.0)),
-                        "🖥 Desktop 1080p",
+                        "🖥️ Desktop 1080p",
                     );
                 });
 

--- a/crates/egui_demo_app/src/wrap_app.rs
+++ b/crates/egui_demo_app/src/wrap_app.rs
@@ -232,7 +232,7 @@ impl WrapApp {
             ),
             #[cfg(feature = "http")]
             (
-                "⬇ HTTP",
+                "⬇️ HTTP",
                 Anchor::Http,
                 &mut self.state.http as &mut dyn DemoApp,
             ),
@@ -243,7 +243,7 @@ impl WrapApp {
             ),
             #[cfg(feature = "image_viewer")]
             (
-                "🖼 Image Viewer",
+                "🖼️ Image Viewer",
                 Anchor::ImageViewer,
                 &mut self.state.image_viewer as &mut dyn DemoApp,
             ),

--- a/crates/egui_demo_app/src/wrap_app.rs
+++ b/crates/egui_demo_app/src/wrap_app.rs
@@ -226,7 +226,7 @@ impl WrapApp {
             ),
             #[cfg(feature = "easymark")]
             (
-                "🖹 EasyMark editor",
+                "📝 EasyMark editor",
                 Anchor::EasyMarkEditor,
                 &mut self.state.easy_mark_editor as &mut dyn DemoApp,
             ),

--- a/crates/egui_demo_app/tests/test_demo_app.rs
+++ b/crates/egui_demo_app/tests/test_demo_app.rs
@@ -61,7 +61,7 @@ fn test_demo_app() {
                     .get_by_role_and_label(Role::TextInput, "URI:")
                     .type_text("file://../eframe/data/icon.png");
 
-                harness.get_by_role_and_label(Role::Button, "✔").click();
+                harness.get_by_role_and_label(Role::Button, "✔️").click();
 
                 // Wait for the image to load
                 harness.try_run_realtime().ok();

--- a/crates/egui_demo_lib/src/demo/code_editor.rs
+++ b/crates/egui_demo_lib/src/demo/code_editor.rs
@@ -23,7 +23,7 @@ fn main() {\n\
 
 impl crate::Demo for CodeEditor {
     fn name(&self) -> &'static str {
-        "🖮 Code Editor"
+        "⌨️ Code Editor"
     }
 
     fn show(&mut self, ui: &mut egui::Ui, open: &mut bool) {

--- a/crates/egui_demo_lib/src/demo/code_example.rs
+++ b/crates/egui_demo_lib/src/demo/code_example.rs
@@ -102,7 +102,7 @@ impl CodeExample {
 
 impl crate::Demo for CodeExample {
     fn name(&self) -> &'static str {
-        "🖮 Code Example"
+        "⌨️ Code Example"
     }
 
     fn show(&mut self, ui: &mut egui::Ui, open: &mut bool) {

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -445,7 +445,7 @@ mod tests {
 
     fn remove_leading_emoji(full_name: &str) -> &str {
         if let Some((start, name)) = full_name.split_once(' ')
-            && start.len() <= 4
+            && start.len() <= 7 // An emoji, plus an optional variation selector
             && start.bytes().next().is_some_and(|byte| byte >= 128)
         {
             return name;

--- a/crates/egui_demo_lib/src/demo/extra_viewport.rs
+++ b/crates/egui_demo_lib/src/demo/extra_viewport.rs
@@ -7,7 +7,7 @@ impl crate::Demo for ExtraViewport {
     }
 
     fn name(&self) -> &'static str {
-        "🗖 Extra Viewport"
+        "🖥️ Extra Viewport"
     }
 
     fn show(&mut self, ui: &mut egui::Ui, open: &mut bool) {

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -237,7 +237,7 @@ fn label_ui(ui: &mut egui::Ui) {
             let _ = ui.small_button("this button");
             ui.label(".");
 
-            ui.label("The default font supports all latin and cyrillic characters (ИÅđ…), common math symbols (∫√∞²⅓…), and many emojis (💓🌟🖩…).")
+            ui.label("The default font supports all latin and cyrillic characters (ИÅđ…), common math symbols (∫√∞²⅓…), and many emojis (💓🌟📐…).")
                 .on_hover_text("There is currently no support for right-to-left languages.");
             ui.label("See the 🔤 Font Book for more!");
 

--- a/crates/egui_demo_lib/src/demo/modals.rs
+++ b/crates/egui_demo_lib/src/demo/modals.rs
@@ -29,7 +29,7 @@ impl Modals {
 
 impl crate::Demo for Modals {
     fn name(&self) -> &'static str {
-        "🗖 Modals"
+        "💭 Modals"
     }
 
     fn show(&mut self, ui: &mut egui::Ui, open: &mut bool) {

--- a/crates/egui_demo_lib/src/demo/painting.rs
+++ b/crates/egui_demo_lib/src/demo/painting.rs
@@ -74,7 +74,7 @@ impl Painting {
 
 impl crate::Demo for Painting {
     fn name(&self) -> &'static str {
-        "🖊 Painting"
+        "🖊️ Painting"
     }
 
     fn show(&mut self, ui: &mut egui::Ui, open: &mut bool) {

--- a/crates/egui_demo_lib/src/demo/panels.rs
+++ b/crates/egui_demo_lib/src/demo/panels.rs
@@ -122,10 +122,10 @@ impl crate::View for Panels {
 
             ui.horizontal(|ui| {
                 ui.label("Panel toggles:");
-                ui.toggle_value(left, "⬅");
-                ui.toggle_value(top, "⬆");
-                ui.toggle_value(bottom, "⬇");
-                ui.toggle_value(right, "➡");
+                ui.toggle_value(left, "⬅️");
+                ui.toggle_value(top, "⬆️");
+                ui.toggle_value(bottom, "⬇️");
+                ui.toggle_value(right, "➡️");
             });
 
             ui.separator();

--- a/crates/egui_demo_lib/src/demo/panels.rs
+++ b/crates/egui_demo_lib/src/demo/panels.rs
@@ -20,7 +20,7 @@ impl Default for Panels {
 
 impl crate::Demo for Panels {
     fn name(&self) -> &'static str {
-        "🗖 Panels"
+        "📰 Panels"
     }
 
     fn show(&mut self, ui: &mut egui::Ui, open: &mut bool) {

--- a/crates/egui_demo_lib/src/demo/password.rs
+++ b/crates/egui_demo_lib/src/demo/password.rs
@@ -27,7 +27,7 @@ pub fn password_ui(ui: &mut egui::Ui, password: &mut String) -> egui::Response {
     let result = ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
         // Toggle the `show_plaintext` bool with a button:
         let response = ui
-            .selectable_label(show_plaintext, "👁")
+            .selectable_label(show_plaintext, "👁️")
             .on_hover_text("Show/hide password");
 
         if response.clicked() {

--- a/crates/egui_demo_lib/src/demo/scrolling.rs
+++ b/crates/egui_demo_lib/src/demo/scrolling.rs
@@ -27,7 +27,7 @@ pub struct Scrolling {
 
 impl crate::Demo for Scrolling {
     fn name(&self) -> &'static str {
-        "↕ Scrolling"
+        "↕️ Scrolling"
     }
 
     fn show(&mut self, ui: &mut egui::Ui, open: &mut bool) {
@@ -301,10 +301,10 @@ impl crate::View for ScrollTo {
                 .speed(1.0)
                 .suffix("px")
                 .ui(ui);
-            if ui.button("⬇").clicked() {
+            if ui.button("⬇️").clicked() {
                 scroll_delta = Some(self.delta * Vec2::UP); // scroll down (move contents up)
             }
-            if ui.button("⬆").clicked() {
+            if ui.button("⬆️").clicked() {
                 scroll_delta = Some(self.delta * Vec2::DOWN); // scroll up (move contents down)
             }
         });

--- a/crates/egui_demo_lib/src/demo/sliders.rs
+++ b/crates/egui_demo_lib/src/demo/sliders.rs
@@ -40,7 +40,7 @@ impl Default for Sliders {
 
 impl crate::Demo for Sliders {
     fn name(&self) -> &'static str {
-        "⬌ Sliders"
+        "↔️ Sliders"
     }
 
     fn show(&mut self, ui: &mut egui::Ui, open: &mut bool) {

--- a/crates/egui_demo_lib/src/demo/table_demo.rs
+++ b/crates/egui_demo_lib/src/demo/table_demo.rs
@@ -186,7 +186,7 @@ impl TableDemo {
                         },
                         |ui| {
                             self.reversed ^=
-                                ui.button(if self.reversed { "⬆" } else { "⬇" }).clicked();
+                                ui.button(if self.reversed { "⬆️" } else { "⬇️" }).clicked();
                         },
                     );
                 });

--- a/crates/egui_demo_lib/src/demo/tests/window_resize_test.rs
+++ b/crates/egui_demo_lib/src/demo/tests/window_resize_test.rs
@@ -18,7 +18,7 @@ impl crate::Demo for WindowResizeTest {
     fn show(&mut self, ui: &mut egui::Ui, open: &mut bool) {
         use egui::{Resize, ScrollArea, TextEdit, Window};
 
-        Window::new("↔ auto-sized")
+        Window::new("↔️ auto-sized")
             .open(open)
             .auto_sized()
             .constrain_to(ui.available_rect_before_wrap())
@@ -31,7 +31,7 @@ impl crate::Demo for WindowResizeTest {
                 ui.heading("Resize the above area!");
             });
 
-        Window::new("↔ resizable + scroll")
+        Window::new("↔️ resizable + scroll")
             .open(open)
             .vscroll(true)
             .resizable(true)
@@ -45,7 +45,7 @@ impl crate::Demo for WindowResizeTest {
                 lorem_ipsum(ui, crate::LOREM_IPSUM_LONG);
             });
 
-        Window::new("↔ resizable + embedded scroll")
+        Window::new("↔️ resizable + embedded scroll")
             .open(open)
             .vscroll(false)
             .resizable(true)
@@ -63,7 +63,7 @@ impl crate::Demo for WindowResizeTest {
                 // ui.heading("Some additional text here, that should also be visible"); // this works, but messes with the resizing a bit
             });
 
-        Window::new("↔ resizable without scroll")
+        Window::new("↔️ resizable without scroll")
             .open(open)
             .vscroll(false)
             .resizable(true)
@@ -75,7 +75,7 @@ impl crate::Demo for WindowResizeTest {
                 lorem_ipsum(ui, crate::LOREM_IPSUM);
             });
 
-        Window::new("↔ resizable with TextEdit")
+        Window::new("↔️ resizable with TextEdit")
             .open(open)
             .vscroll(false)
             .resizable(true)
@@ -86,7 +86,7 @@ impl crate::Demo for WindowResizeTest {
                 ui.add_sized(ui.available_size(), TextEdit::multiline(&mut self.text));
             });
 
-        Window::new("↔ freely resized")
+        Window::new("↔️ freely resized")
             .open(open)
             .vscroll(false)
             .resizable(true)

--- a/crates/egui_demo_lib/src/demo/text_edit.rs
+++ b/crates/egui_demo_lib/src/demo/text_edit.rs
@@ -22,7 +22,7 @@ impl Default for TextEditDemo {
 
 impl crate::Demo for TextEditDemo {
     fn name(&self) -> &'static str {
-        "🖹 TextEdit"
+        "✏️ TextEdit"
     }
 
     fn show(&mut self, ui: &mut egui::Ui, open: &mut bool) {

--- a/crates/egui_demo_lib/src/demo/text_layout.rs
+++ b/crates/egui_demo_lib/src/demo/text_layout.rs
@@ -29,7 +29,7 @@ impl Default for TextLayoutDemo {
 
 impl crate::Demo for TextLayoutDemo {
     fn name(&self) -> &'static str {
-        "🖹 Text Layout"
+        "📄 Text Layout"
     }
 
     fn show(&mut self, ui: &mut egui::Ui, open: &mut bool) {

--- a/crates/egui_demo_lib/src/demo/tooltips.rs
+++ b/crates/egui_demo_lib/src/demo/tooltips.rs
@@ -12,7 +12,7 @@ impl Default for Tooltips {
 
 impl crate::Demo for Tooltips {
     fn name(&self) -> &'static str {
-        "🗖 Tooltips"
+        "💬 Tooltips"
     }
 
     fn show(&mut self, ui: &mut egui::Ui, open: &mut bool) {

--- a/crates/egui_demo_lib/src/demo/widget_gallery.rs
+++ b/crates/egui_demo_lib/src/demo/widget_gallery.rs
@@ -61,7 +61,7 @@ impl WidgetGallery {
 
 impl crate::Demo for WidgetGallery {
     fn name(&self) -> &'static str {
-        "🗄 Widget Gallery"
+        "🗄️ Widget Gallery"
     }
 
     fn show(&mut self, ui: &mut egui::Ui, open: &mut bool) {

--- a/crates/egui_demo_lib/src/demo/window_options.rs
+++ b/crates/egui_demo_lib/src/demo/window_options.rs
@@ -23,7 +23,7 @@ pub struct WindowOptions {
 impl Default for WindowOptions {
     fn default() -> Self {
         Self {
-            title: "🗖 Window Options".to_owned(),
+            title: "🔲 Window Options".to_owned(),
             title_bar: true,
             closable: true,
             collapsible: true,
@@ -42,7 +42,7 @@ impl Default for WindowOptions {
 
 impl crate::Demo for WindowOptions {
     fn name(&self) -> &'static str {
-        "🗖 Window Options"
+        "🔲 Window Options"
     }
 
     fn show(&mut self, ui: &mut egui::Ui, open: &mut bool) {

--- a/crates/egui_extras/src/syntax_highlighting.rs
+++ b/crates/egui_extras/src/syntax_highlighting.rs
@@ -367,7 +367,7 @@ impl CodeTheme {
             ui.selectable_value(&mut self.dark_mode, true, "🌙 Dark theme")
                 .on_hover_text("Use the dark mode theme");
 
-            ui.selectable_value(&mut self.dark_mode, false, "☀ Light theme")
+            ui.selectable_value(&mut self.dark_mode, false, "☀️ Light theme")
                 .on_hover_text("Use the light mode theme");
         });
         let current_theme_is_dark = self.is_dark();
@@ -436,7 +436,7 @@ impl CodeTheme {
                     ui.selectable_value(&mut self.dark_mode, true, "🌙 Dark theme")
                         .on_hover_text("Use the dark mode theme");
 
-                    ui.selectable_value(&mut self.dark_mode, false, "☀ Light theme")
+                    ui.selectable_value(&mut self.dark_mode, false, "☀️ Light theme")
                         .on_hover_text("Use the light mode theme");
                 });
                 ui.scope(|ui| {


### PR DESCRIPTION
Emoji like ☀, ⚙, 🖱, 🖼, and ⬇ have *text* presentation by default, so browsers and most platforms draw them monochrome, next to color emoji like 🌙 and 💻. Reported in https://github.com/emilk/egui/pull/8505#issuecomment-5553069797.

This appends U+FE0F (the emoji presentation selector) wherever such an emoji is used as an icon in egui, egui_extras, and the demos. The selector is zero-width and has no advance, so builds with the bundled monochrome emoji fonts render exactly as before (snapshots unchanged).

Not touched: emoji in doc comments, and the character list in `egui/src/lib.rs`.

* [x] I have followed the instructions in the PR template

PR chain, in order:
* #8490
* #8500
* #8501
* #8502
* #8503
* #8504
* #8491
* #8492
* #8493
* #8508
* #8509
* #8510
* #8511
