### PR TITLE
Add the support of offscreen canvas

### DIFF
--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -262,6 +262,8 @@ web-sys = { workspace = true, features = [
   "Navigator",
   "Node",
   "NodeList",
+  "OffscreenCanvas",
+  "OffscreenCanvasRenderingContext2d",
   "Performance",
   "ResizeObserver",
   "ResizeObserverBoxOptions",

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -857,7 +857,7 @@ pub struct WebInfo {
 ///
 /// Everything has been percent decoded (`%20` -> ` ` etc).
 #[cfg(target_arch = "wasm32")]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Location {
     /// The full URL (`location.href`) without the hash, percent-decoded.
     ///

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -847,6 +847,10 @@ pub struct WebInfo {
 
     /// Information about the URL.
     pub location: Location,
+
+    /// True if the app is rendering to an `OffscreenCanvas` (e.g. inside a
+    /// web worker) rather than to a `<canvas>` element in the main thread.
+    pub offscreen_canvas: bool,
 }
 
 /// Information about the URL.
@@ -938,6 +942,7 @@ impl IntegrationInfo {
                     query_map: Default::default(),
                     origin: "http://localhost".to_owned(),
                 },
+                offscreen_canvas: false,
             },
             cpu_usage: None,
         }

--- a/crates/eframe/src/lib.rs
+++ b/crates/eframe/src/lib.rs
@@ -168,6 +168,8 @@ pub use epi::*;
 
 pub(crate) mod stopwatch;
 
+mod web_events;
+
 // ----------------------------------------------------------------------------
 // When compiling for web
 

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use egui::{ScreenshotCallback, TexturesDelta, ViewportCommand};
 
-use crate::{App, epi, web::web_painter::WebPainter};
+use crate::{App, epi, web::web_painter::WebPainter, web_events::WebEventState};
 
-use super::{NeedRepaint, now_sec, text_agent::TextAgent};
+use super::{NeedRepaint, WebCanvas, WebHost, now_sec, text_agent::TextAgent};
 
 pub struct AppRunner {
     #[allow(clippy::allow_attributes, dead_code)]
@@ -12,11 +12,24 @@ pub struct AppRunner {
     pub(crate) frame: epi::Frame,
     egui_ctx: egui::Context,
     painter: Box<dyn WebPainter>,
+
+    /// The canvas we render to: DOM (`Html`) or worker-owned (`Offscreen`).
+    canvas: WebCanvas,
+
+    /// The channel back to the host page. `None` in DOM mode.
+    host: Option<WebHost>,
+
     pub(crate) input: super::WebInput,
+
+    /// Pointer/wheel state for messages from the host page (worker mode only).
+    pub(crate) offscreen_events: WebEventState,
+
     app: Box<dyn epi::App>,
     pub(crate) needs_repaint: Arc<NeedRepaint>,
     last_save_time: f64,
-    pub(crate) text_agent: TextAgent,
+
+    /// DOM-only hidden `<input>` used for IME. `None` in worker mode.
+    pub(crate) text_agent: Option<TextAgent>,
 
     // If not empty, the painter should capture n frames from now.
     // zero means capture the exact next frame.
@@ -40,11 +53,12 @@ impl AppRunner {
         not(feature = "wgpu_no_default_features"),
         expect(clippy::unused_async)
     )]
-    pub async fn new(
-        canvas: web_sys::HtmlCanvasElement,
+    pub(crate) async fn new(
+        canvas: WebCanvas,
         web_options: crate::WebOptions,
         app_creator: epi::AppCreator<'static>,
-        text_agent: TextAgent,
+        host: Option<WebHost>,
+        text_agent: Option<TextAgent>,
     ) -> Result<Self, String> {
         let egui_ctx = egui::Context::default();
         egui_ctx.set_glyph_rasterizer(Some(super::canvas_glyphs::glyph_rasterizer()));
@@ -63,7 +77,7 @@ impl AppRunner {
                 log::debug!("Using the glow renderer");
                 let painter = super::web_painter_glow::WebPainterGlow::new(
                     egui_ctx.clone(),
-                    canvas,
+                    canvas.clone(),
                     &web_options,
                 )?;
                 gl = Some(Arc::clone(painter.gl()));
@@ -75,7 +89,7 @@ impl AppRunner {
                 log::debug!("Using the wgpu renderer");
                 let painter = super::web_painter_wgpu::WebPainterWgpu::new(
                     egui_ctx.clone(),
-                    canvas,
+                    canvas.clone(),
                     &web_options,
                 )
                 .await?;
@@ -84,18 +98,27 @@ impl AppRunner {
             }
         };
 
+        // `user_agent` and `web_location` read from `window`, which a worker
+        // does not have.
+        let user_agent = super::user_agent().unwrap_or_default();
+        let location = if web_sys::window().is_some() {
+            super::web_location()
+        } else {
+            Default::default()
+        };
+
+        egui_ctx.set_os(egui::os::OperatingSystem::from_user_agent(&user_agent));
+
         let info = epi::IntegrationInfo {
             web_info: epi::WebInfo {
-                user_agent: super::user_agent().unwrap_or_default(),
-                location: super::web_location(),
+                user_agent,
+                location,
+                offscreen_canvas: canvas.as_offscreen().is_some(),
             },
             cpu_usage: None,
         };
         let storage = LocalStorage::default();
 
-        egui_ctx.set_os(egui::os::OperatingSystem::from_user_agent(
-            &super::user_agent().unwrap_or_default(),
-        ));
         super::storage::load_memory(&egui_ctx);
 
         egui_ctx.options_mut(|o| {
@@ -154,7 +177,10 @@ impl AppRunner {
             frame,
             egui_ctx,
             painter,
+            canvas,
+            host,
             input: Default::default(),
+            offscreen_events: Default::default(),
             app,
             needs_repaint,
             last_save_time: now_sec(),
@@ -209,8 +235,12 @@ impl AppRunner {
         self.last_save_time = now_sec();
     }
 
+    pub fn html_canvas(&self) -> &web_sys::HtmlCanvasElement {
+        self.canvas.expect_html()
+    }
+
     pub fn canvas(&self) -> &web_sys::HtmlCanvasElement {
-        self.painter.canvas()
+        self.html_canvas()
     }
 
     pub fn destroy(mut self) {
@@ -227,19 +257,31 @@ impl AppRunner {
     ///
     /// Technically: does either the canvas or the [`TextAgent`] have focus?
     pub fn has_focus(&self) -> bool {
+        if self.host.is_some() {
+            return self.input.focused;
+        }
+
+        let focused = super::has_focus(self.html_canvas());
+
         let window = web_sys::window().unwrap();
         let document = window.document().unwrap();
         if document.hidden() {
             return false;
         }
 
-        super::has_focus(self.canvas()) || self.text_agent.has_focus()
+        focused || self.text_agent.as_ref().is_some_and(|t| t.has_focus())
+    }
+
+    /// Called from the host page's `resize` message.
+    pub(crate) fn on_offscreen_resize(&self, width: u32, height: u32) {
+        self.canvas.set_size(width, height);
+        self.needs_repaint.repaint_asap();
     }
 
     pub fn update_focus(&mut self) {
         let has_focus = self.has_focus();
         if self.input.raw.focused != has_focus {
-            log::trace!("{} Focus changed to {has_focus}", self.canvas().id());
+            log::trace!("{} Focus changed to {has_focus}", self.canvas.id());
             self.input.set_focus(has_focus);
 
             if !has_focus {
@@ -257,14 +299,14 @@ impl AppRunner {
         // We sometimes miss blur/focus events due to the text agent, so let's just poll each frame:
         self.update_focus();
 
-        let canvas_size = super::canvas_size_in_points(self.canvas(), self.egui_ctx());
+        let canvas_size = super::canvas_size_in_points(&self.canvas, self.egui_ctx());
         let mut raw_input = self.input.new_frame(canvas_size);
 
         if super::DEBUG_RESIZE {
             log::info!(
                 "egui running at canvas size: {}x{}, DPR: {}, zoom_factor: {}. egui size: {}x{} points",
-                self.canvas().width(),
-                self.canvas().height(),
+                self.canvas.width(),
+                self.canvas.height(),
                 super::native_pixels_per_point(),
                 self.egui_ctx.zoom_factor(),
                 canvas_size.x,
@@ -410,26 +452,36 @@ impl AppRunner {
             }
         }
 
-        super::set_cursor_icon(self.canvas(), cursor_icon);
+        if let Some(host) = &self.host {
+            host.send_cursor_icon(cursor_icon);
+        } else {
+            super::set_cursor_icon(self.html_canvas(), cursor_icon);
+        }
 
         if self.has_focus() {
             // The eframe app has focus.
-            if let Some(ime) = ime {
+            if let Some(ime) = ime
+                && let Some(text_agent) = &self.text_agent
+            {
                 if ime.should_interrupt_composition {
-                    self.text_agent.interrupt_ime_composition();
+                    text_agent.interrupt_ime_composition();
                 }
                 // We are editing text: give the focus to the text agent.
-                self.text_agent.focus();
+                text_agent.focus();
             } else {
-                // We are not editing text - give the focus to the canvas.
-                self.text_agent.blur();
-                super::focus_without_scroll(self.canvas()).ok();
+                if let Some(text_agent) = &self.text_agent {
+                    // We are not editing text - give the focus to the canvas.
+                    text_agent.blur();
+                }
+                if let Some(canvas) = self.canvas.as_html() {
+                    super::focus_without_scroll(canvas).ok();
+                }
             }
         }
 
-        if let Err(err) = self
-            .text_agent
-            .update(ime, self.canvas(), self.egui_ctx.zoom_factor())
+        if let Some(text_agent) = &self.text_agent
+            && let Err(err) =
+                text_agent.update(ime, self.html_canvas(), self.egui_ctx.zoom_factor())
         {
             log::error!(
                 "failed to update text agent position: {}",

--- a/crates/eframe/src/web/backend.rs
+++ b/crates/eframe/src/web/backend.rs
@@ -9,7 +9,6 @@ use super::percent_decode;
 // ----------------------------------------------------------------------------
 
 /// Data gathered between frames.
-#[derive(Default)]
 pub(crate) struct WebInput {
     /// Required because we don't get a position on touchend
     pub primary_touch: Option<egui::TouchId>,
@@ -28,6 +27,31 @@ pub(crate) struct WebInput {
 
     /// The raw input to `egui`.
     pub raw: egui::RawInput,
+
+    /// Does the app have focus?
+    ///
+    /// In DOM mode this is derived from `document.activeElement`; in worker mode the
+    /// host page reports it with `{type: "focus"}` messages. Defaults to `true`.
+    pub focused: bool,
+
+    /// Is the app occluded (e.g. its tab is hidden)?
+    ///
+    /// In worker mode the host page reports it with `{type: "visibility"}` messages.
+    pub occluded: bool,
+}
+
+impl Default for WebInput {
+    fn default() -> Self {
+        Self {
+            primary_touch: None,
+            accumulated_scale: 0.0,
+            accumulated_rotation: 0.0,
+            modifiers: egui::Modifiers::default(),
+            raw: egui::RawInput::default(),
+            focused: true,
+            occluded: false,
+        }
+    }
 }
 
 impl WebInput {
@@ -44,9 +68,11 @@ impl WebInput {
         viewport.native_pixels_per_point = Some(super::native_pixels_per_point());
 
         // A hidden browser tab is effectively occluded.
+        // A worker has no `document`; the host page reports occlusion instead.
         let hidden = web_sys::window()
             .and_then(|w| w.document())
-            .is_some_and(|doc| doc.hidden());
+            .is_some_and(|doc| doc.hidden())
+            || self.occluded;
         viewport.occluded = Some(hidden);
 
         raw_input

--- a/crates/eframe/src/web/canvas.rs
+++ b/crates/eframe/src/web/canvas.rs
@@ -1,0 +1,95 @@
+//! A canvas that eframe can render to.
+//!
+//! Two flavours exist:
+//! * `Html`: the classic DOM canvas, with focus, CSS geometry and text input.
+//! * `Offscreen`: an `OffscreenCanvas` owned by a web worker: it has pixels and
+//!   a rendering context, but no DOM. Every DOM-only operation must go through
+//!   [`WebCanvas::as_html`], which returns `None` in worker mode.
+
+#[cfg(feature = "glow")]
+use wasm_bindgen::{JsCast as _, JsValue};
+
+/// The canvas an eframe web app renders to.
+#[derive(Clone, Debug)]
+pub(crate) enum WebCanvas {
+    /// A `<canvas>` element in the document.
+    Html(web_sys::HtmlCanvasElement),
+
+    /// An `OffscreenCanvas` transferred into a worker.
+    Offscreen(web_sys::OffscreenCanvas),
+}
+
+impl WebCanvas {
+    pub fn as_html(&self) -> Option<&web_sys::HtmlCanvasElement> {
+        match self {
+            Self::Html(canvas) => Some(canvas),
+            Self::Offscreen(_) => None,
+        }
+    }
+
+    /// The DOM canvas. Panics in worker mode: only call from DOM-only code paths.
+    ///
+    /// # Panics
+    /// Panics if this is an `OffscreenCanvas`.
+    pub fn expect_html(&self) -> &web_sys::HtmlCanvasElement {
+        self.as_html().expect(
+            "tried to use DOM-only canvas functionality in a worker (OffscreenCanvas has no DOM)",
+        )
+    }
+
+    /// The offscreen canvas, if this is one.
+    pub fn as_offscreen(&self) -> Option<&web_sys::OffscreenCanvas> {
+        match self {
+            Self::Html(_) => None,
+            Self::Offscreen(canvas) => Some(canvas),
+        }
+    }
+
+    /// Canvas width in physical pixels.
+    pub fn width(&self) -> u32 {
+        match self {
+            Self::Html(canvas) => canvas.width(),
+            Self::Offscreen(canvas) => canvas.width(),
+        }
+    }
+
+    /// Canvas height in physical pixels.
+    pub fn height(&self) -> u32 {
+        match self {
+            Self::Html(canvas) => canvas.height(),
+            Self::Offscreen(canvas) => canvas.height(),
+        }
+    }
+
+    /// Resize the canvas, in physical pixels.
+    pub fn set_size(&self, width: u32, height: u32) {
+        match self {
+            Self::Html(canvas) => {
+                canvas.set_width(width);
+                canvas.set_height(height);
+            }
+            Self::Offscreen(canvas) => {
+                canvas.set_width(width);
+                canvas.set_height(height);
+            }
+        }
+    }
+
+    /// A stable identifier, for logging only.
+    pub fn id(&self) -> String {
+        match self {
+            Self::Html(canvas) => format!("{canvas:?}"),
+            Self::Offscreen(canvas) => format!("{canvas:?}"),
+        }
+    }
+
+    /// Get a rendering context (e.g. `"webgl2"`) from either canvas flavour.
+    #[cfg(feature = "glow")]
+    pub fn get_context(&self, context_id: &str) -> Result<Option<JsValue>, JsValue> {
+        let context = match self {
+            Self::Html(canvas) => canvas.get_context(context_id)?,
+            Self::Offscreen(canvas) => canvas.get_context(context_id)?,
+        };
+        Ok(context.map(|context| context.unchecked_into::<JsValue>()))
+    }
+}

--- a/crates/eframe/src/web/canvas.rs
+++ b/crates/eframe/src/web/canvas.rs
@@ -1,6 +1,6 @@
 //! A canvas that eframe can render to.
 //!
-//! Two flavours exist:
+//! Two flavors exist:
 //! * `Html`: the classic DOM canvas, with focus, CSS geometry and text input.
 //! * `Offscreen`: an `OffscreenCanvas` owned by a web worker: it has pixels and
 //!   a rendering context, but no DOM. Every DOM-only operation must go through
@@ -83,7 +83,7 @@ impl WebCanvas {
         }
     }
 
-    /// Get a rendering context (e.g. `"webgl2"`) from either canvas flavour.
+    /// Get a rendering context (e.g. `"webgl2"`) from either canvas flavor.
     #[cfg(feature = "glow")]
     pub fn get_context(&self, context_id: &str) -> Result<Option<JsValue>, JsValue> {
         let context = match self {

--- a/crates/eframe/src/web/canvas_glyphs.rs
+++ b/crates/eframe/src/web/canvas_glyphs.rs
@@ -3,6 +3,9 @@
 //! This draws unsupported grapheme clusters with Canvas 2D, then puts the resulting pixels in
 //! egui's font atlas. Clusters the browser cannot render either (tofu) are rejected,
 //! so egui draws its own replacement glyph.
+//!
+//! On the main thread the 2D context comes from a hidden `<canvas>` element.
+//! In a web worker (which has no `document`) it comes from an `OffscreenCanvas`.
 
 use core::cell::RefCell;
 use std::collections::HashMap;
@@ -11,8 +14,11 @@ use egui::{
     ColorImage, GlyphBitmap, GlyphRasterizer, GlyphRasterizerRequest, MAX_GLYPH_SIZE,
     RasterizedGlyph, has_emoji_presentation, vec2,
 };
-use wasm_bindgen::JsCast as _;
-use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement};
+use wasm_bindgen::{JsCast as _, JsValue};
+use web_sys::{
+    CanvasRenderingContext2d, HtmlCanvasElement, ImageData, OffscreenCanvas,
+    OffscreenCanvasRenderingContext2d, TextMetrics,
+};
 
 /// Room for anti-aliased pixels at the glyph bounds, in physical pixels.
 const PADDING: f64 = 2.0;
@@ -34,9 +40,23 @@ struct Drawn {
     advance: f64,
 }
 
+/// The 2D context the browser draws fallback glyphs with.
+enum GlyphCanvas {
+    /// A hidden `<canvas>` element (main thread).
+    Html {
+        canvas: HtmlCanvasElement,
+        context: CanvasRenderingContext2d,
+    },
+
+    /// An `OffscreenCanvas` (web worker: no `document` is available).
+    Offscreen {
+        canvas: OffscreenCanvas,
+        context: OffscreenCanvasRenderingContext2d,
+    },
+}
+
 struct CanvasGlyphs {
-    canvas: HtmlCanvasElement,
-    context: CanvasRenderingContext2d,
+    canvas: GlyphCanvas,
 
     /// What the browser draws for a missing glyph, per `(font, subpixel offset)`.
     ///
@@ -46,20 +66,8 @@ struct CanvasGlyphs {
 
 impl CanvasGlyphs {
     fn new() -> Option<Self> {
-        let document = web_sys::window()?.document()?;
-        let canvas = document
-            .create_element("canvas")
-            .ok()?
-            .dyn_into::<HtmlCanvasElement>()
-            .ok()?;
-        let context = canvas
-            .get_context("2d")
-            .ok()??
-            .dyn_into::<CanvasRenderingContext2d>()
-            .ok()?;
         Some(Self {
-            canvas,
-            context,
+            canvas: GlyphCanvas::new()?,
             tofu_cache: Default::default(),
         })
     }
@@ -149,9 +157,7 @@ impl CanvasGlyphs {
         fill_style: &str,
         subpixel_offset_px: f32,
     ) -> Option<Drawn> {
-        self.context.set_font(font);
-        self.context.set_text_baseline("alphabetic");
-        let metrics = self.context.measure_text(text).ok()?;
+        let metrics = self.canvas.measure(text, font).ok()?;
         let left = metrics.actual_bounding_box_left();
         let ascent = metrics.actual_bounding_box_ascent();
         let right = metrics.actual_bounding_box_right();
@@ -163,22 +169,13 @@ impl CanvasGlyphs {
             return None;
         }
 
-        // Only grow: resizing reallocates the backing store and resets all canvas state.
-        if self.canvas.width() < width {
-            self.canvas.set_width(width);
-        }
-        if self.canvas.height() < height {
-            self.canvas.set_height(height);
-        }
-        self.context
-            .clear_rect(0.0, 0.0, width as f64, height as f64);
-        self.context.set_font(font);
-        self.context.set_text_baseline("alphabetic");
-        self.context.set_fill_style_str(fill_style);
+        self.canvas.prepare(width, height);
         // Canvas positions text by its baseline, while the image starts at its top-left.
-        self.context
-            .fill_text(
+        self.canvas
+            .draw_text(
                 text,
+                font,
+                fill_style,
                 PADDING + left + subpixel_offset_px as f64,
                 PADDING + ascent,
             )
@@ -186,14 +183,7 @@ impl CanvasGlyphs {
 
         // `web-sys` changes the signature of `get_image_data` based on `web_sys_unstable_apis`,
         // so we need to call it differently depending on that cfg.
-        let image_data = cfg_select! {
-            web_sys_unstable_apis => self
-            .context
-            .get_image_data(0, 0, width as i32, height as i32),
-            _ => self
-            .context
-            .get_image_data(0.0, 0.0, width as f64, height as f64),
-        };
+        let image_data = self.canvas.get_image_data(width, height);
         let rgba = image_data.ok()?.data().0;
 
         Some(Drawn {
@@ -204,6 +194,124 @@ impl CanvasGlyphs {
             ascent,
             advance: metrics.width(),
         })
+    }
+}
+
+impl GlyphCanvas {
+    /// A hidden `<canvas>` element, or an `OffscreenCanvas` in a web worker
+    /// (where there is no `document`).
+    fn new() -> Option<Self> {
+        if let Some(canvas) = Self::new_html_canvas() {
+            return Some(canvas);
+        }
+
+        Self::new_offscreen_canvas()
+    }
+
+    fn new_html_canvas() -> Option<Self> {
+        let document = web_sys::window()?.document()?;
+        let canvas = document
+            .create_element("canvas")
+            .ok()?
+            .dyn_into::<HtmlCanvasElement>()
+            .ok()?;
+        let context = canvas
+            .get_context("2d")
+            .ok()??
+            .dyn_into::<CanvasRenderingContext2d>()
+            .ok()?;
+        Some(Self::Html { canvas, context })
+    }
+
+    fn new_offscreen_canvas() -> Option<Self> {
+        let canvas = OffscreenCanvas::new(1, 1).ok()?;
+        let context = canvas
+            .get_context("2d")
+            .ok()??
+            .dyn_into::<OffscreenCanvasRenderingContext2d>()
+            .ok()?;
+        Some(Self::Offscreen { canvas, context })
+    }
+
+    /// Point the 2D context at `font`, then measure `text`.
+    fn measure(&self, text: &str, font: &str) -> Result<TextMetrics, JsValue> {
+        macro_rules! measure_context {
+            ($context:expr) => {{
+                $context.set_font(font);
+                $context.set_text_baseline("alphabetic");
+                $context.measure_text(text)
+            }};
+        }
+
+        match self {
+            Self::Html { context, .. } => measure_context!(context),
+            Self::Offscreen { context, .. } => measure_context!(context),
+        }
+    }
+
+    /// Grow the backing store to fit `width`x`height` and clear it.
+    ///
+    /// Only grow: resizing reallocates the backing store and resets all canvas state.
+    fn prepare(&self, width: u32, height: u32) {
+        macro_rules! prepare_canvas {
+            ($canvas:expr, $context:expr) => {{
+                if $canvas.width() < width {
+                    $canvas.set_width(width);
+                }
+                if $canvas.height() < height {
+                    $canvas.set_height(height);
+                }
+                $context.clear_rect(0.0, 0.0, width as f64, height as f64);
+            }};
+        }
+
+        match self {
+            Self::Html { canvas, context } => prepare_canvas!(canvas, context),
+            Self::Offscreen { canvas, context } => prepare_canvas!(canvas, context),
+        }
+    }
+
+    /// Draw `text` at `(x, y)` in `fill_style`.
+    fn draw_text(
+        &self,
+        text: &str,
+        font: &str,
+        fill_style: &str,
+        x: f64,
+        y: f64,
+    ) -> Result<(), JsValue> {
+        macro_rules! draw_text {
+            ($context:expr) => {{
+                $context.set_font(font);
+                $context.set_text_baseline("alphabetic");
+                $context.set_fill_style_str(fill_style);
+                $context.fill_text(text, x, y)
+            }};
+        }
+
+        match self {
+            Self::Html { context, .. } => draw_text!(context),
+            Self::Offscreen { context, .. } => draw_text!(context),
+        }
+    }
+
+    /// Read back the pixels of the `width`x`height` top-left region.
+    fn get_image_data(&self, width: u32, height: u32) -> Result<ImageData, JsValue> {
+        macro_rules! get_image_data {
+            ($x:expr, $y:expr, $width:expr, $height:expr) => {{
+                match self {
+                    Self::Html { context, .. } => context.get_image_data($x, $y, $width, $height),
+                    Self::Offscreen { context, .. } => {
+                        context.get_image_data($x, $y, $width, $height)
+                    }
+                }
+            }};
+        }
+
+        cfg_select! {
+            web_sys_unstable_apis => get_image_data!(0, 0, width as i32, height as i32),
+            _ => get_image_data!(0.0, 0.0, width as f64, height as f64),
+        }
     }
 }
 

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -156,7 +156,7 @@ fn install_keydown(runner_ref: &WebRunner, target: &EventTarget) -> Result<(), J
             if !modifiers.ctrl
                 && !modifiers.command
                 // When text agent is focused, it is responsible for handling input events
-                && !runner.text_agent.has_focus()
+                && !runner.text_agent.as_ref().is_some_and(|t| t.has_focus())
                 && let Some(text) = text_from_keyboard_event(&event)
             {
                 let egui_event = egui::Event::Text(text);
@@ -257,7 +257,7 @@ fn should_prevent_default_for_key(
         }
     }
 
-    if egui_key == egui::Key::Space && !runner.text_agent.has_focus() {
+    if egui_key == egui::Key::Space && !runner.text_agent.as_ref().is_some_and(|t| t.has_focus()) {
         // Space scrolls the web page, but we don't want that while canvas has focus
         // However, don't prevent it if text agent has focus, or we can't type space!
         return true;
@@ -799,9 +799,11 @@ fn install_touchend(runner_ref: &WebRunner, target: &EventTarget) -> Result<(), 
 
             // Fix virtual keyboard IOS
             // Need call focus at the same time of event
-            if runner.text_agent.has_focus() {
-                runner.text_agent.set_focus(false);
-                runner.text_agent.set_focus(true);
+            if let Some(text_agent) = &runner.text_agent
+                && text_agent.has_focus()
+            {
+                text_agent.set_focus(false);
+                text_agent.set_focus(true);
             }
         }
     })

--- a/crates/eframe/src/web/host.rs
+++ b/crates/eframe/src/web/host.rs
@@ -1,0 +1,69 @@
+//! The channel from the worker back to the host page.
+
+use wasm_bindgen::{JsCast as _, JsValue};
+
+/// Sends messages to the main thread from a worker.
+///
+/// Constructed with [`WebHost::new`], which returns `None` when the global
+/// object has no `postMessage` function.
+#[derive(Clone)]
+pub(crate) struct WebHost {
+    post_message: js_sys::Function,
+
+    /// The `{ type: "request_frame" }` message. It never changes and is posted
+    /// on every paint, so it is built once.
+    request_frame_message: JsValue,
+}
+
+impl core::fmt::Debug for WebHost {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("WebHost")
+    }
+}
+
+impl WebHost {
+    pub fn new() -> Option<Self> {
+        let post_message =
+            js_sys::Reflect::get(&js_sys::global(), &JsValue::from_str("postMessage"))
+                .ok()?
+                .dyn_into::<js_sys::Function>()
+                .ok()?;
+
+        let request_frame_message = js_sys::Object::new();
+        set(&request_frame_message, "type", "request_frame");
+
+        Some(Self {
+            post_message,
+            request_frame_message: request_frame_message.into(),
+        })
+    }
+
+    /// Post a message object to the main thread.
+    pub fn send(&self, message: &JsValue) {
+        if let Err(error) = self.post_message.call1(&js_sys::global(), message) {
+            log::error!(
+                "failed to postMessage to the host page: {}",
+                super::string_from_js_value(&error)
+            );
+        }
+    }
+
+    /// Ask the host page to change the CSS cursor of the visible canvas.
+    pub fn send_cursor_icon(&self, icon: egui::CursorIcon) {
+        let message = js_sys::Object::new();
+        set(&message, "type", "cursor");
+        set(&message, "icon", super::cursor_web_name(icon));
+        self.send(&message);
+    }
+
+    /// Ask the host page to send one `{type: "frame"}` message on its next
+    /// animation frame. Used in worker mode, where there is no `window` to call
+    /// `requestAnimationFrame` on.
+    pub fn request_frame(&self) {
+        self.send(&self.request_frame_message);
+    }
+}
+
+fn set(object: &js_sys::Object, key: &str, value: &str) {
+    let _ = js_sys::Reflect::set(object, &JsValue::from_str(key), &JsValue::from_str(value));
+}

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -5,9 +5,11 @@
 
 mod app_runner;
 mod backend;
+mod canvas;
 mod canvas_glyphs;
 mod dropped_file;
 mod events;
+mod host;
 mod input;
 mod panic_handler;
 mod text_agent;
@@ -22,6 +24,8 @@ pub mod screen_reader;
 pub mod storage;
 
 pub(crate) use app_runner::AppRunner;
+pub(crate) use canvas::WebCanvas;
+pub(crate) use host::WebHost;
 pub use panic_handler::{PanicHandler, PanicSummary};
 pub use web_logger::WebLogger;
 pub use web_runner::WebRunner;
@@ -101,19 +105,65 @@ pub(crate) fn focus_without_scroll(element: &web_sys::HtmlElement) -> Result<(),
 ///
 /// Monotonically increasing.
 pub fn now_sec() -> f64 {
-    web_sys::window()
-        .expect("should have a Window")
-        .performance()
-        .expect("should have a Performance")
-        .now()
-        / 1000.0
+    if let Some(window) = web_sys::window() {
+        return window
+            .performance()
+            .expect("should have a Performance")
+            .now()
+            / 1000.0;
+    }
+
+    // Worker mode: there is no `window`, but the global scope has `performance`.
+    // This must actually advance: egui drives animations (e.g. the fade-in of new
+    // windows) and `request_repaint_after` from it.
+    WORKER_PERFORMANCE.with(|cell| {
+        cell.get_or_init(|| {
+            let value = js_sys::Reflect::get(
+                &js_sys::global(),
+                &wasm_bindgen::JsValue::from_str("performance"),
+            )
+            .ok()?;
+            value.dyn_into::<web_sys::Performance>().ok()
+        })
+        .as_ref()
+        .map_or_else(
+            // Should not happen in a browser worker; wall clock as a last resort.
+            || js_sys::Date::now() / 1000.0,
+            |performance| performance.now() / 1000.0,
+        )
+    })
+}
+
+thread_local! {
+    /// Worker-scope `performance` object. Looked up once: `now_sec` runs every
+    /// frame, and a worker has no `window` to keep it on.
+    static WORKER_PERFORMANCE: core::cell::OnceCell<Option<web_sys::Performance>> =
+        const { core::cell::OnceCell::new() };
+}
+
+thread_local! {
+    /// Set by the host page in worker mode; `None` means "ask the window".
+    static HOST_PIXELS_PER_POINT: core::cell::Cell<Option<f32>> = const { core::cell::Cell::new(None) };
+}
+
+/// Called from [`WebRunner::on_worker_message`] on `resize` messages, with
+/// the host page's `devicePixelRatio`.
+pub(crate) fn set_native_pixels_per_point(pixels_per_point: f32) {
+    HOST_PIXELS_PER_POINT.with(|cell| cell.set(Some(pixels_per_point)));
 }
 
 /// The native GUI scale factor, taking into account the browser zoom.
 ///
 /// Corresponds to [`window.devicePixelRatio`](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio) in JavaScript.
 pub fn native_pixels_per_point() -> f32 {
-    let pixels_per_point = web_sys::window().unwrap().device_pixel_ratio() as f32;
+    if let Some(pixels_per_point) = HOST_PIXELS_PER_POINT.with(core::cell::Cell::get) {
+        return pixels_per_point;
+    }
+    let Some(window) = web_sys::window() else {
+        // No DOM (worker mode), and the host has not told us the DPR yet.
+        return 1.0;
+    };
+    let pixels_per_point = window.device_pixel_ratio() as f32;
     if pixels_per_point > 0.0 && pixels_per_point.is_finite() {
         pixels_per_point
     } else {
@@ -177,7 +227,7 @@ fn canvas_content_rect(canvas: &web_sys::HtmlCanvasElement) -> egui::Rect {
     rect
 }
 
-fn canvas_size_in_points(canvas: &web_sys::HtmlCanvasElement, ctx: &egui::Context) -> egui::Vec2 {
+fn canvas_size_in_points(canvas: &WebCanvas, ctx: &egui::Context) -> egui::Vec2 {
     // ctx.pixels_per_point can be outdated
 
     let pixels_per_point = ctx.zoom_factor() * native_pixels_per_point();
@@ -362,13 +412,10 @@ pub fn open_url(url: &str, new_tab: bool) -> Option<()> {
 ///
 /// Percent decoded
 pub fn location_hash() -> String {
-    percent_decode(
-        &web_sys::window()
-            .unwrap()
-            .location()
-            .hash()
-            .unwrap_or_default(),
-    )
+    let Some(window) = web_sys::window() else {
+        return String::new();
+    };
+    percent_decode(&window.location().hash().unwrap_or_default())
 }
 
 /// Percent-decodes a string.

--- a/crates/eframe/src/web/web_painter.rs
+++ b/crates/eframe/src/web/web_painter.rs
@@ -10,9 +10,6 @@ pub(crate) trait WebPainter {
     // where
     //     Self: Sized;
 
-    /// Reference to the canvas in use.
-    fn canvas(&self) -> &web_sys::HtmlCanvasElement;
-
     /// Maximum size of a texture in one direction.
     fn max_texture_side(&self) -> usize;
 

--- a/crates/eframe/src/web/web_painter_glow.rs
+++ b/crates/eframe/src/web/web_painter_glow.rs
@@ -3,14 +3,13 @@ use egui_glow::glow;
 use std::sync::Arc;
 use wasm_bindgen::JsCast as _;
 use wasm_bindgen::JsValue;
-use web_sys::HtmlCanvasElement;
 
 use crate::{WebGlContextOption, WebOptions};
 
-use super::web_painter::WebPainter;
+use super::{WebCanvas, web_painter::WebPainter};
 
 pub(crate) struct WebPainterGlow {
-    canvas: HtmlCanvasElement,
+    canvas: WebCanvas,
     painter: egui_glow::Painter,
 }
 
@@ -21,7 +20,7 @@ impl WebPainterGlow {
 
     pub fn new(
         _ctx: egui::Context,
-        canvas: HtmlCanvasElement,
+        canvas: WebCanvas,
         options: &WebOptions,
     ) -> Result<Self, String> {
         let (gl, shader_prefix) =
@@ -45,10 +44,6 @@ impl WebPainterGlow {
 impl WebPainter for WebPainterGlow {
     fn max_texture_side(&self) -> usize {
         self.painter.max_texture_side()
-    }
-
-    fn canvas(&self) -> &HtmlCanvasElement {
-        &self.canvas
     }
 
     fn paint_and_update_textures(
@@ -94,7 +89,7 @@ impl WebPainter for WebPainterGlow {
 
 /// Returns glow context and shader prefix.
 fn init_glow_context_from_canvas(
-    canvas: &HtmlCanvasElement,
+    canvas: &WebCanvas,
     options: WebGlContextOption,
 ) -> Result<(glow::Context, &'static str), String> {
     let result = match options {
@@ -117,7 +112,7 @@ fn init_glow_context_from_canvas(
     }
 }
 
-fn init_webgl1(canvas: &HtmlCanvasElement) -> Option<(glow::Context, &'static str)> {
+fn init_webgl1(canvas: &WebCanvas) -> Option<(glow::Context, &'static str)> {
     let gl1_ctx = canvas
         .get_context("webgl")
         .expect("Failed to query about WebGL2 context");
@@ -141,7 +136,7 @@ fn init_webgl1(canvas: &HtmlCanvasElement) -> Option<(glow::Context, &'static st
     Some((gl, shader_prefix))
 }
 
-fn init_webgl2(canvas: &HtmlCanvasElement) -> Option<(glow::Context, &'static str)> {
+fn init_webgl2(canvas: &WebCanvas) -> Option<(glow::Context, &'static str)> {
     let gl2_ctx = canvas
         .get_context("webgl2")
         .expect("Failed to query about WebGL2 context");
@@ -166,7 +161,8 @@ fn webgl1_requires_brightening(gl: &web_sys::WebGlRenderingContext) -> bool {
     // WebKitGTK use WebKit default unmasked vendor and renderer
     // but safari use same vendor and renderer
     // so exclude "Mac OS X" user-agent.
-    let user_agent = web_sys::window().unwrap().navigator().user_agent().unwrap();
+    // In a worker there is no `window`, so `user_agent()` can be `None`.
+    let user_agent = super::user_agent().unwrap_or_default();
     !user_agent.contains("Mac OS X") && is_safari_and_webkit_gtk(gl)
 }
 

--- a/crates/eframe/src/web/web_painter_wgpu.rs
+++ b/crates/eframe/src/web/web_painter_wgpu.rs
@@ -3,12 +3,11 @@ use std::sync::Arc;
 use egui::ScreenshotCallback;
 use egui_wgpu::{RenderState, SurfaceErrorAction, capture::CaptureState};
 use wasm_bindgen::JsValue;
-use web_sys::HtmlCanvasElement;
 
-use super::web_painter::WebPainter;
+use super::{WebCanvas, web_painter::WebPainter};
 
 pub(crate) struct WebPainterWgpu {
-    canvas: HtmlCanvasElement,
+    canvas: WebCanvas,
     instance: wgpu::Instance,
     surface: wgpu::Surface<'static>,
     surface_configuration: wgpu::SurfaceConfiguration,
@@ -72,9 +71,24 @@ impl WebPainterWgpu {
         })
     }
 
+    /// The wgpu surface target for a canvas.
+    ///
+    /// `wgpu` supports `SurfaceTarget::OffscreenCanvas`, but eframe does not use
+    /// it: rendering to an `OffscreenCanvas` requires the `glow` renderer.
+    fn surface_target(canvas: &WebCanvas) -> Result<wgpu::SurfaceTarget<'static>, String> {
+        match canvas {
+            WebCanvas::Html(canvas) => Ok(wgpu::SurfaceTarget::Canvas(canvas.clone())),
+            WebCanvas::Offscreen(_) => {
+                Err("WebGPU rendering on an OffscreenCanvas is not supported; \
+                 use the WebGL (`glow`) backend"
+                    .to_owned())
+            }
+        }
+    }
+
     pub async fn new(
         ctx: egui::Context,
-        canvas: web_sys::HtmlCanvasElement,
+        canvas: WebCanvas,
         options: &crate::WebOptions,
     ) -> Result<Self, String> {
         log::debug!("Creating wgpu painter");
@@ -91,7 +105,7 @@ impl WebPainterWgpu {
 
         let instance = wgpu_options.wgpu_setup.new_instance().await;
         let surface = instance
-            .create_surface(wgpu::SurfaceTarget::Canvas(canvas.clone()))
+            .create_surface(Self::surface_target(&canvas)?)
             .map_err(|err| format!("failed to create wgpu surface: {err}"))?;
 
         let depth_stencil_format = egui_wgpu::depth_format_from_bits(options.depth_buffer, 0);
@@ -140,10 +154,6 @@ impl WebPainterWgpu {
 }
 
 impl WebPainter for WebPainterWgpu {
-    fn canvas(&self) -> &HtmlCanvasElement {
-        &self.canvas
-    }
-
     fn max_texture_side(&self) -> usize {
         self.render_state.as_ref().map_or(0, |state| {
             state.device.limits().max_texture_dimension_2d as _
@@ -172,10 +182,11 @@ impl WebPainter for WebPainterWgpu {
         // surface from the canvas before re-borrowing `self.render_state` for the rest of paint.
         if self.needs_recreate {
             self.needs_recreate = false;
-            match self
-                .instance
-                .create_surface(wgpu::SurfaceTarget::Canvas(self.canvas.clone()))
-            {
+            match Self::surface_target(&self.canvas).and_then(|surface_target| {
+                self.instance
+                    .create_surface(surface_target)
+                    .map_err(|err| err.to_string())
+            }) {
                 Ok(new_surface) => {
                     new_surface.configure(&render_state.device, &self.surface_configuration);
                     self.surface = new_surface;

--- a/crates/eframe/src/web/web_runner.rs
+++ b/crates/eframe/src/web/web_runner.rs
@@ -6,7 +6,7 @@ use wasm_bindgen::prelude::*;
 use crate::{App, epi};
 
 use super::{
-    AppRunner, PanicHandler,
+    AppRunner, PanicHandler, WebCanvas, WebHost,
     events::{self, ResizeObserverContext},
     text_agent::TextAgent,
 };
@@ -33,6 +33,12 @@ pub struct WebRunner {
     /// Current animation frame in flight.
     frame: Rc<RefCell<Option<AnimationFrameRequest>>>,
 
+    /// Channel back to the host page. `Some` only when running in a worker.
+    ///
+    /// Kept here (not only in [`AppRunner`]) because `request_animation_frame`
+    /// needs it without locking the app runner.
+    host: Rc<RefCell<Option<WebHost>>>,
+
     resize_observer: Rc<RefCell<Option<ResizeObserverContext>>>,
 }
 
@@ -47,6 +53,7 @@ impl WebRunner {
             app_runner: Rc::new(RefCell::new(None)),
             events_to_unsubscribe: Rc::new(RefCell::new(Default::default())),
             frame: Default::default(),
+            host: Default::default(),
             resize_observer: Default::default(),
         }
     }
@@ -75,8 +82,14 @@ impl WebRunner {
         {
             // First set up the app runner:
             let text_agent = TextAgent::attach(self, &canvas)?;
-            let app_runner =
-                AppRunner::new(canvas.clone(), web_options, app_creator, text_agent).await?;
+            let app_runner = AppRunner::new(
+                WebCanvas::Html(canvas.clone()),
+                web_options,
+                app_creator,
+                None, // DOM mode: no host-page channel
+                Some(text_agent),
+            )
+            .await?;
             self.app_runner.replace(Some(app_runner));
         }
 
@@ -94,6 +107,95 @@ impl WebRunner {
         log::info!("event handlers installed.");
 
         Ok(())
+    }
+
+    /// Start an egui app on an `OffscreenCanvas` inside a web worker.
+    ///
+    /// The canvas must already have been transferred from the main thread
+    /// (`canvas.transferControlToOffscreen()`), and the host page must forward
+    /// messages — call [`Self::on_worker_message`] from the worker's `onmessage`.
+    ///
+    /// # Errors
+    /// Returns an error if the renderer cannot be initialized.
+    pub async fn start_offscreen(
+        &self,
+        canvas: web_sys::OffscreenCanvas,
+        web_options: crate::WebOptions,
+        app_creator: epi::AppCreator<'static>,
+    ) -> Result<(), JsValue> {
+        let canvas = WebCanvas::Offscreen(canvas);
+        let host =
+            WebHost::new().ok_or_else(|| JsValue::from_str("no postMessage on worker global"))?;
+        // Also keep a copy here: `request_animation_frame` needs it, and it must
+        // not lock the app runner (it is called while the runner is borrowed).
+        self.host.borrow_mut().replace(host.clone());
+        // The panic hook was installed by [`Self::new`].
+        let app_runner = AppRunner::new(
+            canvas,
+            web_options,
+            app_creator,
+            Some(host),
+            None, // worker mode: no DOM, so no text agent
+        )
+        .await?;
+        self.app_runner.replace(Some(app_runner));
+        Ok(())
+    }
+
+    /// Feed one message from the host page into the running app.
+    ///
+    /// Call this from the worker's `onmessage` handler. Unknown messages are ignored.
+    pub fn on_worker_message(&self, message: &JsValue) {
+        let Some(mut runner) = self.try_lock() else {
+            return;
+        };
+        let Some(kind) = js_sys::Reflect::get(message, &JsValue::from_str("type"))
+            .ok()
+            .and_then(|value| value.as_string())
+        else {
+            return;
+        };
+
+        match kind.as_str() {
+            "frame" => {
+                // The host page answered our `request_frame`.
+                let _ = self.frame.borrow_mut().take();
+                drop(runner);
+                events::paint_and_schedule(self).ok();
+            }
+            "resize" => {
+                let width = number(message, "width").unwrap_or(0.0) as u32;
+                let height = number(message, "height").unwrap_or(0.0) as u32;
+                if width > 0 && height > 0 {
+                    runner.on_offscreen_resize(width, height);
+                }
+                if let Some(dpr) = number(message, "dpr") {
+                    super::set_native_pixels_per_point(dpr as f32);
+                }
+                if let Some(rect) = rect_of(message) {
+                    runner
+                        .offscreen_events
+                        .apply(crate::web_events::WebEvent::CanvasRect(rect));
+                }
+                drop(runner);
+                self.request_animation_frame().ok();
+            }
+            "focus" => {
+                runner.input.focused = bool_value(message, "focused").unwrap_or(true);
+            }
+            "visibility" => {
+                runner.input.occluded = bool_value(message, "hidden").unwrap_or(false);
+            }
+            _ => {
+                if let Some(event) = parse_host_message(message) {
+                    let zoom_factor = runner.egui_ctx().zoom_factor();
+                    runner.offscreen_events.set_zoom_factor(zoom_factor);
+                    let events = runner.offscreen_events.apply(event);
+                    runner.input.raw.events.extend(events);
+                    runner.needs_repaint.repaint_asap();
+                }
+            }
+        }
     }
 
     /// Has there been a panic?
@@ -246,7 +348,15 @@ impl WebRunner {
             return Ok(());
         }
 
-        let window = web_sys::window().unwrap();
+        // In a worker there is no `window`. ask the host page for a single frame
+        // instead (see `WebRunner::on_worker_message`). Requesting one frame at a
+        // time is what applies back-pressure: input messages can never queue up
+        // behind a backlog of frame messages.
+        let Some(window) = web_sys::window() else {
+            self.request_animation_frame_from_host();
+            return Ok(());
+        };
+
         let closure = Closure::once({
             let web_runner = self.clone();
             move || {
@@ -271,20 +381,32 @@ impl WebRunner {
             AnimationFrameRequest {
                 id,
                 kind: AnimationFrameKind::Timeout,
-                _closure: closure,
+                _closure: Some(closure),
             }
         } else {
             let id = window.request_animation_frame(closure.as_ref().unchecked_ref())?;
             AnimationFrameRequest {
                 id,
                 kind: AnimationFrameKind::AnimationFrame,
-                _closure: closure,
+                _closure: Some(closure),
             }
         };
 
         self.frame.borrow_mut().replace(request);
 
         Ok(())
+    }
+
+    fn request_animation_frame_from_host(&self) {
+        let Some(host) = self.host.borrow().clone() else {
+            return;
+        };
+        host.request_frame();
+        self.frame.borrow_mut().replace(AnimationFrameRequest {
+            id: 0,
+            kind: AnimationFrameKind::Host,
+            _closure: None,
+        });
     }
 
     /// Cancel any in-flight frame request and schedule a fresh one.
@@ -294,8 +416,10 @@ impl WebRunner {
     /// `requestAnimationFrame` is paused while the tab is hidden, which would otherwise
     /// stall the paint loop and stop `App::update` from running while hidden.
     pub(crate) fn reschedule_frame(&self) -> Result<(), wasm_bindgen::JsValue> {
-        if let Some(frame) = self.frame.borrow_mut().take() {
-            frame.cancel(&web_sys::window().unwrap());
+        if let Some(frame) = self.frame.borrow_mut().take()
+            && let Some(window) = web_sys::window()
+        {
+            frame.cancel(&window);
         }
         self.request_animation_frame()
     }
@@ -313,7 +437,9 @@ struct AnimationFrameRequest {
 
     /// The callback given to `request_animation_frame`, stored here both to prevent it
     /// from being canceled, and from having to `.forget()` it.
-    _closure: Closure<dyn FnMut() -> Result<(), JsValue>>,
+
+    /// `None` for [`AnimationFrameKind::Host`], where the host page owns the callback.
+    _closure: Option<Closure<dyn FnMut() -> Result<(), JsValue>>>,
 }
 
 impl AnimationFrameRequest {
@@ -326,6 +452,8 @@ impl AnimationFrameRequest {
             AnimationFrameKind::Timeout => {
                 window.clear_timeout_with_handle(self.id);
             }
+            // Nothing to cancel: the host page owns the callback.
+            AnimationFrameKind::Host => {}
         }
     }
 }
@@ -337,6 +465,9 @@ enum AnimationFrameKind {
 
     /// Scheduled with `setTimeout` (hidden tab).
     Timeout,
+
+    /// Requested from the host page (worker mode).
+    Host,
 }
 
 struct TargetEvent {
@@ -374,5 +505,94 @@ impl EventToUnsubscribe {
                 Ok(())
             }
         }
+    }
+}
+
+/// Read a numeric field from a host message.
+fn number(message: &JsValue, key: &str) -> Option<f64> {
+    js_sys::Reflect::get(message, &JsValue::from_str(key))
+        .ok()?
+        .as_f64()
+}
+
+/// Read a boolean field from a host message.
+fn bool_value(message: &JsValue, key: &str) -> Option<bool> {
+    js_sys::Reflect::get(message, &JsValue::from_str(key))
+        .ok()?
+        .as_bool()
+}
+
+/// Read the `{left, top, right, bottom}` rect of a `resize` message.
+fn rect_of(message: &JsValue) -> Option<egui::Rect> {
+    let rect = js_sys::Reflect::get(message, &JsValue::from_str("rect")).ok()?;
+    Some(egui::Rect::from_min_max(
+        egui::pos2(number(&rect, "left")? as f32, number(&rect, "top")? as f32),
+        egui::pos2(
+            number(&rect, "right")? as f32,
+            number(&rect, "bottom")? as f32,
+        ),
+    ))
+}
+
+/// Read a pointer or wheel input message posted by `web_demo/offscreen_host.js`.
+///
+/// Returns `None` for unknown message kinds.
+fn parse_host_message(message: &JsValue) -> Option<crate::web_events::WebEvent> {
+    use crate::web_events::{PointerButton, WebEvent};
+
+    fn get(message: &JsValue, key: &str) -> Option<JsValue> {
+        let value = js_sys::Reflect::get(message, &JsValue::from_str(key)).ok()?;
+        if value.is_undefined() || value.is_null() {
+            None
+        } else {
+            Some(value)
+        }
+    }
+
+    fn modifiers_of(message: &JsValue) -> egui::Modifiers {
+        let alt = bool_value(message, "alt").unwrap_or(false);
+        let ctrl = bool_value(message, "ctrl").unwrap_or(false);
+        let shift = bool_value(message, "shift").unwrap_or(false);
+        let meta = bool_value(message, "meta").unwrap_or(false);
+        let is_mac = bool_value(message, "isMac").unwrap_or(false);
+        egui::Modifiers {
+            alt,
+            ctrl,
+            shift,
+            mac_cmd: is_mac && meta,
+            command: if is_mac { meta } else { ctrl },
+        }
+    }
+
+    let kind = get(message, "type")?.as_string()?;
+    match kind.as_str() {
+        "pointer" => {
+            let client = egui::Vec2::new(
+                number(message, "x").unwrap_or(0.0) as f32,
+                number(message, "y").unwrap_or(0.0) as f32,
+            );
+            let modifiers = modifiers_of(message);
+            let pointer_kind = get(message, "kind")?.as_string()?;
+            match pointer_kind.as_str() {
+                "move" => Some(WebEvent::PointerMove { client, modifiers }),
+                "down" | "up" => Some(WebEvent::PointerButton {
+                    client,
+                    button: PointerButton::from_dom(number(message, "button").unwrap_or(0.0) as i16),
+                    pressed: pointer_kind == "down",
+                    modifiers,
+                }),
+                "cancel" | "leave" => Some(WebEvent::PointerGone),
+                _ => None,
+            }
+        }
+        "wheel" => Some(WebEvent::Wheel {
+            delta: egui::Vec2::new(
+                number(message, "dx").unwrap_or(0.0) as f32,
+                number(message, "dy").unwrap_or(0.0) as f32,
+            ),
+            dom_delta_mode: number(message, "mode").unwrap_or(0.0) as u8,
+            modifiers: modifiers_of(message),
+        }),
+        _ => None,
     }
 }

--- a/crates/eframe/src/web_events.rs
+++ b/crates/eframe/src/web_events.rs
@@ -1,0 +1,315 @@
+//! Browser input events, normalized for transmission from a host page to a worker.
+//!
+//! Compiled on `wasm32` and on the host target under `cfg(test)`, so the
+//! semantics below are unit-tested without a browser. The host page's message
+//! objects are parsed into [`WebEvent`]s by `web/web_runner.rs`.
+//!
+//! The JavaScript host may only copy fields out of DOM events; the semantics
+//! (button numbers, wheel units, modifier derivation, coordinate conversion)
+//! live here or in `web/web_runner.rs`. See `web_demo/offscreen_host.js`.
+
+#![cfg_attr(not(any(test, target_arch = "wasm32")), allow(dead_code))]
+
+use egui::{Event, Modifiers, MouseWheelUnit, Pos2, Rect, TouchPhase, Vec2};
+
+/// A mouse button, as identified by `MouseEvent::button()`: <https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button>
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PointerButton {
+    Primary,
+    Secondary,
+    Middle,
+    Extra1,
+    Extra2,
+}
+
+impl PointerButton {
+    /// Map the DOM `MouseEvent.button` number. Returns `None` for unknown buttons.
+    pub fn from_dom(button: i16) -> Option<Self> {
+        match button {
+            0 => Some(Self::Primary),
+            1 => Some(Self::Middle),
+            2 => Some(Self::Secondary),
+            3 => Some(Self::Extra1),
+            4 => Some(Self::Extra2),
+            _ => None,
+        }
+    }
+
+    fn to_egui(self) -> egui::PointerButton {
+        match self {
+            Self::Primary => egui::PointerButton::Primary,
+            Self::Secondary => egui::PointerButton::Secondary,
+            Self::Middle => egui::PointerButton::Middle,
+            Self::Extra1 => egui::PointerButton::Extra1,
+            Self::Extra2 => egui::PointerButton::Extra2,
+        }
+    }
+}
+
+/// A normalized event from the host page.
+///
+/// All positions are in CSS pixels relative to the viewport (`clientX`/`clientY`);
+/// [`WebEventState`] converts them to egui points.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum WebEvent {
+    /// The canvas rectangle changed (also sent once at startup).
+    CanvasRect(Rect),
+    PointerMove {
+        client: Vec2,
+        modifiers: Modifiers,
+    },
+    PointerButton {
+        client: Vec2,
+        button: Option<PointerButton>,
+        pressed: bool,
+        modifiers: Modifiers,
+    },
+    PointerGone,
+    Wheel {
+        delta: Vec2,
+
+        /// `WheelEvent.deltaMode`: 0 = pixel, 1 = line, 2 = page.
+        dom_delta_mode: u8,
+        modifiers: Modifiers,
+    },
+}
+
+/// Mutable state needed to translate [`WebEvent`]s into [`egui::Event`]s.
+#[derive(Clone, Debug)]
+pub(crate) struct WebEventState {
+    canvas_rect: Rect,
+    zoom_factor: f32,
+    pointer_pos: Option<Pos2>,
+}
+
+impl Default for WebEventState {
+    fn default() -> Self {
+        Self {
+            canvas_rect: Rect::ZERO,
+            zoom_factor: 1.0,
+            pointer_pos: None,
+        }
+    }
+}
+
+impl WebEventState {
+    /// The last known pointer position, in egui points.
+    #[cfg(test)]
+    pub fn pointer_pos(&self) -> Option<Pos2> {
+        self.pointer_pos
+    }
+
+    /// Update the canvas rectangle (in CSS pixels, padding/border adjusted).
+    pub fn set_canvas_rect(&mut self, rect: Rect) {
+        self.canvas_rect = rect;
+    }
+
+    /// Update the egui zoom factor (see `egui::Context::zoom_factor`).
+    pub fn set_zoom_factor(&mut self, zoom_factor: f32) {
+        self.zoom_factor = zoom_factor;
+    }
+
+    /// Convert a client-space position to egui points.
+    fn to_points(&self, client: Vec2) -> Pos2 {
+        let zoom_factor = if self.zoom_factor == 0.0 {
+            1.0
+        } else {
+            self.zoom_factor
+        };
+        ((client - self.canvas_rect.min.to_vec2()) / zoom_factor).to_pos2()
+    }
+
+    /// Translate one host event into zero or more egui events.
+    pub fn apply(&mut self, event: WebEvent) -> Vec<Event> {
+        match event {
+            WebEvent::CanvasRect(rect) => {
+                self.set_canvas_rect(rect);
+                Vec::new()
+            }
+            WebEvent::PointerMove { client, .. } => {
+                let pos = self.to_points(client);
+                self.pointer_pos = Some(pos);
+                vec![Event::PointerMoved(pos)]
+            }
+            WebEvent::PointerButton {
+                client,
+                button,
+                pressed,
+                modifiers,
+            } => {
+                let pos = self.to_points(client);
+                self.pointer_pos = Some(pos);
+                let Some(button) = button.map(PointerButton::to_egui) else {
+                    return Vec::new();
+                };
+                vec![Event::PointerButton {
+                    pos,
+                    button,
+                    pressed,
+                    modifiers,
+                }]
+            }
+            WebEvent::PointerGone => {
+                self.pointer_pos = None;
+                vec![Event::PointerGone]
+            }
+            WebEvent::Wheel {
+                delta,
+                dom_delta_mode,
+                modifiers,
+            } => {
+                let unit = match dom_delta_mode {
+                    0 => MouseWheelUnit::Point,
+                    1 => MouseWheelUnit::Line,
+                    _ => MouseWheelUnit::Page,
+                };
+                vec![Event::MouseWheel {
+                    unit,
+                    // Match the DOM path (`install_wheel` negates `WheelEvent` deltas).
+                    delta: -delta,
+                    phase: TouchPhase::Move,
+                    modifiers,
+                }]
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use egui::{Pos2, Rect, Vec2};
+
+    fn state() -> WebEventState {
+        let mut state = WebEventState::default();
+        state.apply(WebEvent::CanvasRect(Rect::from_min_size(
+            Pos2::new(10.0, 20.0),
+            Vec2::new(200.0, 100.0),
+        )));
+        state
+    }
+
+    #[test]
+    fn pointer_move_is_relative_to_canvas() {
+        let mut state = state();
+        let events = state.apply(WebEvent::PointerMove {
+            client: Vec2::new(30.0, 50.0),
+            modifiers: Modifiers::NONE,
+        });
+        assert_eq!(
+            events,
+            vec![egui::Event::PointerMoved(Pos2::new(20.0, 30.0))]
+        );
+    }
+
+    #[test]
+    fn pointer_position_respects_zoom_factor() {
+        let mut state = state();
+        state.set_zoom_factor(2.0);
+        let events = state.apply(WebEvent::PointerMove {
+            client: Vec2::new(30.0, 50.0),
+            modifiers: Modifiers::NONE,
+        });
+        assert_eq!(
+            events,
+            vec![egui::Event::PointerMoved(Pos2::new(10.0, 15.0))]
+        );
+    }
+
+    #[test]
+    fn pointer_button_maps_dom_button_numbers() {
+        let mut state = state();
+        for (dom, expected) in [
+            (0, egui::PointerButton::Primary),
+            (1, egui::PointerButton::Middle),
+            (2, egui::PointerButton::Secondary),
+        ] {
+            let events = state.apply(WebEvent::PointerButton {
+                client: Vec2::new(10.0, 20.0),
+                button: PointerButton::from_dom(dom),
+                pressed: true,
+                modifiers: Modifiers::NONE,
+            });
+            assert_eq!(
+                events,
+                vec![egui::Event::PointerButton {
+                    pos: Pos2::ZERO,
+                    button: expected,
+                    pressed: true,
+                    modifiers: Modifiers::NONE,
+                }]
+            );
+        }
+    }
+
+    #[test]
+    fn wheel_point_mode_maps_to_mouse_wheel() {
+        let mut state = state();
+        let events = state.apply(WebEvent::Wheel {
+            delta: Vec2::new(0.0, 120.0),
+            dom_delta_mode: 0,
+            modifiers: Modifiers::NONE,
+        });
+        assert_eq!(
+            events,
+            vec![egui::Event::MouseWheel {
+                unit: egui::MouseWheelUnit::Point,
+                delta: Vec2::new(0.0, -120.0),
+                phase: egui::TouchPhase::Move,
+                modifiers: Modifiers::NONE,
+            }]
+        );
+    }
+
+    #[test]
+    fn wheel_line_mode_maps_to_lines() {
+        let mut state = state();
+        let events = state.apply(WebEvent::Wheel {
+            delta: Vec2::new(0.0, 3.0),
+            dom_delta_mode: 1,
+            modifiers: Modifiers::NONE,
+        });
+        assert_eq!(
+            events,
+            vec![egui::Event::MouseWheel {
+                unit: egui::MouseWheelUnit::Line,
+                delta: Vec2::new(0.0, -3.0),
+                phase: egui::TouchPhase::Move,
+                modifiers: Modifiers::NONE,
+            }]
+        );
+    }
+
+    #[test]
+    fn pointer_gone_clears_position() {
+        let mut state = state();
+        let _ = state.apply(WebEvent::PointerMove {
+            client: Vec2::new(30.0, 50.0),
+            modifiers: Modifiers::NONE,
+        });
+        let events = state.apply(WebEvent::PointerGone);
+        assert_eq!(events, vec![egui::Event::PointerGone]);
+        assert_eq!(state.pointer_pos(), None);
+    }
+
+    #[test]
+    fn modifiers_are_reported_from_booleans() {
+        let mut state = state();
+        let events = state.apply(WebEvent::PointerButton {
+            client: Vec2::ZERO,
+            button: Some(PointerButton::Primary),
+            pressed: false,
+            modifiers: Modifiers {
+                alt: true,
+                ctrl: false,
+                shift: true,
+                mac_cmd: false,
+                command: false,
+            },
+        });
+        let egui::Event::PointerButton { modifiers, .. } = events[0] else {
+            panic!("expected a pointer button event");
+        };
+        assert!(modifiers.alt && modifiers.shift && !modifiers.ctrl);
+    }
+}

--- a/crates/egui_demo_app/Cargo.toml
+++ b/crates/egui_demo_app/Cargo.toml
@@ -83,7 +83,7 @@ rfd = { workspace = true, optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
-web-sys.workspace = true
+web-sys = { workspace = true, features = ["OffscreenCanvas"] }
 
 [dev-dependencies]
 # `monochrome_emoji_fonts` so that the snapshots keep their emoji:

--- a/crates/egui_demo_app/src/backend_panel.rs
+++ b/crates/egui_demo_app/src/backend_panel.rs
@@ -193,6 +193,16 @@ fn integration_ui(ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
     });
 
     #[cfg(target_arch = "wasm32")]
+    ui.horizontal(|ui| {
+        ui.label("Canvas:");
+        if _frame.info().web_info.offscreen_canvas {
+            ui.monospace("OffscreenCanvas (web worker)");
+        } else {
+            ui.monospace("HtmlCanvasElement (main thread)");
+        }
+    });
+
+    #[cfg(target_arch = "wasm32")]
     ui.collapsing("Web info (location)", |ui| {
         ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
         ui.monospace(format!("{:#?}", _frame.info().web_info.location));

--- a/crates/egui_demo_app/src/web.rs
+++ b/crates/egui_demo_app/src/web.rs
@@ -1,3 +1,5 @@
+use core::cell::RefCell;
+
 use eframe::wasm_bindgen::{self, prelude::*};
 
 use crate::WrapApp;
@@ -74,4 +76,51 @@ impl WebHandle {
     pub fn panic_callstack(&self) -> Option<String> {
         self.runner.panic_summary().map(|s| s.callstack())
     }
+}
+
+thread_local! {
+    /// The runner must outlive `start_offscreen_egui`; the worker has no JS object
+    /// holding it (unlike [`WebHandle`] in DOM mode).
+    static OFFSCREEN_RUNNER: RefCell<Option<eframe::WebRunner>> = const { RefCell::new(None) };
+}
+
+/// Start the demo in a web worker, rendering to an `OffscreenCanvas`.
+///
+/// Call this from the worker's `onmessage` handler with the canvas transferred
+/// by the main thread.
+///
+/// # Errors
+/// Returns an error if the renderer could not be initialized.
+#[wasm_bindgen]
+pub async fn start_offscreen_egui(
+    canvas: web_sys::OffscreenCanvas,
+) -> Result<(), wasm_bindgen::JsValue> {
+    let log_level = if cfg!(debug_assertions) {
+        log::LevelFilter::Trace
+    } else {
+        log::LevelFilter::Debug
+    };
+    eframe::WebLogger::init(log_level).ok();
+
+    let runner = eframe::WebRunner::new();
+    runner
+        .start_offscreen(
+            canvas,
+            eframe::WebOptions::default(),
+            Box::new(|cc| Ok(Box::new(WrapApp::new(cc)))),
+        )
+        .await?;
+    OFFSCREEN_RUNNER.with(|slot| *slot.borrow_mut() = Some(runner));
+    Ok(())
+}
+
+/// Feed one message from the host page into the offscreen app.
+#[wasm_bindgen]
+#[expect(clippy::needless_pass_by_value)]
+pub fn offscreen_on_message(message: wasm_bindgen::JsValue) {
+    OFFSCREEN_RUNNER.with(|slot| {
+        if let Some(runner) = slot.borrow().as_ref() {
+            runner.on_worker_message(&message);
+        }
+    });
 }

--- a/web_demo/offscreen.html
+++ b/web_demo/offscreen.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>eframe OffscreenCanvas demo</title>
+  <style>
+    html, body { margin: 0; height: 100%; background: #202020; }
+    canvas { display: block; width: 100%; height: 100%; touch-action: none; outline: none; }
+  </style>
+</head>
+<body>
+  <canvas id="the_canvas" tabindex="0"></canvas>
+  <script src="offscreen_host.js"></script>
+</body>
+</html>

--- a/web_demo/offscreen_host.js
+++ b/web_demo/offscreen_host.js
@@ -1,0 +1,81 @@
+// Main thread: owns the DOM canvas, transfers it to a worker, forwards input.
+(async () => {
+  const canvas = document.getElementById("the_canvas");
+  const isMac = /Mac|iPhone|iPad/.test(navigator.platform);
+  const offscreen = canvas.transferControlToOffscreen();
+
+  const worker = new Worker("offscreen_worker.js");
+  worker.postMessage({ type: "init", canvas: offscreen }, [offscreen]);
+
+  const post = (message) => worker.postMessage(message);
+
+  // --- sizing ---------------------------------------------------------
+  const sendResize = () => {
+    const rect = canvas.getBoundingClientRect();
+    const style = getComputedStyle(canvas);
+    const px = (name) => parseFloat(style.getPropertyValue(name)) || 0;
+    post({
+      type: "resize",
+      width: Math.max(1, Math.round(rect.width * window.devicePixelRatio)),
+      height: Math.max(1, Math.round(rect.height * window.devicePixelRatio)),
+      dpr: window.devicePixelRatio,
+      rect: {
+        left: rect.left + px("padding-left") + px("border-left-width"),
+        top: rect.top + px("padding-top") + px("border-top-width"),
+        right: rect.right - px("padding-right") - px("border-right-width"),
+        bottom: rect.bottom - px("padding-bottom") - px("border-bottom-width"),
+      },
+    });
+  };
+  new ResizeObserver(sendResize).observe(canvas);
+  window.addEventListener("resize", sendResize);
+  sendResize();
+
+  // The worker asks for one frame at a time (`request_frame`)
+  let frame_scheduled = false;
+  const scheduleFrame = () => {
+    if (frame_scheduled) return;
+    frame_scheduled = true;
+    const run = () => {
+      frame_scheduled = false;
+      post({ type: "frame" });
+    };
+    requestAnimationFrame(run);
+  };
+
+  const mods = (e) => ({ alt: e.altKey, ctrl: e.ctrlKey, meta: e.metaKey, shift: e.shiftKey, isMac });
+
+  canvas.addEventListener("pointerdown", (e) => {
+    try { canvas.setPointerCapture(e.pointerId); } catch (_) { }
+    post({ type: "pointer", kind: "down", x: e.clientX, y: e.clientY, button: e.button, ...mods(e) });
+  });
+  canvas.addEventListener("pointerup", (e) =>
+    post({ type: "pointer", kind: "up", x: e.clientX, y: e.clientY, button: e.button, ...mods(e) }));
+  canvas.addEventListener("pointermove", (e) =>
+    post({ type: "pointer", kind: "move", x: e.clientX, y: e.clientY, button: e.button, ...mods(e) }));
+  canvas.addEventListener("pointercancel", () => post({ type: "pointer", kind: "cancel" }));
+  canvas.addEventListener("pointerleave", () => post({ type: "pointer", kind: "leave" }));
+  canvas.addEventListener("wheel", (e) => {
+    e.preventDefault();
+    post({ type: "wheel", dx: e.deltaX, dy: e.deltaY, mode: e.deltaMode, ...mods(e) });
+  }, { passive: false });
+
+  window.addEventListener("focus", () => post({ type: "focus", focused: true }));
+  window.addEventListener("blur", () => post({ type: "focus", focused: false }));
+  document.addEventListener("visibilitychange", () => {
+    post({ type: "visibility", hidden: document.hidden });
+    // A `requestAnimationFrame` that is already pending is paused while the tab is
+    // hidden, so re-arm with the API that matches the new visibility.
+    frame_scheduled = false;
+    scheduleFrame();
+  });
+
+  worker.addEventListener("message", (event) => {
+    const message = event.data;
+    if (message.type === "request_frame") {
+      scheduleFrame();
+    } else if (message.type === "cursor") {
+      canvas.style.cursor = message.icon;
+    }
+  });
+})();

--- a/web_demo/offscreen_worker.js
+++ b/web_demo/offscreen_worker.js
@@ -1,0 +1,24 @@
+importScripts("egui_demo_app.js");
+
+let ready = false;
+let pending_resize = null;
+
+self.onmessage = async (event) => {
+  const message = event.data;
+  if (!ready) {
+    if (message.type === "resize") {
+      pending_resize = message;
+      return;
+    }
+    if (message.type !== "init") { return; }
+    await wasm_bindgen("egui_demo_app_bg.wasm");
+    await wasm_bindgen.start_offscreen_egui(message.canvas);
+    ready = true;
+    if (pending_resize) {
+      wasm_bindgen.offscreen_on_message(pending_resize);
+      pending_resize = null;
+    }
+    return;
+  }
+  wasm_bindgen.offscreen_on_message(message);
+};


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/main/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* Keep PR description short and to the point! No long LLM slop.
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for it to `egui_demo_lib`, or a new example.
* Do NOT open PR:s from your `master` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until a human has reviewed it
* When you have addressed a PR comment, mark it as resolved.

Please be patient! I will review your PR, but my time is limited!
-->

* Closes <https://github.com/emilk/egui/issues/THE_RELEVANT_ISSUE>
* [x] I have followed the instructions in the PR template

Hello,

This is a pull request to add the support of [OffscreenCanvas](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas)

The context and my goal is to be able to run rerun (or any other library/sdk with egui GUI) into [JupyterLite](https://github.com/jupyterlite).

This adds a way to run an eframe app on an `OffscreenCanvas` owned by a Web Worker, instead of the `<canvas>` element in the page. The classic main-thread path is untouched: nothing changes unless you use the new entry point.

`WebCanvas` (`crates/eframe/src/web/canvas.rs`) is a small `Html` / `Offscreen` enum that the runner, the event wiring and both painters (glow and wgpu) now go through. The offscreen kind is what the new `OffscreenCanvas` / `OffscreenCanvasRenderingContext2d` web-sys features are for.

A worker has no DOM, and DOM events can't be constructed or structured-cloned into it, so the host page keeps the listeners and forwards raw pointer/wheel/modifier data as plain messages (`web/host.rs` on the Rust side). The worker parses those back into egui events (`web_events.rs`), and from there it is the same input pipeline as always.

Glyph/font loading and `web_location()` used to need `window`/`document`, they now fall back gracefully inside a worker, which is what lets the demo render there with its icons intact. `WebInfo::offscreen_canvas` tells the app which mode it is running in, and the demo's Backend panel shows it.

<img width="868" height="845" alt="image" src="https://github.com/user-attachments/assets/b2cc6225-7942-40d3-b1a4-af227125b4ba" />


There is a demo page dedicated for offscreencanvas: `web_demo/offscreen.html`. To try it:

```sh
./scripts/build_demo_web.sh --glow
cd web_demo && python3 -m http.server 8765
# then open http://127.0.0.1:8765/offscreen.html
```

