### PR TITLE
Log at debug level when no font has a char

### DIFF
--- a/crates/epaint/src/text/family.rs
+++ b/crates/epaint/src/text/family.rs
@@ -167,7 +167,15 @@ impl Family {
             // …and if none of them has the char, ask the providers for a new font:
             .or_else(|| self.discover(faces, providers, cluster))
             // No font has the char, so we will render the replacement glyph (e.g. `◻`):
-            .unwrap_or(self.replacement_face_key);
+            .unwrap_or_else(|| {
+                log::debug!(
+                    "No font for {c:?} (U+{:04X}) in {:?}: rendering {:?} instead",
+                    c as u32,
+                    self.name,
+                    self.replacement_char
+                );
+                self.replacement_face_key
+            });
         self.face_cache.insert(c, font_key);
         font_key
     }


### PR DESCRIPTION
Logs once per character (the result is cached in `Family::face_cache`, and the lookup is `#[cold]`):

```
No font for '🖹' (U+1F5B9) in Proportional: rendering '?' instead
```

Makes it easy to see which characters your font set is missing, e.g. after turning off the bundled emoji fonts.

* [x] I have followed the instructions in the PR template

PR chain, in order:
* #8490
* #8500
* #8501
* #8502
* #8503
* #8504
* #8491
* #8492
* #8493
* #8508
* #8509
* #8510
* #8511
