### PR TITLE
Fix eframe web text agent being visible

### DIFF
--- a/crates/eframe/src/web/text_agent.rs
+++ b/crates/eframe/src/web/text_agent.rs
@@ -35,6 +35,9 @@ impl TextAgent {
         // of the page into view.
         let style = input.style();
         style.set_property("background-color", "transparent")?;
+        style.set_property("color", "transparent")?;
+        style.set_property("opacity", "0")?;
+        style.set_property("pointer-events", "none")?;
         style.set_property("border", "none")?;
         style.set_property("outline", "none")?;
         style.set_property("width", "1px")?;


### PR DESCRIPTION
Fixes weird shapes appearing after the cursor in egui textedits:

https://github.com/user-attachments/assets/fceff925-691a-4ab3-8b2c-7a364a47edc3



- introduced in #8045 
