### PR TITLE
Fix deep indents blowing up memory in debug mode

### DIFF
--- a/crates/egui/src/containers/collapsing_header.rs
+++ b/crates/egui/src/containers/collapsing_header.rs
@@ -159,9 +159,10 @@ impl CollapsingState {
         ui: &mut Ui,
         add_body: impl FnOnce(&mut Ui) -> R,
     ) -> Option<InnerResponse<R>> {
-        let id = self.id;
+        // The body is salted with the header id's value, since an `Id` must not be used as an id salt.
+        let id_value = self.id.value();
         self.show_body_unindented(ui, |ui| {
-            ui.indent(id, |ui| {
+            ui.indent(id_value, |ui| {
                 // make as wide as the header:
                 ui.expand_to_include_x(header_response.rect.right());
                 add_body(ui)

--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -818,7 +818,8 @@ impl Panel {
 
         let mut panel_ui = parent_ui.new_child(
             UiBuilder::new()
-                .id_salt(id)
+                // Salted with the panel id's value, since an `Id` must not be used as an id salt.
+                .id_salt(id.value())
                 .ui_stack_info(UiStackInfo::new(side.ui_kind()))
                 .max_rect(shifted_outer_rect)
                 .layout(Layout::top_down(Align::Min)),

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -737,7 +737,8 @@ impl Table<'_> {
         let cursor_position = ui.cursor().min;
 
         let mut scroll_area = ScrollArea::new([false, vscroll])
-            .id_salt(state_id.with("__scroll_area"))
+            // Salted with the state id's value, since an `Id` must not be used as an id salt.
+            .id_salt((state_id.value(), "__scroll_area"))
             .scroll_source(ScrollSource {
                 drag: drag_to_scroll,
                 ..Default::default()


### PR DESCRIPTION
Including the whole Id in the Id chain for indents made memory blow up exponentially. Causing freezes for me in some instances.