### PR TITLE
Add `WidgetText::concat` for joining differently styled `RichText`s

### DIFF
--- a/crates/egui/src/widget_text.rs
+++ b/crates/egui/src/widget_text.rs
@@ -558,6 +558,35 @@ impl Default for WidgetText {
 }
 
 impl WidgetText {
+    /// Concatenate several differently styled pieces of text into a single [`WidgetText`].
+    ///
+    /// The pieces are laid out as one paragraph, without any spacing between them.
+    ///
+    /// ```
+    /// # use egui::{RichText, WidgetText};
+    /// # egui::__run_test_ui(|ui| {
+    /// let text = WidgetText::concat(
+    ///     ui.style(),
+    ///     [
+    ///         RichText::new("Normal, "),
+    ///         RichText::new("strong, ").strong(),
+    ///         RichText::new("and small").small(),
+    ///     ],
+    /// );
+    /// ui.label(text);
+    /// # });
+    /// ```
+    ///
+    /// See also [`RichText::append_to`] for more control over the resulting [`LayoutJob`].
+    pub fn concat(style: &Style, parts: impl IntoIterator<Item = impl Into<RichText>>) -> Self {
+        let mut job = LayoutJob::default();
+        for part in parts {
+            part.into()
+                .append_to(&mut job, style, FontSelection::Default, Align::Center);
+        }
+        job.into()
+    }
+
     /// Override the font size.
     ///
     /// For [`Self::Galley`], this does nothing because it has already been laid out.


### PR DESCRIPTION
* [x] I have followed the instructions in the PR template

Adds `WidgetText::concat(style, parts)`, which joins several `RichText`s into a single `WidgetText` (backed by a `LayoutJob`).

This is the easy way to get e.g. a label that is partly bold, or a label with a small colored badge at the end, without manually building a `LayoutJob` with `RichText::append_to`.

```rust
ui.label(WidgetText::concat(ui.style(), [
    RichText::new("Normal, "),
    RichText::new("strong, ").strong(),
    RichText::new("and small").small(),
]));
```

Extracted from Rerun's `re_ui::egui_ext`.

Written by Claude (LLM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)