### PR TITLE
Fix egui-winit compilation on wasm32

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,6 +91,10 @@ jobs:
       - name: clippy wasm32 eframe
         run: cargo clippy -p eframe --lib --no-default-features --features wgpu,persistence --target wasm32-unknown-unknown
 
+      # eframe only depends on egui-winit on native targets, so check it directly on wasm.
+      - name: check wasm32 egui-winit
+        run: cargo check -p egui-winit --no-default-features --target wasm32-unknown-unknown --locked
+
       - name: wasm-bindgen
         uses: jetli/wasm-bindgen-action@v0.1.0
         with:

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -21,6 +21,7 @@ use egui::{Pos2, Rect, Theme, Vec2, ViewportBuilder, ViewportCommand, ViewportId
 pub use winit;
 
 pub mod clipboard;
+#[cfg(not(target_arch = "wasm32"))]
 mod dropped_file;
 mod safe_area;
 mod window_settings;
@@ -29,6 +30,7 @@ pub use window_settings::WindowSettings;
 
 use raw_window_handle::HasDisplayHandle;
 
+#[cfg(not(target_arch = "wasm32"))]
 use dropped_file::NativeFile;
 
 use winit::{
@@ -477,6 +479,7 @@ impl State {
                     consumed: false,
                 }
             }
+            #[cfg(not(target_arch = "wasm32"))]
             WindowEvent::DroppedFile(path) => {
                 self.egui_input.hovered_files.clear();
                 self.egui_input
@@ -487,6 +490,13 @@ impl State {
                     consumed: false,
                 }
             }
+            // Winit's web backend does not emit file-drop events. Browser file reads
+            // require a browser file handle, which this path-only event cannot provide.
+            #[cfg(target_arch = "wasm32")]
+            WindowEvent::DroppedFile(_) => EventResponse {
+                repaint: false,
+                consumed: false,
+            },
             WindowEvent::ModifiersChanged(state) => {
                 let state = state.state();
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -29,6 +29,7 @@ cargo check --quiet  --all-targets
 cargo check --quiet  --all-targets --all-features
 cargo check --quiet  -p egui_demo_app --lib --target wasm32-unknown-unknown
 cargo check --quiet  -p egui_demo_app --lib --target wasm32-unknown-unknown --all-features
+cargo check --quiet  -p egui-winit --no-default-features --target wasm32-unknown-unknown --locked
 cargo test  --quiet --all-targets --all-features --no-fail-fast # `--no-fail-fast` so that all failing snapshots are reported at once
 cargo test  --quiet --doc # slow - checks all doc-tests
 


### PR DESCRIPTION
Disclosure - AI written PR with GPT 6
I was unable to compile for wasm on my project because I use egui-winnit instead of eframe

See AI explanation below:

## Summary

* Fixes #8436

`egui-winit` unconditionally compiled `NativeFile`, which implements `DroppedFile::bytes()`. On wasm32, the trait requires `bytes_async()` instead, causing compilation to fail.

This change gates the native file implementation and its usage to native targets. An explicit wasm fallback ignores dropped-file events, which winit’s web backend does not emit.

Adds a direct wasm compilation check to CI and the local check script, since eframe’s wasm builds do not compile egui-winit.

## Validation

- wasm32 compilation with default features disabled passes.
- Native Linux/X11 compilation passes.
- Formatting and shell syntax checks pass.
- Strict wasm Clippy encounters six existing, unrelated warnings in clipboard.rs.