### PR TITLE
Allow multiple `GlyphRasterizer`s, with priority over installed fonts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4594,6 +4594,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "svg_glyph"
+version = "0.1.0"
+dependencies = [
+ "eframe",
+ "egui_extras",
+ "env_logger",
+]
+
+[[package]]
 name = "svgtypes"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -47,7 +47,7 @@ impl AppRunner {
         text_agent: TextAgent,
     ) -> Result<Self, String> {
         let egui_ctx = egui::Context::default();
-        egui_ctx.set_glyph_rasterizer(Some(super::canvas_glyphs::glyph_rasterizer()));
+        egui_ctx.add_glyph_rasterizer(super::canvas_glyphs::glyph_rasterizer());
 
         #[allow(clippy::allow_attributes, unused_assignments)]
         #[cfg(feature = "glow")]

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -375,7 +375,7 @@ impl ViewportRepaintInfo {
 struct ContextImpl {
     fonts: Option<Fonts>,
     font_definitions: FontDefinitions,
-    glyph_rasterizer: Option<GlyphRasterizer>,
+    glyph_rasterizers: Vec<GlyphRasterizer>,
     font_providers: Vec<Arc<dyn FontProvider>>,
 
     memory: Memory,
@@ -596,9 +596,7 @@ impl ContextImpl {
             profiling::scope!("Fonts::new");
             let mut fonts = Fonts::new(text_options, self.font_definitions.clone())
                 .with_font_providers(self.font_providers.clone());
-            if let Some(glyph_rasterizer) = &self.glyph_rasterizer {
-                fonts = fonts.with_glyph_rasterizer(glyph_rasterizer.clone());
-            }
+            fonts.set_glyph_rasterizers(self.glyph_rasterizers.clone());
             fonts
         });
 
@@ -769,15 +767,29 @@ impl Default for Context {
 }
 
 impl Context {
-    /// Set the platform glyph rasterizer, e.g. the browser on web.
+    /// Add a [`GlyphRasterizer`], e.g. the browser on web, or for custom glyphs.
     ///
-    /// It is used for grapheme clusters that no installed font can render,
+    /// By default it is a fallback, used for grapheme clusters that no installed font can render,
     /// and that no [`FontProvider`] has a font for.
+    /// With [`crate::FontPriority::Highest`] it instead overrides the installed fonts.
+    /// See [`GlyphRasterizer`] for details.
     ///
-    /// `eframe` sets this on web. Pass `None` to only use the installed fonts.
-    pub fn set_glyph_rasterizer(&self, glyph_rasterizer: Option<GlyphRasterizer>) {
+    /// Rasterizers are asked in the order they were added.
+    /// `eframe` adds the browser rasterizer on web.
+    pub fn add_glyph_rasterizer(&self, glyph_rasterizer: GlyphRasterizer) {
         self.write(|ctx| {
-            ctx.glyph_rasterizer = glyph_rasterizer;
+            ctx.glyph_rasterizers.push(glyph_rasterizer);
+            ctx.fonts = None;
+        });
+    }
+
+    /// Replace all [`GlyphRasterizer`]s. See [`Self::add_glyph_rasterizer`].
+    ///
+    /// Pass an empty list to only use the installed fonts.
+    /// Note that this also removes the browser rasterizer that `eframe` adds on web.
+    pub fn set_glyph_rasterizers(&self, glyph_rasterizers: Vec<GlyphRasterizer>) {
+        self.write(|ctx| {
+            ctx.glyph_rasterizers = glyph_rasterizers;
             ctx.fonts = None;
         });
     }

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -769,10 +769,8 @@ impl Default for Context {
 impl Context {
     /// Add a [`GlyphRasterizer`], e.g. the browser on web, or for custom glyphs.
     ///
-    /// By default it is a fallback, used for grapheme clusters that no installed font can render,
-    /// and that no [`FontProvider`] has a font for.
-    /// With [`crate::FontPriority::Highest`] it instead overrides the installed fonts.
-    /// See [`GlyphRasterizer`] for details.
+    /// Depending on [`FontPriority`] this is either a fallback or an override
+    /// (see [`GlyphRasterizer`] for details).
     ///
     /// Rasterizers are asked in the order they were added.
     /// `eframe` adds the browser rasterizer on web.

--- a/crates/egui_extras/src/lib.rs
+++ b/crates/egui_extras/src/lib.rs
@@ -19,6 +19,8 @@ mod layout;
 pub mod loaders;
 mod sizing;
 mod strip;
+#[cfg(feature = "svg")]
+mod svg_glyph;
 mod table;
 
 #[cfg(feature = "datepicker")]
@@ -27,6 +29,8 @@ pub use crate::datepicker::DatePickerButton;
 pub(crate) use crate::layout::StripLayout;
 pub use crate::sizing::Size;
 pub use crate::strip::*;
+#[cfg(feature = "svg")]
+pub use crate::svg_glyph::SvgGlyph;
 pub use crate::table::*;
 
 pub use loaders::install_image_loaders;

--- a/crates/egui_extras/src/svg_glyph.rs
+++ b/crates/egui_extras/src/svg_glyph.rs
@@ -8,19 +8,20 @@ use egui::{
 };
 use resvg::{
     tiny_skia::Pixmap,
-    usvg::{Transform, Tree},
+    usvg::{Color, Group, Node, Paint, Transform, Tree},
 };
 
 /// A glyph rendered from an SVG, for a [`GlyphRasterizer`].
 ///
-/// Use it to override how a character looks (e.g. `…`),
+/// Use it to override how a character looks
 /// or to add your own icons to a (private use) character.
 ///
 /// The SVG is scaled so that its height is [`Self::with_height`] (default: one em),
 /// and placed with its bottom edge [`Self::with_baseline_offset`] above the baseline (default: on it).
 ///
-/// By default the SVG is treated as a monochrome shape and tinted with the text color.
-/// Use [`Self::with_color`] to keep its own colors.
+/// An SVG that only uses shades of gray is tinted with the text color, like a normal glyph.
+/// One with other colors keeps them, like a color emoji.
+/// Use [`Self::with_color`] to decide yourself.
 ///
 /// ```no_run
 /// # let ctx = egui::Context::default();
@@ -42,6 +43,8 @@ pub struct SvgGlyph {
     advance_em: Option<f32>,
 
     /// Keep the colors of the SVG, instead of tinting it with the text color?
+    ///
+    /// Default: whether the SVG uses any color that is not a shade of gray.
     is_color: bool,
 }
 
@@ -59,11 +62,11 @@ impl SvgGlyph {
     /// Use an already parsed SVG.
     pub fn from_tree(tree: Tree) -> Self {
         Self {
+            is_color: has_color(tree.root()),
             tree: Arc::new(tree),
             height_em: 1.0,
             baseline_offset_em: 0.0,
             advance_em: None,
-            is_color: false,
         }
     }
 
@@ -99,7 +102,7 @@ impl SvgGlyph {
     /// Keep the colors of the SVG (like a color emoji),
     /// instead of tinting its shape with the text color?
     ///
-    /// Default: `false`.
+    /// Default: `true` if the SVG uses any color that is not a shade of gray.
     #[inline]
     pub fn with_color(mut self, is_color: bool) -> Self {
         self.is_color = is_color;
@@ -188,20 +191,63 @@ impl SvgGlyph {
     }
 }
 
+/// Does anything in this group use a color that is not a shade of gray?
+fn has_color(group: &Group) -> bool {
+    group.children().iter().any(|node| match node {
+        Node::Group(group) => has_color(group),
+        Node::Path(path) => {
+            path.fill()
+                .is_some_and(|fill| paint_has_color(fill.paint()))
+                || path
+                    .stroke()
+                    .is_some_and(|stroke| paint_has_color(stroke.paint()))
+        }
+        Node::Image(_) => true,
+        Node::Text(text) => has_color(text.flattened()),
+    })
+}
+
+fn paint_has_color(paint: &Paint) -> bool {
+    match paint {
+        Paint::Color(color) => !is_gray(*color),
+        Paint::LinearGradient(gradient) => {
+            gradient.stops().iter().any(|stop| !is_gray(stop.color()))
+        }
+        Paint::RadialGradient(gradient) => {
+            gradient.stops().iter().any(|stop| !is_gray(stop.color()))
+        }
+        Paint::Pattern(pattern) => has_color(pattern.root()),
+    }
+}
+
+fn is_gray(color: Color) -> bool {
+    let Color { red, green, blue } = color;
+    red == green && green == blue
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// A 10x20 red rectangle.
-    const RED_RECT: &[u8] = br#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="20"><rect width="10" height="20" fill="red"/></svg>"#;
+    /// A 10x20 rectangle.
+    fn rect_svg(fill: &str) -> Vec<u8> {
+        format!(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="20"><rect width="10" height="20" fill="{fill}"/></svg>"#
+        )
+        .into_bytes()
+    }
 
     fn red_rect() -> SvgGlyph {
-        SvgGlyph::from_bytes(RED_RECT).unwrap()
+        SvgGlyph::from_bytes(&rect_svg("red")).unwrap()
+    }
+
+    fn gray_rect() -> SvgGlyph {
+        SvgGlyph::from_bytes(&rect_svg("#808080")).unwrap()
     }
 
     #[test]
-    fn monochrome_by_default() {
-        let glyph = red_rect().rasterize(40.0).unwrap();
+    fn gray_is_tinted() {
+        let glyph = gray_rect().rasterize(40.0).unwrap();
         assert_eq!(glyph.bitmap.image.size, [20, 40]);
         assert!(!glyph.bitmap.is_color);
         assert!(
@@ -217,10 +263,44 @@ mod tests {
     }
 
     #[test]
-    fn keeps_color_when_asked() {
-        let glyph = red_rect().with_color(true).rasterize(40.0).unwrap();
+    fn color_is_kept() {
+        let glyph = red_rect().rasterize(40.0).unwrap();
         assert!(glyph.bitmap.is_color);
         assert!(glyph.bitmap.image.pixels.iter().all(|&p| p == Color32::RED));
+    }
+
+    #[test]
+    fn color_detection_can_be_overridden() {
+        assert!(
+            !red_rect()
+                .with_color(false)
+                .rasterize(40.0)
+                .unwrap()
+                .bitmap
+                .is_color
+        );
+        assert!(
+            gray_rect()
+                .with_color(true)
+                .rasterize(40.0)
+                .unwrap()
+                .bitmap
+                .is_color
+        );
+    }
+
+    #[test]
+    fn detects_color_in_gradients_and_nested_groups() {
+        let svg = br#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+            <defs><linearGradient id="g"><stop offset="0" stop-color="black"/><stop offset="1" stop-color="blue"/></linearGradient></defs>
+            <g><g><rect width="10" height="10" fill="url(#g)"/></g></g>
+        </svg>"#;
+        assert!(SvgGlyph::from_bytes(svg).unwrap().is_color);
+
+        let svg = br#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+            <g><circle cx="5" cy="5" r="4" fill="none" stroke="white"/></g>
+        </svg>"#;
+        assert!(!SvgGlyph::from_bytes(svg).unwrap().is_color);
     }
 
     #[test]

--- a/crates/egui_extras/src/svg_glyph.rs
+++ b/crates/egui_extras/src/svg_glyph.rs
@@ -1,0 +1,280 @@
+//! Render text glyphs from SVG files. See [`SvgGlyph`].
+
+use std::sync::Arc;
+
+use egui::{
+    Color32, ColorImage, FontPriority, GlyphBitmap, GlyphRasterizer, GlyphRasterizerRequest,
+    MAX_GLYPH_SIZE, RasterizedGlyph, Vec2, vec2,
+};
+use resvg::{
+    tiny_skia::Pixmap,
+    usvg::{Transform, Tree},
+};
+
+/// A glyph rendered from an SVG, for a [`GlyphRasterizer`].
+///
+/// Use it to override how a character looks (e.g. `…`),
+/// or to add your own icons to a (private use) character.
+///
+/// The SVG is scaled so that its height is [`Self::with_height`] (default: one em),
+/// and placed with its bottom edge [`Self::with_baseline_offset`] above the baseline (default: on it).
+///
+/// By default the SVG is treated as a monochrome shape and tinted with the text color.
+/// Use [`Self::with_color`] to keep its own colors.
+///
+/// ```no_run
+/// # let ctx = egui::Context::default();
+/// let svg = std::fs::read("ellipsis.svg").unwrap();
+/// let ellipsis = egui_extras::SvgGlyph::from_bytes(&svg).unwrap();
+/// ctx.add_glyph_rasterizer(ellipsis.into_rasterizer("…"));
+/// ```
+#[derive(Clone, Debug)]
+pub struct SvgGlyph {
+    tree: Arc<Tree>,
+
+    /// Height of the rendered SVG, in em (fractions of the font size).
+    height_em: f32,
+
+    /// How far above the baseline the bottom of the SVG sits, in em.
+    baseline_offset_em: f32,
+
+    /// Horizontal advance in em. `None` means the width of the rendered SVG.
+    advance_em: Option<f32>,
+
+    /// Keep the colors of the SVG, instead of tinting it with the text color?
+    is_color: bool,
+}
+
+impl SvgGlyph {
+    /// Parse an SVG with default [`resvg::usvg::Options`].
+    ///
+    /// # Errors
+    /// On invalid SVG.
+    pub fn from_bytes(svg_bytes: &[u8]) -> Result<Self, String> {
+        let options = resvg::usvg::Options::default();
+        let tree = Tree::from_data(svg_bytes, &options).map_err(|err| err.to_string())?;
+        Ok(Self::from_tree(tree))
+    }
+
+    /// Use an already parsed SVG.
+    pub fn from_tree(tree: Tree) -> Self {
+        Self {
+            tree: Arc::new(tree),
+            height_em: 1.0,
+            baseline_offset_em: 0.0,
+            advance_em: None,
+            is_color: false,
+        }
+    }
+
+    /// Height of the rendered SVG, in em (fractions of the font size).
+    ///
+    /// Default: `1.0`. The width follows from the aspect ratio of the SVG.
+    #[inline]
+    pub fn with_height(mut self, height_em: f32) -> Self {
+        self.height_em = height_em;
+        self
+    }
+
+    /// How far above the baseline the bottom of the SVG sits, in em.
+    ///
+    /// Default: `0.0`, i.e. the SVG stands on the baseline.
+    /// Negative values reach below the baseline.
+    #[inline]
+    pub fn with_baseline_offset(mut self, baseline_offset_em: f32) -> Self {
+        self.baseline_offset_em = baseline_offset_em;
+        self
+    }
+
+    /// Horizontal advance in em, i.e. how much room the glyph takes in the text.
+    ///
+    /// Default: the width of the rendered SVG.
+    /// If wider than the SVG, the SVG is centered in the advance.
+    #[inline]
+    pub fn with_advance(mut self, advance_em: f32) -> Self {
+        self.advance_em = Some(advance_em);
+        self
+    }
+
+    /// Keep the colors of the SVG (like a color emoji),
+    /// instead of tinting its shape with the text color?
+    ///
+    /// Default: `false`.
+    #[inline]
+    pub fn with_color(mut self, is_color: bool) -> Self {
+        self.is_color = is_color;
+        self
+    }
+
+    /// Render the SVG for this font size.
+    ///
+    /// Returns `None` for sizes that are not positive and finite,
+    /// or would exceed [`MAX_GLYPH_SIZE`].
+    pub fn rasterize(&self, font_size_px: f32) -> Option<RasterizedGlyph> {
+        profiling::function_scope!();
+
+        let Self {
+            tree,
+            height_em,
+            baseline_offset_em,
+            advance_em,
+            is_color,
+        } = self;
+
+        if !font_size_px.is_finite() || font_size_px <= 0.0 {
+            return None;
+        }
+
+        let source_size = Vec2::new(tree.size().width(), tree.size().height());
+        if source_size.x <= 0.0 || source_size.y <= 0.0 {
+            return None;
+        }
+        let height_px = height_em * font_size_px;
+        let size_px = (source_size * (height_px / source_size.y))
+            .round()
+            .max(Vec2::splat(1.0));
+        let [width, height] = [size_px.x as usize, size_px.y as usize];
+        if MAX_GLYPH_SIZE < width || MAX_GLYPH_SIZE < height {
+            log::warn!("SVG glyph of {width}x{height} px is too big for the font atlas");
+            return None;
+        }
+
+        let mut pixmap = Pixmap::new(width as u32, height as u32)?;
+        resvg::render(
+            tree,
+            Transform::from_scale(size_px.x / source_size.x, size_px.y / source_size.y),
+            &mut pixmap.as_mut(),
+        );
+
+        let mut image = ColorImage::from_rgba_premultiplied([width, height], pixmap.data());
+        if !is_color {
+            // The atlas stores coverage for monochrome glyphs, and the tessellator tints them:
+            for pixel in &mut image.pixels {
+                *pixel = Color32::from_white_alpha(pixel.a());
+            }
+        }
+
+        let advance_px = advance_em.map_or(size_px.x, |advance_em| advance_em * font_size_px);
+        let offset_px = vec2(
+            (advance_px - size_px.x) / 2.0,
+            -(baseline_offset_em * font_size_px + size_px.y),
+        );
+
+        Some(RasterizedGlyph {
+            bitmap: GlyphBitmap {
+                image,
+                offset_px,
+                is_color: *is_color,
+            },
+            advance_px,
+        })
+    }
+
+    /// A [`GlyphRasterizer`] that renders this SVG for the given grapheme cluster
+    /// (usually a single character), in every font family.
+    ///
+    /// It has [`FontPriority::Highest`], so it overrides the installed fonts.
+    /// Use [`GlyphRasterizer::with_priority`] to make it a fallback instead.
+    pub fn into_rasterizer(self, cluster: impl Into<String>) -> GlyphRasterizer {
+        let cluster: String = cluster.into();
+        GlyphRasterizer::new(move |request: &GlyphRasterizerRequest<'_>| {
+            if request.cluster == cluster {
+                self.rasterize(request.font_size_px)
+            } else {
+                None
+            }
+        })
+        .with_priority(FontPriority::Highest)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A 10x20 red rectangle.
+    const RED_RECT: &[u8] = br#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="20"><rect width="10" height="20" fill="red"/></svg>"#;
+
+    fn red_rect() -> SvgGlyph {
+        SvgGlyph::from_bytes(RED_RECT).unwrap()
+    }
+
+    #[test]
+    fn monochrome_by_default() {
+        let glyph = red_rect().rasterize(40.0).unwrap();
+        assert_eq!(glyph.bitmap.image.size, [20, 40]);
+        assert!(!glyph.bitmap.is_color);
+        assert!(
+            glyph
+                .bitmap
+                .image
+                .pixels
+                .iter()
+                .all(|&p| p == Color32::WHITE)
+        );
+        assert_eq!(glyph.bitmap.offset_px, vec2(0.0, -40.0));
+        assert_eq!(glyph.advance_px, 20.0);
+    }
+
+    #[test]
+    fn keeps_color_when_asked() {
+        let glyph = red_rect().with_color(true).rasterize(40.0).unwrap();
+        assert!(glyph.bitmap.is_color);
+        assert!(glyph.bitmap.image.pixels.iter().all(|&p| p == Color32::RED));
+    }
+
+    #[test]
+    fn height_advance_and_baseline_offset() {
+        let glyph = red_rect()
+            .with_height(0.5)
+            .with_advance(1.0)
+            .with_baseline_offset(0.25)
+            .rasterize(40.0)
+            .unwrap();
+        assert_eq!(glyph.bitmap.image.size, [10, 20]);
+        assert_eq!(glyph.advance_px, 40.0);
+        assert_eq!(
+            glyph.bitmap.offset_px,
+            vec2(15.0, -30.0),
+            "Centered in the advance, 10 px above the baseline"
+        );
+    }
+
+    #[test]
+    fn rejects_bad_sizes() {
+        assert!(red_rect().rasterize(0.0).is_none());
+        assert!(red_rect().rasterize(f32::NAN).is_none());
+        assert!(red_rect().rasterize(1e6).is_none());
+    }
+
+    #[test]
+    fn rasterizer_only_handles_its_cluster() {
+        let rasterizer = red_rect().into_rasterizer("…");
+        assert_eq!(rasterizer.priority, FontPriority::Highest);
+        let request = |cluster| GlyphRasterizerRequest {
+            cluster,
+            family: &egui::FontFamily::Proportional,
+            font_size_px: 20.0,
+            subpixel_offset_px: 0.0,
+        };
+        assert!((rasterizer.rasterize)(&request("…")).is_some());
+        assert!((rasterizer.rasterize)(&request("a")).is_none());
+    }
+
+    #[test]
+    fn overrides_glyph_in_layout() {
+        use egui::epaint::text::{FontDefinitions, FontId, Fonts, TextOptions};
+
+        let mut fonts = Fonts::new(TextOptions::default(), FontDefinitions::default())
+            .with_glyph_rasterizer(red_rect().into_rasterizer("…"));
+        let galley = fonts.with_pixels_per_point(1.0).layout_no_wrap(
+            "…".to_owned(),
+            FontId::proportional(20.0),
+            Color32::WHITE,
+        );
+        let glyph = galley.rows[0].row.glyphs[0];
+        assert_eq!(glyph.chr, '…');
+        assert_eq!(glyph.advance_width, 10.0);
+        assert!(!glyph.uv_rect.is_nothing());
+    }
+}

--- a/crates/epaint/src/text/font_definitions.rs
+++ b/crates/epaint/src/text/font_definitions.rs
@@ -84,8 +84,8 @@ pub struct InsertFontFamily {
     pub priority: FontPriority,
 }
 
-/// Whether an inserted font goes before or after the existing fonts of a family.
-#[derive(Debug, Clone)]
+/// Whether an inserted font (or [`crate::text::GlyphRasterizer`]) goes before or after the existing fonts of a family.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub enum FontPriority {
     /// Prefer this font before all existing ones.
     ///

--- a/crates/epaint/src/text/font_provider.rs
+++ b/crates/epaint/src/text/font_provider.rs
@@ -234,7 +234,7 @@ mod tests {
     fn fonts_with(provider: Arc<dyn FontProvider>, rasterizer: Option<GlyphRasterizer>) -> Fonts {
         let mut fonts =
             Fonts::new(TextOptions::default(), hack_only()).with_font_providers(vec![provider]);
-        fonts.set_glyph_rasterizer(rasterizer);
+        fonts.set_glyph_rasterizers(rasterizer.into_iter().collect());
         fonts
     }
 

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -3,8 +3,8 @@ use std::{collections::BTreeMap, sync::Arc};
 use crate::{
     Color32, TextureAtlas,
     text::{
-        FontDefinitions, FontFamily, FontId, FontInsert, FontProvider, Galley, GlyphRasterizer,
-        LayoutJob, TextOptions, VariationCoords,
+        FontDefinitions, FontFamily, FontId, FontInsert, FontPriority, FontProvider, Galley,
+        GlyphRasterizer, LayoutJob, TextOptions, VariationCoords,
         face_store::{FaceStore, FontFaceKey},
         family::{Family, FamilyKey},
         font_face::{FontFace, GlyphInfo, ShapedGlyph},
@@ -50,22 +50,28 @@ impl Fonts {
         }
     }
 
-    /// Use this platform glyph rasterizer, e.g. the browser on web.
+    /// Also use this glyph rasterizer, e.g. the browser on web, or for custom glyphs.
     ///
     /// See [`GlyphRasterizer`].
     #[inline]
     pub fn with_glyph_rasterizer(mut self, glyph_rasterizer: GlyphRasterizer) -> Self {
-        self.set_glyph_rasterizer(Some(glyph_rasterizer));
+        self.add_glyph_rasterizer(glyph_rasterizer);
         self
     }
 
-    /// Use this platform glyph rasterizer, e.g. the browser on web.
-    ///
-    /// Pass `None` to only use the installed fonts.
+    /// Also use this glyph rasterizer, e.g. the browser on web, or for custom glyphs.
     ///
     /// See [`GlyphRasterizer`].
-    pub fn set_glyph_rasterizer(&mut self, glyph_rasterizer: Option<GlyphRasterizer>) {
-        self.fonts.set_glyph_rasterizer(glyph_rasterizer);
+    pub fn add_glyph_rasterizer(&mut self, glyph_rasterizer: GlyphRasterizer) {
+        self.fonts.add_glyph_rasterizer(glyph_rasterizer);
+        self.galley_cache = Default::default();
+    }
+
+    /// Replace all [`GlyphRasterizer`]s.
+    ///
+    /// Pass an empty list to only use the installed fonts.
+    pub fn set_glyph_rasterizers(&mut self, glyph_rasterizers: Vec<GlyphRasterizer>) {
+        self.fonts.set_glyph_rasterizers(glyph_rasterizers);
         self.galley_cache = Default::default();
     }
 
@@ -139,15 +145,15 @@ impl Fonts {
 
     /// Do the installed fonts have this glyph?
     ///
-    /// This does not consult the [`GlyphRasterizer`], so it can return `false`
-    /// for a character that would still render via the rasterizer (e.g. the browser on web).
+    /// This does not consult the [`GlyphRasterizer`]s, so it can return `false`
+    /// for a character that would still render via a rasterizer (e.g. the browser on web).
     pub fn has_glyph(&mut self, font_id: &FontId, c: char) -> bool {
         self.fonts.has_glyph(&font_id.family, c)
     }
 
     /// Do the installed fonts have all the glyphs in this text?
     ///
-    /// See [`Self::has_glyph`] for the caveat about the [`GlyphRasterizer`].
+    /// See [`Self::has_glyph`] for the caveat about the [`GlyphRasterizer`]s.
     pub fn has_glyphs(&mut self, font_id: &FontId, s: &str) -> bool {
         self.fonts.has_glyphs(&font_id.family, s)
     }
@@ -223,22 +229,22 @@ impl FontsView<'_> {
 
     /// Do the installed fonts have this glyph?
     ///
-    /// This does not consult the [`GlyphRasterizer`], so it can return `false`
-    /// for a character that would still render via the rasterizer (e.g. the browser on web).
+    /// This does not consult the [`GlyphRasterizer`]s, so it can return `false`
+    /// for a character that would still render via a rasterizer (e.g. the browser on web).
     pub fn has_glyph(&mut self, font_id: &FontId, c: char) -> bool {
         self.fonts.has_glyph(&font_id.family, c)
     }
 
     /// Do the installed fonts have all the glyphs in this text?
     ///
-    /// See [`Self::has_glyph`] for the caveat about the [`GlyphRasterizer`].
+    /// See [`Self::has_glyph`] for the caveat about the [`GlyphRasterizer`]s.
     pub fn has_glyphs(&mut self, font_id: &FontId, s: &str) -> bool {
         self.fonts.has_glyphs(&font_id.family, s)
     }
 
     /// All characters the fonts of this family support, and the names of the fonts that have each.
     ///
-    /// This does not consult the [`GlyphRasterizer`].
+    /// This does not consult the [`GlyphRasterizer`]s.
     pub fn characters(&mut self, family: &FontFamily) -> &BTreeMap<char, Vec<String>> {
         self.fonts.characters(family)
     }
@@ -356,7 +362,9 @@ pub(crate) struct FontsImpl {
 
     /// Recycled `harfrust` shaping buffer to avoid per-layout allocations.
     shape_buffer: Option<harfrust::UnicodeBuffer>,
-    glyph_rasterizer: Option<GlyphRasterizer>,
+
+    /// In the order they were added. See [`GlyphRasterizer`].
+    glyph_rasterizers: Vec<GlyphRasterizer>,
     font_providers: FontProviders,
 }
 
@@ -371,7 +379,7 @@ impl FontsImpl {
             families: Default::default(),
             family_keys: Default::default(),
             shape_buffer: Some(harfrust::UnicodeBuffer::new()),
-            glyph_rasterizer: None,
+            glyph_rasterizers: Vec::new(),
             font_providers: Default::default(),
         };
         slf.set_font_providers(Vec::new());
@@ -402,22 +410,36 @@ impl FontsImpl {
         self.glyphs = GlyphAtlas::new(options);
     }
 
-    /// Use this platform glyph rasterizer, e.g. the browser on web.
+    /// Also use this glyph rasterizer.
     #[cfg(test)]
     #[inline]
     pub fn with_glyph_rasterizer(mut self, glyph_rasterizer: GlyphRasterizer) -> Self {
-        self.set_glyph_rasterizer(Some(glyph_rasterizer));
+        self.add_glyph_rasterizer(glyph_rasterizer);
         self
     }
 
-    /// Use this platform glyph rasterizer, e.g. the browser on web.
-    ///
-    /// Pass `None` to only use the installed fonts.
+    /// Also use this glyph rasterizer, e.g. the browser on web, or for custom glyphs.
     ///
     /// See [`GlyphRasterizer`].
-    pub fn set_glyph_rasterizer(&mut self, glyph_rasterizer: Option<GlyphRasterizer>) {
-        self.glyph_rasterizer = glyph_rasterizer;
+    pub fn add_glyph_rasterizer(&mut self, glyph_rasterizer: GlyphRasterizer) {
+        self.glyph_rasterizers.push(glyph_rasterizer);
         self.glyphs.clear_raster_glyphs();
+    }
+
+    /// Replace all [`GlyphRasterizer`]s.
+    ///
+    /// Pass an empty list to only use the installed fonts.
+    pub fn set_glyph_rasterizers(&mut self, glyph_rasterizers: Vec<GlyphRasterizer>) {
+        self.glyph_rasterizers = glyph_rasterizers;
+        self.glyphs.clear_raster_glyphs();
+    }
+
+    /// Is there any [`GlyphRasterizer`] with this priority?
+    #[inline]
+    pub fn has_glyph_rasterizer(&self, priority: FontPriority) -> bool {
+        self.glyph_rasterizers
+            .iter()
+            .any(|rasterizer| rasterizer.priority == priority)
     }
 
     pub fn options(&self) -> &TextOptions {
@@ -536,8 +558,8 @@ impl FontsImpl {
 
     /// Do the installed fonts have this glyph?
     ///
-    /// This does not consult the [`GlyphRasterizer`], so it can return `false`
-    /// for a character that would still render via the rasterizer (e.g. the browser on web).
+    /// This does not consult the [`GlyphRasterizer`]s, so it can return `false`
+    /// for a character that would still render via a rasterizer (e.g. the browser on web).
     pub fn has_glyph(&mut self, family: &FontFamily, c: char) -> bool {
         let family = self.family_key(family);
         let face_key = self.resolve_face(family, c);
@@ -583,20 +605,24 @@ impl FontsImpl {
             .allocate_outline(face_key, face, metrics, shaped)
     }
 
-    /// Rasterize a grapheme cluster using the platform [`GlyphRasterizer`].
+    /// Rasterize a grapheme cluster using the [`GlyphRasterizer`]s of the given priority.
     ///
-    /// Returns `None` if there is no rasterizer, or it could not handle the cluster.
+    /// Returns `None` if there is no such rasterizer, or none of them could handle the cluster.
     pub fn rasterize_cluster(
         &mut self,
+        priority: FontPriority,
         family: FamilyKey,
         cluster: &str,
         pixels_per_point: f32,
         font_size: f32,
     ) -> Option<RasterGlyphAllocation> {
-        let rasterizer = self.glyph_rasterizer.as_ref()?;
+        if !self.has_glyph_rasterizer(priority) {
+            return None;
+        }
         let family_name = self.families[family.0].name();
         self.glyphs.allocate_raster(
-            rasterizer,
+            &self.glyph_rasterizers,
+            priority,
             cluster,
             family_name,
             pixels_per_point,

--- a/crates/epaint/src/text/glyph_atlas.rs
+++ b/crates/epaint/src/text/glyph_atlas.rs
@@ -5,8 +5,8 @@ use skrifa::GlyphId;
 use crate::{
     FontColorTransferFunction, ImageDelta, TextOptions, TextureAtlas,
     text::{
-        FontFamily, GlyphBitmap, GlyphRasterizer, GlyphRasterizerRequest, MAX_GLYPH_SIZE,
-        RasterizedGlyph,
+        FontFamily, FontPriority, GlyphBitmap, GlyphRasterizer, GlyphRasterizerRequest,
+        MAX_GLYPH_SIZE, RasterizedGlyph,
         face_store::FontFaceKey,
         font_face::{FontFace, ShapedGlyph},
         styled_metrics::StyledMetrics,
@@ -63,8 +63,8 @@ pub(crate) struct OutlineGlyph {
     pub x_px: i32,
 }
 
-/// A glyph from the [`GlyphRasterizer`], allocated in the atlas.
-#[derive(Clone, Copy)]
+/// A glyph from a [`GlyphRasterizer`], allocated in the atlas.
+#[derive(Clone, Copy, Debug)]
 pub(crate) struct RasterGlyphAllocation {
     pub allocation: GlyphAllocation,
     pub advance_px: f32,
@@ -173,7 +173,7 @@ impl OutlineGlyphKey {
     }
 }
 
-/// Hash of `(cluster, family, pixels_per_point, font_size)`,
+/// Hash of `(priority, cluster, family, pixels_per_point, font_size)`,
 /// so that cache lookups do not allocate.
 #[derive(Hash, PartialEq, Eq)]
 struct RasterGlyphKey(u64);
@@ -181,8 +181,15 @@ struct RasterGlyphKey(u64);
 impl nohash_hasher::IsEnabled for RasterGlyphKey {}
 
 impl RasterGlyphKey {
-    fn new(cluster: &str, family: &FontFamily, pixels_per_point: f32, font_size: f32) -> Self {
+    fn new(
+        priority: FontPriority,
+        cluster: &str,
+        family: &FontFamily,
+        pixels_per_point: f32,
+        font_size: f32,
+    ) -> Self {
         Self(crate::util::hash((
+            priority,
             cluster,
             family,
             pixels_per_point.to_bits(),
@@ -203,9 +210,9 @@ pub(crate) struct GlyphAtlas {
     /// Glyphs rendered from font outlines.
     outline_glyphs: IntMap<OutlineGlyphKey, GlyphAllocation>,
 
-    /// Glyphs from the [`GlyphRasterizer`].
+    /// Glyphs from the [`GlyphRasterizer`]s.
     ///
-    /// `None` means the rasterizer could not handle the cluster.
+    /// `None` means no rasterizer of that priority could handle the cluster.
     raster_glyphs: IntMap<RasterGlyphKey, Option<RasterGlyphAllocation>>,
 }
 
@@ -248,7 +255,7 @@ impl GlyphAtlas {
         *self = Self::new(*self.atlas.options());
     }
 
-    /// Forget what the [`GlyphRasterizer`] produced, e.g. because it was replaced.
+    /// Forget what the [`GlyphRasterizer`]s produced, e.g. because they were replaced.
     pub fn clear_raster_glyphs(&mut self) {
         self.raster_glyphs.clear();
     }
@@ -312,21 +319,24 @@ impl GlyphAtlas {
         OutlineGlyph { allocation, x_px }
     }
 
-    /// Get or rasterize `cluster` using the platform [`GlyphRasterizer`].
+    /// Get or rasterize `cluster` using the [`GlyphRasterizer`]s of the given `priority`.
     ///
-    /// Failures are cached too, so the (potentially slow) rasterizer
-    /// is asked at most once per cluster and size.
+    /// The rasterizers are asked in order, and the first to return `Some` wins.
+    ///
+    /// Failures are cached too, so the (potentially slow) rasterizers
+    /// are asked at most once per cluster and size.
     ///
     /// See [`Self::allocate_bitmap`] for what happens when the atlas is full.
-    pub fn allocate_raster(
+    pub fn allocate_raster<'r>(
         &mut self,
-        rasterizer: &GlyphRasterizer,
+        rasterizers: impl IntoIterator<Item = &'r GlyphRasterizer>,
+        priority: FontPriority,
         cluster: &str,
         family: &FontFamily,
         pixels_per_point: f32,
         font_size: f32,
     ) -> Option<RasterGlyphAllocation> {
-        let key = RasterGlyphKey::new(cluster, family, pixels_per_point, font_size);
+        let key = RasterGlyphKey::new(priority, cluster, family, pixels_per_point, font_size);
         if let Some(allocation) = self.raster_glyphs.get(&key) {
             return *allocation;
         }
@@ -336,8 +346,11 @@ impl GlyphAtlas {
             font_size_px: font_size * pixels_per_point,
             subpixel_offset_px: 0.0,
         };
-        let allocation =
-            (rasterizer.rasterize)(&request).and_then(|RasterizedGlyph { bitmap, advance_px }| {
+        let allocation = rasterizers
+            .into_iter()
+            .filter(|rasterizer| rasterizer.priority == priority)
+            .find_map(|rasterizer| (rasterizer.rasterize)(&request))
+            .and_then(|RasterizedGlyph { bitmap, advance_px }| {
                 let is_color = bitmap.is_color;
                 let transfer = Self::transfer_function(&self.atlas, is_color);
                 let uv_rect =

--- a/crates/epaint/src/text/glyph_rasterizer.rs
+++ b/crates/epaint/src/text/glyph_rasterizer.rs
@@ -1,10 +1,16 @@
 use std::sync::Arc;
 
-use crate::{ColorImage, text::FontFamily};
+use crate::{
+    ColorImage,
+    text::{FontFamily, FontPriority},
+};
 
 /// Input to a [`GlyphRasterizer`].
 pub struct GlyphRasterizerRequest<'a> {
-    /// An unsupported grapheme cluster.
+    /// The grapheme cluster to rasterize.
+    ///
+    /// For a fallback rasterizer ([`FontPriority::Lowest`]) this is a cluster no installed font has.
+    /// A priority rasterizer ([`FontPriority::Highest`]) is asked about every cluster.
     pub cluster: &'a str,
 
     /// The requested font family.
@@ -31,7 +37,7 @@ pub struct GlyphBitmap {
     pub is_color: bool,
 }
 
-/// A glyph rasterized by a platform fallback.
+/// A glyph rasterized by a [`GlyphRasterizer`].
 #[derive(Clone)]
 pub struct RasterizedGlyph {
     pub bitmap: GlyphBitmap,
@@ -45,19 +51,38 @@ type RasterizeFn =
     dyn for<'a> Fn(&GlyphRasterizerRequest<'a>) -> Option<RasterizedGlyph> + Send + Sync;
 
 /// Rasterizes grapheme clusters using something other than the installed fonts,
-/// e.g. the browser on web.
+/// e.g. the browser on web, or your own custom glyphs.
 ///
-/// Used for clusters that no installed font can render,
+/// By default ([`FontPriority::Lowest`]) a rasterizer is a fallback:
+/// it is only asked about clusters that no installed font can render,
 /// after the [`FontProvider`](crate::text::FontProvider)s have been asked for a font for them.
+///
+/// With [`FontPriority::Highest`] it is instead asked about every cluster,
+/// before any font. Use this to override how specific glyphs look,
+/// e.g. to always render `…` your own way.
+/// Return `None` quickly for everything you do not want to override.
+///
+/// Several rasterizers can be installed. Within a priority tier
+/// they are asked in the order they were added, and the first to return `Some` wins.
+///
+/// Results (and failures) are cached per cluster, family, and size,
+/// so each rasterizer is asked at most once per such combination.
 #[derive(Clone)]
 pub struct GlyphRasterizer {
     /// Rasterize one grapheme cluster.
     ///
-    /// Return `None` if the platform cannot render it either.
+    /// Return `None` if this rasterizer does not handle it.
     pub rasterize: Arc<RasterizeFn>,
+
+    /// Is this a fallback ([`FontPriority::Lowest`], the default),
+    /// or does it override the installed fonts ([`FontPriority::Highest`])?
+    pub priority: FontPriority,
 }
 
 impl GlyphRasterizer {
+    /// A fallback rasterizer ([`FontPriority::Lowest`]).
+    ///
+    /// See [`Self::with_priority`].
     pub fn new(
         rasterize: impl for<'a> Fn(&GlyphRasterizerRequest<'a>) -> Option<RasterizedGlyph>
         + Send
@@ -66,13 +91,24 @@ impl GlyphRasterizer {
     ) -> Self {
         Self {
             rasterize: Arc::new(rasterize),
+            priority: FontPriority::Lowest,
         }
+    }
+
+    /// Should this rasterizer be asked before ([`FontPriority::Highest`])
+    /// or after ([`FontPriority::Lowest`]) the installed fonts?
+    #[inline]
+    pub fn with_priority(mut self, priority: FontPriority) -> Self {
+        self.priority = priority;
+        self
     }
 }
 
 impl core::fmt::Debug for GlyphRasterizer {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str("GlyphRasterizer")
+        f.debug_struct("GlyphRasterizer")
+            .field("priority", &self.priority)
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -9,7 +9,7 @@ use crate::{
     Color32, Mesh, Stroke, Vertex,
     stroke::PathStroke,
     text::{
-        ByteIndex, ByteRange,
+        ByteIndex, ByteRange, FontPriority,
         face_store::FontFaceKey,
         fonts::FontsImpl,
         styled_metrics::StyledMetrics,
@@ -207,10 +207,17 @@ impl ShapingContext {
 #[derive(Debug)]
 struct TextRun {
     /// Which font face should shape this run.
+    ///
+    /// Ignored if `raster` is set.
     font_key: FontFaceKey,
 
     /// Byte range within the section text.
     byte_range: ByteRange,
+
+    /// Set if a priority [`GlyphRasterizer`](crate::text::GlyphRasterizer) rendered this run.
+    ///
+    /// Such a run is exactly one grapheme cluster, and is not shaped.
+    raster: Option<RasterGlyphAllocation>,
 }
 
 /// Emit shaped glyphs from a [`harfrust::GlyphBuffer`] into a [`Paragraph`].
@@ -310,6 +317,7 @@ fn layout_shaped_run(
                 .unwrap_or_default();
 
             if let Some(raster) = fonts.rasterize_cluster(
+                FontPriority::Lowest,
                 ctx.family,
                 cluster_text,
                 ctx.pixels_per_point,
@@ -429,6 +437,37 @@ fn raster_glyph(
     )
 }
 
+/// Emit the glyphs of a run that a priority [`GlyphRasterizer`](crate::text::GlyphRasterizer) rendered.
+///
+/// The run is one grapheme cluster: its first char gets the bitmap,
+/// and the rest zero-width continuation glyphs.
+fn layout_raster_run(
+    ctx: &mut ShapingContext,
+    paragraph: &mut Paragraph,
+    run_text: &str,
+    raster: &RasterGlyphAllocation,
+) {
+    let Some(chr) = run_text.chars().next() else {
+        return;
+    };
+    if !ctx.is_first_glyph_in_section {
+        paragraph.cursor_x_px += ctx.extra_letter_spacing * ctx.pixels_per_point;
+    }
+    ctx.is_first_glyph_in_section = false;
+
+    let face_metrics = ctx.font_metrics.clone();
+    let glyph = raster_glyph(ctx, paragraph, chr, raster, &face_metrics);
+    paragraph.glyphs.push(glyph);
+    emit_continuation_glyphs(
+        ctx,
+        paragraph,
+        run_text,
+        0..run_text.len(),
+        1,
+        &face_metrics,
+    );
+}
+
 /// Emit zero-width continuation glyphs when a cluster has more characters than
 /// shaped glyphs.
 ///
@@ -522,11 +561,15 @@ fn layout_section(
             continue;
         }
 
-        segment_into_runs(fonts, family, segment, &mut runs);
+        segment_into_runs(fonts, &ctx, segment, &mut runs);
 
         let num_runs = runs.len();
         for (run_idx, run) in runs.iter().enumerate() {
             let run_text = &segment[run.byte_range.as_usize()];
+            if let Some(raster) = &run.raster {
+                layout_raster_run(&mut ctx, paragraph, run_text, raster);
+                continue;
+            }
             let Some(font_face) = fonts.face(run.font_key) else {
                 continue;
             };
@@ -819,12 +862,36 @@ fn replace_last_glyph_with_overflow_character(
         let family = fonts.family_key(&section.format.font_id.family);
         let font_size = section.format.font_id.size;
 
-        let face_key = fonts.resolve_face(family, overflow_character);
-        let font_face_metrics = fonts
-            .face(face_key)
-            .map(|face| face.styled_metrics(pixels_per_point, font_size, &section.format.coords))
-            .unwrap_or_default();
-        let (_, glyph_info) = fonts.glyph_info(family, overflow_character, &font_face_metrics);
+        let font_metrics =
+            fonts.family_metrics(family, pixels_per_point, font_size, &section.format.coords);
+
+        // A priority rasterizer may override the overflow character, just like any other glyph:
+        let mut utf8 = [0_u8; 4];
+        let raster = fonts.rasterize_cluster(
+            FontPriority::Highest,
+            family,
+            overflow_character.encode_utf8(&mut utf8),
+            pixels_per_point,
+            font_size,
+        );
+
+        let (face_key, font_face_metrics, glyph_info) = if raster.is_some() {
+            (
+                FontFaceKey::INVALID,
+                font_metrics.clone(),
+                GlyphInfo::INVISIBLE,
+            )
+        } else {
+            let face_key = fonts.resolve_face(family, overflow_character);
+            let font_face_metrics = fonts
+                .face(face_key)
+                .map(|face| {
+                    face.styled_metrics(pixels_per_point, font_size, &section.format.coords)
+                })
+                .unwrap_or_default();
+            let (_, glyph_info) = fonts.glyph_info(family, overflow_character, &font_face_metrics);
+            (face_key, font_face_metrics, glyph_info)
+        };
 
         let overflow_glyph_x = if let Some(prev_glyph) = row.glyphs.last() {
             prev_glyph.max_x() + extra_letter_spacing
@@ -832,8 +899,10 @@ fn replace_last_glyph_with_overflow_character(
             0.0 // TODO(emilk): heed paragraph leading_space 😬
         };
 
-        let advance_width_px =
-            glyph_info.advance_width_unscaled.0 * font_face_metrics.px_scale_factor;
+        let advance_width_px = match &raster {
+            Some(raster) => raster.advance_px,
+            None => glyph_info.advance_width_unscaled.0 * font_face_metrics.px_scale_factor,
+        };
         let replacement_glyph_width = advance_width_px / pixels_per_point;
 
         // Check if we're within width budget:
@@ -845,17 +914,21 @@ fn replace_last_glyph_with_overflow_character(
             let OutlineGlyph {
                 allocation: replacement_glyph_alloc,
                 x_px,
-            } = allocate_glyph_info(
-                fonts,
-                face_key,
-                &font_face_metrics,
-                glyph_info,
-                overflow_glyph_x * pixels_per_point,
-                overflow_character,
-            );
+            } = match &raster {
+                Some(raster) => OutlineGlyph {
+                    allocation: raster.allocation,
+                    x_px: (overflow_glyph_x * pixels_per_point).round() as i32,
+                },
+                None => allocate_glyph_info(
+                    fonts,
+                    face_key,
+                    &font_face_metrics,
+                    glyph_info,
+                    overflow_glyph_x * pixels_per_point,
+                    overflow_character,
+                ),
+            };
 
-            let font_metrics =
-                fonts.family_metrics(family, pixels_per_point, font_size, &section.format.coords);
             let line_height = section
                 .format
                 .line_height
@@ -871,7 +944,7 @@ fn replace_last_glyph_with_overflow_character(
                 font_height: font_metrics.row_height,
                 font_ascent: font_metrics.ascent,
                 uv_rect: replacement_glyph_alloc.uv_rect,
-                is_color: false,
+                is_color: replacement_glyph_alloc.is_color,
                 section_index,
                 first_vertex: 0, // filled in later
             });
@@ -1400,6 +1473,9 @@ impl RowBreakCandidates {
 /// falls back to a different font than its base character, it stays
 /// with the base character's font (the shaper will handle it).
 ///
+/// Clusters that a priority [`GlyphRasterizer`](crate::text::GlyphRasterizer)
+/// handles get a run of their own, with [`TextRun::raster`] set.
+///
 /// NOTE: Segmentation is by font face, not by Unicode script. A run may
 /// mix scripts (e.g. Latin + Cyrillic) when they share the same font.
 /// This is acceptable for scripts with similar shaping rules, but would
@@ -1407,7 +1483,12 @@ impl RowBreakCandidates {
 ///
 /// Results are appended to `out` (which is cleared first) to allow
 /// the caller to reuse the allocation across calls.
-fn segment_into_runs(fonts: &mut FontsImpl, family: FamilyKey, text: &str, out: &mut Vec<TextRun>) {
+fn segment_into_runs(
+    fonts: &mut FontsImpl,
+    ctx: &ShapingContext,
+    text: &str,
+    out: &mut Vec<TextRun>,
+) {
     use unicode_segmentation::UnicodeSegmentation as _;
 
     out.clear();
@@ -1416,9 +1497,25 @@ fn segment_into_runs(fonts: &mut FontsImpl, family: FamilyKey, text: &str, out: 
         let byte_offset = ByteIndex(byte_offset);
         let byte_end = byte_offset + grapheme_str.len();
 
-        let font_key = fonts.resolve_cluster_face(family, grapheme_str);
+        if let Some(raster) = fonts.rasterize_cluster(
+            FontPriority::Highest,
+            ctx.family,
+            grapheme_str,
+            ctx.pixels_per_point,
+            ctx.font_size,
+        ) {
+            out.push(TextRun {
+                font_key: FontFaceKey::INVALID,
+                byte_range: byte_offset..byte_end,
+                raster: Some(raster),
+            });
+            continue;
+        }
+
+        let font_key = fonts.resolve_cluster_face(ctx.family, grapheme_str);
 
         if let Some(last_run) = out.last_mut()
+            && last_run.raster.is_none()
             && last_run.font_key == font_key
         {
             last_run.byte_range.end = byte_end;
@@ -1427,6 +1524,7 @@ fn segment_into_runs(fonts: &mut FontsImpl, family: FamilyKey, text: &str, out: 
         out.push(TextRun {
             font_key,
             byte_range: byte_offset..byte_end,
+            raster: None,
         });
     }
 }
@@ -1701,6 +1799,144 @@ mod tests {
             !glyph.uv_rect.is_nothing(),
             "Should render the `.notdef` glyph"
         );
+    }
+
+    /// A priority rasterizer that only handles `cluster`, and records every request.
+    fn priority_rasterizer_for(
+        cluster: &'static str,
+        requests: &Arc<crate::mutex::Mutex<Vec<(String, FontFamily)>>>,
+    ) -> GlyphRasterizer {
+        let requests = Arc::clone(requests);
+        GlyphRasterizer::new(move |request: &GlyphRasterizerRequest<'_>| {
+            requests
+                .lock()
+                .push((request.cluster.to_owned(), request.family.clone()));
+            (request.cluster == cluster).then(color_raster_glyph)
+        })
+        .with_priority(FontPriority::Highest)
+    }
+
+    fn layout_simple(fonts: &mut FontsImpl, text: &str) -> Galley {
+        let job = LayoutJob::simple(
+            text.to_owned(),
+            FontId::proportional(14.0),
+            Color32::WHITE,
+            f32::INFINITY,
+        );
+        layout(fonts, 1.0, Arc::new(job))
+    }
+
+    #[test]
+    #[cfg(feature = "default_fonts")] // The font must have `…` for the override to mean anything
+    fn priority_rasterizer_overrides_installed_glyph() {
+        let requests = Arc::new(crate::mutex::Mutex::new(Vec::new()));
+        let mut fonts = test_fonts().with_glyph_rasterizer(priority_rasterizer_for("…", &requests));
+        assert!(fonts.has_glyph(&FontFamily::Proportional, '…'));
+
+        let galley = layout_simple(&mut fonts, "a…b");
+
+        assert_eq!(
+            glyph_summary(&galley),
+            [('a', false, true), ('…', true, true), ('b', false, true)]
+        );
+        let clusters: Vec<_> = requests
+            .lock()
+            .iter()
+            .map(|(cluster, _)| cluster.clone())
+            .collect();
+        assert_eq!(clusters, ["a", "…", "b"], "Asked about every cluster");
+    }
+
+    #[test]
+    #[cfg(feature = "default_fonts")] // Needs `glyph_summary`
+    fn priority_rasterizer_miss_falls_through_to_font_before_fallback() {
+        let priority_requests = Arc::new(crate::mutex::Mutex::new(Vec::new()));
+        let fallback_requests = Arc::new(crate::mutex::Mutex::new(Vec::new()));
+        let mut fonts = test_fonts()
+            .with_glyph_rasterizer(priority_rasterizer_for("never", &priority_requests))
+            .with_glyph_rasterizer(recording_rasterizer(
+                &fallback_requests,
+                Some(color_raster_glyph()),
+            ));
+
+        let galley = layout_simple(&mut fonts, "a한");
+
+        // 'a' comes from the font, '한' from the fallback:
+        assert_eq!(
+            glyph_summary(&galley),
+            [('a', false, true), ('한', true, true)]
+        );
+        assert_eq!(priority_requests.lock().len(), 2);
+        assert_eq!(
+            *fallback_requests.lock(),
+            [("한".to_owned(), FontFamily::Proportional)],
+            "The fallback should only see what the fonts lack"
+        );
+    }
+
+    #[test]
+    fn rasterizers_are_asked_in_order_until_one_succeeds() {
+        let first_requests = Arc::new(crate::mutex::Mutex::new(Vec::new()));
+        let second_requests = Arc::new(crate::mutex::Mutex::new(Vec::new()));
+        let third_requests = Arc::new(crate::mutex::Mutex::new(Vec::new()));
+        let mut fonts = test_fonts()
+            .with_glyph_rasterizer(recording_rasterizer(&first_requests, None))
+            .with_glyph_rasterizer(recording_rasterizer(
+                &second_requests,
+                Some(white_raster_glyph()),
+            ))
+            .with_glyph_rasterizer(recording_rasterizer(
+                &third_requests,
+                Some(white_raster_glyph()),
+            ));
+
+        let galley = layout_simple(&mut fonts, "한");
+
+        assert!(!galley.rows[0].row.glyphs[0].uv_rect.is_nothing());
+        assert_eq!(first_requests.lock().len(), 1);
+        assert_eq!(second_requests.lock().len(), 1);
+        assert_eq!(
+            third_requests.lock().len(),
+            0,
+            "The second one already succeeded"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "default_fonts")] // Needs `glyph_summary`
+    fn priority_rasterizer_keeps_one_glyph_per_char() {
+        let requests = Arc::new(crate::mutex::Mutex::new(Vec::new()));
+        let family = "👨\u{200D}👩\u{200D}👧";
+        let mut fonts =
+            test_fonts().with_glyph_rasterizer(priority_rasterizer_for(family, &requests));
+
+        let galley = layout_simple(&mut fonts, family);
+
+        let summary = glyph_summary(&galley);
+        assert_eq!(summary.len(), family.chars().count());
+        assert_eq!(summary[0], ('👨', true, true));
+        assert!(summary[1..].iter().all(|(_, _, has_pixels)| !has_pixels));
+    }
+
+    #[test]
+    fn overflow_character_uses_priority_rasterizer() {
+        let requests = Arc::new(crate::mutex::Mutex::new(Vec::new()));
+        let mut fonts = test_fonts().with_glyph_rasterizer(priority_rasterizer_for("…", &requests));
+
+        let mut job = LayoutJob::simple(
+            "Hello wide world".to_owned(),
+            FontId::proportional(14.0),
+            Color32::WHITE,
+            f32::INFINITY,
+        );
+        job.wrap = TextWrapping::truncate_at_width(40.0);
+        let galley = layout(&mut fonts, 1.0, Arc::new(job));
+
+        let glyphs = &galley.rows[0].row.glyphs;
+        let last = &glyphs[glyphs.len() - 1];
+        assert_eq!(last.chr, '…');
+        assert!(last.is_color, "Should come from the priority rasterizer");
+        assert!(!last.uv_rect.is_nothing());
     }
 
     #[test]

--- a/examples/svg_glyph/Cargo.toml
+++ b/examples/svg_glyph/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "svg_glyph"
+version = "0.1.0"
+authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
+license = "MIT OR Apache-2.0"
+edition = "2024"
+rust-version = "1.95"
+publish = false
+
+[lints]
+workspace = true
+
+
+[dependencies]
+eframe = { workspace = true, features = [
+  "default",
+  "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
+] }
+egui_extras = { workspace = true, features = ["default", "svg"] }
+env_logger = { workspace = true, features = ["auto-color", "humantime"] }

--- a/examples/svg_glyph/README.md
+++ b/examples/svg_glyph/README.md
@@ -1,0 +1,7 @@
+Example of how to render text glyphs from SVG files with `egui_extras::SvgGlyph`.
+
+```sh
+cargo run -p svg_glyph
+```
+
+![](screenshot.png)

--- a/examples/svg_glyph/heart.svg
+++ b/examples/svg_glyph/heart.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 18">
+  <circle cx="5.5" cy="5.5" r="5.5" fill="white"/>
+  <circle cx="14.5" cy="5.5" r="5.5" fill="white"/>
+  <path d="M0.8 8.5 L10 18 L19.2 8.5 Z" fill="white"/>
+</svg>

--- a/examples/svg_glyph/screenshot.png
+++ b/examples/svg_glyph/screenshot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41abb53ff9d8eacd6877c6178c0dd7ef123591c8a1eab380e2370b828bb67801
+size 62142

--- a/examples/svg_glyph/src/main.rs
+++ b/examples/svg_glyph/src/main.rs
@@ -1,0 +1,86 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
+
+//! Render text glyphs from SVG files with [`egui_extras::SvgGlyph`].
+//!
+//! A gray SVG is tinted with the text color, like a normal glyph.
+//! A colorful SVG keeps its colors, like a color emoji.
+
+use eframe::egui::{self, Color32, RichText};
+use egui_extras::SvgGlyph;
+
+/// A private use character, rendered as Ferris.
+const FERRIS: char = '\u{E000}';
+
+/// A regular character whose glyph we override.
+const HEART: char = '♥';
+
+fn main() -> eframe::Result {
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([420.0, 320.0]),
+        ..Default::default()
+    };
+    eframe::run_native(
+        "egui example: SVG glyphs",
+        options,
+        Box::new(|cc| Ok(Box::new(MyApp::new(cc)?))),
+    )
+}
+
+/// Render `♥` and a private use character from SVG files.
+fn install_svg_glyphs(ctx: &egui::Context) -> Result<(), String> {
+    // The heart is white, so it is tinted with the text color.
+    // It is a bit smaller than the font size, and lifted slightly above the baseline:
+    let heart = SvgGlyph::from_bytes(include_bytes!("../heart.svg"))?
+        .with_height(0.7)
+        .with_baseline_offset(0.05);
+    ctx.add_glyph_rasterizer(heart.into_rasterizer(HEART.to_string()));
+
+    // Ferris is colorful, so the colors are kept:
+    let ferris = SvgGlyph::from_bytes(include_bytes!("../../images/src/ferris.svg"))?;
+    ctx.add_glyph_rasterizer(ferris.into_rasterizer(FERRIS.to_string()));
+
+    Ok(())
+}
+
+struct MyApp {
+    font_size: f32,
+}
+
+impl MyApp {
+    fn new(cc: &eframe::CreationContext<'_>) -> Result<Self, String> {
+        install_svg_glyphs(&cc.egui_ctx)?;
+        Ok(Self { font_size: 32.0 })
+    }
+}
+
+impl eframe::App for MyApp {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ui, |ui| {
+            ui.heading(format!("I {HEART} Rust {FERRIS}"));
+            ui.label(format!(
+                "The heart is an SVG tinted with the text color. \
+                 Ferris is a color SVG on the private use character U+{:04X}.",
+                FERRIS as u32
+            ));
+            ui.add(egui::Slider::new(&mut self.font_size, 8.0..=128.0).text("Font size"));
+
+            ui.horizontal_wrapped(|ui| {
+                for color in [Color32::RED, Color32::GREEN, Color32::LIGHT_BLUE] {
+                    ui.label(
+                        RichText::new(format!("{HEART}{FERRIS}"))
+                            .color(color)
+                            .size(self.font_size),
+                    );
+                }
+                ui.label(
+                    RichText::new(format!("{HEART}{FERRIS}"))
+                        .monospace()
+                        .size(self.font_size),
+                );
+            });
+
+            let _ = ui.button(format!("{HEART} Button"));
+        });
+    }
+}

--- a/tests/egui_tests/Cargo.toml
+++ b/tests/egui_tests/Cargo.toml
@@ -16,7 +16,7 @@ egui = { workspace = true, default-features = true, features = [
   "monochrome_emoji_fonts",
 ] }
 egui_kittest = { workspace = true, features = ["snapshot", "wgpu"] }
-egui_extras = { workspace = true, features = ["image"] }
+egui_extras = { workspace = true, features = ["image", "svg"] }
 image = { workspace = true, features = ["png"] }
 
 [lints]

--- a/tests/egui_tests/tests/snapshots/svg_glyph.png
+++ b/tests/egui_tests/tests/snapshots/svg_glyph.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a56c6d0780bba4bd66d20417b083476b55b2233625fe5457f2dcd02088fde8ed
+size 22850

--- a/tests/egui_tests/tests/test_svg_glyph.rs
+++ b/tests/egui_tests/tests/test_svg_glyph.rs
@@ -1,0 +1,54 @@
+//! Snapshot test for [`egui_extras::SvgGlyph`].
+
+use egui::{Color32, RichText, vec2};
+use egui_extras::SvgGlyph;
+use egui_kittest::Harness;
+
+/// A private use character, rendered as Ferris.
+const FERRIS: char = '\u{E000}';
+
+/// A regular character whose glyph is overridden.
+const HEART: char = '♥';
+
+#[test]
+fn svg_glyph() {
+    let mut harness = Harness::builder()
+        .with_size(vec2(560.0, 150.0))
+        .build_ui(|ui| {
+            egui::CentralPanel::default().show(ui, |ui| {
+                for size in [12.0, 24.0, 48.0] {
+                    ui.horizontal(|ui| {
+                        for color in [Color32::WHITE, Color32::RED, Color32::LIGHT_BLUE] {
+                            ui.label(
+                                RichText::new(format!("I{HEART}{FERRIS}"))
+                                    .color(color)
+                                    .size(size),
+                            );
+                        }
+                        ui.label(
+                            RichText::new(format!("I{HEART}{FERRIS}"))
+                                .monospace()
+                                .size(size),
+                        );
+                    });
+                }
+            });
+        });
+
+    let heart = SvgGlyph::from_bytes(include_bytes!("../../../examples/svg_glyph/heart.svg"))
+        .unwrap()
+        .with_height(0.7)
+        .with_baseline_offset(0.05);
+    harness
+        .ctx
+        .add_glyph_rasterizer(heart.into_rasterizer(HEART.to_string()));
+
+    let ferris =
+        SvgGlyph::from_bytes(include_bytes!("../../../examples/images/src/ferris.svg")).unwrap();
+    harness
+        .ctx
+        .add_glyph_rasterizer(ferris.into_rasterizer(FERRIS.to_string()));
+
+    harness.run();
+    harness.snapshot("svg_glyph");
+}


### PR DESCRIPTION
`GlyphRasterizer` now has a `FontPriority`:

* `FontPriority::Highest`: asked about every cluster, before any font. Use it to override how specific glyphs looks
* `FontPriority::Lowest` (default): a fallback, only asked about clusters no installed font (or `FontProvider`) has. Same as before.

Several rasterizers can be installed; within a tier they are asked in order, and the first `Some` wins.

```rust
ctx.add_glyph_rasterizer(
    egui::GlyphRasterizer::new(|request| (request.cluster == "…").then(|| my_ellipsis(request)))
        .with_priority(egui::FontPriority::Highest),
);
```

API changes (all unreleased): `Context::set_glyph_rasterizer(Option)` → `add_glyph_rasterizer` / `set_glyph_rasterizers(Vec)`, same on `epaint::Fonts`.

Follow-up to:
* https://github.com/emilk/egui/pull/8512

* [x] I have followed the instructions in the PR template

🤖 Generated with [Claude Code](https://claude.com/claude-code)
