### PR TITLE
Rename `Ui::id` to `Ui::scope_id` and clarify its docstring

### DIFF
--- a/crates/egui/src/containers/menu.rs
+++ b/crates/egui/src/containers/menu.rs
@@ -145,7 +145,7 @@ impl MenuState {
     /// Find the root of the menu and get the state
     pub fn from_ui<R>(ui: &Ui, f: impl FnOnce(&mut Self, &UiStack) -> R) -> R {
         let stack = find_menu_root(ui);
-        Self::from_id(ui.ctx(), stack.id, |state| f(state, stack))
+        Self::from_id(ui.ctx(), stack.unique_id, |state| f(state, stack))
     }
 
     /// Get the state via the menus root [`Ui`] id
@@ -435,7 +435,11 @@ impl SubMenu {
 
         // Get the state from the parent menu
         let (open_item, menu_id, parent_config) = MenuState::from_ui(ui, |state, stack| {
-            (state.open_item, stack.id, MenuConfig::from_stack(stack))
+            (
+                state.open_item,
+                stack.unique_id,
+                MenuConfig::from_stack(stack),
+            )
         });
 
         let mut menu_config = self.config.unwrap_or_else(|| parent_config.clone());

--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -207,7 +207,7 @@ impl PanelSide {
 pub struct Panel {
     side: PanelSide,
 
-    /// Combined with the parent [`Ui::id`] to form the [`Id`] of the panel.
+    /// Combined with the parent [`Ui::scope_id`] to form the [`Id`] of the panel.
     id_salt: IdSalt,
     frame: Option<Frame>,
     resizable: bool,

--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -950,7 +950,7 @@ impl Panel {
     ///
     /// Used as the key for the persisted [`PanelState`].
     fn id(&self, parent_ui: &Ui) -> Id {
-        parent_ui.id().with_salt(self.id_salt)
+        parent_ui.scope_id().with_salt(self.id_salt)
     }
 
     /// The configured [`Frame`], or the default side/top panel frame for this [`Ui`].

--- a/crates/egui/src/containers/scene.rs
+++ b/crates/egui/src/containers/scene.rs
@@ -185,7 +185,7 @@ impl Scene {
         // Create a new egui paint layer, where we can draw our contents:
         let scene_layer_id = LayerId::new(
             parent_ui.layer_id().order,
-            parent_ui.id().with("scene_area"),
+            parent_ui.scope_id().with("scene_area"),
         );
 
         // Put the layer directly on-top of the main layer of the ui:

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -124,7 +124,7 @@ impl Ui {
 
         let placer = Placer::new(max_rect, layout);
         let ui_stack = UiStack {
-            id: scope_id,
+            unique_id: scope_id,
             layout_direction: layout.main_dir,
             info: ui_stack_info,
             parent: None,
@@ -248,7 +248,7 @@ impl Ui {
 
         let placer = Placer::new(max_rect, layout);
         let ui_stack = UiStack {
-            id: unique_id,
+            unique_id,
             layout_direction: layout.main_dir,
             info: ui_stack_info,
             parent: Some(Arc::clone(&self.stack)),

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -316,7 +316,7 @@ impl Ui {
 
     // -------------------------------------------------
 
-    /// The [`Id`] scope of this `Ui`.
+    /// The stable [`Id`] scope of this `Ui`.
     ///
     /// This is _stable_ from one frame to the next,
     /// so it should be used as the base for the [`Id`]s of widgets that store state
@@ -342,7 +342,7 @@ impl Ui {
         self.scope_id
     }
 
-    /// A globally unique [`Id`] of this `Ui`.
+    /// A globally unique, but unstable, [`Id`] of this `Ui`.
     ///
     /// This is NOT _stable_: it is based on where in the widget hierarchy this `Ui` is,
     /// so it changes if widgets are added or removed before it.

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -238,12 +238,12 @@ impl Ui {
         debug_assert!(!max_rect.any_nan(), "max_rect is NaN: {max_rect:?}");
 
         let id_source = id_source.unwrap_or_else(|| IdSource::Child(IdSalt::new("child")));
-        let (stable_id, unique_id) = match id_source {
+        let (scope_id, unique_id) = match id_source {
             IdSource::Explicit(id) => (id, id),
             IdSource::Child(id_salt) => {
-                let stable_id = self.scope_id.with(id_salt);
-                let unique_id = stable_id.with(self.next_auto_id_salt);
-                (stable_id, unique_id)
+                let scope_id = self.scope_id.with(id_salt);
+                let unique_id = scope_id.with(self.next_auto_id_salt);
+                (scope_id, unique_id)
             }
         };
         let next_auto_id_salt = unique_id.value().wrapping_add(1);
@@ -262,7 +262,7 @@ impl Ui {
         };
 
         let mut child_ui = Ui {
-            scope_id: stable_id,
+            scope_id,
             unique_id,
             next_auto_id_salt,
             painter,

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -91,7 +91,7 @@ impl Ui {
     ///
     /// Normally you would not use this directly, but instead use
     /// [`crate::Panel`], [`crate::CentralPanel`], [`crate::Window`] or [`crate::Area`].
-    pub fn new(ctx: Context, id: Id, ui_builder: UiBuilder) -> Self {
+    pub fn new(ctx: Context, scope_id: Id, ui_builder: UiBuilder) -> Self {
         let UiBuilder {
             id_source,
             ui_stack_info,
@@ -124,7 +124,7 @@ impl Ui {
 
         let placer = Placer::new(max_rect, layout);
         let ui_stack = UiStack {
-            id,
+            id: scope_id,
             layout_direction: layout.main_dir,
             info: ui_stack_info,
             parent: None,
@@ -134,9 +134,9 @@ impl Ui {
         };
 
         let mut ui = Ui {
-            scope_id: id,
-            unique_id: id,
-            next_auto_id_salt: id.with("auto").value(),
+            scope_id,
+            unique_id: scope_id,
+            next_auto_id_salt: scope_id.with("auto").value(),
             painter: Painter::new(ctx, layer_id, clip_rect),
             style,
             placer,

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -884,7 +884,7 @@ impl Ui {
     /// Generate an [`Id`] for a widget that has persistent state in [`Memory`].
     ///
     /// This is the same as `ui.scope_id().with(id_salt)`.
-    /// Since it is based on the stable [`Self::scope_id`], it is stable from frame to frame,
+    /// Since it is based on the stable [`Self::scope_id`], it is stable over time,
     /// as long as `id_salt` is unique within the current id scope.
     pub fn make_persistent_id(&self, id_salt: impl AsIdSalt) -> Id {
         self.scope_id.with(id_salt)
@@ -902,7 +902,7 @@ impl Ui {
 
     /// Same as `ui.next_auto_id().with(id_salt)`.
     ///
-    /// Like [`Self::next_auto_id`], this is NOT stable from frame to frame.
+    /// Like [`Self::next_auto_id`], this is NOT stable over time.
     pub fn auto_id_with(&self, id_salt: impl AsIdSalt) -> Id {
         Id::unique(self.next_auto_id_salt).with(id_salt)
     }

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -28,25 +28,10 @@ use emath::GuiRounding as _;
 /// # });
 /// ```
 pub struct Ui {
-    /// Generated based on id of parent ui together with an optional id salt.
-    ///
-    /// This should be stable from one frame to next
-    /// so it can be used as a source for storing state
-    /// (e.g. window position, or if a collapsing header is open).
-    ///
-    /// However, it is not necessarily globally unique.
-    /// For instance, sibling `Ui`s share the same [`Self::id`]
-    /// unless they where explicitly given different id salts using
-    /// [`UiBuilder::id_salt`].
-    id: Id,
+    /// The [`Id`] scope of this `Ui`. See [`Self::scope_id`].
+    scope_id: Id,
 
-    /// This is a globally unique ID of this `Ui`,
-    /// based on where in the hierarchy of widgets this Ui is in.
-    ///
-    /// This means it is not _stable_, as it can change if new widgets
-    /// are added or removed prior to this one.
-    /// It should therefore only be used for transient interactions (clicks etc),
-    /// not for storing state over time.
+    /// A globally unique, but unstable, [`Id`] of this `Ui`. See [`Self::unique_id`].
     unique_id: Id,
 
     /// This is used to create a unique interact ID for some widgets.
@@ -149,7 +134,7 @@ impl Ui {
         };
 
         let mut ui = Ui {
-            id,
+            scope_id: id,
             unique_id: id,
             next_auto_id_salt: id.with("auto").value(),
             painter: Painter::new(ctx, layer_id, clip_rect),
@@ -172,7 +157,7 @@ impl Ui {
         ui.ctx().create_widget(
             WidgetRect {
                 id: ui.unique_id,
-                parent_id: ui.id,
+                parent_id: ui.scope_id,
                 layer_id: ui.layer_id(),
                 rect: start_rect,
                 interact_rect: start_rect,
@@ -252,7 +237,7 @@ impl Ui {
         let (stable_id, unique_id) = match id_source {
             IdSource::Explicit(id) => (id, id),
             IdSource::Child(id_salt) => {
-                let stable_id = self.id.with(id_salt);
+                let stable_id = self.scope_id.with(id_salt);
                 let unique_id = stable_id.with(self.next_auto_id_salt);
                 (stable_id, unique_id)
             }
@@ -273,7 +258,7 @@ impl Ui {
         };
 
         let mut child_ui = Ui {
-            id: stable_id,
+            scope_id: stable_id,
             unique_id,
             next_auto_id_salt,
             painter,
@@ -300,7 +285,7 @@ impl Ui {
         child_ui.ctx().create_widget(
             WidgetRect {
                 id: child_ui.unique_id,
-                parent_id: self.id,
+                parent_id: self.scope_id,
                 layer_id: child_ui.layer_id(),
                 rect: start_rect,
                 interact_rect: start_rect,
@@ -331,28 +316,40 @@ impl Ui {
 
     // -------------------------------------------------
 
-    /// Generated based on id of parent ui together with an optional id salt.
+    /// The [`Id`] scope of this `Ui`.
     ///
-    /// This should be stable from one frame to next
-    /// so it can be used as a source for storing state
-    /// (e.g. window position, or if a collapsing header is open).
+    /// This is _stable_ from one frame to the next,
+    /// so it should be used as the base for the [`Id`]s of widgets that store state
+    /// (e.g. window position, or if a collapsing header is open):
+    /// `ui.scope_id().with("my_widget")`.
+    /// See also [`Self::make_persistent_id`].
     ///
-    /// However, it is not necessarily globally unique.
-    /// For instance, sibling `Ui`s share the same [`Self::id`]
-    /// unless they were explicitly given different id salts using
-    /// [`UiBuilder::id_salt`].
+    /// This is NOT the [`Id`] of this particular `Ui`, but of its _scope_.
+    /// A child `Ui` inherits the scope of its parent (mixed with an optional [`UiBuilder::id_salt`]),
+    /// so sibling `Ui`s share the same scope unless given different salts.
+    /// Use [`Self::push_id`] to create a new scope.
+    ///
+    /// For a globally unique (but unstable) [`Id`] of this `Ui`, see [`Self::unique_id`].
     #[inline]
-    pub fn id(&self) -> Id {
-        self.id
+    pub fn scope_id(&self) -> Id {
+        self.scope_id
     }
 
-    /// This is a globally unique ID of this `Ui`,
-    /// based on where in the hierarchy of widgets this Ui is in.
+    /// Renamed to [`Self::scope_id`].
+    #[deprecated = "Renamed to `Ui::scope_id`"]
+    #[inline]
+    pub fn id(&self) -> Id {
+        self.scope_id
+    }
+
+    /// A globally unique [`Id`] of this `Ui`.
     ///
-    /// This means it is not _stable_, as it can change if new widgets
-    /// are added or removed prior to this one.
+    /// This is NOT _stable_: it is based on where in the widget hierarchy this `Ui` is,
+    /// so it changes if widgets are added or removed before it.
     /// It should therefore only be used for transient interactions (clicks etc),
-    /// not for storing state over time.
+    /// never for storing state over time.
+    ///
+    /// For a stable [`Id`] to base widget state on, see [`Self::scope_id`].
     #[inline]
     pub fn unique_id(&self) -> Id {
         self.unique_id
@@ -882,7 +879,7 @@ impl Ui {
 impl Ui {
     /// Use this to generate widget ids for widgets that have persistent state in [`Memory`].
     pub fn make_persistent_id(&self, id_salt: impl AsIdSalt) -> Id {
-        self.id.with(id_salt)
+        self.scope_id.with(id_salt)
     }
 
     /// This is the `Id` that will be assigned to the next widget added to this `Ui`.
@@ -921,7 +918,7 @@ impl Ui {
         self.ctx().create_widget(
             WidgetRect {
                 id,
-                parent_id: self.id,
+                parent_id: self.scope_id,
                 layer_id: self.layer_id(),
                 rect,
                 interact_rect: self.clip_rect().intersect(rect),
@@ -979,7 +976,7 @@ impl Ui {
         let mut response = self.ctx().create_widget(
             WidgetRect {
                 id: self.unique_id,
-                parent_id: self.id,
+                parent_id: self.scope_id,
                 layer_id: self.layer_id(),
                 rect: self.min_rect(),
                 interact_rect: self.clip_rect().intersect(self.min_rect()),

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -122,9 +122,13 @@ impl Ui {
         let sense = sense.unwrap_or_else(Sense::hover);
         let classes = classes.with_class(class::ROOT);
 
+        // A root `Ui` has no parent to derive a unique id from,
+        // so the caller must provide a globally unique id, which serves as both:
+        let unique_id = scope_id;
+
         let placer = Placer::new(max_rect, layout);
         let ui_stack = UiStack {
-            unique_id: scope_id,
+            unique_id,
             layout_direction: layout.main_dir,
             info: ui_stack_info,
             parent: None,
@@ -135,8 +139,8 @@ impl Ui {
 
         let mut ui = Ui {
             scope_id,
-            unique_id: scope_id,
-            next_auto_id_salt: scope_id.with("auto").value(),
+            unique_id,
+            next_auto_id_salt: unique_id.with("auto").value(),
             painter: Painter::new(ctx, layer_id, clip_rect),
             style,
             placer,

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -877,22 +877,33 @@ impl Ui {
 
 /// # [`Id`] creation
 impl Ui {
-    /// Use this to generate widget ids for widgets that have persistent state in [`Memory`].
+    /// Generate an [`Id`] for a widget that has persistent state in [`Memory`].
+    ///
+    /// This is the same as `ui.scope_id().with(id_salt)`.
+    /// Since it is based on the stable [`Self::scope_id`], it is stable from frame to frame,
+    /// as long as `id_salt` is unique within the current id scope.
     pub fn make_persistent_id(&self, id_salt: impl AsIdSalt) -> Id {
         self.scope_id.with(id_salt)
     }
 
-    /// This is the `Id` that will be assigned to the next widget added to this `Ui`.
+    /// The `Id` that will be assigned to the next widget added to this `Ui`,
+    /// unless it has an explicit `Id`.
+    ///
+    /// This is based on the [`Self::unique_id`] of this `Ui` and the number of widgets added so far.
+    /// It is therefore NOT stable: it changes if widgets are added or removed before it.
+    /// Do not use it for widgets that store state; use [`Self::make_persistent_id`] for that.
     pub fn next_auto_id(&self) -> Id {
         Id::unique(self.next_auto_id_salt)
     }
 
-    /// Same as `ui.next_auto_id().with(id_salt)`
+    /// Same as `ui.next_auto_id().with(id_salt)`.
+    ///
+    /// Like [`Self::next_auto_id`], this is NOT stable from frame to frame.
     pub fn auto_id_with(&self, id_salt: impl AsIdSalt) -> Id {
         Id::unique(self.next_auto_id_salt).with(id_salt)
     }
 
-    /// Pretend like `count` widgets have been allocated.
+    /// Pretend like `count` widgets have been allocated, advancing [`Self::next_auto_id`].
     pub fn skip_ahead_auto_ids(&mut self, count: usize) {
         self.next_auto_id_salt = self.next_auto_id_salt.wrapping_add(count as u64);
     }

--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -48,7 +48,7 @@ impl UiBuilder {
     }
 
     /// Seed the child `Ui` with this `id_salt`, which will be mixed
-    /// with the [`Ui::id`] of the parent.
+    /// with the [`Ui::scope_id`] of the parent.
     ///
     /// You should give each [`Ui`] an `id_salt` that is unique
     /// within the parent, or give it none at all.

--- a/crates/egui/src/ui_builder.rs
+++ b/crates/egui/src/ui_builder.rs
@@ -58,19 +58,26 @@ impl UiBuilder {
         self
     }
 
-    /// Set an id of the new `Ui` that is independent of the parent `Ui`.
+    /// Set the [`Ui::scope_id`] of the new `Ui` to something independent of the parent `Ui`.
     /// This way child widgets can be moved in the ui tree without losing state.
     /// You have to ensure that in a frame the child widgets do not get rendered in multiple places.
     ///
-    /// You should set the same unique `id` at every place in the ui tree where you want the
+    /// You should set the same unique `scope_id` at every place in the ui tree where you want the
     /// child widgets to share state.
     /// If the child widgets are not moved in the ui tree, use [`UiBuilder::id_salt`] instead.
     ///
-    /// This is a shortcut for `.id_salt(my_id).global_scope(true)`.
+    /// The `scope_id` is also used as the [`Ui::unique_id`] of the new `Ui`, so it must be globally unique.
     #[inline]
-    pub fn id(mut self, id: Id) -> Self {
-        self.id_source = Some(IdSource::Explicit(id));
+    pub fn scope_id(mut self, scope_id: Id) -> Self {
+        self.id_source = Some(IdSource::Explicit(scope_id));
         self
+    }
+
+    /// Renamed to [`Self::scope_id`].
+    #[deprecated = "Renamed to `UiBuilder::scope_id`"]
+    #[inline]
+    pub fn id(self, id: Id) -> Self {
+        self.scope_id(id)
     }
 
     /// Provide some information about the new `Ui` being built.

--- a/crates/egui/src/ui_stack.rs
+++ b/crates/egui/src/ui_stack.rs
@@ -209,7 +209,7 @@ pub struct UiStack {
     // stuff that `Ui::child_ui` can deal with directly
     /// The [`crate::Ui::unique_id`] of this [`crate::Ui`].
     ///
-    /// Globally unique, but NOT stable from frame to frame.
+    /// Globally unique, but NOT stable over time.
     /// For the stable id scope, see [`crate::Ui::scope_id`].
     pub unique_id: Id,
     pub info: UiStackInfo,

--- a/crates/egui/src/ui_stack.rs
+++ b/crates/egui/src/ui_stack.rs
@@ -207,7 +207,11 @@ impl UiTags {
 #[derive(Debug)]
 pub struct UiStack {
     // stuff that `Ui::child_ui` can deal with directly
-    pub id: Id,
+    /// The [`crate::Ui::unique_id`] of this [`crate::Ui`].
+    ///
+    /// Globally unique, but NOT stable from frame to frame.
+    /// For the stable id scope, see [`crate::Ui::scope_id`].
+    pub unique_id: Id,
     pub info: UiStackInfo,
     pub layout_direction: Direction,
     pub min_rect: Rect,

--- a/crates/egui_demo_lib/src/demo/misc_demo_window.rs
+++ b/crates/egui_demo_lib/src/demo/misc_demo_window.rs
@@ -677,7 +677,7 @@ fn ui_stack_demo(ui: &mut Ui) {
                     for node in stack.iter() {
                         body.row(18.0, |mut row| {
                             row.col(|ui| {
-                                let response = ui.label(format!("{:?}", node.id));
+                                let response = ui.label(format!("{:?}", node.unique_id));
 
                                 if response.hovered() {
                                     ui.debug_painter().debug_rect(

--- a/crates/egui_demo_lib/src/demo/password.rs
+++ b/crates/egui_demo_lib/src/demo/password.rs
@@ -15,7 +15,7 @@ pub fn password_ui(ui: &mut egui::Ui, password: &mut String) -> egui::Response {
     // If you use the `persistence` feature, it also must implement `serde::{Deserialize, Serialize}`.
 
     // Generate an id for the state
-    let state_id = ui.id().with("show_plaintext");
+    let state_id = ui.scope_id().with("show_plaintext");
 
     // Get state for this widget.
     // You should get state by value, not by reference to avoid borrowing of [`Memory`].

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -444,7 +444,7 @@ impl<'a> TableBuilder<'a> {
 
     /// Reset all column widths.
     pub fn reset(&self) {
-        let state_id = self.ui.id().with(self.id_salt);
+        let state_id = self.ui.scope_id().with(self.id_salt);
         TableState::reset(self.ui, state_id);
     }
 
@@ -464,7 +464,7 @@ impl<'a> TableBuilder<'a> {
         } = self;
 
         for (i, column) in columns.iter_mut().enumerate() {
-            let column_resize_id = ui.id().with("resize_column").with(i);
+            let column_resize_id = ui.scope_id().with("resize_column").with(i);
             if let Some(response) = ui.ctx().read_response(column_resize_id)
                 && response.double_clicked()
             {
@@ -474,7 +474,7 @@ impl<'a> TableBuilder<'a> {
 
         let striped = striped.unwrap_or_else(|| ui.visuals().striped);
 
-        let state_id = ui.id().with(id_salt);
+        let state_id = ui.scope_id().with(id_salt);
 
         let (is_sizing_pass, state) =
             TableState::load(ui, state_id, resizable, &columns, available_width);
@@ -543,7 +543,7 @@ impl<'a> TableBuilder<'a> {
 
         let striped = striped.unwrap_or_else(|| ui.visuals().striped);
 
-        let state_id = ui.id().with(id_salt);
+        let state_id = ui.scope_id().with(id_salt);
 
         let (is_sizing_pass, state) =
             TableState::load(ui, state_id, resizable, &columns, available_width);

--- a/crates/egui_kittest/src/app_kind.rs
+++ b/crates/egui_kittest/src/app_kind.rs
@@ -76,7 +76,7 @@ impl<State> AppKind<'_, State> {
                             "run_ui should only be called with AppKind::Ui or AppKind::UiState"
                         ),
                     }
-                    ui.id()
+                    ui.scope_id()
                 })
                 .inner
         });

--- a/crates/egui_kittest/src/app_kind.rs
+++ b/crates/egui_kittest/src/app_kind.rs
@@ -20,7 +20,7 @@ pub(crate) struct UiRunOutput {
     /// The response of the scope wrapping the ui closure.
     pub response: egui::Response,
 
-    /// The [`egui::Ui::id`] of the `Ui` passed to the ui closure.
+    /// The [`egui::Ui::scope_id`] of the `Ui` passed to the ui closure.
     pub ui_id: egui::Id,
 }
 

--- a/crates/egui_kittest/src/lib.rs
+++ b/crates/egui_kittest/src/lib.rs
@@ -531,7 +531,7 @@ impl<'a, State> Harness<'a, State> {
     }
 
     /// Access the state.
-    /// The [`egui::Ui::id`] of the [`egui::Ui`] passed to the ui closure.
+    /// The [`egui::Ui::scope_id`] of the [`egui::Ui`] passed to the ui closure.
     ///
     /// Use this to compute the [`egui::Id`] of things shown directly in that ui,
     /// e.g. `harness.ui_id().with("my_panel")`.

--- a/tests/egui_tests/tests/regression_tests.rs
+++ b/tests/egui_tests/tests/regression_tests.rs
@@ -288,7 +288,7 @@ fn warn_if_rect_changes_id() {
         // and the label changes on hover:
         let is_hovered = ui.rect_contains_pointer(button_rect);
         let label = if is_hovered { "Hovering!" } else { "Click me" };
-        let id = ui.id().with(label);
+        let id = ui.scope_id().with(label);
         let _response = ui.interact(button_rect, id, Sense::click());
     });
 
@@ -326,7 +326,7 @@ fn warn_if_rect_changes_id_false_positive_parent_shift() {
         // push_id with a changing value causes the child Ui's id to shift,
         // which in turn shifts all widget ids inside it.
         ui.push_id(counter.get(), |ui| {
-            let id = ui.id().with("my_widget");
+            let id = ui.scope_id().with("my_widget");
             let _response = ui.interact(button_rect, id, Sense::click());
         });
     });

--- a/tests/test_ui_stack/src/main.rs
+++ b/tests/test_ui_stack/src/main.rs
@@ -299,7 +299,7 @@ fn stack_ui_impl(ui: &mut egui::Ui, stack: &egui::UiStack) {
                     for node in stack.iter() {
                         body.row(20.0, |mut row| {
                             row.col(|ui| {
-                                if ui.label(format!("{:?}", node.id)).hovered() {
+                                if ui.label(format!("{:?}", node.unique_id)).hovered() {
                                     ui.debug_painter().debug_rect(
                                         node.max_rect,
                                         egui::Color32::GREEN,

--- a/tests/test_viewports/src/main.rs
+++ b/tests/test_viewports/src/main.rs
@@ -202,7 +202,7 @@ fn generic_child_ui(ui: &mut egui::Ui, vp_state: &mut ViewportState, close_butto
 }
 
 fn generic_ui(ui: &mut egui::Ui, children: &[Arc<RwLock<ViewportState>>], close_button: bool) {
-    let container_id = ui.id();
+    let container_id = ui.scope_id();
 
     let ctx = ui.ctx().clone();
     ui.label(format!(
@@ -302,7 +302,7 @@ fn drag_and_drop_test(ui: &mut egui::Ui) {
     use std::collections::HashMap;
     use std::sync::OnceLock;
 
-    let container_id = ui.id();
+    let container_id = ui.scope_id();
 
     const COLS: usize = 2;
     static DATA: OnceLock<RwLock<DragAndDrop>> = OnceLock::new();


### PR DESCRIPTION
`Ui::id` was easy to confuse with `Ui::unique_id`. It is the id of the _scope_ the `Ui` belongs to: stable across frames, shared by sibling `Ui`s, and the base for widget state ids. `Ui::unique_id` is unique per `Ui` but unstable.

This renames `Ui::id` to `Ui::scope_id` (old name deprecated) and rewrites both docstrings to say so.

Follow-up to discussion in:
* https://github.com/emilk/egui/pull/8534#discussion_r3969041538

* [x] I have followed the instructions in the PR template

🤖 Generated with [Claude Code](https://claude.com/claude-code)