### PR TITLE
Ensure nested `AtomLayout`s have unique ids

### DIFF
--- a/crates/egui/src/atomics/atom_layout.rs
+++ b/crates/egui/src/atomics/atom_layout.rs
@@ -354,7 +354,11 @@ impl<'a> AtomLayout<'a> {
             intrinsic_main += gap_space;
         }
 
-        for (idx, item) in atoms.into_iter().enumerate() {
+        for (idx, mut item) in atoms.into_iter().enumerate() {
+            if let AtomKind::Layout(layout) = &mut item.kind {
+                // Ensure children have unique ids
+                layout.id.get_or_insert_with(|| id.with(idx));
+            }
             if item.grow {
                 grow_count += 1;
             }

--- a/tests/egui_tests/tests/test_atoms.rs
+++ b/tests/egui_tests/tests/test_atoms.rs
@@ -6,6 +6,27 @@ use egui::{
 use egui_kittest::{HarnessBuilder, SnapshotResult, SnapshotResults};
 
 #[test]
+fn test_button_with_nested_layouts_is_clickable() {
+    use egui_kittest::kittest::Queryable as _;
+
+    let mut harness = HarnessBuilder::default().build_ui_state(
+        |ui, clicks| {
+            if ui
+                .button((AtomLayout::new("abcdef"), AtomLayout::new("123")))
+                .clicked()
+            {
+                *clicks += 1;
+            }
+        },
+        0,
+    );
+
+    harness.get_by_role(egui::accesskit::Role::Button).click();
+    harness.run();
+    assert_eq!(*harness.state(), 1);
+}
+
+#[test]
 fn test_atoms() {
     let mut results = SnapshotResults::new();
 


### PR DESCRIPTION
Buttons with nested atoms weren't fully clickable

https://github.com/user-attachments/assets/c9bc7075-9b32-4edc-9949-5eb047234e07

