### PR TITLE
Use `Ui::unique_id` for `WidgetRect::parent_id`

### DIFF
--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -152,7 +152,7 @@ bitflags::bitflags! {
 }
 
 impl Response {
-    /// The [`Id`] of the parent [`crate::Ui`] that hosts this widget.
+    /// The [`crate::Ui::unique_id`] of the parent [`crate::Ui`] that hosts this widget.
     ///
     /// Looks up the [`WidgetRect`] from the current (or previous) pass.
     pub fn parent_id(&self) -> Id {

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -172,7 +172,7 @@ impl Ui {
         ui.ctx().create_widget(
             WidgetRect {
                 id: ui.unique_id,
-                parent_id: ui.id,
+                parent_id: ui.unique_id,
                 layer_id: ui.layer_id(),
                 rect: start_rect,
                 interact_rect: start_rect,
@@ -300,7 +300,7 @@ impl Ui {
         child_ui.ctx().create_widget(
             WidgetRect {
                 id: child_ui.unique_id,
-                parent_id: self.id,
+                parent_id: self.unique_id,
                 layer_id: child_ui.layer_id(),
                 rect: start_rect,
                 interact_rect: start_rect,
@@ -921,7 +921,7 @@ impl Ui {
         self.ctx().create_widget(
             WidgetRect {
                 id,
-                parent_id: self.id,
+                parent_id: self.unique_id,
                 layer_id: self.layer_id(),
                 rect,
                 interact_rect: self.clip_rect().intersect(rect),
@@ -979,7 +979,7 @@ impl Ui {
         let mut response = self.ctx().create_widget(
             WidgetRect {
                 id: self.unique_id,
-                parent_id: self.id,
+                parent_id: self.stack.parent.as_ref().map_or(self.unique_id, |p| p.id),
                 layer_id: self.layer_id(),
                 rect: self.min_rect(),
                 interact_rect: self.clip_rect().intersect(self.min_rect()),

--- a/crates/egui/src/widget_rect.rs
+++ b/crates/egui/src/widget_rect.rs
@@ -15,6 +15,9 @@ pub struct WidgetRect {
     /// (see [`crate::Options::warn_on_id_clash`]).
     ///
     /// You can ensure globally unique ids using [`crate::Ui::push_id`].
+    ///
+    /// For the [`WidgetRect`] of a [`crate::Ui`] this is the
+    /// [`crate::Ui::unique_id`] of that [`crate::Ui`].
     pub id: Id,
 
     /// The [`crate::Ui::unique_id`] of the parent [`crate::Ui`] that hosts this widget.

--- a/crates/egui/src/widget_rect.rs
+++ b/crates/egui/src/widget_rect.rs
@@ -17,7 +17,7 @@ pub struct WidgetRect {
     /// You can ensure globally unique ids using [`crate::Ui::push_id`].
     pub id: Id,
 
-    /// The [`Id`] of the parent [`crate::Ui`] that hosts this widget.
+    /// The [`crate::Ui::unique_id`] of the parent [`crate::Ui`] that hosts this widget.
     ///
     /// Used by debug checks to distinguish true id-instability from
     /// cascading id shifts caused by a parent Ui's auto-id changing.

--- a/tests/egui_tests/tests/regression_tests.rs
+++ b/tests/egui_tests/tests/regression_tests.rs
@@ -272,6 +272,16 @@ fn has_red_warning_rect(output: &egui::FullOutput) -> bool {
     })
 }
 
+fn has_red_warning_rect_at(output: &egui::FullOutput, rect: egui::Rect) -> bool {
+    output.shapes.iter().any(|clipped| {
+        matches!(
+            &clipped.shape,
+            Shape::Rect(rect_shape)
+                if rect_shape.stroke.color == Color32::RED && rect_shape.rect == rect
+        )
+    })
+}
+
 /// A button that changes its text on hover, with the Id derived from the text.
 /// This is a plausible bug: the widget keeps the same rect, but its Id changes
 /// between frames because the label (and thus the Id salt) changes on hover.
@@ -352,6 +362,46 @@ fn warn_if_rect_changes_id_false_positive_parent_shift() {
     assert!(
         !has_red_warning_rect(harness.output()),
         "Should NOT warn when parent Ui's id shifted (cascading id change)"
+    );
+}
+
+/// When the auto-id of a parent Ui shifts (e.g. a widget is added before a child Ui),
+/// the child Ui's `unique_id` changes, and so do all auto-ids inside it.
+/// This should NOT trigger `warn_if_rect_changes_id`, since the `parent_id` also changed.
+#[test]
+#[cfg(debug_assertions)]
+fn warn_if_rect_changes_id_false_positive_auto_id_shift() {
+    use core::cell::Cell;
+
+    let skip = Cell::new(false);
+    let button_rect = egui::Rect::from_min_size(egui::pos2(10.0, 10.0), egui::vec2(100.0, 30.0));
+
+    let mut harness = Harness::builder().with_size((200.0, 100.0)).build_ui(|ui| {
+        ui.global_style_mut(|style| style.debug.warn_if_rect_changes_id = true);
+
+        // Shifts the auto-id of the child Ui without changing any layout:
+        if skip.get() {
+            ui.skip_ahead_auto_ids(1);
+        }
+
+        ui.horizontal(|ui| {
+            let id = ui.auto_id_with("my_widget");
+            let _response = ui.interact(button_rect, id, Sense::click());
+        });
+    });
+
+    harness.step();
+    harness.step();
+    assert!(
+        !has_red_warning_rect_at(harness.output(), button_rect),
+        "Should not warn when nothing changed"
+    );
+
+    skip.set(true);
+    harness.step();
+    assert!(
+        !has_red_warning_rect_at(harness.output(), button_rect),
+        "Should NOT warn when parent Ui's auto-id shifted (cascading id change)"
     );
 }
 


### PR DESCRIPTION
`WidgetRect::parent_id` used `Ui::id`, the stable id _scope_ shared by sibling `Ui`s, while accesskit and `WidgetRect::id` use the per-`Ui` `unique_id`. The `warn_if_rect_changes_id` debug check relies on `parent_id` changing during a cascading id shift, but cascades propagate through `unique_id`, not the scope id. So a parent's auto-id shifting produced a false positive for every widget inside it.

Now `parent_id` is the parent's `unique_id`. Adds a regression test.

Known limitation: the child `Ui`'s own `WidgetRect` still warns in that case, since its parent's id is genuinely unchanged. The heuristic cannot tell that apart from a bug.

Found while working on:
* https://github.com/emilk/egui/pull/8542

* [x] I have followed the instructions in the PR template

🤖 Generated with [Claude Code](https://claude.com/claude-code)