### PR TITLE
Keep arrow-key navigation within open menus

### DIFF
--- a/crates/egui/src/containers/menu.rs
+++ b/crates/egui/src/containers/menu.rs
@@ -443,6 +443,9 @@ impl SubMenu {
 
         #[expect(clippy::unwrap_used)] // Since we are a child of that ui, this should always exist
         let menu_root_response = ui.ctx().read_response(menu_id).unwrap();
+        let menu_root = find_menu_root(ui);
+        let parent_is_popup = menu_root.is_root_ui()
+            && matches!(menu_root.kind(), Some(UiKind::Popup | UiKind::Menu));
 
         let hover_pos = ui.ctx().pointer_hover_pos();
 
@@ -514,6 +517,12 @@ impl SubMenu {
                     .with_tag_value(MenuConfig::MENU_CONFIG_TAG, menu_config.clone()),
             )
             .show(|ui| {
+                ui.memory_mut(|mem| {
+                    mem.set_menu_layer(ui.layer_id());
+                    if parent_is_popup {
+                        mem.set_menu_layer(menu_root_response.layer_id);
+                    }
+                });
                 // Ensure our layer stays on top when the button is clicked
                 if button_response.clicked() || button_response.is_pointer_button_down_on() {
                     ui.ctx().move_to_top(ui.layer_id());

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -615,6 +615,9 @@ impl<'a> Popup<'a> {
         }
 
         let mut response = area.show(&ctx, |ui| {
+            if kind == PopupKind::Menu {
+                ui.memory_mut(|mem| mem.set_menu_layer(ui.layer_id()));
+            }
             style.apply(ui.style_mut());
             let frame = frame.unwrap_or_else(|| Frame::popup(ui.style()));
             frame.show(ui, content).inner

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -2848,7 +2848,8 @@ impl ContextImpl {
 
         viewport.repaint.cumulative_pass_nr += 1;
 
-        self.memory.end_pass(&viewport.this_pass.used_ids);
+        self.memory
+            .end_pass(&viewport.this_pass.used_ids, &viewport.this_pass.layers);
 
         if let Some(fonts) = self.fonts.as_mut() {
             let tex_mngr = &mut self.tex_manager.0.write();

--- a/crates/egui/src/memory/mod.rs
+++ b/crates/egui/src/memory/mod.rs
@@ -7,7 +7,7 @@ use epaint::emath::TSTransform;
 
 use crate::{
     EventFilter, Id, IdMap, LayerId, Order, Pos2, Rangef, RawInput, Rect, Style, Vec2, ViewportId,
-    ViewportIdMap, ViewportIdSet, area, vec2,
+    ViewportIdMap, ViewportIdSet, area, pass_state::PerLayerState, vec2,
 };
 
 mod theme;
@@ -532,8 +532,11 @@ pub(crate) struct Focus {
     /// The top-most modal layer from the current frame.
     top_modal_layer_current_frame: Option<LayerId>,
 
-    /// A cache of widget IDs that are interested in focus with their corresponding rectangles.
-    focus_widgets_cache: IdMap<Rect>,
+    /// Widgets interested in focus, with their layers and rectangles.
+    focus_widgets_cache: IdMap<(LayerId, Rect)>,
+
+    /// Menu layers shown this pass. Directional navigation also includes their popup descendants.
+    menu_layers: HashSet<LayerId>,
 }
 
 /// The widget with focus.
@@ -566,6 +569,7 @@ impl Focus {
     }
 
     fn begin_pass(&mut self, new_input: &crate::data::input::RawInput) {
+        self.menu_layers.clear();
         self.id_two_frames_ago = self.id_previous_frame;
         self.id_previous_frame = self.focused();
         if let Some(id) = self.id_next_frame.take() {
@@ -631,9 +635,13 @@ impl Focus {
         }
     }
 
-    pub(crate) fn end_pass(&mut self, used_ids: &IdMap<Rect>) {
+    pub(crate) fn end_pass(
+        &mut self,
+        used_ids: &IdMap<Rect>,
+        layers: &HashMap<LayerId, PerLayerState>,
+    ) {
         if self.focus_direction.is_cardinal()
-            && let Some(found_widget) = self.find_widget_in_direction(used_ids)
+            && let Some(found_widget) = self.find_widget_in_direction(used_ids, layers)
         {
             self.focused_widget = Some(FocusWidget::new(found_widget));
         }
@@ -655,11 +663,12 @@ impl Focus {
         self.id_previous_frame == Some(id)
     }
 
-    fn interested_in_focus(&mut self, id: Id) {
+    fn interested_in_focus(&mut self, id: Id, layer_id: LayerId) {
         // The rect is updated at the end of the frame.
         self.focus_widgets_cache
             .entry(id)
-            .or_insert(Rect::EVERYTHING);
+            .and_modify(|(layer, _)| *layer = layer_id)
+            .or_insert((layer_id, Rect::EVERYTHING));
 
         if self.give_to_next && !self.had_focus_last_frame(id) {
             self.focused_widget = Some(FocusWidget::new(id));
@@ -704,7 +713,11 @@ impl Focus {
         self.focus_direction = FocusDirection::None;
     }
 
-    fn find_widget_in_direction(&mut self, new_rects: &IdMap<Rect>) -> Option<Id> {
+    fn find_widget_in_direction(
+        &mut self,
+        new_rects: &IdMap<Rect>,
+        layers: &HashMap<LayerId, PerLayerState>,
+    ) -> Option<Id> {
         // NOTE: `new_rects` here include some widgets _not_ interested in focus.
 
         /// * negative if `a` is left of `b`
@@ -733,7 +746,7 @@ impl Focus {
         };
 
         // Update cache with new rects
-        self.focus_widgets_cache.retain(|id, old_rect| {
+        self.focus_widgets_cache.retain(|id, (_, old_rect)| {
             if let Some(new_rect) = new_rects.get(id) {
                 *old_rect = *new_rect;
                 true // Keep the item
@@ -742,15 +755,34 @@ impl Focus {
             }
         });
 
-        let current_rect = self.focus_widgets_cache.get(&current_focused.id)?;
+        let (_, current_rect) = self.focus_widgets_cache.get(&current_focused.id)?;
+
+        // Resolve descendants after all popups have been shown, since a submenu can make
+        // its parent a menu after another child popup has already been rendered.
+        let mut pending: Vec<_> = self.menu_layers.iter().copied().collect();
+        while let Some(layer) = pending.pop() {
+            if let Some(state) = layers.get(&layer) {
+                #[expect(clippy::iter_over_hash_type)]
+                // Traversal order does not affect membership.
+                for &popup_id in &state.open_popups {
+                    let popup_layer = LayerId::new(Order::Foreground, popup_id);
+                    if self.menu_layers.insert(popup_layer) {
+                        pending.push(popup_layer);
+                    }
+                }
+            }
+        }
 
         let mut best_score = f32::INFINITY;
         let mut best_id = None;
 
         // iteration order should only matter in case of a tie, and that should be very rare
         #[expect(clippy::iter_over_hash_type)]
-        for (candidate_id, candidate_rect) in &self.focus_widgets_cache {
+        for (candidate_id, (layer_id, candidate_rect)) in &self.focus_widgets_cache {
             if *candidate_id == current_focused.id {
+                continue;
+            }
+            if !self.menu_layers.is_empty() && !self.menu_layers.contains(layer_id) {
                 continue;
             }
 
@@ -807,10 +839,14 @@ impl Memory {
             .begin_pass(new_raw_input);
     }
 
-    pub(crate) fn end_pass(&mut self, used_ids: &IdMap<Rect>) {
+    pub(crate) fn end_pass(
+        &mut self,
+        used_ids: &IdMap<Rect>,
+        layers: &HashMap<LayerId, PerLayerState>,
+    ) {
         self.caches.update();
         self.areas_mut().end_pass();
-        self.focus_mut().end_pass(used_ids);
+        self.focus_mut().end_pass(used_ids, layers);
 
         // Clean up abandoned popups.
         if let Some(popup) = self.popups.get_mut(&self.viewport_id) {
@@ -977,7 +1013,14 @@ impl Memory {
         if !self.allows_interaction(layer_id) {
             return;
         }
-        self.focus_mut().interested_in_focus(id);
+        self.focus_mut().interested_in_focus(id, layer_id);
+    }
+
+    /// Include this menu layer in directional navigation for the current pass.
+    pub(crate) fn set_menu_layer(&mut self, layer_id: LayerId) {
+        if self.allows_interaction(layer_id) {
+            self.focus_mut().menu_layers.insert(layer_id);
+        }
     }
 
     /// Limit focus to widgets on the given layer and above.

--- a/crates/egui_kittest/tests/menu_focus.rs
+++ b/crates/egui_kittest/tests/menu_focus.rs
@@ -1,0 +1,375 @@
+use egui::containers::menu::{MenuBar, SubMenuButton};
+use egui::{Key, Modifiers, Ui};
+use egui_kittest::Harness;
+use kittest::Queryable as _;
+
+fn navigation_menu(context_menu: bool) -> Harness<'static> {
+    Harness::builder()
+        .with_size(egui::vec2(500.0, 400.0))
+        .build_ui(move |ui| {
+            for row in 0..12 {
+                for col in 0..5 {
+                    let rect = egui::Rect::from_min_size(
+                        egui::pos2(col as f32 * 100.0, row as f32 * 30.0),
+                        egui::vec2(90.0, 20.0),
+                    );
+                    let _ = ui.put(rect, egui::Button::new(format!("Behind {row} {col}")));
+                }
+            }
+            ui.scope_builder(
+                egui::UiBuilder::new().max_rect(egui::Rect::from_min_size(
+                    egui::pos2(150.0, 90.0),
+                    egui::vec2(100.0, 20.0),
+                )),
+                |ui| {
+                    let content = |ui: &mut Ui| {
+                        let _ = ui.button("First item");
+                        let _ = ui.button("Second item");
+                        ui.menu_button("Submenu", |ui| {
+                            let _ = ui.button("First child");
+                            ui.menu_button("Nested submenu", |ui| {
+                                let _ = ui.button("Nested item");
+                            });
+                            let _ = ui.button("Last child");
+                        });
+                        let _ = ui.button("Last item");
+                    };
+                    if context_menu {
+                        ui.button("Menu").context_menu(content);
+                    } else {
+                        ui.menu_button("Menu", content);
+                    }
+                },
+            );
+        })
+}
+
+fn open_navigation_menu(harness: &mut Harness<'_>) {
+    harness.get_by_label("Menu").focus();
+    harness.run();
+    harness.key_press(Key::Enter);
+    harness.run();
+}
+
+fn focused_layer(harness: &Harness<'_>) -> egui::LayerId {
+    let id = harness
+        .ctx
+        .memory(|mem| mem.focused())
+        .expect("a focused widget");
+    harness
+        .ctx
+        .read_response(id)
+        .expect("the focused widget is still shown")
+        .layer_id
+}
+
+#[test]
+fn arrow_navigation_stays_in_menu() {
+    for context_menu in [false, true] {
+        let mut harness = navigation_menu(context_menu);
+        if context_menu {
+            harness.get_by_label("Menu").click_secondary();
+            harness.run();
+        } else {
+            open_navigation_menu(&mut harness);
+            harness.key_press(Key::ArrowDown);
+            harness.run();
+            assert!(harness.get_by_label("First item").is_focused());
+        }
+        for (from, key, to) in [
+            ("First item", Key::ArrowDown, "Second item"),
+            ("Second item", Key::ArrowUp, "First item"),
+            ("First item", Key::ArrowUp, "First item"),
+            ("First item", Key::ArrowLeft, "First item"),
+            ("First item", Key::ArrowRight, "First item"),
+            ("Last item", Key::ArrowDown, "Last item"),
+        ] {
+            harness.get_by_label(from).focus();
+            harness.run();
+            harness.key_press(key);
+            harness.run();
+            assert!(
+                harness.get_by_label(to).is_focused(),
+                "{from}, {key:?}, context_menu={context_menu}"
+            );
+        }
+    }
+}
+
+#[test]
+fn arrow_navigation_between_submenus() {
+    let mut harness = navigation_menu(false);
+    open_navigation_menu(&mut harness);
+    harness.get_by_label_contains("Submenu").focus();
+    harness.run();
+    let parent_layer = focused_layer(&harness);
+    harness.key_press(Key::Enter);
+    harness.run();
+    harness.get_by_label("First child").focus();
+    harness.run();
+    let child_layer = focused_layer(&harness);
+    harness.get_by_label_contains("Submenu").focus();
+    harness.run();
+    harness.key_press(Key::ArrowRight);
+    harness.run();
+    // The popup container itself can receive focus, so check the destination layer.
+    assert_eq!(focused_layer(&harness), child_layer);
+    harness.get_by_label("First child").focus();
+    harness.run();
+    harness.key_press(Key::ArrowLeft);
+    harness.run();
+    assert_eq!(focused_layer(&harness), parent_layer);
+
+    harness.get_by_label_contains("Nested submenu").focus();
+    harness.run();
+    harness.key_press(Key::Enter);
+    harness.run();
+    harness.get_by_label("Nested item").focus();
+    harness.run();
+    let nested_layer = focused_layer(&harness);
+    harness.get_by_label_contains("Nested submenu").focus();
+    harness.run();
+    harness.key_press(Key::ArrowRight);
+    harness.run();
+    assert_eq!(focused_layer(&harness), nested_layer);
+    harness.get_by_label("Nested item").focus();
+    harness.run();
+    harness.key_press(Key::ArrowLeft);
+    harness.run();
+    assert_eq!(focused_layer(&harness), child_layer);
+}
+
+#[test]
+fn menu_tab_escape_and_reopen() {
+    let mut harness = navigation_menu(false);
+    for _ in 0..2 {
+        open_navigation_menu(&mut harness);
+        harness.get_by_label("First item").focus();
+        harness.run();
+        harness.key_press(Key::Tab);
+        harness.run();
+        assert!(harness.get_by_label("Second item").is_focused());
+        harness.key_press_modifiers(Modifiers::SHIFT, Key::Tab);
+        harness.run();
+        assert!(harness.get_by_label("First item").is_focused());
+        harness.key_press(Key::Escape);
+        harness.run();
+        assert!(harness.query_by_label("First item").is_none());
+        harness.get_by_label("Behind 10 0").focus();
+        harness.run();
+        harness.key_press(Key::ArrowRight);
+        harness.run();
+        assert!(harness.get_by_label("Behind 10 1").is_focused());
+    }
+}
+
+#[test]
+fn generic_popup_with_submenu_keeps_earlier_popup_reachable() {
+    let mut harness = Harness::builder()
+        .with_size(egui::vec2(800.0, 400.0))
+        .build_ui(|ui| {
+            let _ = ui.put(
+                egui::Rect::from_min_size(egui::pos2(700.0, 50.0), egui::vec2(90.0, 20.0)),
+                egui::Button::new("Background"),
+            );
+            let response = ui.button("Host popup");
+            egui::Popup::from_response(&response).show(|ui| {
+                let response = ui.button("Host first");
+                // This popup is built before the submenu makes its parent a menu scope.
+                egui::Popup::from_response(&response)
+                    .id(response.id.with("earlier popup"))
+                    .align(egui::RectAlign::RIGHT_START)
+                    .show(|ui| {
+                        let _ = ui.button("Earlier popup child");
+                    });
+                ui.menu_button("Hosted submenu", |ui| {
+                    let _ = ui.button("Hosted child");
+                });
+            });
+        });
+    harness.get_by_label_contains("Hosted submenu").focus();
+    harness.run();
+    harness.key_press(Key::Enter);
+    harness.run();
+    harness.get_by_label("Hosted child").focus();
+    harness.run();
+    harness.key_press(Key::ArrowLeft);
+    harness.run();
+    assert!(harness.get_by_label_contains("Hosted submenu").is_focused());
+
+    harness.get_by_label("Earlier popup child").focus();
+    harness.run();
+    let earlier_layer = focused_layer(&harness);
+    harness.get_by_label("Host first").focus();
+    harness.run();
+    harness.key_press(Key::ArrowRight);
+    harness.run();
+    assert_eq!(focused_layer(&harness), earlier_layer);
+    harness.key_press(Key::ArrowRight);
+    harness.run();
+    assert_eq!(focused_layer(&harness), earlier_layer);
+}
+
+#[test]
+fn generic_popup_does_not_contain_arrow_navigation() {
+    let mut harness = Harness::new_ui(|ui| {
+        let _ = ui.put(
+            egui::Rect::from_min_size(egui::pos2(400.0, 50.0), egui::vec2(90.0, 20.0)),
+            egui::Button::new("Background"),
+        );
+        let response = ui.button("Popup");
+        egui::Popup::from_response(&response).show(|ui| {
+            let _ = ui.button("Popup item");
+        });
+    });
+    harness.get_by_label("Popup item").focus();
+    harness.run();
+    harness.key_press(Key::ArrowRight);
+    harness.run();
+    assert!(harness.get_by_label("Background").is_focused());
+}
+
+#[test]
+fn menu_in_modal_keeps_arrow_navigation() {
+    let mut harness = Harness::new_ui(|ui| {
+        let _ = ui.button("Background");
+        egui::Modal::new(egui::Id::unique("modal")).show(ui.ctx(), |ui| {
+            ui.menu_button("Menu", |ui| {
+                let _ = ui.button("First item");
+                let _ = ui.button("Last item");
+            });
+            let _ = ui.button("Other modal item");
+        });
+    });
+    open_navigation_menu(&mut harness);
+    harness.key_press(Key::ArrowDown);
+    harness.run();
+    assert!(harness.get_by_label("First item").is_focused());
+    harness.key_press(Key::ArrowDown);
+    harness.run();
+    assert!(harness.get_by_label("Last item").is_focused());
+    harness.key_press(Key::ArrowDown);
+    harness.run();
+    assert!(harness.get_by_label("Last item").is_focused());
+    harness.key_press(Key::Escape);
+    harness.run();
+    harness.get_by_label("Menu").focus();
+    harness.run();
+    harness.key_press(Key::ArrowDown);
+    harness.run();
+    assert!(harness.get_by_label("Other modal item").is_focused());
+}
+
+#[test]
+fn standalone_submenu_in_menu_bar_excludes_background() {
+    let mut harness = Harness::new_ui(|ui| {
+        MenuBar::new().ui(ui, |ui| {
+            SubMenuButton::new("Standalone submenu").ui(ui, |ui| {
+                let _ = ui.button("Standalone item");
+            });
+        });
+        let _ = ui.put(
+            egui::Rect::from_min_size(egui::pos2(500.0, 10.0), egui::vec2(90.0, 20.0)),
+            egui::Button::new("Background"),
+        );
+    });
+    harness.get_by_label_contains("Standalone submenu").hover();
+    harness.run();
+    harness.get_by_label("Standalone item").focus();
+    harness.run();
+    let submenu_layer = focused_layer(&harness);
+    harness.key_press(Key::ArrowRight);
+    harness.run();
+    assert_eq!(focused_layer(&harness), submenu_layer);
+}
+
+#[test]
+fn blocked_menu_does_not_trap_modal_navigation() {
+    let mut harness = Harness::new_ui_state(
+        |ui, show_modal| {
+            let response = ui.button("Underlying menu");
+            egui::Popup::menu(&response).open(true).show(|ui| {
+                let _ = ui.button("Underlying item");
+            });
+            if *show_modal {
+                egui::Modal::new(egui::Id::unique("modal")).show(ui.ctx(), |ui| {
+                    let _ = ui.button("First modal item");
+                    let _ = ui.button("Last modal item");
+                });
+            }
+        },
+        false,
+    );
+    *harness.state_mut() = true;
+    harness.run();
+    harness.get_by_label("First modal item").focus();
+    harness.run();
+    harness.key_press(Key::ArrowDown);
+    harness.run();
+    assert!(harness.get_by_label("Last modal item").is_focused());
+}
+
+#[test]
+fn combo_box_keyboard_selection() {
+    let mut harness = Harness::new_ui_state(
+        |ui, selected| {
+            egui::ComboBox::from_label("Choice")
+                .show_index(ui, selected, 3, |i| format!("Choice {i}"));
+            let _ = ui.button("Background");
+        },
+        0,
+    );
+    harness.get_by_role(egui::accesskit::Role::ComboBox).focus();
+    harness.run();
+    harness.key_press(Key::Enter);
+    harness.run();
+    harness.get_by_label("Choice 0").focus();
+    harness.run();
+    harness.key_press(Key::ArrowDown);
+    harness.run();
+    assert!(harness.get_by_label("Choice 1").is_focused());
+    harness.key_press(Key::Enter);
+    harness.run();
+    assert_eq!(*harness.state(), 1);
+    harness.key_press(Key::Escape);
+    harness.run();
+    assert!(harness.query_by_label("Choice 2").is_none());
+}
+
+#[test]
+fn color_popup_keeps_pointer_editing() {
+    let mut harness = Harness::new_ui_state(
+        |ui, color| {
+            ui.color_edit_button_srgba(color);
+        },
+        egui::Color32::from_rgb(100, 150, 200),
+    );
+    harness
+        .get_by_role(egui::accesskit::Role::ColorWell)
+        .click();
+    harness.run();
+    let original = *harness.state();
+    let grab = harness
+        .query_all_by_role(egui::accesskit::Role::SpinButton)
+        .next()
+        .unwrap()
+        .rect()
+        .center();
+    let target = grab + egui::vec2(20.0, 0.0);
+    harness.hover_at(grab);
+    harness.run();
+    harness.drag_at(grab);
+    harness.run();
+    harness.hover_at(target);
+    harness.run();
+    harness.drop_at(target);
+    harness.run();
+    assert_ne!(*harness.state(), original);
+    harness.key_press(Key::Escape);
+    harness.run();
+    assert!(
+        harness
+            .query_by_role(egui::accesskit::Role::SpinButton)
+            .is_none()
+    );
+}


### PR DESCRIPTION
## Summary

Keep arrow-key focus inside open menus and their popup descendants, so nearby background controls cannot take focus. Preserve navigation between parent menus and submenus.

Fixes #8327.

## Testing

- Added 10 menu navigation and compatibility tests; five reproduce the bug on the original code.
- egui and egui_kittest tests and doc tests passed.
- Affected-package Clippy with all targets/features, formatting and repository lint passed.
- Checked headless Popups demo renders before and after the fix.
