### PR TITLE
Fix compile error with `web_sys_unstable_apis`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,8 +183,7 @@ unused_lifetimes = "warn"
 trivial_casts = "allow"
 unused_qualifications = "allow"
 
-# `web-sys` gates some APIs (and even some signatures) behind this cfg,
-# which downstream crates may set globally via `.cargo/config.toml`.
+# `web_sys_unstable_apis` changes some signatures, so we need to check for presence of that flag
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
 
 [workspace.lints.rustdoc]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,10 @@ unused_lifetimes = "warn"
 trivial_casts = "allow"
 unused_qualifications = "allow"
 
+# `web-sys` gates some APIs (and even some signatures) behind this cfg,
+# which downstream crates may set globally via `.cargo/config.toml`.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
+
 [workspace.lints.rustdoc]
 all = "warn"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,8 @@ unused_lifetimes = "warn"
 trivial_casts = "allow"
 unused_qualifications = "allow"
 
-# `web_sys_unstable_apis` changes some signatures, so we need to check for presence of that flag
+# `web_sys_unstable_apis` changes some signatures, so we need to check for presence of that flag. This whitelists
+# checking `cfg(web_sys_unstable_apis)` (which the unexpected_cfgs would otherwise deny):
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
 
 [workspace.lints.rustdoc]

--- a/crates/eframe/src/web/canvas_glyphs.rs
+++ b/crates/eframe/src/web/canvas_glyphs.rs
@@ -183,16 +183,17 @@ impl CanvasGlyphs {
                 PADDING + ascent,
             )
             .ok()?;
+
         // `web-sys` changes the signature of `get_image_data` based on `web_sys_unstable_apis`,
         // so we need to call it differently depending on that cfg.
-        #[cfg(not(web_sys_unstable_apis))]
-        let image_data = self
+        let image_data = cfg_select! {
+            web_sys_unstable_apis => self
             .context
-            .get_image_data(0.0, 0.0, width as f64, height as f64);
-        #[cfg(web_sys_unstable_apis)]
-        let image_data = self
+            .get_image_data(0, 0, width as i32, height as i32),
+            _ => self
             .context
-            .get_image_data(0, 0, width as i32, height as i32);
+            .get_image_data(0.0, 0.0, width as f64, height as f64),
+        };
         let rgba = image_data.ok()?.data().0;
 
         Some(Drawn {

--- a/crates/eframe/src/web/canvas_glyphs.rs
+++ b/crates/eframe/src/web/canvas_glyphs.rs
@@ -183,12 +183,17 @@ impl CanvasGlyphs {
                 PADDING + ascent,
             )
             .ok()?;
-        let rgba = self
+        // `web-sys` changes the signature of `get_image_data` based on `web_sys_unstable_apis`,
+        // so we need to call it differently depending on that cfg.
+        #[cfg(not(web_sys_unstable_apis))]
+        let image_data = self
             .context
-            .get_image_data(0.0, 0.0, width as f64, height as f64)
-            .ok()?
-            .data()
-            .0;
+            .get_image_data(0.0, 0.0, width as f64, height as f64);
+        #[cfg(web_sys_unstable_apis)]
+        let image_data = self
+            .context
+            .get_image_data(0, 0, width as i32, height as i32);
+        let rgba = image_data.ok()?.data().0;
 
         Some(Drawn {
             rgba,


### PR DESCRIPTION
Web sys changes the signature of `get_image_data` based on the flag. In rerun we need `web_sys_unstable_apis` so we need to handle this in egui