### PR TITLE
Add `AtomKind::Paint`

### DIFF
--- a/crates/egui/src/atomics/atom.rs
+++ b/crates/egui/src/atomics/atom.rs
@@ -1,5 +1,6 @@
 use crate::{
-    AtomKind, AtomLayout, FontSelection, Id, IntoSizedArgs, IntoSizedResult, SizedAtom, Ui,
+    AtomKind, AtomLayout, AtomPaintArgs, FontSelection, Id, IntoSizedArgs, IntoSizedResult,
+    SizedAtom, Ui,
 };
 use emath::{Align2, NumExt as _, Vec2};
 use epaint::text::TextWrapMode;
@@ -99,6 +100,30 @@ impl<'a> Atom<'a> {
             size: Some(size.into()),
             kind: AtomKind::Empty,
             id: Some(id),
+            ..Default::default()
+        }
+    }
+
+    /// Create an [`AtomKind::Paint`] with a specific size.
+    ///
+    /// The closure paints the atom at the [`AtomPaintArgs::rect`] the layout gives it.
+    ///
+    /// Example:
+    /// ```
+    /// # use egui::{Atom, Button, Color32, CornerRadius, __run_test_ui};
+    /// # use emath::Vec2;
+    /// # __run_test_ui(|ui| {
+    /// let dot = Atom::paint(Vec2::splat(8.0), |ui, args| {
+    ///     ui.painter()
+    ///         .rect_filled(args.rect, CornerRadius::same(4), Color32::RED);
+    /// });
+    /// ui.add(Button::new((dot, "Recording")));
+    /// # });
+    /// ```
+    pub fn paint(size: impl Into<Vec2>, func: impl Fn(&Ui, AtomPaintArgs) + 'a) -> Self {
+        Atom {
+            size: Some(size.into()),
+            kind: AtomKind::paint(func),
             ..Default::default()
         }
     }

--- a/crates/egui/src/atomics/atom_kind.rs
+++ b/crates/egui/src/atomics/atom_kind.rs
@@ -1,7 +1,9 @@
 use crate::{AtomLayout, FontSelection, Image, ImageSource, SizedAtomKind, Ui, WidgetText};
 use core::fmt::Debug;
-use emath::Vec2;
+use emath::{Rect, Vec2};
+use epaint::Color32;
 use epaint::text::TextWrapMode;
+use std::sync::Arc;
 
 /// Args passed when sizing an [`super::Atom`]
 pub struct IntoSizedArgs {
@@ -20,6 +22,22 @@ pub struct IntoSizedResult<'a> {
 // We need 'static in the result (or need to introduce another lifetime on the enum).
 // Otherwise, a single 'static Atom would force the closure to be 'static.
 pub type AtomClosure<'a> = Box<dyn FnOnce(&Ui, IntoSizedArgs) -> IntoSizedResult<'static> + 'a>;
+
+/// Args passed when painting an [`AtomKind::Paint`] atom.
+#[derive(Clone, Copy, Debug)]
+pub struct AtomPaintArgs {
+    /// The rect the layout gave this atom.
+    pub rect: Rect,
+
+    /// The text color of the containing widget, e.g. the color the [`AtomKind::Text`] atoms
+    /// next to this one are painted in.
+    pub fallback_text_color: Color32,
+}
+
+/// See [`AtomKind::Paint`]
+///
+/// It is an [`Arc`] so the atom stays cloneable.
+pub type AtomPaint<'a> = Arc<dyn Fn(&Ui, AtomPaintArgs) + 'a>;
 
 /// The different kinds of [`crate::Atom`]s.
 #[derive(Default)]
@@ -65,6 +83,16 @@ pub enum AtomKind<'a> {
     /// When cloning, this will be cloned as [`AtomKind::Empty`].
     Closure(AtomClosure<'a>),
 
+    /// A closure that paints the atom at the [`Rect`] the layout gives it.
+    ///
+    /// It has no size of its own, so set one with [`crate::AtomExt::atom_size`], or use
+    /// [`crate::Atom::paint`], which does that for you. If the size depends on the [`Ui`],
+    /// return a [`SizedAtomKind::Paint`] from an [`AtomKind::Closure`] instead.
+    ///
+    /// Use this for widgets that draw their own shapes, like the check mark of
+    /// [`crate::Checkbox`].
+    Paint(AtomPaint<'a>),
+
     /// A nested [`AtomLayout`], letting you embed an atom-based widget as a single atom
     /// inside another [`AtomLayout`].
     ///
@@ -83,6 +111,7 @@ impl Clone for AtomKind<'_> {
                 log::warn!("Cannot clone atom closures");
                 AtomKind::Empty
             }
+            AtomKind::Paint(paint) => AtomKind::Paint(Arc::clone(paint)),
             AtomKind::Layout(layout) => AtomKind::Layout(layout.clone()),
         }
     }
@@ -95,6 +124,7 @@ impl Debug for AtomKind<'_> {
             AtomKind::Text(text) => write!(f, "AtomKind::Text({text:?})"),
             AtomKind::Image(image) => write!(f, "AtomKind::Image({image:?})"),
             AtomKind::Closure(_) => write!(f, "AtomKind::Closure(<closure>)"),
+            AtomKind::Paint(_) => write!(f, "AtomKind::Paint(<closure>)"),
             AtomKind::Layout(_) => write!(f, "AtomKind::Layout(<layout>)"),
         }
     }
@@ -109,6 +139,11 @@ impl<'a> AtomKind<'a> {
     /// See [`Self::Image`]
     pub fn image(image: impl Into<Image<'a>>) -> Self {
         AtomKind::Image(image.into())
+    }
+
+    /// See [`Self::Paint`]
+    pub fn paint(func: impl Fn(&Ui, AtomPaintArgs) + 'a) -> Self {
+        AtomKind::Paint(Arc::new(func))
     }
 
     /// See [`Self::Closure`]
@@ -157,6 +192,13 @@ impl<'a> AtomKind<'a> {
                     fallback_font,
                 },
             ),
+            AtomKind::Paint(paint) => IntoSizedResult {
+                intrinsic_size: Vec2::ZERO,
+                sized: SizedAtomKind::Paint {
+                    paint,
+                    size: Vec2::ZERO,
+                },
+            },
             AtomKind::Layout(layout) => {
                 let sized = layout.measure(ui, available_size);
                 IntoSizedResult {

--- a/crates/egui/src/atomics/atom_layout.rs
+++ b/crates/egui/src/atomics/atom_layout.rs
@@ -1,6 +1,7 @@
 use crate::{
-    AtomKind, Atoms, Direction, FontSelection, Frame, Id, Image, IntoAtoms, Response, Sense,
-    SizedAtom, SizedAtomKind, Stroke, Ui, Widget, text_selection::LabelSelectionState,
+    AtomKind, AtomPaintArgs, Atoms, Direction, FontSelection, Frame, Id, Image, IntoAtoms,
+    Response, Sense, SizedAtom, SizedAtomKind, Stroke, Ui, Widget,
+    text_selection::LabelSelectionState,
 };
 use core::ops::{Deref, DerefMut};
 use emath::{Align2, GuiRounding as _, NumExt as _, Rect, Vec2};
@@ -678,6 +679,15 @@ impl<'atom> SizedAtomLayout<'atom> {
                     image.paint_at(ui, item_rect);
                 }
                 SizedAtomKind::Empty { .. } => {}
+                SizedAtomKind::Paint { paint, size: _ } => {
+                    paint(
+                        ui,
+                        AtomPaintArgs {
+                            rect: item_rect,
+                            fallback_text_color,
+                        },
+                    );
+                }
                 SizedAtomKind::Layout(layout) => {
                     // TODO(lucasmerlin): Add some kind of justify flag, right now nested atoms are always
                     // shown fully stretched.

--- a/crates/egui/src/atomics/sized_atom_kind.rs
+++ b/crates/egui/src/atomics/sized_atom_kind.rs
@@ -1,15 +1,33 @@
-use crate::{Image, SizedAtomLayout};
+use crate::{AtomPaint, Image, SizedAtomLayout};
+use core::fmt::Debug;
 use emath::Vec2;
 use epaint::Galley;
 use std::sync::Arc;
 
 /// A sized [`crate::AtomKind`].
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub enum SizedAtomKind<'a> {
     Empty { size: Option<Vec2> },
     Text(Arc<Galley>),
     Image { image: Image<'a>, size: Vec2 },
+    Paint { paint: AtomPaint<'a>, size: Vec2 },
     Layout(Box<SizedAtomLayout<'a>>),
+}
+
+impl Debug for SizedAtomKind<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            SizedAtomKind::Empty { size } => write!(f, "SizedAtomKind::Empty({size:?})"),
+            SizedAtomKind::Text(galley) => write!(f, "SizedAtomKind::Text({galley:?})"),
+            SizedAtomKind::Image { image, size } => {
+                write!(f, "SizedAtomKind::Image({image:?}, {size:?})")
+            }
+            SizedAtomKind::Paint { size, .. } => {
+                write!(f, "SizedAtomKind::Paint(<closure>, {size:?})")
+            }
+            SizedAtomKind::Layout(layout) => write!(f, "SizedAtomKind::Layout({layout:?})"),
+        }
+    }
 }
 
 impl Default for SizedAtomKind<'_> {
@@ -23,7 +41,7 @@ impl SizedAtomKind<'_> {
     pub fn size(&self) -> Vec2 {
         match self {
             SizedAtomKind::Text(galley) => galley.size(),
-            SizedAtomKind::Image { image: _, size } => *size,
+            SizedAtomKind::Image { size, .. } | SizedAtomKind::Paint { size, .. } => *size,
             SizedAtomKind::Empty { size } => size.unwrap_or_default(),
             SizedAtomKind::Layout(layout) => layout.outer_size,
         }


### PR DESCRIPTION
Allows one to do custom painting in places where reading the `AtomLayoutResponse` may be hard or impossible.
Also very useful when combined with `AtomKind::Closure`