### PR TITLE
Render the font's `.notdef` glyph (tofu) for characters no font has

### DIFF
--- a/crates/epaint/src/text/family.rs
+++ b/crates/epaint/src/text/family.rs
@@ -16,7 +16,7 @@ pub(crate) struct FamilyKey(pub(crate) usize);
 ///
 /// This is the only place that decides which face renders a given char:
 /// first the fonts the [`FontProviders`] install up front (the configured fonts),
-/// then fonts they discover on demand, then the replacement glyph.
+/// then fonts they discover on demand, then the `.notdef` glyph ("tofu") of the primary face.
 #[derive(Debug)]
 pub(crate) struct Family {
     name: FontFamily,
@@ -25,15 +25,6 @@ pub(crate) struct Family {
     ///
     /// Configured fonts first, then any discovered by the [`FontProviders`].
     chain: Vec<FontFaceKey>,
-
-    /// The face used when no face in [`Self::chain`] supports a char.
-    replacement_face_key: FontFaceKey,
-
-    /// The char that [`Self::replacement_face_key`] actually contains.
-    ///
-    /// When the user asks about a char that no fallback face supports we
-    /// render this char in its place.
-    replacement_char: char,
 
     /// Cache: `char → which face in the fallback chain owns this char`.
     ///
@@ -46,9 +37,6 @@ pub(crate) struct Family {
 }
 
 impl Family {
-    const PRIMARY_REPLACEMENT_CHAR: char = '◻'; // white medium square
-    const FALLBACK_REPLACEMENT_CHAR: char = '?'; // fallback for the fallback
-
     /// Install the fonts the providers want for `name` up front, in provider order.
     pub fn new(name: &FontFamily, faces: &mut FaceStore, providers: &FontProviders) -> Self {
         let mut chain: Vec<FontFaceKey> = Vec::new();
@@ -68,36 +56,12 @@ impl Family {
             log::error!("No font provider has any font for FontFamily::{name:?}");
         }
 
-        let mut slf = Self {
+        Self {
             name: name.clone(),
             chain,
-            replacement_face_key: FontFaceKey::INVALID,
-            replacement_char: Self::PRIMARY_REPLACEMENT_CHAR,
             face_cache: Default::default(),
             characters: None,
-        };
-
-        if !slf.chain.is_empty() {
-            let (replacement_face_key, replacement_char) = slf
-                .find_face_for_char(Self::PRIMARY_REPLACEMENT_CHAR, faces)
-                .map(|key| (key, Self::PRIMARY_REPLACEMENT_CHAR))
-                .or_else(|| {
-                    slf.find_face_for_char(Self::FALLBACK_REPLACEMENT_CHAR, faces)
-                        .map(|key| (key, Self::FALLBACK_REPLACEMENT_CHAR))
-                })
-                .unwrap_or_else(|| {
-                    log::warn!(
-                        "Failed to find replacement characters {:?} or {:?}. Will use empty glyph.",
-                        Self::PRIMARY_REPLACEMENT_CHAR,
-                        Self::FALLBACK_REPLACEMENT_CHAR
-                    );
-                    (FontFaceKey::INVALID, Self::PRIMARY_REPLACEMENT_CHAR)
-                });
-            slf.replacement_face_key = replacement_face_key;
-            slf.replacement_char = replacement_char;
         }
-
-        slf
     }
 
     #[inline]
@@ -111,17 +75,12 @@ impl Family {
         self.chain.first().copied()
     }
 
-    /// The char rendered in place of chars no face in the chain has.
-    #[inline]
-    pub fn replacement_char(&self) -> char {
-        self.replacement_char
-    }
-
     /// Find which face in the fallback chain owns `c`.
     ///
     /// Location-independent: fallback choice depends only on charmap support.
     /// Asks the [`FontProviders`] when no face has `c`,
-    /// and falls back to the replacement-glyph face when they have no font for it either.
+    /// and falls back to the primary face (whose `.notdef` glyph we then render)
+    /// when they have no font for it either.
     #[inline]
     pub fn resolve(
         &mut self,
@@ -144,7 +103,7 @@ impl Family {
         cluster: &str,
     ) -> FontFaceKey {
         let Some(base_char) = cluster.chars().next() else {
-            return self.replacement_face_key;
+            return self.notdef_face();
         };
         if let Some(font_key) = self.face_cache.get(&base_char) {
             return *font_key;
@@ -166,18 +125,23 @@ impl Family {
             .find_face_for_char(c, faces)
             // …and if none of them has the char, ask the providers for a new font:
             .or_else(|| self.discover(faces, providers, cluster))
-            // No font has the char, so we will render the replacement glyph (e.g. `◻`):
+            // No font has the char, so we will render the `.notdef` glyph ("tofu"):
             .unwrap_or_else(|| {
                 log::debug!(
-                    "No font for {c:?} (U+{:04X}) in {:?}: rendering {:?} instead",
+                    "No font for {c:?} (U+{:04X}) in {:?}: rendering the tofu glyph instead",
                     c as u32,
-                    self.name,
-                    self.replacement_char
+                    self.name
                 );
-                self.replacement_face_key
+                self.notdef_face()
             });
         self.face_cache.insert(c, font_key);
         font_key
+    }
+
+    /// The face whose `.notdef` glyph ("tofu") we render for chars no face has.
+    #[inline]
+    fn notdef_face(&self) -> FontFaceKey {
+        self.primary().unwrap_or(FontFaceKey::INVALID)
     }
 
     /// Ask the providers for a new font with the first char of `cluster`, and append it to the chain.

--- a/crates/epaint/src/text/font_face.rs
+++ b/crates/epaint/src/text/font_face.rs
@@ -100,11 +100,6 @@ impl FontCell {
         bin: SubpixelBin,
         hinting_target: skrifa::outline::Target,
     ) -> Option<GlyphBitmap> {
-        debug_assert!(
-            glyph_id != skrifa::GlyphId::NOTDEF,
-            "Can't rasterize glyph id 0"
-        );
-
         let location: skrifa::instance::LocationRef<'_> = (&metrics.location).into();
 
         // Color emoji fonts often have empty outlines next to their bitmap or `COLR` glyphs,
@@ -454,7 +449,7 @@ impl FontFace {
         });
     }
 
-    /// Code points that will always be replaced by the replacement character.
+    /// Code points that will always be replaced by the `.notdef` glyph ("tofu").
     ///
     /// See also [`invisible_char`].
     fn ignore_character(&self, chr: char) -> bool {
@@ -507,7 +502,7 @@ impl FontFace {
         }
 
         if self.ignore_character(c) {
-            return None; // these will result in the replacement character when rendering
+            return None; // these will result in the `.notdef` glyph ("tofu") when rendering
         }
 
         let resolution = if c == '\t' || c == '\u{2009}' || c == '\u{202F}' {
@@ -576,6 +571,21 @@ impl FontFace {
             },
         };
         Some(glyph_info)
+    }
+
+    /// The `.notdef` glyph ("tofu"), rendered in place of chars that no face has.
+    pub(super) fn notdef_glyph_info(&self, metrics: &StyledMetrics) -> GlyphInfo {
+        let font_data = self.font.borrow_dependent();
+        let glyph_metrics = font_data
+            .skrifa
+            .glyph_metrics(skrifa::instance::Size::unscaled(), &metrics.location);
+        GlyphInfo {
+            id: Some(GlyphId::NOTDEF),
+            advance_width_unscaled: glyph_metrics
+                .advance_width(GlyphId::NOTDEF)
+                .unwrap_or_default()
+                .into(),
+        }
     }
 
     #[inline(always)]

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -473,7 +473,7 @@ impl FontsImpl {
 
     /// Resolve `c` to its (face, [`GlyphInfo`]) at the given face's location.
     ///
-    /// `\n` will (intentionally) show up as the replacement character.
+    /// `\n` will (intentionally) show up as the `.notdef` glyph ("tofu").
     ///
     /// `metrics` must be the resolved [`StyledMetrics`] for the face that ends
     /// up owning `c`. Most callers pass the metrics of their text run's primary
@@ -494,12 +494,11 @@ impl FontsImpl {
             return (face_key, glyph_info);
         }
 
-        // `c` is in no face: render the replacement character instead.
-        let replacement_char = self.family(family).replacement_char();
+        // `c` is in no face: render the face's `.notdef` glyph ("tofu") instead.
         let glyph_info = self
             .faces
-            .get_mut(face_key)
-            .and_then(|face| face.glyph_info(replacement_char, metrics))
+            .get(face_key)
+            .map(|face| face.notdef_glyph_info(metrics))
             .unwrap_or(GlyphInfo::INVISIBLE);
         (face_key, glyph_info)
     }

--- a/crates/epaint/src/text/glyph_atlas.rs
+++ b/crates/epaint/src/text/glyph_atlas.rs
@@ -255,6 +255,9 @@ impl GlyphAtlas {
 
     /// Get or render the glyph of `face` for `shaped`.
     ///
+    /// [`GlyphId::NOTDEF`] renders the face's `.notdef` glyph ("tofu"),
+    /// which is what we show for characters no font has.
+    ///
     /// The bitmap is rendered at the sub-pixel bin of [`ShapedGlyph::h_pos`]
     /// (if the face has sub-pixel binning on, and the glyph is not CJK),
     /// so the same glyph can occupy up to four slots in the atlas.
@@ -272,14 +275,6 @@ impl GlyphAtlas {
             h_pos,
             is_cjk,
         } = *shaped;
-
-        if glyph_id == GlyphId::NOTDEF {
-            // invisible
-            return OutlineGlyph {
-                allocation: GlyphAllocation::default(),
-                x_px: h_pos.round() as i32,
-            };
-        }
 
         let subpixel_binning =
             face.subpixel_binning() && !is_cjk && !face.is_color_glyph(metrics, glyph_id);

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -21,7 +21,7 @@ use super::{
     ByteRangeExt as _, Galley, Glyph, LayoutJob, LayoutSection, PlacedRow, Row, RowVisuals,
     VariationCoords,
     family::FamilyKey,
-    font_face::{FontFace, ShapedGlyph},
+    font_face::{FontFace, GlyphInfo, ShapedGlyph},
     glyph_atlas::{GlyphAllocation, OutlineGlyph, RasterGlyphAllocation},
 };
 
@@ -297,7 +297,7 @@ fn layout_shaped_run(
         let glyph = if glyph_id == skrifa::GlyphId::NOTDEF {
             // The shaper couldn't map this character. Drop combining marks and duplicate
             // NOTDEF glyphs within the same cluster. The first base character is rasterized,
-            // or rendered as a replacement glyph if no rasterizer can handle the cluster.
+            // or rendered as the `.notdef` glyph ("tofu") if no rasterizer can handle the cluster.
             if is_combining_mark(chr) || !is_new_cluster {
                 continue;
             }
@@ -332,14 +332,13 @@ fn layout_shaped_run(
                 let (_, glyph_info) = fonts.glyph_info(ctx.family, chr, &fallback_metrics);
                 let advance_width_px =
                     glyph_info.advance_width_unscaled.0 * fallback_metrics.px_scale_factor;
-                let OutlineGlyph { allocation, x_px } = fonts.allocate_glyph(
+                let OutlineGlyph { allocation, x_px } = allocate_glyph_info(
+                    fonts,
                     fallback_key,
                     &fallback_metrics,
-                    &ShapedGlyph {
-                        glyph_id: glyph_info.id.unwrap_or(skrifa::GlyphId::NOTDEF),
-                        h_pos: paragraph.cursor_x_px,
-                        is_cjk: is_cjk(chr),
-                    },
+                    glyph_info,
+                    paragraph.cursor_x_px,
+                    chr,
                 );
 
                 paragraph.cursor_x_px += advance_width_px;
@@ -383,6 +382,32 @@ fn layout_shaped_run(
             face_metrics,
         );
     }
+}
+
+/// Put `glyph_info` in the atlas, or nothing at all if it is invisible.
+fn allocate_glyph_info(
+    fonts: &mut FontsImpl,
+    face_key: FontFaceKey,
+    metrics: &StyledMetrics,
+    glyph_info: GlyphInfo,
+    h_pos_px: f32,
+    chr: char,
+) -> OutlineGlyph {
+    let Some(glyph_id) = glyph_info.id else {
+        return OutlineGlyph {
+            allocation: GlyphAllocation::default(),
+            x_px: h_pos_px.round() as i32,
+        };
+    };
+    fonts.allocate_glyph(
+        face_key,
+        metrics,
+        &ShapedGlyph {
+            glyph_id,
+            h_pos: h_pos_px,
+            is_cjk: is_cjk(chr),
+        },
+    )
 }
 
 /// Emit one glyph for a rasterized cluster and advance the cursor.
@@ -820,14 +845,13 @@ fn replace_last_glyph_with_overflow_character(
             let OutlineGlyph {
                 allocation: replacement_glyph_alloc,
                 x_px,
-            } = fonts.allocate_glyph(
+            } = allocate_glyph_info(
+                fonts,
                 face_key,
                 &font_face_metrics,
-                &ShapedGlyph {
-                    glyph_id: glyph_info.id.unwrap_or(skrifa::GlyphId::NOTDEF),
-                    h_pos: overflow_glyph_x * pixels_per_point,
-                    is_cjk: is_cjk(overflow_character),
-                },
+                glyph_info,
+                overflow_glyph_x * pixels_per_point,
+                overflow_character,
             );
 
             let font_metrics =
@@ -1675,7 +1699,7 @@ mod tests {
         assert_eq!(glyph.chr, '한');
         assert!(
             !glyph.uv_rect.is_nothing(),
-            "Should render the replacement glyph"
+            "Should render the `.notdef` glyph"
         );
     }
 
@@ -1739,9 +1763,8 @@ mod tests {
     }
 
     #[test]
-    // No bundled font has CJK glyphs, so the line breaks depend on the width of the
-    // replacement glyph, and that depends on which fonts are bundled.
-    #[cfg(feature = "monochrome_emoji_fonts")]
+    // No bundled font has CJK glyphs, so the line breaks depend on
+    // the width of the `.notdef` glyph of the primary font.
     fn test_cjk() {
         let pixels_per_point = 1.0;
         let mut fonts = test_fonts();
@@ -1753,14 +1776,13 @@ mod tests {
         let galley = layout(&mut fonts, pixels_per_point, layout_job.into());
         assert_eq!(
             galley.rows.iter().map(|row| row.text()).collect::<Vec<_>>(),
-            vec!["日本語と", "Englishの混在", "した文章"]
+            vec!["日本語とEnglishの混", "在した文章"]
         );
     }
 
     #[test]
-    // No bundled font has CJK glyphs, so the line breaks depend on the width of the
-    // replacement glyph, and that depends on which fonts are bundled.
-    #[cfg(feature = "monochrome_emoji_fonts")]
+    // No bundled font has CJK glyphs, so the line breaks depend on
+    // the width of the `.notdef` glyph of the primary font.
     fn test_pre_cjk() {
         let pixels_per_point = 1.0;
         let mut fonts = test_fonts();
@@ -1772,7 +1794,7 @@ mod tests {
         let galley = layout(&mut fonts, pixels_per_point, layout_job.into());
         assert_eq!(
             galley.rows.iter().map(|row| row.text()).collect::<Vec<_>>(),
-            vec!["日本語とEnglish", "の混在した文章"]
+            vec!["日本語とEnglishの混在した", "文章"]
         );
     }
 
@@ -1914,7 +1936,7 @@ mod tests {
         // ɔ̃ = U+0254 (LATIN SMALL LETTER OPEN O) + U+0303 (COMBINING TILDE)
         // With text shaping, the combining tilde should NOT produce a separate
         // advance — it should be positioned above ɔ via GPOS anchors.
-        // Note: the default fonts don't contain U+0254, so the replacement glyph
+        // Note: the default fonts don't contain U+0254, so the `.notdef` glyph
         // is used. The key test is that the combining mark does NOT add extra width.
         let pixels_per_point = 1.0;
         let mut fonts = test_fonts();

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -73,7 +73,7 @@ pub struct LayoutJob {
     /// starting on a new row.
     ///
     /// If `false`, all `\n` characters will be ignored
-    /// and show up as the replacement character.
+    /// and show up as the `.notdef` glyph ("tofu").
     ///
     /// Default: `true`.
     pub break_on_newline: bool,
@@ -155,7 +155,7 @@ impl LayoutJob {
         }
     }
 
-    /// Does not break on `\n`, but shows the replacement character instead.
+    /// Does not break on `\n`, but shows the `.notdef` glyph ("tofu") instead.
     #[inline]
     pub fn simple_singleline(text: String, font_id: FontId, color: Color32) -> Self {
         Self {


### PR DESCRIPTION
Characters that no font in the family has were rendered as the *character* ◻ (U+25FB), or as `?` when no font in the chain had ◻. Only the bundled emoji fonts have ◻, so after #8493 made those opt-in, every missing character showed up as `?`.

Now we render glyph 0, the `.notdef` glyph, of the family's primary face. Every font has one (both Hack and Ubuntu-Light draw a box), so the tofu is always there and always matches the text font.

* `Family` loses `replacement_face_key` and `replacement_char`
* `GlyphAtlas::allocate_outline` renders `NOTDEF` instead of skipping it; invisible glyphs are skipped by the caller instead
* The CJK layout tests no longer depend on which fonts are bundled, so they run in both feature configurations. Their expected line breaks changed, since the tofu is narrower than ◻ was.

PR chain, in order:
* #8490
* #8500
* #8501
* #8502
* #8503
* #8504
* #8491
* #8492
* #8493
* #8508
* #8509
* #8510
* #8511
