### PR TITLE
Fix outdated default in `TableBuilder::max_scroll_height` docstring

### DIFF
--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -375,7 +375,7 @@ impl<'a> TableBuilder<'a> {
     /// Don't make the scroll area higher than this (add scroll-bars instead!).
     ///
     /// In other words: add scroll-bars when this height is reached.
-    /// Default: `800.0`.
+    /// Default: `f32::INFINITY`.
     #[inline]
     pub fn max_scroll_height(mut self, max_scroll_height: f32) -> Self {
         self.scroll_options.max_scroll_height = max_scroll_height;


### PR DESCRIPTION
The default was changed to `f32::INFINITY` in #4817, but the docstring still claimed `800.0`.

* Related: <https://github.com/emilk/egui/issues/3114>
