### PR TITLE
 non-blocking webp loader

### DIFF
--- a/crates/egui_extras/src/loaders/webp_loader.rs
+++ b/crates/egui_extras/src/loaders/webp_loader.rs
@@ -1,12 +1,15 @@
 use ahash::HashMap;
-use core::{mem::size_of, time::Duration};
+use core::{mem::size_of, task::Poll, time::Duration};
 use egui::{
     ColorImage, FrameDurations, Id, decode_animated_image_uri, has_webp_header,
-    load::{BytesPoll, ImageLoadResult, ImageLoader, ImagePoll, LoadError, SizeHint},
+    load::{Bytes, BytesPoll, ImageLoadResult, ImageLoader, ImagePoll, LoadError, SizeHint},
     mutex::Mutex,
 };
 use image::{AnimationDecoder as _, ColorType, ImageDecoder as _, Rgba, codecs::webp::WebPDecoder};
 use std::{io::Cursor, sync::Arc};
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::thread;
 
 #[derive(Clone)]
 enum WebP {
@@ -113,11 +116,17 @@ impl AnimatedImage {
     }
 }
 
-type Entry = Result<WebP, String>;
+fn store_frame_durations(ctx: &egui::Context, image_uri: &str, frame_durations: FrameDurations) {
+    ctx.data_mut(|data| {
+        *data.get_temp_mut_or_default(Id::new(image_uri)) = frame_durations;
+    });
+}
+
+type Entry = Poll<Result<WebP, String>>;
 
 #[derive(Default)]
 pub struct WebPLoader {
-    cache: Mutex<HashMap<String, Entry>>,
+    cache: Arc<Mutex<HashMap<String, Entry>>>,
 }
 
 impl WebPLoader {
@@ -133,13 +142,107 @@ impl ImageLoader for WebPLoader {
         let (image_uri, frame_index) =
             decode_animated_image_uri(frame_uri).map_err(|_error| LoadError::NotSupported)?;
 
-        let mut cache = self.cache.lock();
-        if let Some(entry) = cache.get(image_uri).cloned() {
-            match entry {
+        #[cfg(not(target_arch = "wasm32"))]
+        #[expect(clippy::unnecessary_wraps)] // needed here to match other return types
+        fn load_image(
+            ctx: &egui::Context,
+            image_uri: &str,
+            _frame_index: usize,
+            cache: &Arc<Mutex<HashMap<String, Entry>>>,
+            bytes: &Bytes,
+        ) -> ImageLoadResult {
+            let image_uri = image_uri.to_owned();
+            cache.lock().insert(image_uri.clone(), Poll::Pending);
+
+            // Do the image parsing on a bg thread
+            thread::Builder::new()
+                .name(format!("egui_extras::WebPLoader::load({image_uri:?}"))
+                .spawn({
+                    let ctx = ctx.clone();
+                    let cache = Arc::clone(cache);
+                    let bytes = bytes.clone();
+                    move || {
+                        log::trace!("WebPLoader - started loading {image_uri:?}");
+                        let result = WebP::load(&bytes);
+                        let frame_durations = match &result {
+                            Ok(WebP::Animated(animated_image)) => {
+                                Some(animated_image.frame_durations.clone())
+                            }
+                            _ => None,
+                        };
+                        let found = {
+                            let mut cache = cache.lock();
+
+                            if let std::collections::hash_map::Entry::Occupied(mut entry) =
+                                cache.entry(image_uri.clone())
+                            {
+                                let entry = entry.get_mut();
+                                *entry = Poll::Ready(result);
+                                log::trace!("WebPLoader - finished loading {image_uri:?}");
+                                true
+                            } else {
+                                log::trace!("WebPLoader - canceled loading {image_uri:?}\nNote: This can happen if `forget_image` is called while the image is still loading");
+                                false
+                            }
+                        };
+                        // We may not lock Context while the cache lock is held, since this can
+                        // deadlock.
+                        // Example deadlock scenario:
+                        // - loader thread: lock cache
+                        // - main thread: lock ctx (e.g. in `Context::has_pending_images`)
+                        // - loader thread: try to lock ctx (in `request_repaint`)
+                        // - main thread: try to lock cache (from `Self::has_pending`)
+                        if found {
+                            if let Some(frame_durations) = frame_durations {
+                                store_frame_durations(&ctx, &image_uri, frame_durations);
+                            }
+                            ctx.request_repaint();
+                        }
+                    }
+                })
+                .expect("failed to spawn thread");
+
+            Ok(ImagePoll::Pending { size: None })
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        fn load_image(
+            ctx: &egui::Context,
+            image_uri: &str,
+            frame_index: usize,
+            cache: &Arc<Mutex<HashMap<String, Entry>>>,
+            bytes: &Bytes,
+        ) -> ImageLoadResult {
+            log::trace!("WebPLoader - started loading {image_uri:?}");
+
+            let result = WebP::load(bytes);
+
+            if let Ok(WebP::Animated(animated_image)) = &result {
+                store_frame_durations(ctx, image_uri, animated_image.frame_durations.clone());
+            }
+
+            log::trace!("WebPLoader - finished loading {image_uri:?}");
+
+            let image_result = match &result {
                 Ok(image) => Ok(ImagePoll::Ready {
                     image: image.get_image(frame_index),
                 }),
-                Err(error) => Err(LoadError::Loading(error)),
+                Err(error) => Err(LoadError::Loading(error.clone())),
+            };
+            cache.lock().insert(image_uri.into(), Poll::Ready(result));
+            image_result
+        }
+
+        let entry = self.cache.lock().get(image_uri).cloned();
+        if let Some(entry) = entry {
+            match entry {
+                Poll::Ready(res) => match res {
+                    Ok(image) => Ok(ImagePoll::Ready {
+                        image: image.get_image(frame_index),
+                    }),
+                    Err(error) => Err(LoadError::Loading(error)),
+                },
+                Poll::Pending => Ok(ImagePoll::Pending { size: None }),
             }
         } else {
             match ctx.try_load_bytes(image_uri) {
@@ -147,28 +250,7 @@ impl ImageLoader for WebPLoader {
                     if !has_webp_header(&bytes) {
                         return Err(LoadError::NotSupported);
                     }
-
-                    log::trace!("started loading {image_uri:?}");
-
-                    let result = WebP::load(&bytes);
-
-                    if let Ok(WebP::Animated(animated_image)) = &result {
-                        ctx.data_mut(|data| {
-                            *data.get_temp_mut_or_default(Id::new(image_uri)) =
-                                animated_image.frame_durations.clone();
-                        });
-                    }
-
-                    log::trace!("finished loading {image_uri:?}");
-
-                    cache.insert(image_uri.into(), result.clone());
-
-                    match result {
-                        Ok(image) => Ok(ImagePoll::Ready {
-                            image: image.get_image(frame_index),
-                        }),
-                        Err(error) => Err(LoadError::Loading(error)),
-                    }
+                    load_image(ctx, image_uri, frame_index, &self.cache, &bytes)
                 }
                 Ok(BytesPoll::Pending { size }) => Ok(ImagePoll::Pending { size }),
                 Err(error) => Err(error),
@@ -189,9 +271,16 @@ impl ImageLoader for WebPLoader {
             .lock()
             .values()
             .map(|entry| match entry {
-                Ok(entry_value) => entry_value.byte_len(),
-                Err(error) => error.len(),
+                Poll::Ready(res) => match res {
+                    Ok(entry_value) => entry_value.byte_len(),
+                    Err(error) => error.len(),
+                },
+                Poll::Pending => 0,
             })
             .sum()
+    }
+
+    fn has_pending(&self) -> bool {
+        self.cache.lock().values().any(|result| result.is_pending())
     }
 }


### PR DESCRIPTION
Currently `ImageCrateLoader` spawns threads to load every image, while `WebPLoader` doesn't.
This is particularly bad since the webp loader is used for animations, which take longer than normal images and can *really* stall the app on load.

* Related to <https://github.com/emilk/egui/issues/5375>
* [x] I have followed the instructions in the PR template
